### PR TITLE
refactor: centralize API base URL and use API utilities

### DIFF
--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -1,5 +1,6 @@
 // src/api/api.ts
-const API_BASE = 'http://localhost:4000'; // change to Azure URL later
+// Read API base URL from environment or fall back to localhost
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
 
 export async function login(email: string, password: string) {
   const res = await fetch(`${API_BASE}/users/login`, {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { addUser } from '../../api/api';
 
 export default function AddUser({ token }: { token: string }) {
   const [email, setEmail] = useState('');
@@ -14,12 +15,7 @@ export default function AddUser({ token }: { token: string }) {
       return;
     }
     try {
-      const res = await fetch('http://localhost:4000/users', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: token },
-        body: JSON.stringify({ email, role, name, password, phone }), // ✅ send password & phone
-      });
-      if (!res.ok) throw new Error(await res.text());
+      await addUser(token, name, email, password, role, phone);
       setMessage('User added successfully');
       setEmail('');
       setName('');

--- a/MJ_FB_Frontend/src/components/StaffDashboard/ManageHolidays.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/ManageHolidays.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { getHolidays, addHoliday as apiAddHoliday, removeHoliday as apiRemoveHoliday } from '../../api/api';
 
 export default function ManageHolidays({ token }: { token: string }) {
   const [holidays, setHolidays] = useState<string[]>([]);
@@ -11,11 +12,7 @@ export default function ManageHolidays({ token }: { token: string }) {
 
   async function fetchHolidays() {
     try {
-      const res = await fetch('http://localhost:4000/holidays', {
-        headers: { Authorization: token }
-      });
-      if (!res.ok) throw new Error(await res.text());
-      const data = await res.json();
+      const data = await getHolidays(token);
       setHolidays(data);
     } catch (err: any) {
       setMessage(err.message);
@@ -25,12 +22,7 @@ export default function ManageHolidays({ token }: { token: string }) {
   async function addHoliday() {
     if (!newDate) return setMessage('Select a date to add');
     try {
-      const res = await fetch('http://localhost:4000/holidays', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: token },
-        body: JSON.stringify({ date: newDate }),
-      });
-      if (!res.ok) throw new Error(await res.text());
+      await apiAddHoliday(token, newDate);
       setMessage('Holiday added');
       setNewDate('');
       fetchHolidays();
@@ -41,11 +33,7 @@ export default function ManageHolidays({ token }: { token: string }) {
 
   async function removeHoliday(date: string) {
     try {
-      const res = await fetch(`http://localhost:4000/holidays/${date}`, {
-        method: 'DELETE',
-        headers: { Authorization: token },
-      });
-      if (!res.ok) throw new Error(await res.text());
+      await apiRemoveHoliday(token, date);
       setMessage('Holiday removed');
       fetchHolidays();
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- read API base URL from `VITE_API_BASE` with fallback to localhost
- update AddUser component to use `addUser` API helper
- use API helpers for holiday management instead of hard-coded fetch calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, react-hooks/exhaustive-deps warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6891242599ac832da15f5a8c8b5bbb6d