### PR TITLE
Add booking history tab and action buttons in history table

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import Profile from './components/Profile';
 import StaffDashboard from './components/StaffDashboard/StaffDashboard';
 import ManageAvailability from './components/StaffDashboard/ManageAvailability';
-import UserHistory from './components/StaffDashboard/UserHistory';
+import UserHistory from './components/UserHistory';
 import SlotBooking from './components/SlotBooking';
 import AddUser from './components/StaffDashboard/AddUser';
 import ViewSchedule from './components/StaffDashboard/ViewSchedule';
@@ -48,7 +48,10 @@ export default function App() {
       { label: 'User History', id: 'userHistory' },
     ]);
   } else if (role === 'shopper') {
-    navLinks = navLinks.concat([{ label: 'Booking Slots', id: 'slots' }]);
+    navLinks = navLinks.concat([
+      { label: 'Booking History', id: 'bookingHistory' },
+      { label: 'Booking Slots', id: 'slots' },
+    ]);
   }
 
   return (
@@ -125,7 +128,10 @@ export default function App() {
               <AddUser token={token} />
             )}
             {activePage === 'userHistory' && role === 'staff' && (
-              <UserHistory token={token} />
+              <UserHistory token={token} role={role} />
+            )}
+            {activePage === 'bookingHistory' && role === 'shopper' && (
+              <UserHistory token={token} role={role} />
             )}
           </main>
         </>

--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -1,60 +1,8 @@
-import { useState, useEffect } from 'react';
-import { getBookingHistory, cancelBooking } from '../api/api';
-import ConfirmDialog from './ConfirmDialog';
 import type { Role } from '../types';
 
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  start_time: string;
-  end_time: string;
-  reason?: string;
-}
-
 export default function Profile() {
-  const token = localStorage.getItem('token') || '';
   const role = (localStorage.getItem('role') || '') as Role;
-  const [filter, setFilter] = useState('all');
-  const [bookings, setBookings] = useState<Booking[]>([]);
-  const [confirm, setConfirm] = useState<{ id: number; reschedule: boolean } | null>(null);
-
-  useEffect(() => {
-    async function load() {
-      if (!token || role === 'staff') return;
-      const opts: { status?: string; past?: boolean } = {};
-      if (filter === 'past') opts.past = true;
-      else if (filter !== 'all') opts.status = filter;
-      try {
-        const data: Booking[] = await getBookingHistory(token, opts);
-        setBookings(data);
-      } catch (err) {
-        console.error('Error loading history:', err);
-      }
-    }
-    load();
-  }, [token, role, filter]);
-
-  function handleCancel(id: number, reschedule = false) {
-    setConfirm({ id, reschedule });
-  }
-
-  async function confirmCancel() {
-    if (!confirm) return;
-    try {
-      await cancelBooking(token, confirm.id.toString());
-      if (confirm.reschedule) {
-        window.dispatchEvent(new CustomEvent('navigate', { detail: 'slots' }));
-      } else {
-        const data: Booking[] = await getBookingHistory(token, {});
-        setBookings(data);
-      }
-    } catch (err) {
-      console.error('Error cancelling booking:', err);
-    } finally {
-      setConfirm(null);
-    }
-  }
+  const name = localStorage.getItem('name') || '';
 
   if (role === 'staff') {
     return (
@@ -68,42 +16,9 @@ export default function Profile() {
   return (
     <div>
       <h2>User Profile</h2>
-      <div>
-        <label htmlFor="filter">Filter:</label>{' '}
-        <select id="filter" value={filter} onChange={e => setFilter(e.target.value)}>
-          <option value="all">All</option>
-          <option value="approved">Approved</option>
-          <option value="rejected">Rejected</option>
-          <option value="pending">Pending</option>
-          <option value="past">Past</option>
-        </select>
-      </div>
-      <ul style={{ listStyle: 'none', padding: 0 }}>
-        {bookings.length === 0 && <li>No bookings.</li>}
-        {bookings.map(b => {
-          const canModify = ['submitted', 'approved'].includes(b.status) && b.date >= new Date().toISOString().split('T')[0];
-          return (
-            <li key={b.id} style={{ marginBottom: 8 }}>
-              <strong>{b.date}</strong>{' '}
-              {b.start_time && b.end_time ? `${b.start_time}-${b.end_time}` : ''} - {b.status}
-              {b.reason && <em> ({b.reason})</em>}
-              {canModify && (
-                <>
-                  <button style={{ marginLeft: 8 }} onClick={() => handleCancel(b.id)}>Cancel</button>
-                  <button style={{ marginLeft: 4 }} onClick={() => handleCancel(b.id, true)}>Reschedule</button>
-                </>
-              )}
-            </li>
-          );
-        })}
-      </ul>
-      {confirm && (
-        <ConfirmDialog
-          message={confirm.reschedule ? 'Cancel booking to reschedule?' : 'Cancel booking?'}
-          onConfirm={confirmCancel}
-          onCancel={() => setConfirm(null)}
-        />
-      )}
+      {name && <p>Name: {name}</p>}
+      <p>Booking history is available under the 'Booking History' tab.</p>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- Add Booking History tab for shoppers and reuse UserHistory for both roles
- Simplify Profile page to direct users to the new history tab
- Enhance UserHistory with cancel/reject actions and reasonable confirmation dialogs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68919cd47c90832d991b6c74c386bf6c