### PR TITLE
feat: add approval confirmation for pending bookings

### DIFF
--- a/MJ_FB_Frontend/src/components/StaffDashboard/ViewSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/ViewSchedule.tsx
@@ -184,7 +184,12 @@ export default function ViewSchedule({ token }: { token: string }) {
                         }}
                         onClick={() => {
                           if (booking) {
-                            if (booking.status === 'submitted') approveBooking(booking.id);
+                            if (
+                              booking.status === 'submitted' &&
+                              window.confirm('Approve this booking?')
+                            ) {
+                              approveBooking(booking.id);
+                            }
                           } else if (!isClosed) {
                             setAssignSlot(slot);
                           } else {


### PR DESCRIPTION
## Summary
- ask staff to confirm before approving an orange pending booking

## Testing
- `cd MJ_FB_Frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689140e0e1d4832db67185f8f7272eee