### PR TITLE
Add password-based user login

### DIFF
--- a/MJ_FB_Backend/src/models/user.ts
+++ b/MJ_FB_Backend/src/models/user.ts
@@ -8,4 +8,5 @@ export interface User {
   role: 'shopper' | 'delivery';
   bookingsThisMonth: number;
   bookingCountLastUpdated: string;
+  password?: string;
 }

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -24,12 +24,26 @@ async function handleResponse(res: Response) {
   return res.json();
 }
 
-export async function login(identifier: string, password?: string): Promise<LoginResponse> {
-  const body = password ? { email: identifier, password } : { clientId: identifier };
+export async function loginUser(
+  clientId: string,
+  password: string
+): Promise<LoginResponse> {
   const res = await fetch(`${API_BASE}/users/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ clientId: Number(clientId), password }),
+  });
+  return handleResponse(res);
+}
+
+export async function loginStaff(
+  email: string,
+  password: string
+): Promise<LoginResponse> {
+  const res = await fetch(`${API_BASE}/users/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
   });
   return handleResponse(res);
 }
@@ -92,6 +106,7 @@ export async function addUser(
   lastName: string,
   clientId: string,
   role: string,
+  password: string,
   email?: string,
   phone?: string
 ) {
@@ -101,7 +116,15 @@ export async function addUser(
       'Content-Type': 'application/json',
       Authorization: token,
     },
-    body: JSON.stringify({ firstName, lastName, clientId: Number(clientId), role, email, phone }),
+    body: JSON.stringify({
+      firstName,
+      lastName,
+      clientId: Number(clientId),
+      role,
+      password,
+      email,
+      phone,
+    }),
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -1,15 +1,16 @@
 import { useState } from 'react';
-import { login } from '../api/api';
+import { loginUser } from '../api/api';
 import type { LoginResponse } from '../api/api';
 
 export default function Login({ onLogin, onStaff }: { onLogin: (user: LoginResponse) => void; onStaff: () => void }) {
   const [clientId, setClientId] = useState('');
+  const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      const user = await login(clientId);
+      const user = await loginUser(clientId, password);
       localStorage.setItem('token', user.token);
       localStorage.setItem('role', user.role);
       localStorage.setItem('name', user.name);
@@ -26,6 +27,7 @@ export default function Login({ onLogin, onStaff }: { onLogin: (user: LoginRespo
       {error && <p style={{color:'red'}}>{error}</p>}
       <form onSubmit={handleSubmit}>
         <input value={clientId} onChange={e=>setClientId(e.target.value)} placeholder="Client ID"/>
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
         <button type="submit">Login</button>
       </form>
     </div>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -17,18 +17,28 @@ export default function AddUser({ token }: { token: string }) {
   const [password, setPassword] = useState('');
 
   async function submitUser() {
-    if (!firstName || !lastName || !clientId) {
-      setMessage('First name, last name and client ID required');
+    if (!firstName || !lastName || !clientId || !password) {
+      setMessage('First name, last name, client ID and password required');
       return;
     }
     try {
-      await addUser(token, firstName, lastName, clientId, role, email || undefined, phone || undefined);
+      await addUser(
+        token,
+        firstName,
+        lastName,
+        clientId,
+        role,
+        password,
+        email || undefined,
+        phone || undefined
+      );
       setMessage('User added successfully');
       setFirstName('');
       setLastName('');
       setClientId('');
       setEmail('');
       setPhone('');
+      setPassword('');
       setRole('shopper');
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
@@ -92,6 +102,12 @@ export default function AddUser({ token }: { token: string }) {
             <label>
               Phone (optional):{' '}
               <input type="text" value={phone} onChange={e => setPhone(e.target.value)} />
+            </label>
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label>
+              Password:{' '}
+              <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
             </label>
           </div>
           <div style={{ marginBottom: 8 }}>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { login, staffExists, createAdmin } from '../api/api';
+import { loginStaff, staffExists, createAdmin } from '../api/api';
 import type { LoginResponse } from '../api/api';
 import type { StaffRole } from '../types';
 
@@ -37,7 +37,7 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      const user = await login(email, password);
+      const user = await loginStaff(email, password);
       if (user.role !== 'staff') {
         setError('Not a staff account');
         return;


### PR DESCRIPTION
## Summary
- require password when creating users and login
- support client password login in frontend and API

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd ../MJ_FB_Frontend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68915bf19154832d9532f80bb11a31b5