### PR TITLE
Add volunteer login page

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -8,6 +8,7 @@ import AddUser from './components/StaffDashboard/AddUser';
 import ViewSchedule from './components/StaffDashboard/ViewSchedule';
 import Login from './components/Login';
 import StaffLogin from './components/StaffLogin';
+import VolunteerLogin from './components/VolunteerLogin';
 import type { Role } from './types';
 
 export default function App() {
@@ -16,7 +17,7 @@ export default function App() {
   const [activePage, setActivePage] = useState('profile');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [loginMode, setLoginMode] = useState<'user' | 'staff'>('user');
+  const [loginMode, setLoginMode] = useState<'user' | 'staff' | 'volunteer'>('user');
   const isStaff = role === 'staff' || role === 'volunteer_coordinator';
 
   useEffect(() => {
@@ -59,7 +60,7 @@ export default function App() {
     <div className="app-container">
       {!token ? (
         loginMode === 'user' ? (
-              <Login
+          <Login
             onLogin={(u) => {
               setToken(u.token);
               setRole(u.role);
@@ -71,8 +72,9 @@ export default function App() {
               }
             }}
             onStaff={() => setLoginMode('staff')}
+            onVolunteer={() => setLoginMode('volunteer')}
           />
-        ) : (
+        ) : loginMode === 'staff' ? (
           <StaffLogin
             onLogin={(u) => {
               setToken(u.token);
@@ -81,6 +83,17 @@ export default function App() {
               localStorage.setItem('role', u.role);
               localStorage.setItem('name', u.name);
               localStorage.removeItem('bookingsThisMonth');
+            }}
+            onBack={() => setLoginMode('user')}
+          />
+        ) : (
+          <VolunteerLogin
+            onLogin={(u) => {
+              setToken(u.token);
+              setRole(u.role);
+              localStorage.setItem('token', u.token);
+              localStorage.setItem('role', u.role);
+              localStorage.setItem('name', u.name);
             }}
             onBack={() => setLoginMode('user')}
           />

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -49,6 +49,18 @@ export async function loginStaff(
   return handleResponse(res);
 }
 
+export async function loginVolunteer(
+  email: string,
+  password: string
+): Promise<LoginResponse> {
+  const res = await fetch(`${API_BASE}/volunteers/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  return handleResponse(res);
+}
+
 export async function staffExists(): Promise<boolean> {
   const res = await fetch(`${API_BASE}/staff/exists`);
   const data = await handleResponse(res);

--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -3,7 +3,7 @@ import { loginUser } from '../api/api';
 import type { LoginResponse } from '../api/api';
 import { formatInTimeZone } from 'date-fns-tz';
 
-export default function Login({ onLogin, onStaff }: { onLogin: (user: LoginResponse) => void; onStaff: () => void }) {
+export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (user: LoginResponse) => void; onStaff: () => void; onVolunteer: () => void }) {
   const [clientId, setClientId] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -28,7 +28,10 @@ export default function Login({ onLogin, onStaff }: { onLogin: (user: LoginRespo
 
   return (
     <div>
-      <a onClick={onStaff} style={{ cursor: 'pointer' }}>Staff Login</a>
+      <div>
+        <a onClick={onStaff} style={{ cursor: 'pointer', marginRight: '10px' }}>Staff Login</a>
+        <a onClick={onVolunteer} style={{ cursor: 'pointer' }}>Volunteer Login</a>
+      </div>
       <h2>User Login</h2>
       {error && <p style={{color:'red'}}>{error}</p>}
       <form onSubmit={handleSubmit}>

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { loginVolunteer } from '../api/api';
+import type { LoginResponse } from '../api/api';
+
+export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const user = await loginVolunteer(email, password);
+      localStorage.setItem('token', user.token);
+      localStorage.setItem('role', user.role);
+      localStorage.setItem('name', user.name);
+      onLogin(user);
+      window.location.href = '/volunteer-dashboard';
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <div>
+      <a onClick={onBack} style={{ cursor: 'pointer' }}>User Login</a>
+      <h2>Volunteer Login</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <form onSubmit={submit}>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Username" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -2,7 +2,8 @@ export type Role =
   | 'staff'
   | 'shopper'
   | 'delivery'
-  | 'volunteer_coordinator';
+  | 'volunteer_coordinator'
+  | 'volunteer';
 export type UserRole = 'shopper' | 'delivery';
 export type StaffRole = 'staff' | 'volunteer_coordinator';
 


### PR DESCRIPTION
## Summary
- add API client and role type for volunteers
- create volunteer login component that redirects to dashboard
- wire volunteer login into app flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689236138c04832d97c94b0389924b1c