### PR TITLE
fix: rewrite API proxy path for dev server

### DIFF
--- a/MJ_FB_Frontend/vite.config.ts
+++ b/MJ_FB_Frontend/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         target: 'http://localhost:4000',
         changeOrigin: true,
         secure: false,
+        rewrite: path => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
## Summary
- rewrite dev server proxy so `/api` prefix is stripped before forwarding to backend

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6891beeca5f8832daea0e9d703459aaf