### PR TITLE
feat: add staff schedule view

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -4,6 +4,7 @@ import StaffDashboard from './components/StaffDashboard/StaffDashboard';
 import ManageHolidays from './components/StaffDashboard/ManageHolidays';
 import SlotBooking from './components/SlotBooking';
 import AddUser from './components/StaffDashboard/AddUser';
+import ViewSchedule from './components/StaffDashboard/ViewSchedule';
 import Login from './components/Login';
 import type { Role } from './types';
 
@@ -30,6 +31,7 @@ export default function App() {
     navLinks = navLinks.concat([
       { label: 'Staff Dashboard', id: 'staffDashboard' },
       { label: 'Manage Holidays', id: 'manageHolidays' },
+      { label: 'View Schedule', id: 'viewSchedule' },
       { label: 'User Bookings', id: 'userBookings' },
       { label: 'Add User', id: 'addUser' },
     ]);
@@ -125,6 +127,9 @@ export default function App() {
             )}
             {activePage === 'manageHolidays' && role === 'staff' && (
               <ManageHolidays token={token} />
+            )}
+            {activePage === 'viewSchedule' && role === 'staff' && (
+              <ViewSchedule token={token} />
             )}
             {activePage === 'userBookings' && role === 'staff' && (
               <SlotBooking token={token} role="staff" />

--- a/MJ_FB_Frontend/src/components/StaffDashboard/ViewSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/ViewSchedule.tsx
@@ -1,0 +1,208 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getSlots, getBookings, getHolidays, searchUsers, createBookingForUser } from '../../api/api';
+import type { Slot } from '../../types';
+
+interface Booking {
+  id: number;
+  status: string;
+  date: string;
+  slot_id: number;
+  user_name: string;
+}
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export default function ViewSchedule({ token }: { token: string }) {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [slots, setSlots] = useState<Slot[]>([]);
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [holidays, setHolidays] = useState<string[]>([]);
+  const [assignSlot, setAssignSlot] = useState<Slot | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [userResults, setUserResults] = useState<User[]>([]);
+  const [message, setMessage] = useState('');
+
+  const formatDate = (date: Date) => date.toISOString().split('T')[0];
+
+  const loadData = useCallback(async () => {
+    const dateStr = formatDate(currentDate);
+    try {
+      const [slotsData, bookingsData] = await Promise.all([
+        getSlots(token, dateStr),
+        getBookings(token),
+      ]);
+      setSlots(slotsData);
+      const filtered = bookingsData.filter((b: Booking) =>
+        b.date.split('T')[0] === dateStr && b.status === 'approved'
+      );
+      setBookings(filtered);
+    } catch (err) {
+      console.error(err);
+    }
+  }, [currentDate, token]);
+
+  useEffect(() => {
+    getHolidays(token).then(setHolidays).catch(() => {});
+  }, [token]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    if (assignSlot && searchTerm.length >= 3) {
+      const delay = setTimeout(() => {
+        searchUsers(token, searchTerm)
+          .then((data: User[]) => setUserResults(data.slice(0, 5)))
+          .catch(() => setUserResults([]));
+      }, 300);
+      return () => clearTimeout(delay);
+    } else {
+      setUserResults([]);
+    }
+  }, [searchTerm, token, assignSlot]);
+
+  function changeDay(delta: number) {
+    setCurrentDate(d => new Date(d.getTime() + delta * 86400000));
+  }
+
+  async function assignUser(user: User) {
+    if (!assignSlot) return;
+    try {
+      await createBookingForUser(
+        token,
+        user.id,
+        parseInt(assignSlot.id),
+        formatDate(currentDate),
+        true
+      );
+      setAssignSlot(null);
+      setSearchTerm('');
+      await loadData();
+    } catch (err) {
+      console.error(err);
+      setMessage('Failed to assign user');
+    }
+  }
+
+  const dateStr = formatDate(currentDate);
+  const dayName = currentDate.toLocaleDateString(undefined, { weekday: 'long' });
+  const isHoliday = holidays.includes(dateStr);
+
+  // prepare slots with lunch break
+  const displaySlots: (Slot | { id: string; startTime: string; endTime: string; lunch: true })[] = [];
+  const sortedSlots = [...slots].sort((a, b) => a.startTime.localeCompare(b.startTime));
+  let lunchInserted = false;
+  for (const s of sortedSlots) {
+    if (!lunchInserted && s.startTime >= '13:00') {
+      displaySlots.push({ id: 'lunch', startTime: '12:00', endTime: '13:00', lunch: true });
+      lunchInserted = true;
+    }
+    displaySlots.push(s);
+  }
+  if (!lunchInserted) {
+    displaySlots.push({ id: 'lunch', startTime: '12:00', endTime: '13:00', lunch: true });
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <button onClick={() => changeDay(-1)}>Previous</button>
+        <h3>{dateStr} - {dayName}{isHoliday ? ' (Holiday)' : ''}</h3>
+        <button onClick={() => changeDay(1)}>Next</button>
+      </div>
+      {message && <p style={{ color: 'red' }}>{message}</p>}
+      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+        <thead>
+          <tr>
+            <th style={{ border: '1px solid #ccc', padding: 8, width: '120px' }}>Time</th>
+            {[1,2,3,4].map(i => (
+              <th key={i} style={{ border: '1px solid #ccc', padding: 8 }}>Slot {i}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {displaySlots.map((slot, idx) => {
+            if ('lunch' in slot) {
+              return (
+                <tr key={idx} style={{ backgroundColor: '#f5f5f5' }}>
+                  <td style={{ border: '1px solid #ccc', padding: 8 }}>12:00 - 13:00</td>
+                  <td colSpan={4} style={{ border: '1px solid #ccc', padding: 8, textAlign: 'center' }}>Lunch Break</td>
+                </tr>
+              );
+            }
+            const slotBookings = bookings.filter(b => b.slot_id === parseInt(slot.id));
+            return (
+              <tr key={slot.id}>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{slot.startTime} - {slot.endTime}</td>
+                {Array.from({ length: 4 }).map((_, i) => {
+                  const booking = slotBookings[i];
+                  return (
+                    <td
+                      key={i}
+                      style={{
+                        border: '1px solid #ccc',
+                        padding: 8,
+                        height: 40,
+                        cursor: booking ? 'default' : 'pointer',
+                        backgroundColor: booking ? '#e0f7e0' : 'transparent',
+                      }}
+                      onClick={() => {
+                        if (!booking) setAssignSlot(slot);
+                      }}
+                    >
+                      {booking ? booking.user_name : ''}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {assignSlot && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0,0,0,0.3)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div style={{ background: 'white', padding: 16, borderRadius: 4, width: '300px' }}>
+            <h4>Assign User</h4>
+            <input
+              type="text"
+              placeholder="Search users"
+              value={searchTerm}
+              onChange={e => setSearchTerm(e.target.value)}
+              style={{ width: '100%', marginBottom: 8 }}
+            />
+            <ul style={{ listStyle: 'none', paddingLeft: 0, maxHeight: '150px', overflowY: 'auto' }}>
+              {userResults.map(u => (
+                <li key={u.id} style={{ marginBottom: 4 }}>
+                  {u.name} ({u.email})
+                  <button style={{ marginLeft: 4 }} onClick={() => assignUser(u)}>
+                    Assign
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <button onClick={() => { setAssignSlot(null); setSearchTerm(''); }}>Close</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add new `ViewSchedule` component for staff schedule viewing and user assignment
- wire schedule tab into staff navigation

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891383f83b4832d886a6ef2c7a84a8f