### PR TITLE
Remove admin role and bootstrap first staff account

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -132,7 +132,7 @@ export async function cancelBooking(req: Request, res: Response) {
   const bookingId = req.params.id;
   const requester = req.user;
   if (!requester) return res.status(401).json({ message: 'Unauthorized' });
-  const reason = ['staff', 'volunteer_coordinator', 'admin'].includes(requester.role)
+  const reason = ['staff', 'volunteer_coordinator'].includes(requester.role)
     ? (req.body.reason as string) || ''
     : 'user cancelled';
 
@@ -142,7 +142,7 @@ export async function cancelBooking(req: Request, res: Response) {
     const booking = bookingRes.rows[0];
 
     if (
-      !['staff', 'volunteer_coordinator', 'admin'].includes(requester.role) &&
+      !['staff', 'volunteer_coordinator'].includes(requester.role) &&
       booking.user_id !== Number(requester.id)
     ) {
       return res.status(403).json({ message: 'Forbidden' });
@@ -171,10 +171,7 @@ export async function cancelBooking(req: Request, res: Response) {
 
 // --- Staff: create preapproved booking for walk-in user ---
 export async function createPreapprovedBooking(req: Request, res: Response) {
-  if (
-    !req.user ||
-    !['staff', 'volunteer_coordinator', 'admin'].includes(req.user.role)
-  )
+  if (!req.user || !['staff', 'volunteer_coordinator'].includes(req.user.role))
     return res.status(403).json({ message: 'Forbidden' });
 
   const { name, slotId, requestData, date } = req.body;
@@ -230,10 +227,7 @@ export async function createPreapprovedBooking(req: Request, res: Response) {
 
 // --- Staff: create booking for existing user ---
 export async function createBookingForUser(req: Request, res: Response) {
-  if (
-    !req.user ||
-    !['staff', 'volunteer_coordinator', 'admin'].includes(req.user.role)
-  )
+  if (!req.user || !['staff', 'volunteer_coordinator'].includes(req.user.role))
     return res.status(403).json({ message: 'Forbidden' });
 
   const { userId, slotId, date, isStaffBooking } = req.body;
@@ -274,7 +268,7 @@ export async function getBookingHistory(req: Request, res: Response) {
     if (!requester) return res.status(401).json({ message: 'Unauthorized' });
 
     let userId: number | null = null;
-    if (['staff', 'volunteer_coordinator', 'admin'].includes(requester.role)) {
+    if (['staff', 'volunteer_coordinator'].includes(requester.role)) {
       const paramId = req.query.userId as string;
       if (!paramId) {
         return res.status(400).json({ message: 'userId query parameter required' });

--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -16,50 +16,7 @@ export async function checkStaffExists(_req: Request, res: Response) {
   }
 }
 
-export async function createAdmin(req: Request, res: Response) {
-  const { firstName, lastName, email, password } = req.body as {
-    firstName: string;
-    lastName: string;
-    email: string;
-    password: string;
-  };
-
-  if (!firstName || !lastName || !email || !password) {
-    return res.status(400).json({ message: 'Missing fields' });
-  }
-
-  try {
-    const exists = await pool.query('SELECT COUNT(*) FROM staff');
-    if (parseInt(exists.rows[0].count, 10) > 0) {
-      return res.status(400).json({ message: 'Admin already exists' });
-    }
-
-    const emailCheck = await pool.query('SELECT id FROM staff WHERE email = $1', [email]);
-    if (emailCheck.rowCount && emailCheck.rowCount > 0) {
-      return res.status(400).json({ message: 'Email already exists' });
-    }
-
-    const hashed = await bcrypt.hash(password, 10);
-
-    await pool.query(
-      `INSERT INTO staff (first_name, last_name, role, email, password) VALUES ($1, $2, 'admin', $3, $4)`,
-      [firstName, lastName, email, hashed]
-    );
-
-    res.status(201).json({ message: 'Admin account created' });
-  } catch (error) {
-    console.error('Error creating admin:', error);
-    res
-      .status(500)
-      .json({ message: `Database error creating admin: ${(error as Error).message}` });
-  }
-}
-
 export async function createStaff(req: Request, res: Response) {
-  if (!req.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
-  }
-
   const { firstName, lastName, role, email, password } = req.body as {
     firstName: string;
     lastName: string;
@@ -72,7 +29,7 @@ export async function createStaff(req: Request, res: Response) {
     return res.status(400).json({ message: 'Missing fields' });
   }
 
-  if (!['staff', 'volunteer_coordinator', 'admin'].includes(role)) {
+  if (!['staff', 'volunteer_coordinator'].includes(role)) {
     return res.status(400).json({ message: 'Invalid role' });
   }
 

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -65,10 +65,7 @@ export async function loginUser(req: Request, res: Response) {
 }
 
 export async function createUser(req: Request, res: Response) {
-  if (
-    !req.user ||
-    !['staff', 'volunteer_coordinator', 'admin'].includes(req.user.role)
-  ) {
+  if (!req.user || !['staff', 'volunteer_coordinator'].includes(req.user.role)) {
     return res.status(403).json({ message: 'Forbidden' });
   }
 

--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -1,4 +1,4 @@
-export type StaffRole = 'staff' | 'volunteer_coordinator' | 'admin';
+export type StaffRole = 'staff' | 'volunteer_coordinator';
 
 export interface Staff {
   id: number;

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -14,10 +14,7 @@ const router = express.Router();
 
 // Wrapper to handle bookings created by staff or regular users
 const handleCreateBooking = (req: Request, res: Response) => {
-  if (
-    req.user &&
-    ['staff', 'volunteer_coordinator', 'admin'].includes(req.user.role)
-  ) {
+  if (req.user && ['staff', 'volunteer_coordinator'].includes(req.user.role)) {
     // Allow staff to create a booking for themselves or another user
     if (!req.body.userId) {
       req.body.userId = req.user.id;
@@ -31,7 +28,7 @@ const handleCreateBooking = (req: Request, res: Response) => {
 router.post(
   '/',
   authMiddleware,
-  authorizeRoles('shopper', 'delivery', 'staff', 'volunteer_coordinator', 'admin'),
+  authorizeRoles('shopper', 'delivery', 'staff', 'volunteer_coordinator'),
   handleCreateBooking
 );
 
@@ -39,7 +36,7 @@ router.post(
 router.get(
   '/',
   authMiddleware,
-  authorizeRoles('staff', 'volunteer_coordinator', 'admin'),
+  authorizeRoles('staff', 'volunteer_coordinator'),
   listBookings
 );
 
@@ -50,7 +47,7 @@ router.get('/history', authMiddleware, getBookingHistory);
 router.post(
   '/:id/decision',
   authMiddleware,
-  authorizeRoles('staff', 'volunteer_coordinator', 'admin'),
+  authorizeRoles('staff', 'volunteer_coordinator'),
   decideBooking
 );
 
@@ -61,7 +58,7 @@ router.post('/:id/cancel', authMiddleware, cancelBooking);
 router.post(
   '/preapproved',
   authMiddleware,
-  authorizeRoles('staff', 'volunteer_coordinator', 'admin'),
+  authorizeRoles('staff', 'volunteer_coordinator'),
   createPreapprovedBooking
 );
 
@@ -69,7 +66,7 @@ router.post(
 router.post(
   '/staff',
   authMiddleware,
-  authorizeRoles('staff', 'volunteer_coordinator', 'admin'),
+  authorizeRoles('staff', 'volunteer_coordinator'),
   createBookingForUser
 );
 

--- a/MJ_FB_Backend/src/routes/staff.ts
+++ b/MJ_FB_Backend/src/routes/staff.ts
@@ -1,20 +1,25 @@
 import express from 'express';
-import { checkStaffExists, createAdmin, createStaff } from '../controllers/staffController';
+import { checkStaffExists, createStaff } from '../controllers/staffController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import pool from '../db';
 
 const router = express.Router();
 
 router.get('/exists', checkStaffExists);
-router.post('/admin', createAdmin);
-// Allow any authenticated staff role to create staff members
-// Previously only admins could create staff, which resulted in 403 errors
-// for standard staff accounts attempting to add new staff. Expanding the
-// authorized roles aligns this endpoint with the user creation permissions.
-router.post(
-  '/',
-  authMiddleware,
-  authorizeRoles('staff', 'volunteer_coordinator', 'admin'),
-  createStaff
-);
+
+// Allow creation of the first staff account without authentication. Once at
+// least one staff member exists, require standard staff authorization.
+router.post('/', async (req, res) => {
+  const result = await pool.query('SELECT COUNT(*) FROM staff');
+  const count = parseInt(result.rows[0].count, 10);
+  if (count === 0) {
+    return createStaff(req, res);
+  }
+  authMiddleware(req, res, () => {
+    authorizeRoles('staff', 'volunteer_coordinator')(req, res, () =>
+      createStaff(req, res)
+    );
+  });
+});
 
 export default router;

--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -5,18 +5,8 @@ import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 const router = express.Router();
 
 router.post('/login', loginUser);
-router.post(
-  '/',
-  authMiddleware,
-  authorizeRoles('staff', 'volunteer_coordinator', 'admin'),
-  createUser
-);
-router.get(
-  '/search',
-  authMiddleware,
-  authorizeRoles('staff', 'volunteer_coordinator', 'admin'),
-  searchUsers
-);
+router.post('/', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator'), createUser);
+router.get('/search', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator'), searchUsers);
 
 
 export default router;

--- a/MJ_FB_Backend/src/types/express.d.ts
+++ b/MJ_FB_Backend/src/types/express.d.ts
@@ -2,7 +2,7 @@ declare namespace Express {
   export interface Request {
     user?: {
       id: string;
-      role: 'shopper' | 'delivery' | 'staff' | 'volunteer_coordinator' | 'admin';
+      role: 'shopper' | 'delivery' | 'staff' | 'volunteer_coordinator';
     };
   }
 }

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -17,7 +17,7 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [loginMode, setLoginMode] = useState<'user' | 'staff'>('user');
-  const isStaff = role === 'staff' || role === 'volunteer_coordinator' || role === 'admin';
+  const isStaff = role === 'staff' || role === 'volunteer_coordinator';
 
   useEffect(() => {
     function handler(e: Event) {

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -55,34 +55,21 @@ export async function staffExists(): Promise<boolean> {
   return data.exists as boolean;
 }
 
-export async function createAdmin(
-  firstName: string,
-  lastName: string,
-  email: string,
-  password: string
-) {
-  const res = await fetch(`${API_BASE}/staff/admin`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ firstName, lastName, email, password }),
-  });
-  return handleResponse(res);
-}
-
 export async function createStaff(
-  token: string,
   firstName: string,
   lastName: string,
   role: StaffRole,
   email: string,
-  password: string
+  password: string,
+  token?: string
 ) {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (token) headers.Authorization = token;
   const res = await fetch(`${API_BASE}/staff`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: token,
-    },
+    headers,
     body: JSON.stringify({ firstName, lastName, role, email, password }),
   });
   return handleResponse(res);

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -6,7 +6,7 @@ type NavbarProps = {
   };
   
   export default function Navbar({ role, name, onPageChange, onLogout }: NavbarProps) {
-    const isStaff = role === 'staff' || role === 'volunteer_coordinator' || role === 'admin';
+  const isStaff = role === 'staff' || role === 'volunteer_coordinator';
     return (
       <nav
         style={{

--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -24,7 +24,7 @@ export default function Profile() {
 
   useEffect(() => {
     async function load() {
-      if (!token || ['staff', 'volunteer_coordinator', 'admin'].includes(role)) return;
+      if (!token || ['staff', 'volunteer_coordinator'].includes(role)) return;
       const opts: { status?: string; past?: boolean } = {};
       if (filter === 'past') opts.past = true;
       else if (filter !== 'all') opts.status = filter;
@@ -59,7 +59,7 @@ export default function Profile() {
     }
   }
 
-  if (['staff', 'volunteer_coordinator', 'admin'].includes(role)) {
+  if (['staff', 'volunteer_coordinator'].includes(role)) {
     return (
       <div>
         <h2>User Profile</h2>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -50,7 +50,7 @@ export default function AddUser({ token }: { token: string }) {
       return;
     }
     try {
-      await createStaff(token, firstName, lastName, staffRole, email, password);
+      await createStaff(firstName, lastName, staffRole, email, password, token);
       setMessage('Staff added successfully');
       setFirstName('');
       setLastName('');
@@ -139,7 +139,6 @@ export default function AddUser({ token }: { token: string }) {
               <select value={staffRole} onChange={e => setStaffRole(e.target.value as StaffRole)}>
                 <option value="staff">Staff</option>
                 <option value="volunteer_coordinator">Volunteer Coordinator</option>
-                <option value="admin">Admin</option>
               </select>
             </label>
           </div>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { loginStaff, staffExists, createAdmin } from '../api/api';
+import { loginStaff, staffExists, createStaff } from '../api/api';
 import type { LoginResponse } from '../api/api';
 
 export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
@@ -24,7 +24,7 @@ export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResp
   return hasStaff ? (
     <StaffLoginForm onLogin={onLogin} error={error} onBack={onBack} />
   ) : (
-    <CreateAdminForm onCreated={() => setHasStaff(true)} error={error} />
+    <CreateStaffForm onCreated={() => setHasStaff(true)} error={error} />
   );
 }
 
@@ -61,7 +61,7 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
   );
 }
 
-function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => void; error: string }) {
+function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => void; error: string }) {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
@@ -72,8 +72,8 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      await createAdmin(firstName, lastName, email, password);
-      setMessage('Admin created. You can login now.');
+      await createStaff(firstName, lastName, 'staff', email, password);
+      setMessage('Staff account created. You can login now.');
       setTimeout(onCreated, 1000);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
@@ -82,7 +82,7 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
 
   return (
     <div>
-      <h2>Create Admin Account</h2>
+      <h2>Create Staff Account</h2>
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {message && <p style={{ color: 'green' }}>{message}</p>}
       <form onSubmit={submit}>
@@ -90,7 +90,7 @@ function CreateAdminForm({ onCreated, error: initError }: { onCreated: () => voi
         <input value={lastName} onChange={e => setLastName(e.target.value)} placeholder="Last name" />
         <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
         <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
-        <button type="submit">Create Admin</button>
+        <button type="submit">Create Staff</button>
       </form>
     </div>
   );

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -2,10 +2,9 @@ export type Role =
   | 'staff'
   | 'shopper'
   | 'delivery'
-  | 'volunteer_coordinator'
-  | 'admin';
+  | 'volunteer_coordinator';
 export type UserRole = 'shopper' | 'delivery';
-export type StaffRole = 'staff' | 'volunteer_coordinator' | 'admin';
+export type StaffRole = 'staff' | 'volunteer_coordinator';
 
 export interface Slot {
   id: string;


### PR DESCRIPTION
## Summary
- Drop legacy `admin` role across backend and frontend, simplifying role enums and authorization checks
- Allow creation of the very first staff member without authentication, then require staff authorization for subsequent creations
- Update client logic to create initial staff via `createStaff` and remove admin-specific UI elements

## Testing
- `npm test` (backend)
- `npm test` *(fails: Missing script "test"; frontend)*
- `npm run build` (backend)
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6891d3216f04832d84bb3e7cfd7e74d2