### PR TITLE
feat: add volunteer roles selection and search

### DIFF
--- a/MJ_FB_Backend/src/routes/volunteers.ts
+++ b/MJ_FB_Backend/src/routes/volunteers.ts
@@ -1,5 +1,10 @@
 import express from 'express';
-import { updateTrainedAreas, loginVolunteer, createVolunteer } from '../controllers/volunteerController';
+import {
+  updateTrainedAreas,
+  loginVolunteer,
+  createVolunteer,
+  searchVolunteers,
+} from '../controllers/volunteerController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 
 const router = express.Router();
@@ -11,6 +16,13 @@ router.post(
   authMiddleware,
   authorizeRoles('volunteer_coordinator'),
   createVolunteer
+);
+
+router.get(
+  '/search',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  searchVolunteers
 );
 
 router.put(

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -280,6 +280,16 @@ export async function searchUsers(token: string, search: string) {
     });
     return handleResponse(res); // returns array of users
   }
+
+export async function searchVolunteers(token: string, search: string) {
+  const res = await fetch(
+    `${API_BASE}/volunteers/search?search=${encodeURIComponent(search)}`,
+    {
+      headers: { Authorization: token },
+    }
+  );
+  return handleResponse(res);
+}
   
   export async function createBookingForUser(
     token: string,
@@ -372,6 +382,7 @@ export async function createVolunteer(
   lastName: string,
   username: string,
   password: string,
+  trainedArea: string,
   email?: string,
   phone?: string
 ) {
@@ -386,10 +397,26 @@ export async function createVolunteer(
       lastName,
       username,
       password,
+      trainedArea,
       email,
       phone,
-      trainedAreas: [],
     }),
+  });
+  return handleResponse(res);
+}
+
+export async function updateVolunteerTrainedAreas(
+  token: string,
+  id: number,
+  trainedAreas: string[]
+) {
+  const res = await fetch(`${API_BASE}/volunteers/${id}/trained-areas`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: token,
+    },
+    body: JSON.stringify({ trainedAreas }),
   });
   return handleResponse(res);
 }


### PR DESCRIPTION
## Summary
- allow assigning an initial trained area when creating a volunteer and enable searching for volunteers on the backend
- expose volunteer search endpoint and role management utilities in the frontend API
- enhance coordinator dashboard with role dropdown, volunteer search, and role editing capabilities

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test"?)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68926039d290832d872f4735129b6f3c