### PR TITLE
feat: separate staff creation endpoint

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -87,6 +87,10 @@ export async function createUser(req: Request, res: Response) {
     return res.status(400).json({ message: 'Missing fields' });
   }
 
+  if (!['shopper', 'delivery'].includes(role)) {
+    return res.status(400).json({ message: 'Invalid role' });
+  }
+
   if (clientId < 1 || clientId > 9999999) {
     return res
       .status(400)

--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -1,8 +1,10 @@
+export type StaffRole = 'staff' | 'volunteer_coordinator' | 'admin';
+
 export interface Staff {
   id: number;
   first_name: string;
   last_name: string;
-  role: 'staff' | 'volunteer_coordinator' | 'admin';
+  role: StaffRole;
   email: string;
   password: string;
 }

--- a/MJ_FB_Backend/src/routes/staff.ts
+++ b/MJ_FB_Backend/src/routes/staff.ts
@@ -1,11 +1,11 @@
 import express from 'express';
 import { checkStaffExists, createAdmin, createStaff } from '../controllers/staffController';
-import { authMiddleware } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
 router.get('/exists', checkStaffExists);
 router.post('/admin', createAdmin);
-router.post('/', authMiddleware, createStaff);
+router.post('/', authMiddleware, authorizeRoles('admin'), createStaff);
 
 export default router;

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -1,6 +1,6 @@
 // src/api/api.ts
 // Read API base URL from environment or fall back to localhost
-import type { Role, UserRole } from '../types';
+import type { Role, UserRole, StaffRole } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
 
@@ -73,7 +73,7 @@ export async function createStaff(
   token: string,
   firstName: string,
   lastName: string,
-  role: string,
+  role: StaffRole,
   email: string,
   password: string
 ) {


### PR DESCRIPTION
## Summary
- restrict user creation endpoint to shopper or delivery roles
- introduce dedicated staff creation handler with explicit role validation
- expose staff creation on `/staff` route and update client API typings

## Testing
- `npm test` (backend)
- `npm test` (frontend)
- `npm run build` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6891cf1e44f0832d9d8f154d432a42a0