### PR TITLE
feat: disable holiday selection

### DIFF
--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -62,6 +62,16 @@ export default function SlotBooking({ token, role }: Props) {
     getHolidays(token).then(setHolidays).catch(() => {});
   }, [token]);
 
+  // Automatically choose the first available date (non-weekend and non-holiday)
+  useEffect(() => {
+    const today = toZonedTime(new Date(), reginaTimeZone);
+    let date = new Date(today.toDateString());
+    if (isWeekend(date) || isHoliday(date)) {
+      date = getNextAvailableDate(date);
+    }
+    setSelectedDate(date);
+  }, [holidays, isWeekend, isHoliday, getNextAvailableDate]);
+
   useEffect(() => {
     if (role === 'staff') {
       const delayDebounce = setTimeout(() => {
@@ -173,8 +183,9 @@ export default function SlotBooking({ token, role }: Props) {
           const zoned = toZonedTime(date, reginaTimeZone);
           const today = toZonedTime(new Date(), reginaTimeZone);
           const isPast = zoned < new Date(today.toDateString());
-          return isPast;
+          return isPast || isHoliday(date);
         }}
+        tileClassName={({ date }) => (isHoliday(date) ? 'holiday-tile' : undefined)}
       />
       {selectedDate && (
         <div className="slot-day-container">

--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -157,6 +157,11 @@ select {
   cursor: not-allowed;
 }
 
+.holiday-tile {
+  background-color: #e0e0e0 !important;
+  color: #666 !important;
+}
+
 .error-message {
   color: red;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- disable holiday selection in calendar
- auto-pick first valid date and visually mark holidays

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68915f89acd4832d8b758a69f3870f6b