### PR TITLE
Auto-generate staff IDs and simplify staff forms

### DIFF
--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -58,7 +58,6 @@ export async function staffExists(): Promise<boolean> {
 export async function createAdmin(
   firstName: string,
   lastName: string,
-  staffId: string,
   role: string,
   email: string,
   password: string
@@ -66,7 +65,7 @@ export async function createAdmin(
   const res = await fetch(`${API_BASE}/staff/admin`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ firstName, lastName, staffId, role, email, password }),
+    body: JSON.stringify({ firstName, lastName, role, email, password }),
   });
   return handleResponse(res);
 }
@@ -75,7 +74,6 @@ export async function createStaff(
   token: string,
   firstName: string,
   lastName: string,
-  staffId: string,
   role: string,
   email: string,
   password: string
@@ -86,7 +84,7 @@ export async function createStaff(
       'Content-Type': 'application/json',
       Authorization: token,
     },
-    body: JSON.stringify({ firstName, lastName, staffId, role, email, password }),
+    body: JSON.stringify({ firstName, lastName, role, email, password }),
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -12,7 +12,6 @@ export default function AddUser({ token }: { token: string }) {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [clientId, setClientId] = useState('');
-  const [staffId, setStaffId] = useState('');
   const [staffRole, setStaffRole] = useState<StaffRole>('staff');
   const [password, setPassword] = useState('');
 
@@ -46,18 +45,17 @@ export default function AddUser({ token }: { token: string }) {
   }
 
   async function submitStaff() {
-    if (!firstName || !lastName || !email || !password || !staffId) {
+    if (!firstName || !lastName || !email || !password) {
       setMessage('All fields required');
       return;
     }
     try {
-      await createStaff(token, firstName, lastName, staffId, staffRole, email, password);
+      await createStaff(token, firstName, lastName, staffRole, email, password);
       setMessage('Staff added successfully');
       setFirstName('');
       setLastName('');
       setEmail('');
       setPassword('');
-      setStaffId('');
       setStaffRole('staff');
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
@@ -133,12 +131,6 @@ export default function AddUser({ token }: { token: string }) {
             <label>
               Last Name:{' '}
               <input type="text" value={lastName} onChange={e => setLastName(e.target.value)} />
-            </label>
-          </div>
-          <div style={{ marginBottom: 8 }}>
-            <label>
-              Staff ID:{' '}
-              <input type="text" value={staffId} onChange={e => setStaffId(e.target.value)} />
             </label>
           </div>
           <div style={{ marginBottom: 8 }}>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -67,7 +67,6 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [staffId, setStaffId] = useState('');
   const [role, setRole] = useState<StaffRole>('admin');
   const [error, setError] = useState(initError);
   const [message, setMessage] = useState('');
@@ -75,7 +74,7 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      await createAdmin(firstName, lastName, staffId, role, email, password);
+      await createAdmin(firstName, lastName, role, email, password);
       setMessage('Admin created. You can login now.');
       setTimeout(onCreated, 1000);
     } catch (err: unknown) {
@@ -91,7 +90,6 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
       <form onSubmit={submit}>
         <input value={firstName} onChange={e => setFirstName(e.target.value)} placeholder="First name" />
         <input value={lastName} onChange={e => setLastName(e.target.value)} placeholder="Last name" />
-        <input value={staffId} onChange={e => setStaffId(e.target.value)} placeholder="Staff ID" />
         <select value={role} onChange={e => setRole(e.target.value as StaffRole)}>
           <option value="staff">Staff</option>
           <option value="volunteer_coordinator">Volunteer Coordinator</option>


### PR DESCRIPTION
## Summary
- Remove manual staff ID entry and compute next staff ID server-side
- Drop staff ID fields from staff creation forms and API

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891a0c87f04832db310b7977435eda4