### PR TITLE
Unify backend slot model

### DIFF
--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import pool from '../db';
+import { Slot } from '../models/slot';
 
 export async function listSlots(req: Request, res: Response) {
   const date = req.query.date as string;
@@ -48,7 +49,7 @@ export async function listSlots(req: Request, res: Response) {
       approvedMap[row.slot_id] = Number(row.approved_count);
     }
 
-    const slotsWithAvailability = slots.map((slot: any) => ({
+    const slotsWithAvailability: Slot[] = slots.map((slot: any) => ({
       id: slot.id.toString(),
       startTime: slot.start_time,
       endTime: slot.end_time,

--- a/MJ_FB_Backend/src/data.ts
+++ b/MJ_FB_Backend/src/data.ts
@@ -1,3 +1,5 @@
+import { Slot } from './models/slot';
+
 export type UserRole = 'staff' | 'shopper' | 'delivery';
 
 export interface User {
@@ -7,13 +9,6 @@ export interface User {
   password: string;
   role: UserRole;
   phone?: string;
-}
-
-export interface Slot {
-  id: string;
-  startTime: string; // "09:30"
-  endTime: string;   // "10:00"
-  maxCapacity: number;
 }
 
 export type BookingStatus = 'submitted' | 'approved' | 'rejected' | 'preapproved';

--- a/MJ_FB_Backend/src/models/slot.ts
+++ b/MJ_FB_Backend/src/models/slot.ts
@@ -1,6 +1,8 @@
 export interface Slot {
-    id: string;
-    date: string;  // e.g., "2025-07-21"
-    time: string;  // e.g., "09:30"
-    maxCapacity: number;  // e.g., 4
-  }
+  id: string;
+  startTime: string; // e.g., "09:30"
+  endTime: string;   // e.g., "10:00"
+  maxCapacity: number;
+  available?: number;
+}
+


### PR DESCRIPTION
## Summary
- standardize Slot interface with start/end time and optional availability
- use unified Slot model across data layer and slot controller

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689125816004832d9f3f3b219563ff6f