### PR TITLE
feat: add booking cancellation and reschedule flow

### DIFF
--- a/MJ_FB_Backend/src/data.ts
+++ b/MJ_FB_Backend/src/data.ts
@@ -14,7 +14,7 @@ export interface User {
   bookingCountLastUpdated: string;
 }
 
-export type BookingStatus = 'submitted' | 'approved' | 'rejected' | 'preapproved';
+export type BookingStatus = 'submitted' | 'approved' | 'rejected' | 'preapproved' | 'cancelled';
 
 export interface Booking {
   id: string;

--- a/MJ_FB_Backend/src/models/booking.ts
+++ b/MJ_FB_Backend/src/models/booking.ts
@@ -9,4 +9,5 @@ interface Booking {
   slot_id: number | null;
   start_time: string | null;
   end_time: string | null;
+  reason?: string | null;
 }

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -6,7 +6,8 @@ import {
   decideBooking,
   createPreapprovedBooking,
   createBookingForUser,   // ✅ make sure to import this controller
-  getBookingHistory
+  getBookingHistory,
+  cancelBooking
 } from '../controllers/bookingController';
 
 const router = express.Router();
@@ -22,6 +23,9 @@ router.get('/history', authMiddleware, getBookingHistory);
 
 // Staff approve/reject booking
 router.post('/:id/decision', authMiddleware, authorizeRoles('staff'), decideBooking);
+
+// Cancel booking (staff or user)
+router.post('/:id/cancel', authMiddleware, cancelBooking);
 
 // Staff create preapproved booking for walk-in users
 router.post('/preapproved', authMiddleware, authorizeRoles('staff'), createPreapprovedBooking);

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Profile from './components/Profile';
 import StaffDashboard from './components/StaffDashboard/StaffDashboard';
 import ManageAvailability from './components/StaffDashboard/ManageAvailability';
@@ -17,6 +17,15 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [loginMode, setLoginMode] = useState<'user' | 'staff'>('user');
+
+  useEffect(() => {
+    function handler(e: Event) {
+      const detail = (e as CustomEvent<string>).detail;
+      if (detail) setActivePage(detail);
+    }
+    window.addEventListener('navigate', handler as EventListener);
+    return () => window.removeEventListener('navigate', handler as EventListener);
+  }, []);
 
   function logout() {
     setToken('');

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -254,14 +254,26 @@ export async function removeBreak(token: string, dayOfWeek: number, slotId: numb
   return handleResponse(res);
 }
 
-export async function decideBooking(token: string, bookingId: string, decision: 'approve'|'reject') {
+export async function decideBooking(token: string, bookingId: string, decision: 'approve'|'reject', reason: string) {
   const res = await fetch(`${API_BASE}/bookings/${bookingId}/decision`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: token
     },
-    body: JSON.stringify({ decision }),
+    body: JSON.stringify({ decision, reason }),
+  });
+  return handleResponse(res);
+}
+
+export async function cancelBooking(token: string, bookingId: string, reason: string) {
+  const res = await fetch(`${API_BASE}/bookings/${bookingId}/cancel`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: token,
+    },
+    body: JSON.stringify({ reason }),
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -13,6 +13,7 @@ interface Booking {
   date: string;
   start_time: string;
   end_time: string;
+  reason?: string;
 }
 
 export default function UserHistory({ token }: { token: string }) {
@@ -96,6 +97,7 @@ export default function UserHistory({ token }: { token: string }) {
               <li key={b.id} style={{ marginBottom: 8 }}>
                 <strong>{b.date}</strong>{' '}
                 {b.start_time && b.end_time ? `${b.start_time}-${b.end_time}` : ''} - {b.status}
+                {b.reason && <em> ({b.reason})</em>}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- allow staff and users to cancel appointments with a reason and re-book
- show cancellation/rejection reasons in booking history
- update navigation so rescheduling jumps to the booking calendar

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68917f1d1144832d8d8e1f628da34efd