### PR TITLE
feat: add staff login and admin setup

### DIFF
--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -1,0 +1,100 @@
+import { Request, Response } from 'express';
+import pool from '../db';
+import bcrypt from 'bcrypt';
+
+export async function checkStaffExists(_req: Request, res: Response) {
+  try {
+    const result = await pool.query('SELECT COUNT(*) FROM staff');
+    const count = parseInt(result.rows[0].count, 10);
+    res.json({ exists: count > 0 });
+  } catch (error) {
+    console.error('Error checking staff:', error);
+    res.status(500).json({ message: 'Database error' });
+  }
+}
+
+export async function createAdmin(req: Request, res: Response) {
+  const { firstName, lastName, staffId, role, email, password } = req.body as {
+    firstName: string;
+    lastName: string;
+    staffId: string;
+    role: string;
+    email: string;
+    password: string;
+  };
+
+  if (!firstName || !lastName || !staffId || !role || !email || !password) {
+    return res.status(400).json({ message: 'Missing fields' });
+  }
+
+  try {
+    const exists = await pool.query('SELECT COUNT(*) FROM staff');
+    if (parseInt(exists.rows[0].count, 10) > 0) {
+      return res.status(400).json({ message: 'Admin already exists' });
+    }
+
+    const hashed = await bcrypt.hash(password, 10);
+    const userRes = await pool.query(
+      `INSERT INTO users (name, email, password, role)
+       VALUES ($1, $2, $3, 'staff') RETURNING id`,
+      [`${firstName} ${lastName}`, email, hashed]
+    );
+    const userId = userRes.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO staff (id, first_name, last_name, staff_id, role, is_admin)
+       VALUES ($1, $2, $3, $4, $5, TRUE)`,
+      [userId, firstName, lastName, staffId, role]
+    );
+
+    res.status(201).json({ message: 'Admin account created' });
+  } catch (error) {
+    console.error('Error creating admin:', error);
+    res.status(500).json({ message: 'Database error' });
+  }
+}
+
+export async function createStaff(req: Request, res: Response) {
+  if (!req.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const { firstName, lastName, staffId, role, email, password } = req.body as {
+    firstName: string;
+    lastName: string;
+    staffId: string;
+    role: string;
+    email: string;
+    password: string;
+  };
+
+  if (!firstName || !lastName || !staffId || !role || !email || !password) {
+    return res.status(400).json({ message: 'Missing fields' });
+  }
+
+  try {
+    const adminCheck = await pool.query('SELECT is_admin FROM staff WHERE id = $1', [req.user.id]);
+    if (adminCheck.rowCount === 0 || !adminCheck.rows[0].is_admin) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const hashed = await bcrypt.hash(password, 10);
+    const userRes = await pool.query(
+      `INSERT INTO users (name, email, password, role)
+       VALUES ($1, $2, $3, 'staff') RETURNING id`,
+      [`${firstName} ${lastName}`, email, hashed]
+    );
+    const userId = userRes.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO staff (id, first_name, last_name, staff_id, role, is_admin)
+       VALUES ($1, $2, $3, $4, $5, FALSE)`,
+      [userId, firstName, lastName, staffId, role]
+    );
+
+    res.status(201).json({ message: 'Staff created' });
+  } catch (error) {
+    console.error('Error creating staff:', error);
+    res.status(500).json({ message: 'Database error' });
+  }
+}

--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -1,0 +1,8 @@
+export interface Staff {
+  id: number;
+  first_name: string;
+  last_name: string;
+  staff_id: string;
+  role: 'warehouse_lead' | 'pantry_lead' | 'volunteer_lead';
+  is_admin: boolean;
+}

--- a/MJ_FB_Backend/src/routes/staff.ts
+++ b/MJ_FB_Backend/src/routes/staff.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import { checkStaffExists, createAdmin, createStaff } from '../controllers/staffController';
+import { authMiddleware } from '../middleware/authMiddleware';
+
+const router = express.Router();
+
+router.get('/exists', checkStaffExists);
+router.post('/admin', createAdmin);
+router.post('/', authMiddleware, createStaff);
+
+export default router;

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -5,6 +5,7 @@ import usersRoutes from './routes/users';
 import slotsRoutes from './routes/slots';
 import bookingsRoutes from './routes/bookings';
 import holidaysRoutes from './routes/holidays';
