### PR TITLE
feat: allow configuring frontend origin

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -3,3 +3,8 @@ Frontend: https://github.com/Amrutha-A-J/MJ_FB_Frontend
 Backend: https://github.com/Amrutha-A-J/MJ_FB_Backend
 
 
+## Environment Variables
+
+`FRONTEND_ORIGIN` – Origin URL of the frontend allowed for CORS. Defaults to `http://localhost:5173` if unset.
+
+

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -1,16 +1,19 @@
 import express from 'express';
 import cors from 'cors'; // add this
+import dotenv from 'dotenv';
 import usersRoutes from './routes/users';
 import slotsRoutes from './routes/slots';
 import bookingsRoutes from './routes/bookings';
 import holidaysRoutes from './routes/holidays';
 import { initializeSlots } from './data';
 
+dotenv.config();
+
 const app = express();
 
 // ⭐ Add CORS middleware before routes
 app.use(cors({
-  origin: 'http://localhost:5173', // allow your frontend
+  origin: process.env.FRONTEND_ORIGIN || 'http://localhost:5173', // allow your frontend
   credentials: true
 }));
 


### PR DESCRIPTION
## Summary
- make backend CORS origin configurable with `FRONTEND_ORIGIN`
- document `FRONTEND_ORIGIN` env var for backend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68911ea3b130832d909ecd47907cf29e