### PR TITLE
feat: improve user history presentation

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -290,11 +290,11 @@ export async function getBookingHistory(req: Request, res: Response) {
     }
 
     const result = await pool.query(
-      `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason, s.start_time, s.end_time
+      `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason, s.start_time, s.end_time, b.created_at
        FROM bookings b
        INNER JOIN slots s ON b.slot_id = s.id
        WHERE ${where}
-       ORDER BY b.date DESC`,
+       ORDER BY b.created_at DESC`,
       params
     );
     res.json(result.rows);

--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -214,3 +214,36 @@ select {
     gap: 0.25rem;
   }
 }
+
+/* User history table */
+.history-table-container {
+  overflow-x: auto;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.history-table th,
+.history-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .history-table th,
+  .history-table td {
+    font-size: 0.85rem;
+    padding: 0.3rem;
+  }
+}


### PR DESCRIPTION
## Summary
- sort booking history by creation date for last six months
- add responsive, paginated user history table with Regina timezone formatting

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: Missing script "test")
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689198472884832d882cb7e215ab834f