### PR TITLE
refactor: drop staff_id and is_admin from staff

### DIFF
--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -2,9 +2,7 @@ export interface Staff {
   id: number;
   first_name: string;
   last_name: string;
-  staff_id: string;
   role: 'staff' | 'volunteer_coordinator' | 'admin';
   email: string;
   password: string;
-  is_admin: boolean;
 }


### PR DESCRIPTION
## Summary
- remove deprecated `staff_id` and `is_admin` fields from staff interface
- rely on `role` for admin logic and staff creation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891a5cc6d98832d84cc5e2f22e9a117