### PR TITLE
Fix admin creation role to satisfy DB constraint

### DIFF
--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -49,7 +49,7 @@ export async function createAdmin(req: Request, res: Response) {
 
     await pool.query(
       `INSERT INTO staff (first_name, last_name, staff_id, role, email, password, is_admin)
-       VALUES ($1, $2, $3, 'admin', $4, $5, TRUE)`,
+       VALUES ($1, $2, $3, 'staff', $4, $5, TRUE)`,
       [firstName, lastName, staffId, email, hashed]
     );
 


### PR DESCRIPTION
## Summary
- ensure admin creation stores `staff` role while setting `is_admin` flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689152c91fd0832daab243be0c1573a4