### PR TITLE
Revamp volunteer booking schema for date-based scheduling

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerSlotController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerSlotController.ts
@@ -6,7 +6,6 @@ async function ensureVolunteerSlotsTable() {
     CREATE TABLE IF NOT EXISTS volunteer_slots (
       id SERIAL PRIMARY KEY,
       role_id INTEGER NOT NULL REFERENCES volunteer_roles_master(id) ON DELETE CASCADE,
-      slot_date DATE NOT NULL,
       start_time TIME NOT NULL,
       end_time TIME NOT NULL,
       max_volunteers INTEGER NOT NULL
@@ -15,27 +14,26 @@ async function ensureVolunteerSlotsTable() {
 }
 
 export async function addVolunteerSlot(req: Request, res: Response) {
-  const { roleId, date, startTime, endTime, maxVolunteers } = req.body as {
+  const { roleId, startTime, endTime, maxVolunteers } = req.body as {
     roleId?: number;
-    date?: string;
     startTime?: string;
     endTime?: string;
     maxVolunteers?: number;
   };
 
-  if (!roleId || !date || !startTime || !endTime || !maxVolunteers) {
+  if (!roleId || !startTime || !endTime || !maxVolunteers) {
     return res
       .status(400)
-      .json({ message: 'roleId, date, startTime, endTime and maxVolunteers are required' });
+      .json({ message: 'roleId, startTime, endTime and maxVolunteers are required' });
   }
 
   try {
     await ensureVolunteerSlotsTable();
     const result = await pool.query(
-      `INSERT INTO volunteer_slots (role_id, slot_date, start_time, end_time, max_volunteers)
-       VALUES ($1, $2, $3, $4, $5)
-       RETURNING id, role_id, slot_date, start_time, end_time, max_volunteers`,
-      [roleId, date, startTime, endTime, maxVolunteers]
+      `INSERT INTO volunteer_slots (role_id, start_time, end_time, max_volunteers)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, role_id, start_time, end_time, max_volunteers`,
+      [roleId, startTime, endTime, maxVolunteers]
     );
     res.status(201).json(result.rows[0]);
   } catch (error) {
@@ -47,36 +45,20 @@ export async function addVolunteerSlot(req: Request, res: Response) {
 }
 
 export async function listVolunteerSlots(req: Request, res: Response) {
-  const { role_id, date_from, date_to } = req.query as {
+  const { role_id } = req.query as {
     role_id?: string;
-    date_from?: string;
-    date_to?: string;
   };
 
   try {
     await ensureVolunteerSlotsTable();
     const params: any[] = [];
-    const conditions: string[] = [];
-
+    let query =
+      'SELECT id, role_id, start_time, end_time, max_volunteers FROM volunteer_slots';
     if (role_id) {
       params.push(role_id);
-      conditions.push(`role_id = $${params.length}`);
+      query += ' WHERE role_id = $1';
     }
-    if (date_from) {
-      params.push(date_from);
-      conditions.push(`slot_date >= $${params.length}`);
-    }
-    if (date_to) {
-      params.push(date_to);
-      conditions.push(`slot_date <= $${params.length}`);
-    }
-
-    let query =
-      'SELECT id, role_id, slot_date, start_time, end_time, max_volunteers FROM volunteer_slots';
-    if (conditions.length > 0) {
-      query += ' WHERE ' + conditions.join(' AND ');
-    }
-    query += ' ORDER BY slot_date, start_time';
+    query += ' ORDER BY start_time';
 
     const result = await pool.query(query, params);
     res.json(result.rows);
@@ -90,28 +72,27 @@ export async function listVolunteerSlots(req: Request, res: Response) {
 
 export async function updateVolunteerSlot(req: Request, res: Response) {
   const { id } = req.params;
-  const { roleId, date, startTime, endTime, maxVolunteers } = req.body as {
+  const { roleId, startTime, endTime, maxVolunteers } = req.body as {
     roleId?: number;
-    date?: string;
     startTime?: string;
     endTime?: string;
     maxVolunteers?: number;
   };
 
-  if (!roleId || !date || !startTime || !endTime || !maxVolunteers) {
+  if (!roleId || !startTime || !endTime || !maxVolunteers) {
     return res
       .status(400)
-      .json({ message: 'roleId, date, startTime, endTime and maxVolunteers are required' });
+      .json({ message: 'roleId, startTime, endTime and maxVolunteers are required' });
   }
 
   try {
     await ensureVolunteerSlotsTable();
     const result = await pool.query(
       `UPDATE volunteer_slots
-       SET role_id = $1, slot_date = $2, start_time = $3, end_time = $4, max_volunteers = $5
-       WHERE id = $6
-       RETURNING id, role_id, slot_date, start_time, end_time, max_volunteers`,
-      [roleId, date, startTime, endTime, maxVolunteers, id]
+       SET role_id = $1, start_time = $2, end_time = $3, max_volunteers = $4
+       WHERE id = $5
+       RETURNING id, role_id, start_time, end_time, max_volunteers`,
+      [roleId, startTime, endTime, maxVolunteers, id]
     );
     if (result.rowCount === 0) {
       return res.status(404).json({ message: 'Slot not found' });
@@ -149,6 +130,10 @@ export async function deleteVolunteerSlot(req: Request, res: Response) {
 export async function listVolunteerSlotsForVolunteer(req: Request, res: Response) {
   const user = req.user;
   if (!user) return res.status(401).json({ message: 'Unauthorized' });
+  const { date } = req.query as { date?: string };
+  if (!date) {
+    return res.status(400).json({ message: 'date query parameter is required' });
+  }
   try {
     await ensureVolunteerSlotsTable();
     const volunteerRes = await pool.query(
@@ -163,19 +148,19 @@ export async function listVolunteerSlotsForVolunteer(req: Request, res: Response
       return res.json([]);
     }
     const result = await pool.query(
-      `SELECT vs.id, vs.role_id, vr.name AS role_name, vs.slot_date, vs.start_time, vs.end_time, vs.max_volunteers,
-              COALESCE(b.count,0) AS booked
+      `SELECT vs.id, vs.role_id, vr.name AS role_name, vs.start_time, vs.end_time, vs.max_volunteers,
+              COALESCE(b.count,0) AS booked, $1::date AS date
        FROM volunteer_slots vs
        JOIN volunteer_roles_master vr ON vs.role_id = vr.id
        LEFT JOIN (
          SELECT slot_id, COUNT(*) AS count
          FROM volunteer_bookings
-         WHERE status IN ('pending','approved')
+         WHERE status IN ('pending','approved') AND date = $1
          GROUP BY slot_id
        ) b ON vs.id = b.slot_id
-       WHERE vs.role_id = ANY($1)
-       ORDER BY vs.slot_date, vs.start_time`,
-      [trained]
+       WHERE vs.role_id = ANY($2)
+       ORDER BY vs.start_time`,
+      [date, trained]
     );
     const slots = result.rows.map((row: any) => ({
       ...row,

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -299,21 +299,25 @@ export async function searchUsers(token: string, search: string) {
     return handleResponse(res);
   }
 
-export async function getVolunteerSlots(token: string) {
-  const res = await fetch(`${API_BASE}/volunteer-slots/mine`, {
+export async function getVolunteerSlots(token: string, date: string) {
+  const res = await fetch(`${API_BASE}/volunteer-slots/mine?date=${date}`, {
     headers: { Authorization: token },
   });
   return handleResponse(res);
 }
 
-export async function requestVolunteerBooking(token: string, slotId: number) {
+export async function requestVolunteerBooking(
+  token: string,
+  slotId: number,
+  date: string
+) {
   const res = await fetch(`${API_BASE}/volunteer-bookings`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: token,
     },
-    body: JSON.stringify({ slotId }),
+    body: JSON.stringify({ slotId, date }),
   });
   return handleResponse(res);
 }
@@ -342,7 +346,7 @@ export async function getVolunteerBookingsByRole(token: string, roleId: number) 
 export async function updateVolunteerBookingStatus(
   token: string,
   bookingId: number,
-  status: 'approved' | 'rejected'
+  status: 'approved' | 'rejected' | 'cancelled'
 ) {
   const res = await fetch(`${API_BASE}/volunteer-bookings/${bookingId}`, {
     method: 'PATCH',

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -34,20 +34,20 @@ export interface VolunteerSlot {
   id: number;
   role_id: number;
   role_name: string;
-  slot_date: string;
   start_time: string;
   end_time: string;
   max_volunteers: number;
   booked: number;
   available: number;
   status: string;
+  date: string;
 }
 
 export interface VolunteerBooking {
   id: number;
   status: string;
   slot_id: number;
-  slot_date: string;
+  date: string;
   start_time: string;
   end_time: string;
   role_name: string;
@@ -60,7 +60,7 @@ export interface VolunteerBookingDetail {
   slot_id: number;
   volunteer_id: number;
   volunteer_name: string;
-  slot_date: string;
+  date: string;
   start_time: string;
   end_time: string;
   status_color?: string;


### PR DESCRIPTION
## Summary
- remove slot_date from volunteer_slots and require date when listing slots for volunteers
- store volunteer bookings with a date and extended statuses (pending/approved/rejected/cancelled)
- update dashboards and API calls to send a date, show per-day availability and allow cancellations

## Testing
- `npm test` (backend)
- `npm run build` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6892461f18e8832d95f2bb895946d5eb