### PR TITLE
feat: add volunteer dashboard booking features

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerSlotController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerSlotController.ts
@@ -163,9 +163,10 @@ export async function listVolunteerSlotsForVolunteer(req: Request, res: Response
       return res.json([]);
     }
     const result = await pool.query(
-      `SELECT vs.id, vs.role_id, vs.slot_date, vs.start_time, vs.end_time, vs.max_volunteers,
+      `SELECT vs.id, vs.role_id, vr.name AS role_name, vs.slot_date, vs.start_time, vs.end_time, vs.max_volunteers,
               COALESCE(b.count,0) AS booked
        FROM volunteer_slots vs
+       JOIN volunteer_roles_master vr ON vs.role_id = vr.id
        LEFT JOIN (
          SELECT slot_id, COUNT(*) AS count
          FROM volunteer_bookings

--- a/MJ_FB_Backend/src/routes/volunteerBookings.ts
+++ b/MJ_FB_Backend/src/routes/volunteerBookings.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import {
   createVolunteerBooking,
   listVolunteerBookingsByRole,
+  listMyVolunteerBookings,
   updateVolunteerBookingStatus,
 } from '../controllers/volunteerBookingController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
@@ -10,6 +11,7 @@ import { verifyVolunteerToken } from '../middleware/verifyVolunteerToken';
 const router = express.Router();
 
 router.post('/', verifyVolunteerToken, createVolunteerBooking);
+router.get('/mine', verifyVolunteerToken, listMyVolunteerBookings);
 router.get('/:role_id', authMiddleware, authorizeRoles('volunteer_coordinator'), listVolunteerBookingsByRole);
 router.patch('/:id', authMiddleware, authorizeRoles('volunteer_coordinator'), updateVolunteerBookingStatus);
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -9,12 +9,15 @@ import ViewSchedule from './components/StaffDashboard/ViewSchedule';
 import Login from './components/Login';
 import StaffLogin from './components/StaffLogin';
 import VolunteerLogin from './components/VolunteerLogin';
+import VolunteerDashboard from './components/VolunteerDashboard';
 import type { Role } from './types';
 
 export default function App() {
   const [token, setToken] = useState(localStorage.getItem('token') || '');
   const [role, setRole] = useState<Role>((localStorage.getItem('role') || '') as Role);
-  const [activePage, setActivePage] = useState('profile');
+  const [activePage, setActivePage] = useState(() => {
+    return window.location.pathname === '/volunteer-dashboard' ? 'volunteerDashboard' : 'profile';
+  });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [loginMode, setLoginMode] = useState<'user' | 'staff' | 'volunteer'>('user');
@@ -54,6 +57,8 @@ export default function App() {
       { label: 'Booking Slots', id: 'slots' },
       { label: 'Booking History', id: 'bookingHistory' },
     ]);
+  } else if (role === 'volunteer') {
+    navLinks = navLinks.concat([{ label: 'Volunteer Dashboard', id: 'volunteerDashboard' }]);
   }
 
   return (
@@ -149,6 +154,9 @@ export default function App() {
             )}
             {activePage === 'userHistory' && isStaff && (
               <UserHistory token={token} />
+            )}
+            {activePage === 'volunteerDashboard' && role === 'volunteer' && (
+              <VolunteerDashboard token={token} />
             )}
           </main>
         </>

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -298,4 +298,30 @@ export async function searchUsers(token: string, search: string) {
     });
     return handleResponse(res);
   }
+
+export async function getVolunteerSlots(token: string) {
+  const res = await fetch(`${API_BASE}/volunteer-slots/mine`, {
+    headers: { Authorization: token },
+  });
+  return handleResponse(res);
+}
+
+export async function requestVolunteerBooking(token: string, slotId: number) {
+  const res = await fetch(`${API_BASE}/volunteer-bookings`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: token,
+    },
+    body: JSON.stringify({ slotId }),
+  });
+  return handleResponse(res);
+}
+
+export async function getMyVolunteerBookings(token: string) {
+  const res = await fetch(`${API_BASE}/volunteer-bookings/mine`, {
+    headers: { Authorization: token },
+  });
+  return handleResponse(res);
+}
   

