### PR TITLE
Add booking history views and staff search

### DIFF
--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -5,7 +5,8 @@ import {
   listBookings,
   decideBooking,
   createPreapprovedBooking,
-  createBookingForUser   // ✅ make sure to import this controller
+  createBookingForUser,   // ✅ make sure to import this controller
+  getBookingHistory
 } from '../controllers/bookingController';
 
 const router = express.Router();
@@ -15,6 +16,9 @@ router.post('/', authMiddleware, authorizeRoles('shopper', 'delivery'), createBo
 
 // Staff list all bookings
 router.get('/', authMiddleware, authorizeRoles('staff'), listBookings);
+
+// Booking history for user or staff lookup
+router.get('/history', authMiddleware, getBookingHistory);
 
 // Staff approve/reject booking
 router.post('/:id/decision', authMiddleware, authorizeRoles('staff'), decideBooking);

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Profile from './components/Profile';
 import StaffDashboard from './components/StaffDashboard/StaffDashboard';
 import ManageAvailability from './components/StaffDashboard/ManageAvailability';
+import UserHistory from './components/StaffDashboard/UserHistory';
 import SlotBooking from './components/SlotBooking';
 import AddUser from './components/StaffDashboard/AddUser';
 import ViewSchedule from './components/StaffDashboard/ViewSchedule';
@@ -35,6 +36,7 @@ export default function App() {
       { label: 'Manage Availability', id: 'manageAvailability' },
       { label: 'View Schedule', id: 'viewSchedule' },
       { label: 'Add User', id: 'addUser' },
+      { label: 'User History', id: 'userHistory' },
     ]);
   } else if (role === 'shopper') {
     navLinks = navLinks.concat([{ label: 'Booking Slots', id: 'slots' }]);
@@ -112,6 +114,9 @@ export default function App() {
             )}
             {activePage === 'addUser' && role === 'staff' && (
               <AddUser token={token} />
+            )}
+            {activePage === 'userHistory' && role === 'staff' && (
+              <UserHistory token={token} />
             )}
           </main>
         </>

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -149,6 +149,23 @@ export async function getBookings(token: string) {
   return handleResponse(res);
 }
 
+export async function getBookingHistory(
+  token: string,
+  opts: { status?: string; past?: boolean; userId?: number } = {}
+) {
+  const params = new URLSearchParams();
+  if (opts.status) params.append('status', opts.status);
+  if (opts.past) params.append('past', 'true');
+  if (opts.userId) params.append('userId', String(opts.userId));
+  const res = await fetch(
+    `${API_BASE}/bookings/history?${params.toString()}`,
+    {
+      headers: { Authorization: token },
+    }
+  );
+  return handleResponse(res);
+}
+
 export async function getHolidays(token: string) {
     const res = await fetch(`${API_BASE}/holidays`, {
       headers: { Authorization: token }

--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -1,8 +1,57 @@
+import { useState, useEffect } from 'react';
+import { getBookingHistory } from '../api/api';
+
+interface Booking {
+  id: number;
+  status: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+}
+
 export default function Profile() {
+  const token = localStorage.getItem('token') || '';
+  const [filter, setFilter] = useState('all');
+  const [bookings, setBookings] = useState<Booking[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      if (!token) return;
+      const opts: { status?: string; past?: boolean } = {};
+      if (filter === 'past') opts.past = true;
+      else if (filter !== 'all') opts.status = filter;
+      try {
+        const data: Booking[] = await getBookingHistory(token, opts);
+        setBookings(data);
+      } catch (err) {
+        console.error('Error loading history:', err);
+      }
+    }
+    load();
+  }, [token, filter]);
+
   return (
     <div>
       <h2>User Profile</h2>
-      <p>Show user info, booking history, etc. here.</p>
+      <div>
+        <label htmlFor="filter">Filter:</label>{' '}
+        <select id="filter" value={filter} onChange={e => setFilter(e.target.value)}>
+          <option value="all">All</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+          <option value="pending">Pending</option>
+          <option value="past">Past</option>
+        </select>
+      </div>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {bookings.length === 0 && <li>No bookings.</li>}
+        {bookings.map(b => (
+          <li key={b.id} style={{ marginBottom: 8 }}>
+            <strong>{b.date}</strong>{' '}
+            {b.start_time && b.end_time ? `${b.start_time}-${b.end_time}` : ''} - {b.status}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from 'react';
+import { searchUsers, getBookingHistory } from '../../api/api';
+
+interface User {
+  id: number;
+  name: string;
+  client_id: number;
+}
+
+interface Booking {
+  id: number;
+  status: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+}
+
+export default function UserHistory({ token }: { token: string }) {
+  const [search, setSearch] = useState('');
+  const [results, setResults] = useState<User[]>([]);
+  const [selected, setSelected] = useState<User | null>(null);
+  const [filter, setFilter] = useState('all');
+  const [bookings, setBookings] = useState<Booking[]>([]);
+
+  useEffect(() => {
+    if (search.length < 3) {
+      setResults([]);
+      return;
+    }
+    let active = true;
+    searchUsers(token, search)
+      .then(data => {
+        if (active) setResults(data);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [search, token]);
+
+  useEffect(() => {
+    if (!selected) return;
+    const opts: { status?: string; past?: boolean; userId: number } = { userId: selected.id };
+    if (filter === 'past') opts.past = true;
+    else if (filter !== 'all') opts.status = filter;
+    getBookingHistory(token, opts)
+      .then(data => setBookings(data))
+      .catch(err => console.error('Error loading history:', err));
+  }, [selected, filter, token]);
+
+  return (
+    <div>
+      <h2>User History</h2>
+      <input
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        placeholder="Search by name or client ID"
+      />
+      {results.length > 0 && (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {results.map(u => (
+            <li key={u.id}>
+              <button
+                onClick={() => {
+                  setSelected(u);
+                  setSearch(u.name);
+                  setResults([]);
+                }}
+              >
+                {u.name} ({u.client_id})
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {selected && (
+        <div>
+          <h3>History for {selected.name}</h3>
+          <div>
+            <label htmlFor="filterStaff">Filter:</label>{' '}
+            <select
+              id="filterStaff"
+              value={filter}
+              onChange={e => setFilter(e.target.value)}
+            >
+              <option value="all">All</option>
+              <option value="approved">Approved</option>
+              <option value="rejected">Rejected</option>
+              <option value="pending">Pending</option>
+              <option value="past">Past</option>
+            </select>
+          </div>
+          <ul style={{ listStyle: 'none', padding: 0 }}>
+            {bookings.length === 0 && <li>No bookings.</li>}
+            {bookings.map(b => (
+              <li key={b.id} style={{ marginBottom: 8 }}>
+                <strong>{b.date}</strong>{' '}
+                {b.start_time && b.end_time ? `${b.start_time}-${b.end_time}` : ''} - {b.status}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow users and staff to fetch booking history filtered by status or past visits
- expose booking history API and user/staff views on the frontend
- add staff search page to view any user's last 6 months of bookings

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Backend && npm run build`
- `cd MJ_FB_Frontend && npm run lint`
- `cd MJ_FB_Frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68917c5eea58832d90f7636315e5f92b