### PR TITLE
feat: fix auth token handling for user and staff creation

### DIFF
--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -2,10 +2,15 @@ import { Request, Response, NextFunction } from 'express';
 import pool from '../db';
 
 export async function authMiddleware(req: Request, res: Response, next: NextFunction) {
-  const token = req.headers['authorization'];
-  if (!token || typeof token !== 'string') {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || typeof authHeader !== 'string') {
     return res.status(401).json({ message: 'Missing token' });
   }
+
+  // Allow standard "Bearer <token>" format in addition to raw tokens
+  const token = authHeader.startsWith('Bearer ')
+    ? authHeader.slice(7).trim()
+    : authHeader;
 
   try {
     const match = token.match(/^(staff|user)[:\-](\d+)$/);


### PR DESCRIPTION
## Summary
- allow auth middleware to read tokens with optional Bearer prefix

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891ccc016cc832db3a398c84ee5d622