### PR TITLE
Validate staff role and document allowed values

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -8,3 +8,8 @@ Backend: https://github.com/Amrutha-A-J/MJ_FB_Backend
 `FRONTEND_ORIGIN` – Origin URL of the frontend allowed for CORS. Defaults to `http://localhost:5173` if unset.
 
 
+## Staff Roles
+
+Valid roles for staff accounts are `staff`, `volunteer_coordinator`, and `admin`. Use the exact spelling `volunteer_coordinator` (with both "o"s) when creating staff members.
+
+

--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -71,6 +71,13 @@ export async function createStaff(req: Request, res: Response) {
     return res.status(400).json({ message: 'Missing fields' });
   }
 
+  const validRoles = ['staff', 'volunteer_coordinator', 'admin'];
+  if (!validRoles.includes(role)) {
+    return res
+      .status(400)
+      .json({ message: `Invalid role. Allowed roles: ${validRoles.join(', ')}` });
+  }
+
   try {
     if (req.user.role !== 'admin') {
       return res.status(403).json({ message: 'Forbidden' });


### PR DESCRIPTION
## Summary
- add validation of staff roles before insert to prevent misspelled roles
- document valid staff roles and correct spelling in backend README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891a89fc860832d9cd48274aba8b516