### PR TITLE
Fix booking calendar disappearing due to invalid calendar type

### DIFF
--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -123,7 +123,7 @@ export default function SlotBooking({ token, role }: Props) {
           if (value instanceof Date) setSelectedDate(value);
         }}
         value={selectedDate}
-        calendarType="US"
+        calendarType="gregory"
         tileDisabled={({ date }) => {
           const zoned = toZonedTime(date, reginaTimeZone);
           const day = zoned.getDay();


### PR DESCRIPTION
## Summary
- Update react-calendar usage to use supported `gregory` calendar type

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689134ccfcc0832d82facf3a57104a68