### PR TITLE
Add README with submodule setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# MJ FoodBank Booking
+
+This repository uses Git submodules for the backend and frontend components. After cloning, make sure to pull in the submodules and install their dependencies.
+
+## Clone and initialize submodules
+
+```bash
+git clone <repository-url>
+cd MJ_FoodBank_Booking
+git submodule update --init --recursive
+```
+
+## Backend setup (`MJ_FB_Backend`)
+
+Prerequisites:
+- Node.js and npm
+
+Install and run:
+```bash
+cd MJ_FB_Backend
+npm install
+npm start   # or npm run dev
+```
+
+## Frontend setup (`MJ_FB_Frontend`)
+
+Prerequisites:
+- Node.js and npm
+
+Install and run:
+```bash
+cd MJ_FB_Frontend
+npm install
+npm start   # or npm run dev
+```
+
+Refer to the submodule repositories for detailed configuration and environment variables.


### PR DESCRIPTION
## Summary
- document how to initialize git submodules
- note prerequisites and basic install/run commands for backend and frontend

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689111b5a9ac832d9e9abce7f7126504