### PR TITLE
Use role IDs for volunteer assignments

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerController.ts
@@ -8,7 +8,7 @@ async function ensureVolunteersTable() {
       id SERIAL PRIMARY KEY,
       first_name TEXT NOT NULL,
       last_name TEXT NOT NULL,
-      trained_areas TEXT[] DEFAULT '{}',
+      trained_areas INTEGER[] DEFAULT '{}',
       email TEXT,
       phone TEXT,
       username TEXT UNIQUE NOT NULL,
@@ -19,14 +19,23 @@ async function ensureVolunteersTable() {
 
 export async function updateTrainedAreas(req: Request, res: Response) {
   const { id } = req.params;
-  const { trainedAreas } = req.body as { trainedAreas?: string[] };
-  if (!Array.isArray(trainedAreas)) {
-    return res.status(400).json({ message: 'trainedAreas must be an array' });
+  const { roleIds } = req.body as { roleIds?: number[] };
+  if (!Array.isArray(roleIds) || roleIds.some(r => typeof r !== 'number')) {
+    return res
+      .status(400)
+      .json({ message: 'roleIds must be an array of numbers' });
   }
   try {
+    const validRoles = await pool.query(
+      `SELECT id FROM volunteer_roles_master WHERE id = ANY($1)`,
+      [roleIds]
+    );
+    if (validRoles.rowCount !== roleIds.length) {
+      return res.status(400).json({ message: 'Invalid roleIds' });
+    }
     const result = await pool.query(
       `UPDATE volunteers SET trained_areas = $1 WHERE id = $2 RETURNING id, trained_areas`,
-      [trainedAreas, id]
+      [roleIds, id]
     );
     if (result.rowCount === 0) {
       return res.status(404).json({ message: 'Volunteer not found' });
@@ -84,7 +93,7 @@ export async function createVolunteer(req: Request, res: Response) {
     password,
     email,
     phone,
-    trainedArea,
+    roleIds,
   } = req.body as {
     firstName?: string;
     lastName?: string;
@@ -92,19 +101,22 @@ export async function createVolunteer(req: Request, res: Response) {
     password?: string;
     email?: string;
     phone?: string;
-    trainedArea?: string;
+    roleIds?: number[];
   };
 
-  if (!firstName || !lastName || !username || !password || !trainedArea) {
+  if (
+    !firstName ||
+    !lastName ||
+    !username ||
+    !password ||
+    !Array.isArray(roleIds) ||
+    roleIds.length === 0 ||
+    roleIds.some(r => typeof r !== 'number')
+  ) {
     return res.status(400).json({
       message:
-        'First name, last name, username, password and trained area required',
+        'First name, last name, username, password and at least one role required',
     });
-  }
-
-  const validAreas = ['Warehouse Food Sorter', 'Pantry Greeter'];
-  if (!validAreas.includes(trainedArea)) {
-    return res.status(400).json({ message: 'Invalid trained area' });
   }
 
   try {
@@ -125,12 +137,20 @@ export async function createVolunteer(req: Request, res: Response) {
       }
     }
 
+    const validRoles = await pool.query(
+      `SELECT id FROM volunteer_roles_master WHERE id = ANY($1)`,
+      [roleIds]
+    );
+    if (validRoles.rowCount !== roleIds.length) {
+      return res.status(400).json({ message: 'Invalid roleIds' });
+    }
+
     const hashed = await bcrypt.hash(password, 10);
     const result = await pool.query(
       `INSERT INTO volunteers (first_name, last_name, trained_areas, email, phone, username, password)
        VALUES ($1,$2,$3,$4,$5,$6,$7)
        RETURNING id`,
-      [firstName, lastName, [trainedArea], email, phone, username, hashed]
+      [firstName, lastName, roleIds, email, phone, username, hashed]
     );
     res.status(201).json({ id: result.rows[0].id });
   } catch (error) {
@@ -165,7 +185,7 @@ export async function searchVolunteers(req: Request, res: Response) {
     const formatted = result.rows.map(v => ({
       id: v.id,
       name: `${v.first_name} ${v.last_name}`.trim(),
-      trainedAreas: v.trained_areas || [],
+      trainedAreas: (v.trained_areas || []).map((n: any) => Number(n)),
     }));
 
     res.json(formatted);

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -382,7 +382,7 @@ export async function createVolunteer(
   lastName: string,
   username: string,
   password: string,
-  trainedArea: string,
+  roleIds: number[],
   email?: string,
   phone?: string
 ) {
@@ -397,7 +397,7 @@ export async function createVolunteer(
       lastName,
       username,
       password,
-      trainedArea,
+      roleIds,
       email,
       phone,
     }),
@@ -408,7 +408,7 @@ export async function createVolunteer(
 export async function updateVolunteerTrainedAreas(
   token: string,
   id: number,
-  trainedAreas: string[]
+  roleIds: number[]
 ) {
   const res = await fetch(`${API_BASE}/volunteers/${id}/trained-areas`, {
     method: 'PUT',
@@ -416,7 +416,7 @@ export async function updateVolunteerTrainedAreas(
       'Content-Type': 'application/json',
       Authorization: token,
     },
-    body: JSON.stringify({ trainedAreas }),
+    body: JSON.stringify({ roleIds }),
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -19,7 +19,7 @@ interface RoleOption {
 interface VolunteerResult {
   id: number;
   name: string;
-  trainedAreas: string[];
+  trainedAreas: number[];
 }
 
 interface SlotGroup {
@@ -48,7 +48,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
   const [search, setSearch] = useState('');
   const [results, setResults] = useState<VolunteerResult[]>([]);
   const [selectedVolunteer, setSelectedVolunteer] = useState<VolunteerResult | null>(null);
-  const [trainedEdit, setTrainedEdit] = useState<string[]>([]);
+  const [trainedEdit, setTrainedEdit] = useState<number[]>([]);
   const [editMsg, setEditMsg] = useState('');
   const [history, setHistory] = useState<VolunteerBookingDetail[]>([]);
 
@@ -58,7 +58,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
   const [password, setPassword] = useState('');
-  const [trainedArea, setTrainedArea] = useState('');
+  const [selectedCreateRoles, setSelectedCreateRoles] = useState<number[]>([]);
   const [createMsg, setCreateMsg] = useState('');
 
   useEffect(() => {
@@ -162,9 +162,15 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
     }
   }
 
-  function toggleTrained(name: string, checked: boolean) {
+  function toggleTrained(id: number, checked: boolean) {
     setTrainedEdit(prev =>
-      checked ? [...prev, name] : prev.filter(t => t !== name)
+      checked ? [...prev, id] : prev.filter(t => t !== id)
+    );
+  }
+
+  function toggleCreateRole(id: number, checked: boolean) {
+    setSelectedCreateRoles(prev =>
+      checked ? [...prev, id] : prev.filter(r => r !== id)
     );
   }
 
@@ -179,9 +185,15 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
   }
 
   async function submitVolunteer() {
-    if (!firstName || !lastName || !username || !password || !trainedArea) {
+    if (
+      !firstName ||
+      !lastName ||
+      !username ||
+      !password ||
+      selectedCreateRoles.length === 0
+    ) {
       setCreateMsg(
-        'First name, last name, username, password and trained area required'
+        'First name, last name, username, password and at least one role required'
       );
       return;
     }
@@ -192,7 +204,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
         lastName,
         username,
         password,
-        trainedArea,
+        selectedCreateRoles,
         email || undefined,
         phone || undefined
       );
@@ -203,7 +215,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
       setEmail('');
       setPhone('');
       setPassword('');
-      setTrainedArea('');
+      setSelectedCreateRoles([]);
     } catch (e) {
       setCreateMsg(e instanceof Error ? e.message : String(e));
     }
@@ -291,9 +303,9 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
                   <label key={r.id} style={{ display: 'block' }}>
                     <input
                       type="checkbox"
-                      value={r.name}
-                      checked={trainedEdit.includes(r.name)}
-                      onChange={e => toggleTrained(r.name, e.target.checked)}
+                      value={r.id}
+                      checked={trainedEdit.includes(r.id)}
+                      onChange={e => toggleTrained(r.id, e.target.checked)}
                     />{' '}
                     {r.name}
                   </label>
@@ -365,21 +377,18 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
             <label>Password: <input type="password" value={password} onChange={e => setPassword(e.target.value)} /></label>
           </div>
           <div style={{ marginBottom: 8 }}>
-            <label>
-              Trained Area:{' '}
-              <select value={trainedArea} onChange={e => setTrainedArea(e.target.value)}>
-                <option value="">Select role</option>
-                {roles
-                  .filter(r =>
-                    ['Warehouse Food Sorter', 'Pantry Greeter'].includes(r.name)
-                  )
-                  .map(r => (
-                    <option key={r.id} value={r.name}>
-                      {r.name}
-                    </option>
-                  ))}
-              </select>
-            </label>
+            <label>Roles:</label>
+            {roles.map(r => (
+              <label key={r.id} style={{ display: 'block' }}>
+                <input
+                  type="checkbox"
+                  value={r.id}
+                  checked={selectedCreateRoles.includes(r.id)}
+                  onChange={e => toggleCreateRole(r.id, e.target.checked)}
+                />{' '}
+                {r.name}
+              </label>
+            ))}
           </div>
           <button onClick={submitVolunteer}>Add Volunteer</button>
           {createMsg && <p>{createMsg}</p>}


### PR DESCRIPTION
## Summary
- store volunteer roles as ID array
- allow creating volunteers with selected role IDs
- edit volunteer roles with checkbox lists

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892a5efc334832db77dfd218b7c39c7