### PR TITLE
Enable admin staff management and broaden role handling

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -9,6 +9,7 @@ import ViewSchedule from './components/StaffDashboard/ViewSchedule';
 import Login from './components/Login';
 import StaffLogin from './components/StaffLogin';
 import type { Role } from './types';
+import { isStaffRole } from './types';
 
 export default function App() {
   const [token, setToken] = useState(localStorage.getItem('token') || '');
@@ -39,7 +40,7 @@ export default function App() {
   }
 
   let navLinks: { label: string; id: string }[] = [{ label: 'Profile', id: 'profile' }];
-  if (role === 'staff') {
+  if (isStaffRole(role)) {
     navLinks = navLinks.concat([
       { label: 'Staff Dashboard', id: 'staffDashboard' },
       { label: 'Manage Availability', id: 'manageAvailability' },
@@ -112,22 +113,22 @@ export default function App() {
 
           <main>
             {activePage === 'profile' && <Profile />}
-            {activePage === 'staffDashboard' && role === 'staff' && (
+            {activePage === 'staffDashboard' && isStaffRole(role) && (
               <StaffDashboard token={token} setError={setError} setLoading={setLoading} />
             )}
-            {activePage === 'manageAvailability' && role === 'staff' && (
+            {activePage === 'manageAvailability' && isStaffRole(role) && (
               <ManageAvailability token={token} />
             )}
-            {activePage === 'viewSchedule' && role === 'staff' && (
+            {activePage === 'viewSchedule' && isStaffRole(role) && (
               <ViewSchedule token={token} />
             )}
             {activePage === 'slots' && role === 'shopper' && (
               <SlotBooking token={token} role="shopper" />
             )}
-            {activePage === 'addUser' && role === 'staff' && (
-              <AddUser token={token} />
+            {activePage === 'addUser' && isStaffRole(role) && (
+              <AddUser token={token} role={role} />
             )}
-            {activePage === 'userHistory' && role === 'staff' && (
+            {activePage === 'userHistory' && isStaffRole(role) && (
               <UserHistory token={token} role={role} />
             )}
             {activePage === 'bookingHistory' && role === 'shopper' && (

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -1,10 +1,13 @@
+import { isStaffRole } from '../types';
+import type { Role } from '../types';
+
 type NavbarProps = {
-    role: string;
+    role: Role;
     name?: string;
     onPageChange: (page: string) => void;
     onLogout: () => void;
   };
-  
+
   export default function Navbar({ role, name, onPageChange, onLogout }: NavbarProps) {
     return (
       <nav
@@ -34,7 +37,7 @@ type NavbarProps = {
             </>
           )}
   
-          {role === 'staff' && (
+          {isStaffRole(role) && (
             <>
               <button onClick={() => onPageChange('home')} style={buttonStyle}>
                 Pending

--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -1,10 +1,11 @@
 import type { Role } from '../types';
+import { isStaffRole } from '../types';
 
 export default function Profile() {
   const role = (localStorage.getItem('role') || '') as Role;
   const name = localStorage.getItem('name') || '';
 
-  if (role === 'staff') {
+  if (isStaffRole(role)) {
     return (
       <div>
         <h2>User Profile</h2>

--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -3,7 +3,8 @@ import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import { searchUsers, createBookingForUser, createBooking, getSlots, getHolidays } from '../api/api';
 import { toZonedTime, fromZonedTime, formatInTimeZone } from 'date-fns-tz';
-import type { Slot, Holiday } from '../types';
+import type { Slot, Holiday, Role } from '../types';
+import { isStaffRole } from '../types';
 import { formatTime } from '../utils/time';
 
 const reginaTimeZone = 'America/Regina';
@@ -19,7 +20,7 @@ interface User {
 
 interface Props {
   token: string;
-  role: 'staff' | 'shopper';
+  role: Role;
 }
 
 function toReginaDate(date: Date): Date {
@@ -102,7 +103,7 @@ export default function SlotBooking({ token, role }: Props) {
   }, [holidays, isWeekend, isHoliday, getNextAvailableDate]);
 
   useEffect(() => {
-    if (role === 'staff') {
+    if (isStaffRole(role)) {
       const delayDebounce = setTimeout(() => {
         if (searchTerm.length >= 3) {
           searchUsers(token, searchTerm)
@@ -153,7 +154,7 @@ export default function SlotBooking({ token, role }: Props) {
     }
 
     try {
-      if (role === 'staff') {
+      if (isStaffRole(role)) {
         if (!selectedUser) {
           setMessage('Please select a user');
           return;
@@ -194,7 +195,7 @@ export default function SlotBooking({ token, role }: Props) {
     );
   }
 
-  if (role === 'staff' && !selectedUser) {
+  if (isStaffRole(role) && !selectedUser) {
     return (
       <div>
         <input
@@ -219,7 +220,7 @@ export default function SlotBooking({ token, role }: Props) {
   return (
     <div className="slot-booking">
       <h3>
-        {role === 'staff' && selectedUser ? `Booking for: ${selectedUser.name}` : `Booking for: ${loggedInName}`}
+        {isStaffRole(role) && selectedUser ? `Booking for: ${selectedUser.name}` : `Booking for: ${loggedInName}`}
       </h3>
       <Calendar
         onChange={value => {
@@ -266,14 +267,14 @@ export default function SlotBooking({ token, role }: Props) {
                 ))}
               </ul>
               <button disabled={!selectedSlotId} onClick={submitBooking}>
-                {role === 'staff' ? 'Submit Booking' : 'Book Selected Slot'}
+                {isStaffRole(role) ? 'Submit Booking' : 'Book Selected Slot'}
               </button>
             </>
           )}
         </div>
       )}
 
-      {role === 'staff' && <button onClick={() => setSelectedUser(null)}>Back to Search</button>}
+      {isStaffRole(role) && <button onClick={() => setSelectedUser(null)}>Back to Search</button>}
       {message && (
         <p className={message.startsWith('Booking') ? 'success-message' : 'error-message'}>{message}</p>
       )}

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react';
 import { addUser, createStaff } from '../../api/api';
 import type { Role, StaffRole } from '../../types';
 
-export default function AddUser({ token }: { token: string }) {
+export default function AddUser({ token, role }: { token: string; role: Role }) {
   const [mode, setMode] = useState<'user' | 'staff'>('user');
   const [email, setEmail] = useState('');
-  const [role, setRole] = useState<Role>('shopper');
+  const [userRole, setUserRole] = useState<Role>('shopper');
   const [phone, setPhone] = useState('');
   const [message, setMessage] = useState('');
 
@@ -26,7 +26,7 @@ export default function AddUser({ token }: { token: string }) {
         firstName,
         lastName,
         clientId,
-        role,
+        userRole,
         password,
         email || undefined,
         phone || undefined
@@ -38,7 +38,7 @@ export default function AddUser({ token }: { token: string }) {
       setEmail('');
       setPhone('');
       setPassword('');
-      setRole('shopper');
+      setUserRole('shopper');
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
     }
@@ -65,10 +65,14 @@ export default function AddUser({ token }: { token: string }) {
   return (
     <div>
       <h2>{mode === 'user' ? 'Create User' : 'Create Staff'}</h2>
-      <div style={{ marginBottom: 12 }}>
-        <button onClick={() => setMode('user')}>Create User</button>
-        <button onClick={() => setMode('staff')} style={{ marginLeft: 8 }}>Create Staff</button>
-      </div>
+      {role === 'admin' && (
+        <div style={{ marginBottom: 12 }}>
+          <button onClick={() => setMode('user')}>Create User</button>
+          <button onClick={() => setMode('staff')} style={{ marginLeft: 8 }}>
+            Create Staff
+          </button>
+        </div>
+      )}
       {message && <p>{message}</p>}
       {mode === 'user' ? (
         <>
@@ -111,7 +115,7 @@ export default function AddUser({ token }: { token: string }) {
           <div style={{ marginBottom: 8 }}>
             <label>
               Role:{' '}
-              <select value={role} onChange={e => setRole(e.target.value as Role)}>
+              <select value={userRole} onChange={e => setUserRole(e.target.value as Role)}>
                 <option value="shopper">Shopper</option>
                 <option value="delivery">Delivery</option>
               </select>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -38,10 +38,6 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
     e.preventDefault();
     try {
       const user = await loginStaff(email, password);
-      if (user.role !== 'staff') {
-        setError('Not a staff account');
-        return;
-      }
       onLogin(user);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));

--- a/MJ_FB_Frontend/src/components/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/UserHistory.tsx
@@ -8,6 +8,7 @@ import {
 import { formatInTimeZone } from 'date-fns-tz';
 import ConfirmDialog from './ConfirmDialog';
 import type { Role } from '../types';
+import { isStaffRole } from '../types';
 
 const TIMEZONE = 'America/Regina';
 
@@ -53,7 +54,7 @@ export default function UserHistory({ token, role }: { token: string; role: Role
         await decideBooking(token, confirm.id.toString(), 'reject', confirm.reason);
       }
       const opts: { status?: string; past?: boolean; userId?: number } = {};
-      if (role === 'staff' && selected) opts.userId = selected.id;
+      if (isStaffRole(role) && selected) opts.userId = selected.id;
       if (filter === 'past') opts.past = true;
       else if (filter !== 'all') opts.status = filter;
       const data = await getBookingHistory(token, opts);
@@ -69,7 +70,7 @@ export default function UserHistory({ token, role }: { token: string; role: Role
   }
 
   useEffect(() => {
-    if (role !== 'staff') return;
+    if (!isStaffRole(role)) return;
     if (search.length < 3) {
       setResults([]);
       return;
@@ -86,9 +87,9 @@ export default function UserHistory({ token, role }: { token: string; role: Role
   }, [search, token, role]);
 
   useEffect(() => {
-    if (role === 'staff' && !selected) return;
+    if (isStaffRole(role) && !selected) return;
     const opts: { status?: string; past?: boolean; userId?: number } = {};
-    if (role === 'staff' && selected) opts.userId = selected.id;
+    if (isStaffRole(role) && selected) opts.userId = selected.id;
     if (filter === 'past') opts.past = true;
     else if (filter !== 'all') opts.status = filter;
     getBookingHistory(token, opts)
@@ -108,7 +109,7 @@ export default function UserHistory({ token, role }: { token: string; role: Role
   return (
     <div>
       <h2>Booking History</h2>
-      {role === 'staff' && (
+      {isStaffRole(role) && (
         <>
           <input
             value={search}
@@ -134,9 +135,9 @@ export default function UserHistory({ token, role }: { token: string; role: Role
           )}
         </>
       )}
-      {(role === 'staff' ? selected !== null : true) && (
+      {(isStaffRole(role) ? selected !== null : true) && (
         <div>
-          {role === 'staff' && selected && <h3>History for {selected.name}</h3>}
+          {isStaffRole(role) && selected && <h3>History for {selected.name}</h3>}
           <div>
             <label htmlFor="filterHistory">Filter:</label>{' '}
             <select
@@ -191,8 +192,8 @@ export default function UserHistory({ token, role }: { token: string; role: Role
                   })();
                   const showCancel =
                     role === 'shopper' && ['approved', 'submitted'].includes(b.status);
-                  const staffReject = role === 'staff' && b.status === 'submitted';
-                  const staffCancel = role === 'staff' && b.status === 'approved';
+                  const staffReject = isStaffRole(role) && b.status === 'submitted';
+                  const staffCancel = isStaffRole(role) && b.status === 'approved';
                   return (
                     <tr key={b.id}>
                       <td>{dateCell}</td>

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -1,5 +1,15 @@
-export type Role = 'staff' | 'shopper' | 'delivery';
+export type Role =
+  | 'staff'
+  | 'shopper'
+  | 'delivery'
+  | 'volunteer_coordinator'
+  | 'admin';
+
 export type StaffRole = 'staff' | 'volunteer_coordinator' | 'admin';
+
+export function isStaffRole(role: Role): boolean {
+  return role === 'staff' || role === 'volunteer_coordinator' || role === 'admin';
+}
 
 export interface Slot {
   id: string;


### PR DESCRIPTION
## Summary
- allow admin accounts to log in and access staff pages
- add general staff role helper and use it across components
- restrict "Create Staff" UI to admins when adding users

## Testing
- `npm test` (backend)
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6891af6924e0832d8a58c788b440e761