### PR TITLE
Fix staff role handling

### DIFF
--- a/MJ_FB_Backend/src/types/express.d.ts
+++ b/MJ_FB_Backend/src/types/express.d.ts
@@ -2,7 +2,15 @@ declare namespace Express {
   export interface Request {
     user?: {
       id: string;
-      role: 'shopper' | 'delivery' | 'staff';
+      role:
+        | 'shopper'
+        | 'delivery'
+        | 'staff'
+        | 'volunteer_coordinator'
+        | 'admin';
+      name?: string;
+      email?: string;
+      phone?: string;
     };
   }
 }


### PR DESCRIPTION
## Summary
- include volunteer coordinator and admin in Express request typing
- pull staff role from DB in auth middleware and expand staff authorization to include volunteer coordinator and admin

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891a32258c0832d8554b3b99d57b975