### PR TITLE
chore: set TypeScript outDir

### DIFF
--- a/MJ_FB_Backend/tsconfig.json
+++ b/MJ_FB_Backend/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "rootDir": "src"
+    "rootDir": "src",
+    "outDir": "dist"
   }
 }


### PR DESCRIPTION
## Summary
- output compiled backend files to `dist`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68911d32dd3c832dabc0ce6a8d503609