### PR TITLE
Fix staff dashboard date parsing and staff profile error

### DIFF
--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getBookingHistory, cancelBooking } from '../api/api';
+import type { Role } from '../types';
 
 interface Booking {
   id: number;
@@ -12,12 +13,13 @@ interface Booking {
 
 export default function Profile() {
   const token = localStorage.getItem('token') || '';
+  const role = (localStorage.getItem('role') || '') as Role;
   const [filter, setFilter] = useState('all');
   const [bookings, setBookings] = useState<Booking[]>([]);
 
   useEffect(() => {
     async function load() {
-      if (!token) return;
+      if (!token || role === 'staff') return;
       const opts: { status?: string; past?: boolean } = {};
       if (filter === 'past') opts.past = true;
       else if (filter !== 'all') opts.status = filter;
@@ -29,7 +31,7 @@ export default function Profile() {
       }
     }
     load();
-  }, [token, filter]);
+  }, [token, role, filter]);
 
   async function handleCancel(id: number, reschedule = false) {
     const reason = prompt('Please provide a reason');
@@ -45,6 +47,15 @@ export default function Profile() {
     } catch (err) {
       console.error('Error cancelling booking:', err);
     }
+  }
+
+  if (role === 'staff') {
+    return (
+      <div>
+        <h2>User Profile</h2>
+        <p>Profile view is only available for shoppers.</p>
+      </div>
+    );
   }
 
   return (

--- a/MJ_FB_Frontend/src/components/StaffDashboard/StaffDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/StaffDashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { getBookings, decideBooking } from '../../api/api';
-import { formatInTimeZone, fromZonedTime } from 'date-fns-tz';
+import { formatInTimeZone } from 'date-fns-tz';
 
 interface Booking {
   id: number;
@@ -50,7 +50,7 @@ export default function StaffDashboard({
     setLoading(true);
     setError('');
     try {
-      await decideBooking(token, id.toString(), decision);
+      await decideBooking(token, id.toString(), decision, '');
       setMessage(`Booking ${decision}d`);
       await loadBookings();
     } catch (err: unknown) {
@@ -63,8 +63,11 @@ export default function StaffDashboard({
 
   const pending = bookings.filter(b => b.status === 'submitted');
   const reginaTimeZone = 'America/Regina';
-  const formatDate = (date: string) =>
-    formatInTimeZone(fromZonedTime(`${date}T00:00:00`, reginaTimeZone), reginaTimeZone, 'yyyy-MM-dd');
+  const formatDate = (dateStr: string) => {
+    const parsed = new Date(dateStr);
+    if (isNaN(parsed.getTime())) return dateStr;
+    return formatInTimeZone(parsed, reginaTimeZone, 'yyyy-MM-dd', {});
+  };
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Avoid date parsing crash in staff dashboard by safely converting date strings
- Pass a placeholder reason to booking decisions
- Skip booking history loading for staff profiles

## Testing
- `npm test` *(frontend; script missing)*
- `npm run lint`
- `npm run build`
- `npm test` *(backend)*
- `npm run build` *(backend)*

------
https://chatgpt.com/codex/tasks/task_e_6891853214d0832db04a6e5ded631536