### PR TITLE
feat: add volunteer booking endpoints

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
@@ -1,0 +1,163 @@
+import { Request, Response } from 'express';
+import pool from '../db';
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'light orange',
+  approved: 'green',
+};
+
+async function ensureVolunteerBookingsTable() {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS volunteer_bookings (
+      id SERIAL PRIMARY KEY,
+      slot_id INTEGER NOT NULL REFERENCES volunteer_slots(id) ON DELETE CASCADE,
+      volunteer_id INTEGER NOT NULL REFERENCES volunteers(id) ON DELETE CASCADE,
+      status VARCHAR(20) NOT NULL DEFAULT 'pending',
+      created_at TIMESTAMP DEFAULT NOW()
+    )
+  `);
+}
+
+function statusColor(status: string) {
+  return STATUS_COLORS[status] || null;
+}
+
+export async function createVolunteerBooking(req: Request, res: Response) {
+  const user = req.user;
+  const { slotId } = req.body as { slotId?: number };
+  if (!user) return res.status(401).json({ message: 'Unauthorized' });
+  if (!slotId) {
+    return res.status(400).json({ message: 'slotId is required' });
+  }
+
+  try {
+    await ensureVolunteerBookingsTable();
+
+    const slotRes = await pool.query(
+      'SELECT role_id, max_volunteers FROM volunteer_slots WHERE id = $1',
+      [slotId]
+    );
+    if (slotRes.rowCount === 0) {
+      return res.status(404).json({ message: 'Slot not found' });
+    }
+    const slot = slotRes.rows[0];
+
+    const volRes = await pool.query(
+      'SELECT trained_areas FROM volunteers WHERE id = $1',
+      [user.id]
+    );
+    if (volRes.rowCount === 0) {
+      return res.status(403).json({ message: 'Volunteer not found' });
+    }
+    const trained = volRes.rows[0].trained_areas || [];
+    if (!trained.includes(slot.role_id)) {
+      return res.status(400).json({ message: 'Not trained for this role' });
+    }
+
+    const countRes = await pool.query(
+      `SELECT COUNT(*) FROM volunteer_bookings
+       WHERE slot_id = $1 AND status IN ('pending','approved')`,
+      [slotId]
+    );
+    const currentCount = Number(countRes.rows[0].count);
+    if (currentCount >= slot.max_volunteers) {
+      return res.status(400).json({ message: 'Slot is full' });
+    }
+
+    const insertRes = await pool.query(
+      `INSERT INTO volunteer_bookings (slot_id, volunteer_id)
+       VALUES ($1, $2)
+       RETURNING id, slot_id, volunteer_id, status`,
+      [slotId, user.id]
+    );
+
+    const booking = insertRes.rows[0];
+    booking.status_color = statusColor(booking.status);
+    res.status(201).json(booking);
+  } catch (error) {
+    console.error('Error creating volunteer booking:', error);
+    res.status(500).json({
+      message: `Database error creating volunteer booking: ${(error as Error).message}`,
+    });
+  }
+}
+
+export async function listVolunteerBookingsByRole(req: Request, res: Response) {
+  const { role_id } = req.params;
+  try {
+    await ensureVolunteerBookingsTable();
+    const result = await pool.query(
+      `SELECT vb.id, vb.status, vb.slot_id, vb.volunteer_id,
+              vs.slot_date, vs.start_time, vs.end_time,
+              u.first_name || ' ' || u.last_name AS volunteer_name
+       FROM volunteer_bookings vb
+       JOIN volunteer_slots vs ON vb.slot_id = vs.id
+       JOIN users u ON vb.volunteer_id = u.id
+       WHERE vs.role_id = $1
+       ORDER BY vs.slot_date, vs.start_time`,
+      [role_id]
+    );
+    const bookings = result.rows.map((b: any) => ({
+      ...b,
+      status_color: statusColor(b.status),
+    }));
+    res.json(bookings);
+  } catch (error) {
+    console.error('Error listing volunteer bookings:', error);
+    res.status(500).json({
+      message: `Database error listing volunteer bookings: ${(error as Error).message}`,
+    });
+  }
+}
+
+export async function updateVolunteerBookingStatus(req: Request, res: Response) {
+  const { id } = req.params;
+  const { status } = req.body as { status?: string };
+  if (!status || !['approved', 'rejected'].includes(status)) {
+    return res.status(400).json({ message: 'Status must be approved or rejected' });
+  }
+
+  try {
+    await ensureVolunteerBookingsTable();
+    const bookingRes = await pool.query('SELECT * FROM volunteer_bookings WHERE id=$1', [
+      id,
+    ]);
+    if (bookingRes.rowCount === 0) {
+      return res.status(404).json({ message: 'Booking not found' });
+    }
+    const booking = bookingRes.rows[0];
+    if (booking.status !== 'pending') {
+      return res.status(400).json({ message: 'Booking already processed' });
+    }
+
+    if (status === 'approved') {
+      const slotRes = await pool.query(
+        'SELECT max_volunteers FROM volunteer_slots WHERE id=$1',
+        [booking.slot_id]
+      );
+      const countRes = await pool.query(
+        `SELECT COUNT(*) FROM volunteer_bookings
+         WHERE slot_id=$1 AND status='approved'`,
+        [booking.slot_id]
+      );
+      if (Number(countRes.rows[0].count) >= slotRes.rows[0].max_volunteers) {
+        return res.status(400).json({ message: 'Slot is full' });
+      }
+    }
+
+    const updateRes = await pool.query(
+      `UPDATE volunteer_bookings SET status=$1 WHERE id=$2
+       RETURNING id, slot_id, volunteer_id, status`,
+      [status, id]
+    );
+    const updated = updateRes.rows[0];
+    updated.status_color = statusColor(updated.status);
+    res.json(updated);
+  } catch (error) {
+    console.error('Error updating volunteer booking:', error);
+    res.status(500).json({
+      message: `Database error updating volunteer booking: ${(error as Error).message}`,
+    });
+  }
+}
+

--- a/MJ_FB_Backend/src/routes/volunteerBookings.ts
+++ b/MJ_FB_Backend/src/routes/volunteerBookings.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import {
+  createVolunteerBooking,
+  listVolunteerBookingsByRole,
+  updateVolunteerBookingStatus,
+} from '../controllers/volunteerBookingController';
+import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+
+const router = express.Router();
+
+router.post('/', authMiddleware, authorizeRoles('volunteer'), createVolunteerBooking);
+router.get('/:role_id', authMiddleware, authorizeRoles('volunteer_coordinator'), listVolunteerBookingsByRole);
+router.patch('/:id', authMiddleware, authorizeRoles('volunteer_coordinator'), updateVolunteerBookingStatus);
+
+export default router;

--- a/MJ_FB_Backend/src/routes/volunteerSlots.ts
+++ b/MJ_FB_Backend/src/routes/volunteerSlots.ts
@@ -4,16 +4,21 @@ import {
   listVolunteerSlots,
   updateVolunteerSlot,
   deleteVolunteerSlot,
+  listVolunteerSlotsForVolunteer,
 } from '../controllers/volunteerSlotController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
-router.use(authMiddleware, authorizeRoles('volunteer_coordinator'));
+router.get('/', authMiddleware, (req, res) => {
+  if (req.user && req.user.role === 'volunteer_coordinator') {
+    return listVolunteerSlots(req, res);
+  }
+  return listVolunteerSlotsForVolunteer(req, res);
+});
 
-router.post('/', addVolunteerSlot);
-router.get('/', listVolunteerSlots);
-router.put('/:id', updateVolunteerSlot);
-router.delete('/:id', deleteVolunteerSlot);
+router.post('/', authMiddleware, authorizeRoles('volunteer_coordinator'), addVolunteerSlot);
+router.put('/:id', authMiddleware, authorizeRoles('volunteer_coordinator'), updateVolunteerSlot);
+router.delete('/:id', authMiddleware, authorizeRoles('volunteer_coordinator'), deleteVolunteerSlot);
 
 export default router;

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -11,6 +11,7 @@ import staffRoutes from './routes/staff';
 import volunteerRolesRoutes from './routes/volunteerRoles';
 import volunteersRoutes from './routes/volunteers';
 import volunteerSlotsRoutes from './routes/volunteerSlots';
+import volunteerBookingsRoutes from './routes/volunteerBookings';
 import { initializeSlots } from './data';
 import pool from './db';
 
@@ -21,7 +22,7 @@ const app = express();
 // ⭐ Add CORS middleware before routes
 app.use(cors({
   origin: process.env.FRONTEND_ORIGIN || 'http://localhost:5173', // allow your frontend
-  credentials: true
+  credentials: true,
 }));
 
 app.use(express.json());
@@ -38,6 +39,7 @@ app.use('/staff', staffRoutes);
 app.use('/volunteer-roles', volunteerRolesRoutes);
 app.use('/volunteers', volunteersRoutes);
 app.use('/volunteer-slots', volunteerSlotsRoutes);
+app.use('/volunteer-bookings', volunteerBookingsRoutes);
 
 const PORT = 4000;
 

--- a/MJ_FB_Backend/src/types/express.d.ts
+++ b/MJ_FB_Backend/src/types/express.d.ts
@@ -2,7 +2,7 @@ declare namespace Express {
   export interface Request {
     user?: {
       id: string;
-      role: 'shopper' | 'delivery' | 'staff' | 'volunteer_coordinator';
+      role: 'shopper' | 'delivery' | 'staff' | 'volunteer_coordinator' | 'volunteer';
     };
   }
 }


### PR DESCRIPTION
## Summary
- allow volunteers to view bookable slots by their trained roles
- enable volunteers to request slots and coordinators to manage bookings
- expose volunteer booking routes and status color mapping

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689232a308f0832d98ab46de5b8779d7