### PR TITLE
feat: align staff roles with database

### DIFF
--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -3,6 +3,6 @@ export interface Staff {
   first_name: string;
   last_name: string;
   staff_id: string;
-  role: 'warehouse_lead' | 'pantry_lead' | 'volunteer_lead';
+  role: 'staff' | 'volunteer_coordinator' | 'admin';
   is_admin: boolean;
 }

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -14,7 +14,7 @@ export default function AddUser({ token }: { token: string }) {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [staffId, setStaffId] = useState('');
-  const [staffRole, setStaffRole] = useState<StaffRole>('warehouse_lead');
+  const [staffRole, setStaffRole] = useState<StaffRole>('staff');
 
   async function submitUser() {
     if (!email || !name || !password) {
@@ -47,7 +47,7 @@ export default function AddUser({ token }: { token: string }) {
       setEmail('');
       setPassword('');
       setStaffId('');
-      setStaffRole('warehouse_lead');
+      setStaffRole('staff');
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
     }
@@ -123,9 +123,9 @@ export default function AddUser({ token }: { token: string }) {
             <label>
               Staff Role:{' '}
               <select value={staffRole} onChange={e => setStaffRole(e.target.value as StaffRole)}>
-                <option value="warehouse_lead">Warehouse Lead</option>
-                <option value="pantry_lead">Pantry Lead</option>
-                <option value="volunteer_lead">Volunteer Lead</option>
+                <option value="staff">Staff</option>
+                <option value="volunteer_coordinator">Volunteer Coordinator</option>
+                <option value="admin">Admin</option>
               </select>
             </label>
           </div>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -68,7 +68,7 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [staffId, setStaffId] = useState('');
-  const [role, setRole] = useState<StaffRole>('warehouse_lead');
+  const [role, setRole] = useState<StaffRole>('admin');
   const [error, setError] = useState(initError);
   const [message, setMessage] = useState('');
 
@@ -93,9 +93,9 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
         <input value={lastName} onChange={e => setLastName(e.target.value)} placeholder="Last name" />
         <input value={staffId} onChange={e => setStaffId(e.target.value)} placeholder="Staff ID" />
         <select value={role} onChange={e => setRole(e.target.value as StaffRole)}>
-          <option value="warehouse_lead">Warehouse Lead</option>
-          <option value="pantry_lead">Pantry Lead</option>
-          <option value="volunteer_lead">Volunteer Lead</option>
+          <option value="staff">Staff</option>
+          <option value="volunteer_coordinator">Volunteer Coordinator</option>
+          <option value="admin">Admin</option>
         </select>
         <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
         <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -1,5 +1,5 @@
 export type Role = 'staff' | 'shopper' | 'delivery';
-export type StaffRole = 'warehouse_lead' | 'pantry_lead' | 'volunteer_lead';
+export type StaffRole = 'staff' | 'volunteer_coordinator' | 'admin';
 
 export interface Slot {
   id: string;


### PR DESCRIPTION
## Summary
- align Staff role types with DB constraint
- update staff-facing UI to offer staff, volunteer coordinator, or admin roles

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68914a187cd8832d8d467b74161876c5