### PR TITLE
feat: show client visits and group volunteer roles

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerController.ts
@@ -12,7 +12,7 @@ export async function updateTrainedArea(req: Request, res: Response) {
   }
   try {
     const validRoles = await pool.query(
-      `SELECT id FROM volunteer_roles WHERE id = ANY($1::int[])`,
+      `SELECT DISTINCT role_id FROM volunteer_roles WHERE role_id = ANY($1::int[])`,
       [roleIds]
     );
     if (validRoles.rowCount !== roleIds.length) {
@@ -122,7 +122,7 @@ export async function createVolunteer(req: Request, res: Response) {
     }
 
     const validRoles = await pool.query(
-      `SELECT id FROM volunteer_roles WHERE id = ANY($1::int[])`,
+      `SELECT DISTINCT role_id FROM volunteer_roles WHERE role_id = ANY($1::int[])`,
       [roleIds]
     );
     if (validRoles.rowCount !== roleIds.length) {

--- a/MJ_FB_Backend/src/controllers/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerRoleController.ts
@@ -2,26 +2,37 @@ import { Request, Response } from 'express';
 import pool from '../db';
 
 export async function addVolunteerRole(req: Request, res: Response) {
-  const { name, category, startTime, endTime, maxVolunteers } = req.body as {
-    name?: string;
-    category?: string;
-    startTime?: string;
-    endTime?: string;
-    maxVolunteers?: number;
-  };
-  if (!name || !category || !startTime || !endTime || typeof maxVolunteers !== 'number') {
+  const { name, category, startTime, endTime, maxVolunteers, roleId, isWednesdaySlot } =
+    req.body as {
+      name?: string;
+      category?: string;
+      startTime?: string;
+      endTime?: string;
+      maxVolunteers?: number;
+      roleId?: number;
+      isWednesdaySlot?: boolean;
+    };
+  if (
+    !name ||
+    !category ||
+    !startTime ||
+    !endTime ||
+    typeof maxVolunteers !== 'number' ||
+    typeof roleId !== 'number'
+  ) {
     return res
       .status(400)
       .json({
-        message: 'Name, category, startTime, endTime and maxVolunteers are required',
+        message:
+          'Name, category, startTime, endTime, maxVolunteers and roleId are required',
       });
   }
   try {
     const result = await pool.query(
-      `INSERT INTO volunteer_roles (name, category, start_time, end_time, max_volunteers)
-       VALUES ($1,$2,$3,$4,$5)
-       RETURNING id, name, category, start_time, end_time, max_volunteers`,
-      [name, category, startTime, endTime, maxVolunteers]
+      `INSERT INTO volunteer_roles (name, category, start_time, end_time, max_volunteers, role_id, is_wednesday_slot)
+       VALUES ($1,$2,$3,$4,$5,$6,$7)
+       RETURNING id, name, category, start_time, end_time, max_volunteers, role_id, is_wednesday_slot`,
+      [name, category, startTime, endTime, maxVolunteers, roleId, isWednesdaySlot || false]
     );
     res.status(201).json(result.rows[0]);
   } catch (error) {
@@ -35,7 +46,7 @@ export async function addVolunteerRole(req: Request, res: Response) {
 export async function listVolunteerRoles(req: Request, res: Response) {
   try {
     const result = await pool.query(
-      `SELECT id, name, category, start_time, end_time, max_volunteers FROM volunteer_roles ORDER BY id`
+      `SELECT id, name, category, start_time, end_time, max_volunteers, role_id, is_wednesday_slot FROM volunteer_roles ORDER BY id`
     );
     res.json(result.rows);
   } catch (error) {
@@ -48,27 +59,38 @@ export async function listVolunteerRoles(req: Request, res: Response) {
 
 export async function updateVolunteerRole(req: Request, res: Response) {
   const { id } = req.params;
-  const { name, category, startTime, endTime, maxVolunteers } = req.body as {
-    name?: string;
-    category?: string;
-    startTime?: string;
-    endTime?: string;
-    maxVolunteers?: number;
-  };
-  if (!name || !category || !startTime || !endTime || typeof maxVolunteers !== 'number') {
+  const { name, category, startTime, endTime, maxVolunteers, roleId, isWednesdaySlot } =
+    req.body as {
+      name?: string;
+      category?: string;
+      startTime?: string;
+      endTime?: string;
+      maxVolunteers?: number;
+      roleId?: number;
+      isWednesdaySlot?: boolean;
+    };
+  if (
+    !name ||
+    !category ||
+    !startTime ||
+    !endTime ||
+    typeof maxVolunteers !== 'number' ||
+    typeof roleId !== 'number'
+  ) {
     return res
       .status(400)
       .json({
-        message: 'Name, category, startTime, endTime and maxVolunteers are required',
+        message:
+          'Name, category, startTime, endTime, maxVolunteers and roleId are required',
       });
   }
   try {
     const result = await pool.query(
       `UPDATE volunteer_roles
-       SET name = $1, category = $2, start_time = $3, end_time = $4, max_volunteers = $5
-       WHERE id = $6
-       RETURNING id, name, category, start_time, end_time, max_volunteers`,
-      [name, category, startTime, endTime, maxVolunteers, id]
+       SET name = $1, category = $2, start_time = $3, end_time = $4, max_volunteers = $5, role_id = $6, is_wednesday_slot = $7
+       WHERE id = $8
+       RETURNING id, name, category, start_time, end_time, max_volunteers, role_id, is_wednesday_slot`,
+      [name, category, startTime, endTime, maxVolunteers, roleId, isWednesdaySlot || false, id]
     );
     if (result.rowCount === 0) {
       return res.status(404).json({ message: 'Role not found' });
@@ -118,7 +140,7 @@ export async function listVolunteerRolesForVolunteer(req: Request, res: Response
     }
     const roleIds = volunteerRes.rows.map(r => r.role_id);
     const result = await pool.query(
-      `SELECT vr.id, vr.name, vr.category, vr.start_time, vr.end_time, vr.max_volunteers,
+      `SELECT vr.id, vr.name, vr.category, vr.start_time, vr.end_time, vr.max_volunteers, vr.role_id, vr.is_wednesday_slot,
               COALESCE(b.count,0) AS booked, $1::date AS date
        FROM volunteer_roles vr
        LEFT JOIN (
@@ -127,7 +149,8 @@ export async function listVolunteerRolesForVolunteer(req: Request, res: Response
          WHERE status IN ('pending','approved') AND date = $1
          GROUP BY role_id
        ) b ON vr.id = b.role_id
-       WHERE vr.id = ANY($2::int[])
+       WHERE vr.role_id = ANY($2::int[])
+         AND (vr.is_wednesday_slot = false OR EXTRACT(DOW FROM $1::date) = 3)
        ORDER BY vr.start_time`,
       [date, roleIds]
     );

--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { loginUser, createUser, searchUsers } from '../controllers/userController';
+import { loginUser, createUser, searchUsers, getUserProfile } from '../controllers/userController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 
 const router = express.Router();
@@ -7,6 +7,7 @@ const router = express.Router();
 router.post('/login', loginUser);
 router.post('/', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator'), createUser);
 router.get('/search', authMiddleware, authorizeRoles('staff', 'volunteer_coordinator'), searchUsers);
+router.get('/me', authMiddleware, getUserProfile);
 
 
 export default router;

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -62,7 +62,9 @@ CREATE TABLE IF NOT EXISTS volunteer_roles (
     category text NOT NULL,
     start_time time without time zone NOT NULL,
     end_time time without time zone NOT NULL,
-    max_volunteers integer NOT NULL
+    max_volunteers integer NOT NULL,
+    role_id integer NOT NULL,
+    is_wednesday_slot boolean DEFAULT false
 );
 
 CREATE TABLE IF NOT EXISTS volunteers (
@@ -79,8 +81,7 @@ CREATE TABLE IF NOT EXISTS volunteer_trained_roles (
     volunteer_id integer NOT NULL,
     role_id integer NOT NULL,
     PRIMARY KEY (volunteer_id, role_id),
-    FOREIGN KEY (volunteer_id) REFERENCES public.volunteers(id) ON DELETE CASCADE,
-    FOREIGN KEY (role_id) REFERENCES public.volunteer_roles(id) ON DELETE CASCADE
+    FOREIGN KEY (volunteer_id) REFERENCES public.volunteers(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS bookings (
@@ -176,28 +177,28 @@ INSERT INTO staff (first_name, last_name, role, email, password) VALUES
 ('Terri', 'Smith', 'volunteer_coordinator', 'terri@mjfb.com', '$2b$10$hg6FdP2Pn0ROS.YTKQviXu7EEXsvQedZ4PqStdI61HS6uX/kA/bhm')
 ON CONFLICT (email) DO NOTHING;
 
-INSERT INTO volunteer_roles (name, category, start_time, end_time, max_volunteers) VALUES
-('Food Sorter', 'Warehouse', '09:00:00', '12:00:00', 3),
-('Production Worker', 'Warehouse', '09:00:00', '12:00:00', 3),
-('Driver Assistant', 'Warehouse', '09:00:00', '12:00:00', 1),
-('Loading Dock Personnel', 'Warehouse', '09:00:00', '12:00:00', 1),
-('General Cleaning & Maintenance', 'Warehouse', '08:00:00', '11:00:00', 1),
-('Reception (Morning)', 'Pantry', '09:30:00', '12:30:00', 1),
-('Reception (Afternoon)', 'Pantry', '12:30:00', '15:30:00', 1),
-('Reception (Wednesday Evening)', 'Pantry', '15:30:00', '18:30:00', 1),
-('Greeter/Pantry Assistant (Morning)', 'Pantry', '09:00:00', '12:00:00', 3),
-('Greeter/Pantry Assistant (Afternoon)', 'Pantry', '12:30:00', '15:30:00', 3),
-('Greeter/Pantry Assistant (Wednesday Evening)', 'Pantry', '15:30:00', '18:30:00', 2),
-('Greeter/Pantry Assistant (Wednesday Late Evening)', 'Pantry', '16:30:00', '19:30:00', 2),
-('Stock Person (Morning)', 'Pantry', '08:00:00', '11:00:00', 1),
-('Stock Person (Afternoon)', 'Pantry', '12:00:00', '15:00:00', 1),
-('Gardening Assistant', 'Gardening', '13:00:00', '16:00:00', 2),
-('Event Organizer', 'Special Events', '09:00:00', '17:00:00', 5),
-('Event Resource Specialist', 'Special Events', '09:00:00', '17:00:00', 5),
-('Volunteer Marketing Associate', 'Administration', '08:00:00', '16:00:00', 1),
-('Client Resource Associate', 'Administration', '08:00:00', '16:00:00', 1),
-('Assistant Volunteer Coordinator', 'Administration', '08:00:00', '16:00:00', 1),
-('Volunteer Office Administrator', 'Administration', '08:00:00', '16:00:00', 1)
+INSERT INTO volunteer_roles (name, category, start_time, end_time, max_volunteers, role_id, is_wednesday_slot) VALUES
+('Food Sorter', 'Warehouse', '09:00:00', '12:00:00', 3, 1, false),
+('Production Worker', 'Warehouse', '09:00:00', '12:00:00', 3, 2, false),
+('Driver Assistant', 'Warehouse', '09:00:00', '12:00:00', 1, 3, false),
+('Loading Dock Personnel', 'Warehouse', '09:00:00', '12:00:00', 1, 4, false),
+('General Cleaning & Maintenance', 'Warehouse', '08:00:00', '11:00:00', 1, 5, false),
+('Reception (Morning)', 'Pantry', '09:30:00', '12:30:00', 1, 6, false),
+('Reception (Afternoon)', 'Pantry', '12:30:00', '15:30:00', 1, 6, false),
+('Reception (Wednesday Evening)', 'Pantry', '15:30:00', '18:30:00', 1, 6, true),
+('Greeter/Pantry Assistant (Morning)', 'Pantry', '09:00:00', '12:00:00', 3, 7, false),
+('Greeter/Pantry Assistant (Afternoon)', 'Pantry', '12:30:00', '15:30:00', 3, 7, false),
+('Greeter/Pantry Assistant (Wednesday Evening)', 'Pantry', '15:30:00', '18:30:00', 2, 7, true),
+('Greeter/Pantry Assistant (Wednesday Late Evening)', 'Pantry', '16:30:00', '19:30:00', 2, 7, true),
+('Stock Person (Morning)', 'Pantry', '08:00:00', '11:00:00', 1, 8, false),
+('Stock Person (Afternoon)', 'Pantry', '12:00:00', '15:00:00', 1, 8, false),
+('Gardening Assistant', 'Gardening', '13:00:00', '16:00:00', 2, 9, false),
+('Event Organizer', 'Special Events', '09:00:00', '17:00:00', 5, 10, false),
+('Event Resource Specialist', 'Special Events', '09:00:00', '17:00:00', 5, 11, false),
+('Volunteer Marketing Associate', 'Administration', '08:00:00', '16:00:00', 1, 12, false),
+('Client Resource Associate', 'Administration', '08:00:00', '16:00:00', 1, 13, false),
+('Assistant Volunteer Coordinator', 'Administration', '08:00:00', '16:00:00', 1, 14, false),
+('Volunteer Office Administrator', 'Administration', '08:00:00', '16:00:00', 1, 15, false)
 ON CONFLICT (name) DO NOTHING;
 `);
 

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -1,6 +1,6 @@
 // src/api/api.ts
 // Read API base URL from environment or fall back to localhost
-import type { Role, UserRole, StaffRole } from '../types';
+import type { Role, UserRole, StaffRole, UserProfile } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
 
@@ -57,6 +57,13 @@ export async function loginVolunteer(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password }),
+  });
+  return handleResponse(res);
+}
+
+export async function getUserProfile(token: string): Promise<UserProfile> {
+  const res = await fetch(`${API_BASE}/users/me`, {
+    headers: { Authorization: token },
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -1,8 +1,20 @@
-import type { Role } from '../types';
+import { useEffect, useState } from 'react';
+import type { Role, UserProfile } from '../types';
+import { getUserProfile } from '../api/api';
 
 export default function Profile() {
   const role = (localStorage.getItem('role') || '') as Role;
-  const name = localStorage.getItem('name') || '';
+  const token = localStorage.getItem('token') || '';
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (role === 'shopper') {
+      getUserProfile(token)
+        .then(setProfile)
+        .catch(e => setError(e instanceof Error ? e.message : String(e)));
+    }
+  }, [role, token]);
 
   if (['staff', 'volunteer_coordinator'].includes(role)) {
     return (
@@ -16,7 +28,19 @@ export default function Profile() {
   return (
     <div>
       <h2>User Profile</h2>
-      <p>Welcome, {name}!</p>
+      {error && <p>{error}</p>}
+      {!profile && !error && <p>Loading...</p>}
+      {profile && (
+        <ul>
+          <li>
+            Name: {profile.firstName} {profile.lastName}
+          </li>
+          <li>Client ID: {profile.clientId}</li>
+          <li>Email: {profile.email || 'N/A'}</li>
+          <li>Phone: {profile.phone || 'N/A'}</li>
+          <li>Visits this month: {profile.bookingsThisMonth}</li>
+        </ul>
+      )}
     </div>
   );
 }

--- a/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
@@ -24,7 +24,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
       .then(data => {
         setRolesData(data);
         const map = new Map<number, string>();
-        data.forEach((r: VolunteerRole) => map.set(r.id, r.name));
+        data.forEach((r: VolunteerRole) => map.set(r.role_id, r.name));
         const arr = Array.from(map, ([id, name]) => ({ id, name }));
         setRoles(arr);
         if (arr.length > 0) setSelectedRole(arr[0].id);
@@ -40,7 +40,9 @@ export default function VolunteerDashboard({ token }: { token: string }) {
     }
   }, [tab, token]);
 
-  const filteredRoles = rolesData.filter(r => selectedRole === '' || r.id === selectedRole);
+  const filteredRoles = rolesData.filter(
+    r => selectedRole === '' || r.role_id === selectedRole
+  );
 
   async function submitBooking() {
     if (!modalRole) return;

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -41,6 +41,8 @@ export interface VolunteerRole {
   available: number;
   status: string;
   date: string;
+  role_id: number;
+  is_wednesday_slot: boolean;
 }
 
 export interface VolunteerBooking {
@@ -65,4 +67,15 @@ export interface VolunteerBookingDetail {
   end_time: string;
   status_color?: string;
   role_name?: string;
+}
+
+export interface UserProfile {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  phone: string | null;
+  clientId: number;
+  role: Role;
+  bookingsThisMonth: number;
 }


### PR DESCRIPTION
## Summary
- expose `/users/me` to return profile details including client ID and monthly visit count
- group volunteer roles by new `role_id` field with optional Wednesday-only slots
- surface user profile info on frontend and group volunteer slots by role

## Testing
- `npm test`
- `npm run lint`
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6892d6272f54832d9de97c679bac1b19