### PR TITLE
Decouple volunteers from users table

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
@@ -89,10 +89,10 @@ export async function listVolunteerBookingsByRole(req: Request, res: Response) {
     const result = await pool.query(
       `SELECT vb.id, vb.status, vb.slot_id, vb.volunteer_id,
               vs.slot_date, vs.start_time, vs.end_time,
-              u.first_name || ' ' || u.last_name AS volunteer_name
+              v.first_name || ' ' || v.last_name AS volunteer_name
        FROM volunteer_bookings vb
        JOIN volunteer_slots vs ON vb.slot_id = vs.id
-       JOIN users u ON vb.volunteer_id = u.id
+       JOIN volunteers v ON vb.volunteer_id = v.id
        WHERE vs.role_id = $1
        ORDER BY vs.slot_date, vs.start_time`,
       [role_id]

--- a/MJ_FB_Backend/src/middleware/verifyVolunteerToken.ts
+++ b/MJ_FB_Backend/src/middleware/verifyVolunteerToken.ts
@@ -23,7 +23,7 @@ export async function verifyVolunteerToken(
 
   try {
     const result = await pool.query(
-      `SELECT id, first_name, last_name, email FROM users WHERE id = $1 AND role = 'volunteer'`,
+      `SELECT id, first_name, last_name, email FROM volunteers WHERE id = $1`,
       [id]
     );
     if (result.rowCount === 0) {


### PR DESCRIPTION
## Summary
- Create a standalone `volunteers` table with name, email, password, and training fields
- Handle volunteer creation and login directly against the `volunteers` table
- Update volunteer auth middleware and booking queries to use `volunteers`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68923daa570c832d8970428e27532bb0