--- a/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect } from 'react';
+import {
+  getVolunteerSlots,
+  requestVolunteerBooking,
+  getMyVolunteerBookings,
+} from '../api/api';
+import type { VolunteerSlot, VolunteerBooking } from '../types';
+import { formatTime } from '../utils/time';
+
+export default function VolunteerDashboard({ token }: { token: string }) {
+  const [slots, setSlots] = useState<VolunteerSlot[]>([]);
+  const [roles, setRoles] = useState<{ id: number; name: string }[]>([]);
+  const [selectedRole, setSelectedRole] = useState<number | ''>('');
+  const [modalSlot, setModalSlot] = useState<VolunteerSlot | null>(null);
+  const [message, setMessage] = useState('');
+  const [tab, setTab] = useState<'slots' | 'history'>('slots');
+  const [history, setHistory] = useState<VolunteerBooking[]>([]);
+
+  useEffect(() => {
+    getVolunteerSlots(token)
+      .then(data => {
+        setSlots(data);
+        const map = new Map<number, string>();
+        data.forEach((s: VolunteerSlot) => map.set(s.role_id, s.role_name));
+        const arr = Array.from(map, ([id, name]) => ({ id, name }));
+        setRoles(arr);
+        if (arr.length > 0) setSelectedRole(arr[0].id);
+      })
+      .catch(() => {});
+  }, [token]);
+
+  useEffect(() => {
+    if (tab === 'history') {
+      getMyVolunteerBookings(token)
+        .then(setHistory)
+        .catch(() => {});
+    }
+  }, [tab, token]);
+
+  const filteredSlots = slots.filter(s => selectedRole === '' || s.role_id === selectedRole);
+
+  async function submitBooking() {
+    if (!modalSlot) return;
+    try {
+      await requestVolunteerBooking(token, modalSlot.id);
+      setMessage('Request submitted!');
+      setModalSlot(null);
+      const updated = await getVolunteerSlots(token);
+      setSlots(updated);
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  return (
+    <div>
+      <h2>Volunteer Dashboard</h2>
+      <div style={{ marginBottom: 16 }}>
+        <button onClick={() => setTab('slots')} disabled={tab === 'slots'}>
+          Available Slots
+        </button>
+        <button onClick={() => setTab('history')} disabled={tab === 'history'} style={{ marginLeft: 8 }}>
+          Booking History
+        </button>
+      </div>
+
+      {tab === 'slots' && (
+        <div>
+          {roles.length > 0 ? (
+            <>
+              <label htmlFor="roleSelect">Role: </label>
+              <select
+                id="roleSelect"
+                value={selectedRole}
+                onChange={e => setSelectedRole(Number(e.target.value))}
+              >
+                {roles.map(r => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+              </select>
+              <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: 16 }}>
+                <thead>
+                  <tr>
+                    <th style={{ border: '1px solid #ccc', padding: 8 }}>Date</th>
+                    <th style={{ border: '1px solid #ccc', padding: 8 }}>Time</th>
+                    <th style={{ border: '1px solid #ccc', padding: 8 }}>Available</th>
+                    <th style={{ border: '1px solid #ccc', padding: 8 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredSlots.map(s => (
+                    <tr key={s.id}>
+                      <td style={{ border: '1px solid #ccc', padding: 8 }}>{s.slot_date}</td>
+                      <td style={{ border: '1px solid #ccc', padding: 8 }}>
+                        {formatTime(s.start_time)} - {formatTime(s.end_time)}
+                      </td>
+                      <td style={{ border: '1px solid #ccc', padding: 8 }}>
+                        {s.available}/{s.max_volunteers}
+                      </td>
+                      <td style={{ border: '1px solid #ccc', padding: 8, textAlign: 'center' }}>
+                        {s.available > 0 ? (
+                          <button onClick={() => setModalSlot(s)}>Request</button>
+                        ) : (
+                          'Full'
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                  {filteredSlots.length === 0 && (
+                    <tr>
+                      <td colSpan={4} style={{ textAlign: 'center', padding: 8 }}>
+                        No slots.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </>
+          ) : (
+            <p>No trained roles assigned.</p>
+          )}
+          {message && <p style={{ color: 'green' }}>{message}</p>}
+        </div>
+      )}
+
+      {tab === 'history' && (
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th style={{ border: '1px solid #ccc', padding: 8 }}>Role</th>
+              <th style={{ border: '1px solid #ccc', padding: 8 }}>Date</th>
+              <th style={{ border: '1px solid #ccc', padding: 8 }}>Time</th>
+              <th style={{ border: '1px solid #ccc', padding: 8 }}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {history.map(h => (
+              <tr key={h.id}>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{h.role_name}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{h.slot_date}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>
+                  {formatTime(h.start_time)} - {formatTime(h.end_time)}
+                </td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{h.status}</td>
+              </tr>
+            ))}
+            {history.length === 0 && (
+              <tr>
+                <td colSpan={4} style={{ textAlign: 'center', padding: 8 }}>
+                  No bookings.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      )}
+
+      {modalSlot && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0,0,0,0.3)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div style={{ background: 'white', padding: 16, borderRadius: 4, width: 300 }}>
+            <p>
+              Request booking for {modalSlot.slot_date} {formatTime(modalSlot.start_time)} -{' '}
+              {formatTime(modalSlot.end_time)}?
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 12 }}>
+              <button onClick={submitBooking}>Submit</button>
+              <button onClick={() => setModalSlot(null)}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -29,3 +29,27 @@ export interface BlockedSlot {
   slotId: number;
   reason: string;
 }
+
+export interface VolunteerSlot {
+  id: number;
+  role_id: number;
+  role_name: string;
+  slot_date: string;
+  start_time: string;
+  end_time: string;
+  max_volunteers: number;
+  booked: number;
+  available: number;
+  status: string;
+}
+
+export interface VolunteerBooking {
+  id: number;
+  status: string;
+  slot_id: number;
+  slot_date: string;
+  start_time: string;
+  end_time: string;
+  role_name: string;
+  status_color?: string;
+}


### PR DESCRIPTION
## Summary
- expose volunteer slots with role names and volunteer booking history
- add API helpers and React VolunteerDashboard with role filter, slot booking modal, and booking history tab
- show Volunteer Dashboard in app navigation for volunteer users

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892389077dc832daf99e3c24441c71a