### PR TITLE
Fix staff creation forbidden error due to token collision

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -28,7 +28,7 @@ export async function loginUser(req: Request, res: Response) {
       }
       const bookingsThisMonth = await updateBookingsThisMonth(user.id);
       return res.json({
-        token: user.id.toString(),
+        token: `user-${user.id.toString()}`,
         role: user.role,
         name: `${user.first_name} ${user.last_name}`,
         bookingsThisMonth,
@@ -52,7 +52,7 @@ export async function loginUser(req: Request, res: Response) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
     res.json({
-      token: staff.id.toString(),
+      token: `staff-${staff.id.toString()}`,
       role: staff.role,
       name: `${staff.first_name} ${staff.last_name}`,
     });

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -8,13 +8,18 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
   }
 
   try {
-    // Simple: use token as user.id to find user
-    const userRes = await pool.query(
-      'SELECT id, first_name, last_name, email, role, phone FROM users WHERE id = $1',
-      [token]
-    );
+    const [prefix, id] = token.split('-');
 
-    if (userRes.rowCount && userRes.rowCount > 0) {
+    if (prefix === 'user') {
+      const userRes = await pool.query(
+        'SELECT id, first_name, last_name, email, role, phone FROM users WHERE id = $1',
+        [id]
+      );
+
+      if (userRes.rowCount === 0) {
+        return res.status(401).json({ message: 'Invalid token' });
+      }
+
       req.user = {
         id: userRes.rows[0].id.toString(),
         role: userRes.rows[0].role,
@@ -25,22 +30,26 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
       return next();
     }
 
-    const staffRes = await pool.query(
-      'SELECT id, first_name, last_name, email, role FROM staff WHERE id = $1',
-      [token]
-    );
+    if (prefix === 'staff') {
+      const staffRes = await pool.query(
+        'SELECT id, first_name, last_name, email, role FROM staff WHERE id = $1',
+        [id]
+      );
 
-    if (staffRes.rowCount === 0) {
-      return res.status(401).json({ message: 'Invalid token' });
+      if (staffRes.rowCount === 0) {
+        return res.status(401).json({ message: 'Invalid token' });
+      }
+
+      req.user = {
+        id: staffRes.rows[0].id.toString(),
+        role: staffRes.rows[0].role,
+        name: `${staffRes.rows[0].first_name} ${staffRes.rows[0].last_name}`,
+        email: staffRes.rows[0].email,
+      } as any;
+      return next();
     }
 
-    req.user = {
-      id: staffRes.rows[0].id.toString(),
-      role: staffRes.rows[0].role,
-      name: `${staffRes.rows[0].first_name} ${staffRes.rows[0].last_name}`,
-      email: staffRes.rows[0].email,
-    } as any;
-    next();
+    return res.status(401).json({ message: 'Invalid token' });
   } catch (error) {
     console.error('Auth error:', error);
     res


### PR DESCRIPTION
## Summary
- Namespace user and staff auth tokens to avoid id collisions
- Parse new token prefixes in auth middleware

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891ac5a6f6c832d89ed7d848bf5c6ee