### PR TITLE
Improve error message clarity across frontend and backend

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -60,7 +60,9 @@ export async function listBookings(req: Request, res: Response) {
     res.json(result.rows);
   } catch (error) {
     console.error('Error listing bookings:', error);
-    res.status(500).json({ message: 'Database error' });
+    res
+      .status(500)
+      .json({ message: `Database error listing bookings: ${(error as Error).message}` });
   }
 }
 

--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -60,6 +60,8 @@ export async function listSlots(req: Request, res: Response) {
     res.json(slotsWithAvailability);
   } catch (error) {
     console.error('Error listing slots:', error);
-    res.status(500).json({ message: 'Database error' });
+    res
+      .status(500)
+      .json({ message: `Database error listing slots: ${(error as Error).message}` });
   }
 }

--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -9,7 +9,9 @@ export async function checkStaffExists(_req: Request, res: Response) {
     res.json({ exists: count > 0 });
   } catch (error) {
     console.error('Error checking staff:', error);
-    res.status(500).json({ message: 'Database error' });
+    res
+      .status(500)
+      .json({ message: `Database error checking staff: ${(error as Error).message}` });
   }
 }
 
@@ -55,7 +57,9 @@ export async function createAdmin(req: Request, res: Response) {
     res.status(201).json({ message: 'Admin account created' });
   } catch (error) {
     console.error('Error creating admin:', error);
-    res.status(500).json({ message: 'Database error' });
+    res
+      .status(500)
+      .json({ message: `Database error creating admin: ${(error as Error).message}` });
   }
 }
 
@@ -104,6 +108,8 @@ export async function createStaff(req: Request, res: Response) {
     res.status(201).json({ message: 'Staff created' });
   } catch (error) {
     console.error('Error creating staff:', error);
-    res.status(500).json({ message: 'Database error' });
+    res
+      .status(500)
+      .json({ message: `Database error creating staff: ${(error as Error).message}` });
   }
 }

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -37,7 +37,9 @@ export async function loginUser(req: Request, res: Response) {
     res.json({ token: user.id.toString(), role: user.role, name: user.name });
   } catch (error) {
     console.error('Error logging in:', error);
-    res.status(500).json({ message: 'Database error' });
+    res
+      .status(500)
+      .json({ message: `Database error logging in: ${(error as Error).message}` });
   }
 }
 
@@ -76,7 +78,9 @@ export async function createUser(req: Request, res: Response) {
     res.status(201).json({ message: 'User created' });
   } catch (error) {
     console.error('Error creating user:', error);
-    res.status(500).json({ message: 'Database error' });
+    res
+      .status(500)
+      .json({ message: `Database error creating user: ${(error as Error).message}` });
   }
 }
 
@@ -101,7 +105,9 @@ export async function searchUsers(req: Request, res: Response) {
     res.json(usersResult.rows);
   } catch (error) {
     console.error('Error searching users:', (error as Error).message);
-    res.status(500).json({ message: 'Server error searching users' });
+    res
+      .status(500)
+      .json({ message: `Server error searching users: ${(error as Error).message}` });
   }
 }
 

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -40,7 +40,9 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     next();
   } catch (error) {
     console.error('Auth error:', error);
-    res.status(500).json({ message: 'Database error' });
+    res
+      .status(500)
+      .json({ message: `Database error during authentication: ${(error as Error).message}` });
   }
 }
 

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -10,20 +10,32 @@ export interface LoginResponse {
   name: string;
 }
 
+async function handleResponse(res: Response) {
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      message = data.message || data.error || JSON.stringify(data);
+    } catch {
+      message = await res.text();
+    }
+    throw new Error(message);
+  }
+  return res.json();
+}
+
 export async function login(email: string, password: string): Promise<LoginResponse> {
   const res = await fetch(`${API_BASE}/users/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email, password }),
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function staffExists(): Promise<boolean> {
   const res = await fetch(`${API_BASE}/staff/exists`);
-  if (!res.ok) throw new Error(await res.text());
-  const data = await res.json();
+  const data = await handleResponse(res);
   return data.exists as boolean;
 }
 
@@ -40,8 +52,7 @@ export async function createAdmin(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ firstName, lastName, staffId, role, email, password }),
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function createStaff(
@@ -61,8 +72,7 @@ export async function createStaff(
     },
     body: JSON.stringify({ firstName, lastName, staffId, role, email, password }),
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function getSlots(token: string, date?: string) {
@@ -71,8 +81,7 @@ export async function getSlots(token: string, date?: string) {
     const res = await fetch(url, {
       headers: { Authorization: token }
     });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json();
+    return handleResponse(res);
   }
 
 // api.ts
@@ -92,9 +101,8 @@ export async function addUser(
     },
     body: JSON.stringify({ name, email, password, role, phone }),
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
-} 
+  return handleResponse(res);
+}
   
   export async function createBooking(token: string, slotId: string, date: string) {
     const res = await fetch(`${API_BASE}/bookings`, {
@@ -105,24 +113,21 @@ export async function addUser(
       },
       body: JSON.stringify({ slotId, date, requestData: '' }),
     });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json();
+    return handleResponse(res);
   }
 
 export async function getBookings(token: string) {
   const res = await fetch(`${API_BASE}/bookings`, {
     headers: { Authorization: token }
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function getHolidays(token: string) {
     const res = await fetch(`${API_BASE}/holidays`, {
       headers: { Authorization: token }
     });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json(); // assume returns: string[] of dates like "2025-07-21"
+    return handleResponse(res); // assume returns: string[] of dates like "2025-07-21"
   }
   
   export async function addHoliday(token: string, date: string) {
@@ -134,8 +139,7 @@ export async function getHolidays(token: string) {
       },
       body: JSON.stringify({ date })
     });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json();
+    return handleResponse(res);
   }
   
   export async function removeHoliday(token: string, date: string) {
@@ -143,8 +147,7 @@ export async function getHolidays(token: string) {
       method: 'DELETE',
       headers: { Authorization: token }
     });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json();
+    return handleResponse(res);
   }
 
 export async function decideBooking(token: string, bookingId: string, decision: 'approve'|'reject') {
@@ -156,16 +159,14 @@ export async function decideBooking(token: string, bookingId: string, decision: 
     },
     body: JSON.stringify({ decision }),
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function searchUsers(token: string, search: string) {
     const res = await fetch(`${API_BASE}/users/search?search=${encodeURIComponent(search)}`, {
       headers: { Authorization: token }
     });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json(); // returns array of users
+    return handleResponse(res); // returns array of users
   }
   
   export async function createBookingForUser(
@@ -183,7 +184,6 @@ export async function searchUsers(token: string, search: string) {
       },
       body: JSON.stringify({ userId, slotId, date, isStaffBooking })
     });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json();
+    return handleResponse(res);
   }
   


### PR DESCRIPTION
## Summary
- return detailed messages for database failures across middleware and controllers
- centralize frontend API response handling and surface server-provided error messages

## Testing
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68914fac4ba4832da3ab0c8c4b6954bd