### PR TITLE
Accept snake_case names for staff creation

### DIFF
--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -16,12 +16,13 @@ export async function checkStaffExists(_req: Request, res: Response) {
 }
 
 export async function createAdmin(req: Request, res: Response) {
-  const { firstName, lastName, email, password } = req.body as {
-    firstName: string;
-    lastName: string;
-    email: string;
-    password: string;
-  };
+  const { first_name: firstName, last_name: lastName, email, password } =
+    req.body as {
+      first_name: string;
+      last_name: string;
+      email: string;
+      password: string;
+    };
 
   if (!firstName || !lastName || !email || !password) {
     return res.status(400).json({ message: 'Missing fields' });
@@ -59,13 +60,14 @@ export async function createStaff(req: Request, res: Response) {
     return res.status(401).json({ message: 'Unauthorized' });
   }
 
-  const { firstName, lastName, role, email, password } = req.body as {
-    firstName: string;
-    lastName: string;
-    role: string;
-    email: string;
-    password: string;
-  };
+  const { first_name: firstName, last_name: lastName, role, email, password } =
+    req.body as {
+      first_name: string;
+      last_name: string;
+      role: string;
+      email: string;
+      password: string;
+    };
 
   if (!firstName || !lastName || !role || !email || !password) {
     return res.status(400).json({ message: 'Missing fields' });

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -65,7 +65,13 @@ export async function createAdmin(
   const res = await fetch(`${API_BASE}/staff/admin`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ firstName, lastName, role, email, password }),
+    body: JSON.stringify({
+      first_name: firstName,
+      last_name: lastName,
+      role,
+      email,
+      password,
+    }),
   });
   return handleResponse(res);
 }
@@ -84,7 +90,13 @@ export async function createStaff(
       'Content-Type': 'application/json',
       Authorization: token,
     },
-    body: JSON.stringify({ firstName, lastName, role, email, password }),
+    body: JSON.stringify({
+      first_name: firstName,
+      last_name: lastName,
+      role,
+      email,
+      password,
+    }),
   });
   return handleResponse(res);
 }


### PR DESCRIPTION
## Summary
- Accept `first_name` and `last_name` fields in staff controller
- Send `first_name`/`last_name` from frontend API helpers

## Testing
- `npm test` *(backend)*
- `npm run build` *(backend)*
- `npm test` *(frontend, fails: Missing script: "test")*
- `npm run build` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_6891aae7ad54832db19e99e43003450b