### PR TITLE
feat: proxy api requests and use relative base

### DIFF
--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -2,7 +2,12 @@
 // Read API base URL from environment or fall back to localhost
 import type { Role } from '../types';
 
-const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
+// Allow the API base to be configured via environment variable.  When no
+// explicit base is provided we fall back to a relative `/api` path so that the
+// Vite dev server can proxy requests during development and the same code can
+// run in production where the backend is served from the same origin.
+// Trailing slashes are stripped to avoid `//` in constructed URLs.
+const API_BASE = (import.meta.env.VITE_API_BASE || '/api').replace(/\/$/, '');
 
 export interface LoginResponse {
   token: string;

--- a/MJ_FB_Frontend/vite.config.ts
+++ b/MJ_FB_Frontend/vite.config.ts
@@ -4,4 +4,16 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // During development proxy API requests to the backend server so that the
+  // frontend can make calls to relative `/api` paths without hitting CORS
+  // issues or needing the absolute backend URL.
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- use `/api` as default backend base and strip trailing slashes
- add dev proxy so Vite forwards `/api` requests to backend

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6891bbfc7d74832d85f718b1c220d38a