### PR TITLE
Align code with updated staff schema

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -132,14 +132,17 @@ export async function cancelBooking(req: Request, res: Response) {
   const bookingId = req.params.id;
   const requester = req.user;
   if (!requester) return res.status(401).json({ message: 'Unauthorized' });
-  const reason = requester.role === 'staff' ? (req.body.reason as string) || '' : 'user cancelled';
+  const reason = ['staff', 'volunteer_coordinator', 'admin'].includes(requester.role)
+    ? ((req.body.reason as string) || '')
+    : 'user cancelled';
 
   try {
     const bookingRes = await pool.query('SELECT * FROM bookings WHERE id=$1', [bookingId]);
     if (bookingRes.rowCount === 0) return res.status(404).json({ message: 'Booking not found' });
     const booking = bookingRes.rows[0];
 
-    if (requester.role !== 'staff' && booking.user_id !== Number(requester.id)) {
+    if (!['staff', 'volunteer_coordinator', 'admin'].includes(requester.role) &&
+        booking.user_id !== Number(requester.id)) {
       return res.status(403).json({ message: 'Forbidden' });
     }
 
@@ -166,7 +169,7 @@ export async function cancelBooking(req: Request, res: Response) {
 
 // --- Staff: create preapproved booking for walk-in user ---
 export async function createPreapprovedBooking(req: Request, res: Response) {
-  if (!req.user || req.user.role !== 'staff')
+  if (!req.user || !['staff', 'volunteer_coordinator', 'admin'].includes(req.user.role))
     return res.status(403).json({ message: 'Forbidden' });
 
   const { name, slotId, requestData, date } = req.body;
@@ -222,7 +225,7 @@ export async function createPreapprovedBooking(req: Request, res: Response) {
 
 // --- Staff: create booking for existing user ---
 export async function createBookingForUser(req: Request, res: Response) {
-  if (!req.user || req.user.role !== 'staff')
+  if (!req.user || !['staff', 'volunteer_coordinator', 'admin'].includes(req.user.role))
     return res.status(403).json({ message: 'Forbidden' });
 
   const { userId, slotId, date, isStaffBooking } = req.body;

--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -16,15 +16,14 @@ export async function checkStaffExists(_req: Request, res: Response) {
 }
 
 export async function createAdmin(req: Request, res: Response) {
-  const { firstName, lastName, staffId, email, password } = req.body as {
+  const { firstName, lastName, email, password } = req.body as {
     firstName: string;
     lastName: string;
-    staffId: string;
     email: string;
     password: string;
   };
 
-  if (!firstName || !lastName || !staffId || !email || !password) {
+  if (!firstName || !lastName || !email || !password) {
     return res.status(400).json({ message: 'Missing fields' });
   }
 
@@ -34,23 +33,17 @@ export async function createAdmin(req: Request, res: Response) {
       return res.status(400).json({ message: 'Admin already exists' });
     }
 
-    // Prevent duplicate email or staff ID from causing a database error
     const emailCheck = await pool.query('SELECT id FROM staff WHERE email = $1', [email]);
     if (emailCheck.rowCount && emailCheck.rowCount > 0) {
       return res.status(400).json({ message: 'Email already exists' });
     }
 
-    const staffIdCheck = await pool.query('SELECT id FROM staff WHERE staff_id = $1', [staffId]);
-    if (staffIdCheck.rowCount && staffIdCheck.rowCount > 0) {
-      return res.status(400).json({ message: 'Staff ID already exists' });
-    }
-
     const hashed = await bcrypt.hash(password, 10);
 
     await pool.query(
-      `INSERT INTO staff (first_name, last_name, staff_id, role, email, password, is_admin)
-       VALUES ($1, $2, $3, 'staff', $4, $5, TRUE)`,
-      [firstName, lastName, staffId, email, hashed]
+      `INSERT INTO staff (first_name, last_name, role, email, password)
+       VALUES ($1, $2, 'admin', $3, $4)`,
+      [firstName, lastName, email, hashed]
     );
 
     res.status(201).json({ message: 'Admin account created' });
@@ -67,22 +60,20 @@ export async function createStaff(req: Request, res: Response) {
     return res.status(401).json({ message: 'Unauthorized' });
   }
 
-  const { firstName, lastName, staffId, role, email, password } = req.body as {
+  const { firstName, lastName, role, email, password } = req.body as {
     firstName: string;
     lastName: string;
-    staffId: string;
     role: string;
     email: string;
     password: string;
   };
 
-  if (!firstName || !lastName || !staffId || !role || !email || !password) {
+  if (!firstName || !lastName || !role || !email || !password) {
     return res.status(400).json({ message: 'Missing fields' });
   }
 
   try {
-    const adminCheck = await pool.query('SELECT is_admin FROM staff WHERE id = $1', [req.user.id]);
-    if (adminCheck.rowCount === 0 || !adminCheck.rows[0].is_admin) {
+    if (req.user.role !== 'admin') {
       return res.status(403).json({ message: 'Forbidden' });
     }
 
@@ -91,17 +82,12 @@ export async function createStaff(req: Request, res: Response) {
       return res.status(400).json({ message: 'Email already exists' });
     }
 
-    const staffIdCheck = await pool.query('SELECT id FROM staff WHERE staff_id = $1', [staffId]);
-    if (staffIdCheck.rowCount && staffIdCheck.rowCount > 0) {
-      return res.status(400).json({ message: 'Staff ID already exists' });
-    }
-
     const hashed = await bcrypt.hash(password, 10);
 
     await pool.query(
-      `INSERT INTO staff (first_name, last_name, staff_id, role, email, password, is_admin)
-       VALUES ($1, $2, $3, $4, $5, $6, FALSE)`,
-      [firstName, lastName, staffId, role, email, hashed]
+      `INSERT INTO staff (first_name, last_name, role, email, password)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [firstName, lastName, role, email, hashed]
     );
 
     res.status(201).json({ message: 'Staff created' });

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -65,7 +65,7 @@ export async function loginUser(req: Request, res: Response) {
 }
 
 export async function createUser(req: Request, res: Response) {
-  if (!req.user || req.user.role !== 'staff') {
+  if (!req.user || !['staff', 'volunteer_coordinator', 'admin'].includes(req.user.role)) {
     return res.status(403).json({ message: 'Forbidden' });
   }
 

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -26,7 +26,7 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     }
 
     const staffRes = await pool.query(
-      'SELECT id, first_name, last_name, email FROM staff WHERE id = $1',
+      'SELECT id, first_name, last_name, email, role FROM staff WHERE id = $1',
       [token]
     );
 
@@ -36,7 +36,7 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
 
     req.user = {
       id: staffRes.rows[0].id.toString(),
-      role: 'staff',
+      role: staffRes.rows[0].role,
       name: `${staffRes.rows[0].first_name} ${staffRes.rows[0].last_name}`,
       email: staffRes.rows[0].email,
     } as any;

--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -2,9 +2,7 @@ export interface Staff {
   id: number;
   first_name: string;
   last_name: string;
-  staff_id: string;
   role: 'staff' | 'volunteer_coordinator' | 'admin';
   email: string;
   password: string;
-  is_admin: boolean;
 }

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -16,21 +16,21 @@ const router = express.Router();
 router.post('/', authMiddleware, authorizeRoles('shopper', 'delivery'), createBooking);
 
 // Staff list all bookings
-router.get('/', authMiddleware, authorizeRoles('staff'), listBookings);
+router.get('/', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator', 'admin'), listBookings);
 
 // Booking history for user or staff lookup
 router.get('/history', authMiddleware, getBookingHistory);
 
 // Staff approve/reject booking
-router.post('/:id/decision', authMiddleware, authorizeRoles('staff'), decideBooking);
+router.post('/:id/decision', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator', 'admin'), decideBooking);
 
 // Cancel booking (staff or user)
 router.post('/:id/cancel', authMiddleware, cancelBooking);
 
 // Staff create preapproved booking for walk-in users
-router.post('/preapproved', authMiddleware, authorizeRoles('staff'), createPreapprovedBooking);
+router.post('/preapproved', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator', 'admin'), createPreapprovedBooking);
 
 // ✅ Staff create booking for existing user (what you need)
-router.post('/staff', authMiddleware, authorizeRoles('staff'), createBookingForUser);
+router.post('/staff', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator', 'admin'), createBookingForUser);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -5,8 +5,8 @@ import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 const router = express.Router();
 
 router.post('/login', loginUser);
-router.post('/', authMiddleware, authorizeRoles('staff'), createUser);
-router.get('/search', authMiddleware, authorizeRoles('staff'), searchUsers);
+router.post('/', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator', 'admin'), createUser);
+router.get('/search', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator', 'admin'), searchUsers);
 
 
 export default router;

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -58,15 +58,13 @@ export async function staffExists(): Promise<boolean> {
 export async function createAdmin(
   firstName: string,
   lastName: string,
-  staffId: string,
-  role: string,
   email: string,
   password: string
 ) {
   const res = await fetch(`${API_BASE}/staff/admin`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ firstName, lastName, staffId, role, email, password }),
+    body: JSON.stringify({ firstName, lastName, email, password }),
   });
   return handleResponse(res);
 }
@@ -75,7 +73,6 @@ export async function createStaff(
   token: string,
   firstName: string,
   lastName: string,
-  staffId: string,
   role: string,
   email: string,
   password: string
@@ -86,7 +83,7 @@ export async function createStaff(
       'Content-Type': 'application/json',
       Authorization: token,
     },
-    body: JSON.stringify({ firstName, lastName, staffId, role, email, password }),
+    body: JSON.stringify({ firstName, lastName, role, email, password }),
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -12,7 +12,6 @@ export default function AddUser({ token }: { token: string }) {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [clientId, setClientId] = useState('');
-  const [staffId, setStaffId] = useState('');
   const [staffRole, setStaffRole] = useState<StaffRole>('staff');
   const [password, setPassword] = useState('');
 
@@ -46,18 +45,17 @@ export default function AddUser({ token }: { token: string }) {
   }
 
   async function submitStaff() {
-    if (!firstName || !lastName || !email || !password || !staffId) {
+    if (!firstName || !lastName || !email || !password) {
       setMessage('All fields required');
       return;
     }
     try {
-      await createStaff(token, firstName, lastName, staffId, staffRole, email, password);
+      await createStaff(token, firstName, lastName, staffRole, email, password);
       setMessage('Staff added successfully');
       setFirstName('');
       setLastName('');
       setEmail('');
       setPassword('');
-      setStaffId('');
       setStaffRole('staff');
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
@@ -133,12 +131,6 @@ export default function AddUser({ token }: { token: string }) {
             <label>
               Last Name:{' '}
               <input type="text" value={lastName} onChange={e => setLastName(e.target.value)} />
-            </label>
-          </div>
-          <div style={{ marginBottom: 8 }}>
-            <label>
-              Staff ID:{' '}
-              <input type="text" value={staffId} onChange={e => setStaffId(e.target.value)} />
             </label>
           </div>
           <div style={{ marginBottom: 8 }}>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { loginStaff, staffExists, createAdmin } from '../api/api';
 import type { LoginResponse } from '../api/api';
-import type { StaffRole } from '../types';
 
 export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
   const [checking, setChecking] = useState(true);
@@ -38,7 +37,7 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
     e.preventDefault();
     try {
       const user = await loginStaff(email, password);
-      if (user.role !== 'staff') {
+      if (!['staff', 'volunteer_coordinator', 'admin'].includes(user.role)) {
         setError('Not a staff account');
         return;
       }
@@ -67,15 +66,13 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [staffId, setStaffId] = useState('');
-  const [role, setRole] = useState<StaffRole>('admin');
   const [error, setError] = useState(initError);
   const [message, setMessage] = useState('');
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      await createAdmin(firstName, lastName, staffId, role, email, password);
+      await createAdmin(firstName, lastName, email, password);
       setMessage('Admin created. You can login now.');
       setTimeout(onCreated, 1000);
     } catch (err: unknown) {
@@ -91,12 +88,6 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
       <form onSubmit={submit}>
         <input value={firstName} onChange={e => setFirstName(e.target.value)} placeholder="First name" />
         <input value={lastName} onChange={e => setLastName(e.target.value)} placeholder="Last name" />
-        <input value={staffId} onChange={e => setStaffId(e.target.value)} placeholder="Staff ID" />
-        <select value={role} onChange={e => setRole(e.target.value as StaffRole)}>
-          <option value="staff">Staff</option>
-          <option value="volunteer_coordinator">Volunteer Coordinator</option>
-          <option value="admin">Admin</option>
-        </select>
         <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
         <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
         <button type="submit">Create Admin</button>

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -1,4 +1,4 @@
-export type Role = 'staff' | 'shopper' | 'delivery';
+export type Role = 'staff' | 'volunteer_coordinator' | 'admin' | 'shopper' | 'delivery';
 export type StaffRole = 'staff' | 'volunteer_coordinator' | 'admin';
 
 export interface Slot {


### PR DESCRIPTION
## Summary
- Replace legacy `staff_id`/`is_admin` usage with role-based checks and inserts for staff management
- Permit admin and volunteer coordinator roles throughout booking and user APIs and match front-end API calls and forms

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891b81bfb04832da329214c09fe4f60