### PR TITLE
Support new bookings table schema

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -301,7 +301,7 @@ export async function getBookingHistory(req: Request, res: Response) {
     }
 
     const result = await pool.query(
-      `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason, s.start_time, s.end_time, b.created_at
+      `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason, s.start_time, s.end_time, b.created_at, b.is_staff_booking
        FROM bookings b
        INNER JOIN slots s ON b.slot_id = s.id
        WHERE ${where}

--- a/MJ_FB_Backend/src/data.ts
+++ b/MJ_FB_Backend/src/data.ts
@@ -10,6 +10,8 @@ export interface Booking {
   status: BookingStatus;
   requestData: string;
   date?: string | null; // Add date here
+  isStaffBooking?: boolean;
+  createdAt?: string;
 }
 
 

--- a/MJ_FB_Backend/src/models/booking.ts
+++ b/MJ_FB_Backend/src/models/booking.ts
@@ -9,5 +9,7 @@ interface Booking {
   slot_id: number | null;
   start_time: string | null;
   end_time: string | null;
+  is_staff_booking: boolean;
+  created_at: string;
   reason?: string | null;
 }

--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -7,8 +7,11 @@ interface Booking {
   id: number;
   status: string;
   date: string;
+  slot_id: number;
   start_time: string;
   end_time: string;
+  created_at: string;
+  is_staff_booking: boolean;
   reason?: string;
 }
 

--- a/MJ_FB_Frontend/src/components/StaffDashboard/StaffDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/StaffDashboard.tsx
@@ -13,6 +13,8 @@ interface Booking {
   slot_id: number;
   start_time: string;
   end_time: string;
+  is_staff_booking: boolean;
+  created_at: string;
 }
 
 export default function StaffDashboard({

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -17,6 +17,8 @@ interface Booking {
   start_time: string;
   end_time: string;
   created_at: string;
+  slot_id: number;
+  is_staff_booking: boolean;
   reason?: string;
 }
 

--- a/MJ_FB_Frontend/src/components/StaffDashboard/ViewSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/ViewSchedule.tsx
@@ -10,6 +10,7 @@ interface Booking {
   date: string;
   slot_id: number;
   user_name: string;
+  is_staff_booking: boolean;
 }
 
 interface User {


### PR DESCRIPTION
## Summary
- expand booking model and client types with `is_staff_booking` and timestamps
- include staff-created flag in booking history query
- adjust frontend components to consume new booking schema

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891c70db5b4832d8d4c0e35c12771ad