### PR TITLE
Remove staff user bookings page

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -34,7 +34,6 @@ export default function App() {
       { label: 'Staff Dashboard', id: 'staffDashboard' },
       { label: 'Manage Holidays', id: 'manageHolidays' },
       { label: 'View Schedule', id: 'viewSchedule' },
-      { label: 'User Bookings', id: 'userBookings' },
       { label: 'Add User', id: 'addUser' },
     ]);
   } else if (role === 'shopper') {
@@ -103,9 +102,6 @@ export default function App() {
             )}
             {activePage === 'viewSchedule' && role === 'staff' && (
               <ViewSchedule token={token} />
-            )}
-            {activePage === 'userBookings' && role === 'staff' && (
-              <SlotBooking token={token} role="staff" />
             )}
             {activePage === 'slots' && role === 'shopper' && (
               <SlotBooking token={token} role="shopper" />


### PR DESCRIPTION
## Summary
- Drop "User Bookings" tab from staff navigation
- Ensure only shoppers use SlotBooking; staff book via schedule

## Testing
- `npm test` *(frontend: Missing script)*
- `npm run lint` (frontend)
- `npm test` *(backend: No tests specified)*
- `npm run lint` *(backend: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689154d6b578832db318a4d6c915001c