### PR TITLE
Clarify pantry vs volunteer schedule components

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -5,7 +5,7 @@ import ManageAvailability from './components/StaffDashboard/ManageAvailability';
 import UserHistory from './components/StaffDashboard/UserHistory';
 import SlotBooking from './components/SlotBooking';
 import AddUser from './components/StaffDashboard/AddUser';
-import ViewSchedule from './components/StaffDashboard/ViewSchedule';
+import PantrySchedule from './components/StaffDashboard/PantrySchedule';
 import Login from './components/Login';
 import StaffLogin from './components/StaffLogin';
 import VolunteerLogin from './components/VolunteerLogin';
@@ -50,7 +50,7 @@ export default function App() {
     navLinks = navLinks.concat([
       { label: 'Staff Dashboard', id: 'staffDashboard' },
       { label: 'Manage Availability', id: 'manageAvailability' },
-      { label: 'View Schedule', id: 'viewSchedule' },
+      { label: 'Pantry Schedule', id: 'pantrySchedule' },
       { label: 'Add User', id: 'addUser' },
       { label: 'User History', id: 'userHistory' },
     ]);
@@ -142,8 +142,8 @@ export default function App() {
             {activePage === 'manageAvailability' && isStaff && (
               <ManageAvailability token={token} />
             )}
-            {activePage === 'viewSchedule' && isStaff && (
-              <ViewSchedule token={token} />
+            {activePage === 'pantrySchedule' && isStaff && (
+              <PantrySchedule token={token} />
             )}
             {activePage === 'slots' && role === 'shopper' && (
               <SlotBooking token={token} role="shopper" />

--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -11,7 +11,7 @@ import {
 } from '../api/api';
 import type { VolunteerBookingDetail } from '../types';
 import { formatTime } from '../utils/time';
-import ScheduleTable from './ScheduleTable';
+import VolunteerScheduleTable from './VolunteerScheduleTable';
 import { fromZonedTime, formatInTimeZone } from 'date-fns-tz';
 
 interface RoleOption {
@@ -310,7 +310,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
                 <h3>{formatDate(currentDate)}</h3>
                 <button onClick={() => changeDay(1)}>Next</button>
               </div>
-              <ScheduleTable maxSlots={roleInfo.max_volunteers} rows={rows} />
+              <VolunteerScheduleTable maxSlots={roleInfo.max_volunteers} rows={rows} />
             </>
           ) : (
             <p style={{ marginTop: 16 }}>Select a role to view schedule.</p>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
@@ -3,7 +3,7 @@ import { getSlots, getBookings, getHolidays, searchUsers, createBookingForUser, 
 import type { Slot, Break, Holiday, BlockedSlot } from '../../types';
 import { fromZonedTime, toZonedTime, formatInTimeZone } from 'date-fns-tz';
 import { formatTime } from '../../utils/time';
-import ScheduleTable from '../ScheduleTable';
+import VolunteerScheduleTable from '../VolunteerScheduleTable';
 
 interface Booking {
   id: number;
@@ -22,7 +22,7 @@ interface User {
 
 const reginaTimeZone = 'America/Regina';
 
-export default function ViewSchedule({ token }: { token: string }) {
+export default function PantrySchedule({ token }: { token: string }) {
   const [currentDate, setCurrentDate] = useState(() => {
     const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
     return fromZonedTime(`${todayStr}T00:00:00`, reginaTimeZone);
@@ -241,7 +241,7 @@ export default function ViewSchedule({ token }: { token: string }) {
       {isClosed ? (
         <p style={{ textAlign: 'center' }}>Moose Jaw food bank is closed for {dayName}</p>
       ) : (
-        <ScheduleTable maxSlots={4} rows={rows} />
+        <VolunteerScheduleTable maxSlots={4} rows={rows} />
       )}
 
       {assignSlot && (

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -15,7 +15,7 @@ interface Props {
   rows: Row[];
 }
 
-export default function ScheduleTable({ maxSlots, rows }: Props) {
+export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   return (
     <table style={{ borderCollapse: 'collapse', width: '100%' }}>
       <thead>


### PR DESCRIPTION
## Summary
- rename `ScheduleTable` component to `VolunteerScheduleTable`
- rename `ViewSchedule` staff view to `PantrySchedule`
- update navigation and imports for new component names

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6892d85fc714832dbc6631b6fc81fab6