### PR TITLE
Add foreign keys for slot references

### DIFF
--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -15,11 +15,11 @@ export async function listSlots(req: Request, res: Response) {
     if (day === 0 || day === 6) return res.json([]);
 
     await pool.query(
-      'CREATE TABLE IF NOT EXISTS blocked_slots (date DATE NOT NULL, slot_id INTEGER NOT NULL, reason TEXT, PRIMARY KEY (date, slot_id))'
+      'CREATE TABLE IF NOT EXISTS blocked_slots (date DATE NOT NULL, slot_id INTEGER NOT NULL, reason TEXT, PRIMARY KEY (date, slot_id), FOREIGN KEY (slot_id) REFERENCES slots(id))'
     );
     await pool.query('ALTER TABLE blocked_slots ADD COLUMN IF NOT EXISTS reason TEXT');
     await pool.query(
-      'CREATE TABLE IF NOT EXISTS breaks (day_of_week INTEGER NOT NULL, slot_id INTEGER NOT NULL, reason TEXT, PRIMARY KEY (day_of_week, slot_id))'
+      'CREATE TABLE IF NOT EXISTS breaks (day_of_week INTEGER NOT NULL, slot_id INTEGER NOT NULL, reason TEXT, PRIMARY KEY (day_of_week, slot_id), FOREIGN KEY (slot_id) REFERENCES slots(id))'
     );
     await pool.query('ALTER TABLE breaks ADD COLUMN IF NOT EXISTS reason TEXT');
 

--- a/MJ_FB_Backend/src/routes/blockedSlots.ts
+++ b/MJ_FB_Backend/src/routes/blockedSlots.ts
@@ -6,7 +6,7 @@ const router = express.Router();
 
 async function ensureTable() {
   await pool.query(
-    'CREATE TABLE IF NOT EXISTS blocked_slots (date DATE NOT NULL, slot_id INTEGER NOT NULL, reason TEXT, PRIMARY KEY (date, slot_id))'
+    'CREATE TABLE IF NOT EXISTS blocked_slots (date DATE NOT NULL, slot_id INTEGER NOT NULL, reason TEXT, PRIMARY KEY (date, slot_id), FOREIGN KEY (slot_id) REFERENCES slots(id))'
   );
   await pool.query('ALTER TABLE blocked_slots ADD COLUMN IF NOT EXISTS reason TEXT');
 }

--- a/MJ_FB_Backend/src/routes/breaks.ts
+++ b/MJ_FB_Backend/src/routes/breaks.ts
@@ -6,7 +6,7 @@ const router = express.Router();
 
 async function ensureTable() {
   await pool.query(
-    'CREATE TABLE IF NOT EXISTS breaks (day_of_week INTEGER NOT NULL, slot_id INTEGER NOT NULL, reason TEXT, PRIMARY KEY (day_of_week, slot_id))'
+    'CREATE TABLE IF NOT EXISTS breaks (day_of_week INTEGER NOT NULL, slot_id INTEGER NOT NULL, reason TEXT, PRIMARY KEY (day_of_week, slot_id), FOREIGN KEY (slot_id) REFERENCES slots(id))'
   );
   await pool.query('ALTER TABLE breaks ADD COLUMN IF NOT EXISTS reason TEXT');
 }

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -95,14 +95,16 @@ CREATE TABLE IF NOT EXISTS breaks (
     day_of_week integer NOT NULL,
     slot_id integer NOT NULL,
     reason text,
-    PRIMARY KEY (day_of_week, slot_id)
+    PRIMARY KEY (day_of_week, slot_id),
+    FOREIGN KEY (slot_id) REFERENCES public.slots(id)
 );
 
 CREATE TABLE IF NOT EXISTS blocked_slots (
     date date NOT NULL,
     slot_id integer NOT NULL,
     reason text,
-    PRIMARY KEY (date, slot_id)
+    PRIMARY KEY (date, slot_id),
+    FOREIGN KEY (slot_id) REFERENCES public.slots(id)
 );
 
 CREATE TABLE IF NOT EXISTS holidays (


### PR DESCRIPTION
## Summary
- enforce slot relationships in `breaks` and `blocked_slots` tables by adding foreign keys
- ensure route handlers and controller create tables with slot foreign keys

## Testing
- `npm --prefix MJ_FB_Backend test`


------
https://chatgpt.com/codex/tasks/task_e_6892b3283d58832d93fb820731f99421