### PR TITLE
refactor: connect to database during server startup

### DIFF
--- a/MJ_FB_Backend/src/db.ts
+++ b/MJ_FB_Backend/src/db.ts
@@ -9,10 +9,4 @@ const pool = new Pool({
   port: Number(process.env.PG_PORT),
   database: process.env.PG_DATABASE,
 });
-
-// Test the connection
-pool.connect()
-  .then(() => console.log('✅ Connected to the database successfully!'))
-  .catch(err => console.error('❌ Failed to connect to the database:', err));
-
 export default pool;

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -6,6 +6,7 @@ import slotsRoutes from './routes/slots';
 import bookingsRoutes from './routes/bookings';
 import holidaysRoutes from './routes/holidays';
 import { initializeSlots } from './data';
+import pool from './db';
 
 dotenv.config();
 
@@ -26,8 +27,21 @@ app.use('/slots', slotsRoutes);
 app.use('/bookings', bookingsRoutes);
 app.use('/holidays', holidaysRoutes);
 
-
 const PORT = 4000;
-app.listen(PORT, () => {
-  console.log(`Server running at http://localhost:${PORT}`);
-});
+
+async function init() {
+  try {
+    const client = await pool.connect();
+    console.log('✅ Connected to the database successfully!');
+    client.release();
+
+    app.listen(PORT, () => {
+      console.log(`Server running at http://localhost:${PORT}`);
+    });
+  } catch (err) {
+    console.error('❌ Failed to connect to the database:', err);
+    process.exit(1);
+  }
+}
+
+init();


### PR DESCRIPTION
## Summary
- clean up database module by removing eager connection attempts
- connect to the database during server initialization and exit on failure

## Testing
- `npm test` (fails: missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689122e9d764832d93aa50f9eb0ad664