+import staffRoutes from './routes/staff';
 import { initializeSlots } from './data';
 import pool from './db';
 
@@ -26,6 +27,7 @@ app.use('/users', usersRoutes);
 app.use('/slots', slotsRoutes);
 app.use('/bookings', bookingsRoutes);
 app.use('/holidays', holidaysRoutes);
+app.use('/staff', staffRoutes);
 
 const PORT = 4000;
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -6,6 +6,7 @@ import SlotBooking from './components/SlotBooking';
 import AddUser from './components/StaffDashboard/AddUser';
 import ViewSchedule from './components/StaffDashboard/ViewSchedule';
 import Login from './components/Login';
+import StaffLogin from './components/StaffLogin';
 import type { Role } from './types';
 
 export default function App() {
@@ -14,6 +15,7 @@ export default function App() {
   const [activePage, setActivePage] = useState('profile');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [loginMode, setLoginMode] = useState<'user' | 'staff'>('user');
 
   function logout() {
     setToken('');
@@ -50,15 +52,29 @@ export default function App() {
       }}
     >
       {!token ? (
-        <Login
-          onLogin={(u) => {
-            setToken(u.token);
-            setRole(u.role);
-            localStorage.setItem('token', u.token);
-            localStorage.setItem('role', u.role);
-            localStorage.setItem('name', u.name);
-          }}
-        />
+        loginMode === 'user' ? (
+          <Login
+            onLogin={(u) => {
+              setToken(u.token);
+              setRole(u.role);
+              localStorage.setItem('token', u.token);
+              localStorage.setItem('role', u.role);
+              localStorage.setItem('name', u.name);
+            }}
+            onStaff={() => setLoginMode('staff')}
+          />
+        ) : (
+          <StaffLogin
+            onLogin={(u) => {
+              setToken(u.token);
+              setRole(u.role);
+              localStorage.setItem('token', u.token);
+              localStorage.setItem('role', u.role);
+              localStorage.setItem('name', u.name);
+            }}
+            onBack={() => setLoginMode('user')}
+          />
+        )
       ) : (
         <>
           <nav

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -20,6 +20,51 @@ export async function login(email: string, password: string): Promise<LoginRespo
   return res.json();
 }
 
+export async function staffExists(): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/staff/exists`);
+  if (!res.ok) throw new Error(await res.text());
+  const data = await res.json();
+  return data.exists as boolean;
+}
+
+export async function createAdmin(
+  firstName: string,
+  lastName: string,
+  staffId: string,
+  role: string,
+  email: string,
+  password: string
+) {
+  const res = await fetch(`${API_BASE}/staff/admin`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ firstName, lastName, staffId, role, email, password }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function createStaff(
+  token: string,
+  firstName: string,
+  lastName: string,
+  staffId: string,
+  role: string,
+  email: string,
+  password: string
+) {
+  const res = await fetch(`${API_BASE}/staff`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: token,
+    },
+    body: JSON.stringify({ firstName, lastName, staffId, role, email, password }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
 export async function getSlots(token: string, date?: string) {
     let url = `${API_BASE}/slots`;
     if (date) url += `?date=${encodeURIComponent(date)}`;

--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { login } from '../api/api';
 import type { LoginResponse } from '../api/api';
 
-export default function Login({ onLogin }: { onLogin: (user: LoginResponse) => void }) {
+export default function Login({ onLogin, onStaff }: { onLogin: (user: LoginResponse) => void; onStaff: () => void }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -22,7 +22,8 @@ export default function Login({ onLogin }: { onLogin: (user: LoginResponse) => v
 
   return (
     <div>
-      <h2>Login</h2>
+      <a onClick={onStaff} style={{ cursor: 'pointer' }}>Staff Login</a>
+      <h2>User Login</h2>
       {error && <p style={{color:'red'}}>{error}</p>}
       <form onSubmit={handleSubmit}>
         <input value={email} onChange={e=>setEmail(e.target.value)} placeholder="Email"/>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -1,16 +1,22 @@
 import { useState } from 'react';
-import { addUser } from '../../api/api';
-import type { Role } from '../../types';
+import { addUser, createStaff } from '../../api/api';
+import type { Role, StaffRole } from '../../types';
 
 export default function AddUser({ token }: { token: string }) {
+  const [mode, setMode] = useState<'user' | 'staff'>('user');
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<Role>('shopper');
   const [name, setName] = useState('');
-  const [password, setPassword] = useState('');   // ✅ NEW
-  const [phone, setPhone] = useState('');         // optional
+  const [password, setPassword] = useState('');
+  const [phone, setPhone] = useState('');
   const [message, setMessage] = useState('');
 
-  async function submit() {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [staffId, setStaffId] = useState('');
+  const [staffRole, setStaffRole] = useState<StaffRole>('warehouse_lead');
+
+  async function submitUser() {
     if (!email || !name || !password) {
       setMessage('Name, email and password required');
       return;
@@ -28,65 +34,116 @@ export default function AddUser({ token }: { token: string }) {
     }
   }
 
+  async function submitStaff() {
+    if (!firstName || !lastName || !email || !password || !staffId) {
+      setMessage('All fields required');
+      return;
+    }
+    try {
+      await createStaff(token, firstName, lastName, staffId, staffRole, email, password);
+      setMessage('Staff added successfully');
+      setFirstName('');
+      setLastName('');
+      setEmail('');
+      setPassword('');
+      setStaffId('');
+      setStaffRole('warehouse_lead');
+    } catch (err: unknown) {
+      setMessage(err instanceof Error ? err.message : String(err));
+    }
+  }
+
   return (
     <div>
-      <h2>Add User</h2>
+      <h2>{mode === 'user' ? 'Create User' : 'Create Staff'}</h2>
+      <div style={{ marginBottom: 12 }}>
+        <button onClick={() => setMode('user')}>Create User</button>
+        <button onClick={() => setMode('staff')} style={{ marginLeft: 8 }}>Create Staff</button>
+      </div>
       {message && <p>{message}</p>}
-      <div style={{ marginBottom: 8 }}>
-        <label>
-          Name:{' '}
-          <input
-            type="text"
-            value={name}
-            onChange={e => setName(e.target.value)}
-            placeholder="Full name"
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: 8 }}>
-        <label>
-          Email:{' '}
-          <input
-            type="email"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-            placeholder="user@example.com"
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: 8 }}>
-        <label>
-          Password:{' '}
-          <input
-            type="password"
-            value={password}
-            onChange={e => setPassword(e.target.value)}
-            placeholder="Secret password"
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: 8 }}>
-        <label>
-          Phone (optional):{' '}
-          <input
-            type="text"
-            value={phone}
-            onChange={e => setPhone(e.target.value)}
-            placeholder="555-1111"
-          />
-        </label>
-      </div>
-      <div style={{ marginBottom: 8 }}>
-        <label>
-          Role:{' '}
-          <select value={role} onChange={e => setRole(e.target.value as Role)}>
-            <option value="shopper">Shopper</option>
-            <option value="staff">Staff</option>
-            <option value="delivery">Delivery</option>
-          </select>
-        </label>
-      </div>
-      <button onClick={submit}>Add User</button>
+      {mode === 'user' ? (
+        <>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Name:{' '}
+              <input type="text" value={name} onChange={e => setName(e.target.value)} placeholder="Full name" />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Email:{' '}
+              <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="user@example.com" />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Password:{' '}
+              <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Secret password" />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Phone (optional):{' '}
+              <input type="text" value={phone} onChange={e => setPhone(e.target.value)} placeholder="555-1111" />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Role:{' '}
+              <select value={role} onChange={e => setRole(e.target.value as Role)}>
+                <option value="shopper">Shopper</option>
+                <option value="staff">Staff</option>
+                <option value="delivery">Delivery</option>
+              </select>
+            </label>
+          </div>
+          <button onClick={submitUser}>Add User</button>
+        </>
+      ) : (
+        <>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              First Name:{' '}
+              <input type="text" value={firstName} onChange={e => setFirstName(e.target.value)} />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Last Name:{' '}
+              <input type="text" value={lastName} onChange={e => setLastName(e.target.value)} />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Staff ID:{' '}
+              <input type="text" value={staffId} onChange={e => setStaffId(e.target.value)} />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Staff Role:{' '}
+              <select value={staffRole} onChange={e => setStaffRole(e.target.value as StaffRole)}>
+                <option value="warehouse_lead">Warehouse Lead</option>
+                <option value="pantry_lead">Pantry Lead</option>
+                <option value="volunteer_lead">Volunteer Lead</option>
+              </select>
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Email:{' '}
+              <input type="email" value={email} onChange={e => setEmail(e.target.value)} />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Password:{' '}
+              <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+            </label>
+          </div>
+          <button onClick={submitStaff}>Add Staff</button>
+        </>
+      )}
     </div>
   );
 }

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { login, staffExists, createAdmin } from '../api/api';
+import type { LoginResponse } from '../api/api';
+import type { StaffRole } from '../types';
+
+export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
+  const [checking, setChecking] = useState(true);
+  const [hasStaff, setHasStaff] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    staffExists()
+      .then(exists => {
+        setHasStaff(exists);
+        setChecking(false);
+      })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : String(err));
+        setChecking(false);
+      });
+  }, []);
+
+  if (checking) return <div>Loading...</div>;
+
+  return hasStaff ? (
+    <StaffLoginForm onLogin={onLogin} error={error} onBack={onBack} />
+  ) : (
+    <CreateAdminForm onCreated={() => setHasStaff(true)} error={error} />
+  );
+}
+
+function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: LoginResponse) => void; error: string; onBack: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(initError);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const user = await login(email, password);
+      if (user.role !== 'staff') {
+        setError('Not a staff account');
+        return;
+      }
+      onLogin(user);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <div>
+      <a onClick={onBack} style={{ cursor: 'pointer' }}>User Login</a>
+      <h2>Staff Login</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <form onSubmit={submit}>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
+}
+
+function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => void; error: string }) {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [staffId, setStaffId] = useState('');
+  const [role, setRole] = useState<StaffRole>('warehouse_lead');
+  const [error, setError] = useState(initError);
+  const [message, setMessage] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      await createAdmin(firstName, lastName, staffId, role, email, password);
+      setMessage('Admin created. You can login now.');
+      setTimeout(onCreated, 1000);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <div>
+      <h2>Create Admin Account</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {message && <p style={{ color: 'green' }}>{message}</p>}
+      <form onSubmit={submit}>
+        <input value={firstName} onChange={e => setFirstName(e.target.value)} placeholder="First name" />
+        <input value={lastName} onChange={e => setLastName(e.target.value)} placeholder="Last name" />
+        <input value={staffId} onChange={e => setStaffId(e.target.value)} placeholder="Staff ID" />
+        <select value={role} onChange={e => setRole(e.target.value as StaffRole)}>
+          <option value="warehouse_lead">Warehouse Lead</option>
+          <option value="pantry_lead">Pantry Lead</option>
+          <option value="volunteer_lead">Volunteer Lead</option>
+        </select>
+        <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Create Admin</button>
+      </form>
+    </div>
+  );
+}

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -1,4 +1,5 @@
 export type Role = 'staff' | 'shopper' | 'delivery';
+export type StaffRole = 'warehouse_lead' | 'pantry_lead' | 'volunteer_lead';
 
 export interface Slot {
   id: string;


### PR DESCRIPTION
## Summary
- add backend staff routes for admin setup and staff creation
- introduce dedicated staff login with admin bootstrap flow
- allow staff dashboard to create both regular users and staff records

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd ../MJ_FB_Frontend && npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689145723264832daba2593007d4049d