### PR TITLE
Allow staff roles to create staff members

### DIFF
--- a/MJ_FB_Backend/src/routes/staff.ts
+++ b/MJ_FB_Backend/src/routes/staff.ts
@@ -6,6 +6,15 @@ const router = express.Router();
 
 router.get('/exists', checkStaffExists);
 router.post('/admin', createAdmin);
-router.post('/', authMiddleware, authorizeRoles('admin'), createStaff);
+// Allow any authenticated staff role to create staff members
+// Previously only admins could create staff, which resulted in 403 errors
+// for standard staff accounts attempting to add new staff. Expanding the
+// authorized roles aligns this endpoint with the user creation permissions.
+router.post(
+  '/',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator', 'admin'),
+  createStaff
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- permit staff and volunteer coordinators to create staff accounts
- expand staff route authorization

## Testing
- `cd MJ_FB_Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891d1f62438832da49f1ad566651687