### PR TITLE
feat: add volunteer authentication

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import pool from '../db';
+import bcrypt from 'bcrypt';
 
 export async function updateTrainedAreas(req: Request, res: Response) {
   const { id } = req.params;
@@ -20,6 +21,39 @@ export async function updateTrainedAreas(req: Request, res: Response) {
     console.error('Error updating trained areas:', error);
     res.status(500).json({
       message: `Database error updating trained areas: ${(error as Error).message}`,
+    });
+  }
+}
+
+export async function loginVolunteer(req: Request, res: Response) {
+  const { email, password } = req.body as { email?: string; password?: string };
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password required' });
+  }
+  try {
+    const result = await pool.query(
+      `SELECT id, first_name, last_name, email, password
+       FROM users
+       WHERE email = $1 AND role = 'volunteer'`,
+      [email]
+    );
+    if (result.rowCount === 0) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const volunteer = result.rows[0];
+    const match = await bcrypt.compare(password, volunteer.password);
+    if (!match) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    res.json({
+      token: `volunteer:${volunteer.id}`,
+      role: 'volunteer',
+      name: `${volunteer.first_name} ${volunteer.last_name}`,
+    });
+  } catch (error) {
+    console.error('Error logging in volunteer:', error);
+    res.status(500).json({
+      message: `Database error logging in volunteer: ${(error as Error).message}`,
     });
   }
 }

--- a/MJ_FB_Backend/src/middleware/verifyVolunteerToken.ts
+++ b/MJ_FB_Backend/src/middleware/verifyVolunteerToken.ts
@@ -1,0 +1,46 @@
+import { Request, Response, NextFunction } from 'express';
+import pool from '../db';
+
+export async function verifyVolunteerToken(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || typeof authHeader !== 'string') {
+    return res.status(401).json({ message: 'Missing token' });
+  }
+
+  const token = authHeader.startsWith('Bearer ')
+    ? authHeader.slice(7).trim()
+    : authHeader;
+
+  const match = token.match(/^volunteer[:\-](\d+)$/);
+  if (!match) {
+    return res.status(401).json({ message: 'Invalid token format' });
+  }
+  const [, id] = match;
+
+  try {
+    const result = await pool.query(
+      `SELECT id, first_name, last_name, email FROM users WHERE id = $1 AND role = 'volunteer'`,
+      [id]
+    );
+    if (result.rowCount === 0) {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+    const volunteer = result.rows[0];
+    req.user = {
+      id: volunteer.id.toString(),
+      role: 'volunteer',
+      name: `${volunteer.first_name} ${volunteer.last_name}`,
+      email: volunteer.email,
+    } as any;
+    next();
+  } catch (error) {
+    console.error('Volunteer auth error:', error);
+    res.status(500).json({
+      message: `Database error during volunteer authentication: ${(error as Error).message}`,
+    });
+  }
+}

--- a/MJ_FB_Backend/src/routes/volunteerBookings.ts
+++ b/MJ_FB_Backend/src/routes/volunteerBookings.ts
@@ -5,10 +5,11 @@ import {
   updateVolunteerBookingStatus,
 } from '../controllers/volunteerBookingController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { verifyVolunteerToken } from '../middleware/verifyVolunteerToken';
 
 const router = express.Router();
 
-router.post('/', authMiddleware, authorizeRoles('volunteer'), createVolunteerBooking);
+router.post('/', verifyVolunteerToken, createVolunteerBooking);
 router.get('/:role_id', authMiddleware, authorizeRoles('volunteer_coordinator'), listVolunteerBookingsByRole);
 router.patch('/:id', authMiddleware, authorizeRoles('volunteer_coordinator'), updateVolunteerBookingStatus);
 

--- a/MJ_FB_Backend/src/routes/volunteerSlots.ts
+++ b/MJ_FB_Backend/src/routes/volunteerSlots.ts
@@ -7,15 +7,13 @@ import {
   listVolunteerSlotsForVolunteer,
 } from '../controllers/volunteerSlotController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { verifyVolunteerToken } from '../middleware/verifyVolunteerToken';
 
 const router = express.Router();
 
-router.get('/', authMiddleware, (req, res) => {
-  if (req.user && req.user.role === 'volunteer_coordinator') {
-    return listVolunteerSlots(req, res);
-  }
-  return listVolunteerSlotsForVolunteer(req, res);
-});
+router.get('/', authMiddleware, authorizeRoles('volunteer_coordinator'), listVolunteerSlots);
+
+router.get('/mine', verifyVolunteerToken, listVolunteerSlotsForVolunteer);
 
 router.post('/', authMiddleware, authorizeRoles('volunteer_coordinator'), addVolunteerSlot);
 router.put('/:id', authMiddleware, authorizeRoles('volunteer_coordinator'), updateVolunteerSlot);

--- a/MJ_FB_Backend/src/routes/volunteers.ts
+++ b/MJ_FB_Backend/src/routes/volunteers.ts
@@ -1,8 +1,10 @@
 import express from 'express';
-import { updateTrainedAreas } from '../controllers/volunteerController';
+import { updateTrainedAreas, loginVolunteer } from '../controllers/volunteerController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 
 const router = express.Router();
+
+router.post('/login', loginVolunteer);
 
 router.put(
   '/:id/trained-areas',


### PR DESCRIPTION
## Summary
- add volunteer login endpoint and token verification middleware
- secure volunteer bookings and slot lookups with volunteer tokens

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689234909ce4832da149c334c6c4b753