### PR TITLE
feat: add volunteer schedule component

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
@@ -1,36 +1,12 @@
 import { useState, useEffect } from 'react';
-import {
-  getVolunteerRolesForVolunteer,
-  requestVolunteerBooking,
-  getMyVolunteerBookings,
-} from '../api/api';
-import type { VolunteerRole, VolunteerBooking } from '../types';
+import { getMyVolunteerBookings } from '../api/api';
+import type { VolunteerBooking } from '../types';
 import { formatTime } from '../utils/time';
+import VolunteerSchedule from './VolunteerSchedule';
 
 export default function VolunteerDashboard({ token }: { token: string }) {
-  const [rolesData, setRolesData] = useState<VolunteerRole[]>([]);
-  const [roles, setRoles] = useState<{ id: number; name: string }[]>([]);
-  const [selectedRole, setSelectedRole] = useState<number | ''>('');
-  const [modalRole, setModalRole] = useState<VolunteerRole | null>(null);
-  const [message, setMessage] = useState('');
-  const [tab, setTab] = useState<'slots' | 'history'>('slots');
+  const [tab, setTab] = useState<'schedule' | 'history'>('schedule');
   const [history, setHistory] = useState<VolunteerBooking[]>([]);
-  const [selectedDate, setSelectedDate] = useState(
-    () => new Date().toISOString().split('T')[0]
-  );
-
-  useEffect(() => {
-    getVolunteerRolesForVolunteer(token, selectedDate)
-      .then(data => {
-        setRolesData(data);
-        const map = new Map<number, string>();
-        data.forEach((r: VolunteerRole) => map.set(r.role_id, r.name));
-        const arr = Array.from(map, ([id, name]) => ({ id, name }));
-        setRoles(arr);
-        if (arr.length > 0) setSelectedRole(arr[0].id);
-      })
-      .catch(() => {});
-  }, [token, selectedDate]);
 
   useEffect(() => {
     if (tab === 'history') {
@@ -40,104 +16,23 @@ export default function VolunteerDashboard({ token }: { token: string }) {
     }
   }, [tab, token]);
 
-  const filteredRoles = rolesData.filter(
-    r => selectedRole === '' || r.role_id === selectedRole
-  );
-
-  async function submitBooking() {
-    if (!modalRole) return;
-    try {
-      await requestVolunteerBooking(token, modalRole.id, selectedDate);
-      setMessage('Request submitted!');
-      setModalRole(null);
-      const updated = await getVolunteerRolesForVolunteer(token, selectedDate);
-      setRolesData(updated);
-    } catch (e) {
-      setMessage(e instanceof Error ? e.message : String(e));
-    }
-  }
-
   return (
     <div>
       <h2>Volunteer Dashboard</h2>
       <div style={{ marginBottom: 16 }}>
-        <button onClick={() => setTab('slots')} disabled={tab === 'slots'}>
-          Available Slots
+        <button onClick={() => setTab('schedule')} disabled={tab === 'schedule'}>
+          Schedule
         </button>
-        <button onClick={() => setTab('history')} disabled={tab === 'history'} style={{ marginLeft: 8 }}>
+        <button
+          onClick={() => setTab('history')}
+          disabled={tab === 'history'}
+          style={{ marginLeft: 8 }}
+        >
           Booking History
         </button>
       </div>
 
-      {tab === 'slots' && (
-        <div>
-          {roles.length > 0 ? (
-            <>
-              <label htmlFor="dateSelect">Date: </label>
-              <input
-                type="date"
-                id="dateSelect"
-                value={selectedDate}
-                onChange={e => setSelectedDate(e.target.value)}
-              />
-              <label htmlFor="roleSelect" style={{ marginLeft: 8 }}>
-                Role:{' '}
-              </label>
-              <select
-                id="roleSelect"
-                value={selectedRole}
-                onChange={e => setSelectedRole(Number(e.target.value))}
-              >
-                {roles.map(r => (
-                  <option key={r.id} value={r.id}>
-                    {r.name}
-                  </option>
-                ))}
-              </select>
-              <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: 16 }}>
-                <thead>
-                  <tr>
-                    <th style={{ border: '1px solid #ccc', padding: 8 }}>Date</th>
-                    <th style={{ border: '1px solid #ccc', padding: 8 }}>Time</th>
-                    <th style={{ border: '1px solid #ccc', padding: 8 }}>Available</th>
-                    <th style={{ border: '1px solid #ccc', padding: 8 }}></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredRoles.map(r => (
-                    <tr key={r.id}>
-                      <td style={{ border: '1px solid #ccc', padding: 8 }}>{r.date}</td>
-                      <td style={{ border: '1px solid #ccc', padding: 8 }}>
-                        {formatTime(r.start_time)} - {formatTime(r.end_time)}
-                      </td>
-                      <td style={{ border: '1px solid #ccc', padding: 8 }}>
-                        {r.available}/{r.max_volunteers}
-                      </td>
-                      <td style={{ border: '1px solid #ccc', padding: 8, textAlign: 'center' }}>
-                        {r.available > 0 ? (
-                          <button onClick={() => setModalRole(r)}>Request</button>
-                        ) : (
-                          'Full'
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                  {filteredRoles.length === 0 && (
-                    <tr>
-                      <td colSpan={4} style={{ textAlign: 'center', padding: 8 }}>
-                        No slots.
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </>
-          ) : (
-            <p>No trained roles assigned.</p>
-          )}
-          {message && <p style={{ color: 'green' }}>{message}</p>}
-        </div>
-      )}
+      {tab === 'schedule' && <VolunteerSchedule token={token} />}
 
       {tab === 'history' && (
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
@@ -152,7 +47,9 @@ export default function VolunteerDashboard({ token }: { token: string }) {
           <tbody>
             {history.map(h => (
               <tr key={h.id}>
-                <td style={{ border: '1px solid #ccc', padding: 8 }}>{h.role_name}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>
+                  {h.role_name}
+                </td>
                 <td style={{ border: '1px solid #ccc', padding: 8 }}>{h.date}</td>
                 <td style={{ border: '1px solid #ccc', padding: 8 }}>
                   {formatTime(h.start_time)} - {formatTime(h.end_time)}
@@ -169,33 +66,6 @@ export default function VolunteerDashboard({ token }: { token: string }) {
             )}
           </tbody>
         </table>
-      )}
-
-      {modalRole && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0,0,0,0.3)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <div style={{ background: 'white', padding: 16, borderRadius: 4, width: 300 }}>
-            <p>
-              Request booking for {modalRole.date} {formatTime(modalRole.start_time)} -{' '}
-              {formatTime(modalRole.end_time)}?
-            </p>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 12 }}>
-              <button onClick={submitBooking}>Submit</button>
-              <button onClick={() => setModalRole(null)}>Cancel</button>
-            </div>
-          </div>
-        </div>
       )}
     </div>
   );

--- a/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
@@ -1,0 +1,272 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  getVolunteerRolesForVolunteer,
+  requestVolunteerBooking,
+  getMyVolunteerBookings,
+  getHolidays,
+  updateVolunteerBookingStatus,
+} from '../api/api';
+import type { VolunteerRole, Holiday, VolunteerBooking } from '../types';
+import { fromZonedTime, toZonedTime, formatInTimeZone } from 'date-fns-tz';
+import { formatTime } from '../utils/time';
+import VolunteerScheduleTable from './VolunteerScheduleTable';
+
+const reginaTimeZone = 'America/Regina';
+
+export default function VolunteerSchedule({ token }: { token: string }) {
+  const [currentDate, setCurrentDate] = useState(() => {
+    const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
+    return fromZonedTime(`${todayStr}T00:00:00`, reginaTimeZone);
+  });
+  const [roles, setRoles] = useState<VolunteerRole[]>([]);
+  const [bookings, setBookings] = useState<VolunteerBooking[]>([]);
+  const [holidays, setHolidays] = useState<Holiday[]>([]);
+  const [requestRole, setRequestRole] = useState<VolunteerRole | null>(null);
+  const [decisionBooking, setDecisionBooking] =
+    useState<VolunteerBooking | null>(null);
+  const [decisionReason, setDecisionReason] = useState('');
+  const [message, setMessage] = useState('');
+
+  const formatDate = (date: Date) =>
+    formatInTimeZone(date, reginaTimeZone, 'yyyy-MM-dd');
+
+  const loadData = useCallback(async () => {
+    const dateStr = formatDate(currentDate);
+    const reginaDate = toZonedTime(currentDate, reginaTimeZone);
+    const weekend = reginaDate.getDay() === 0 || reginaDate.getDay() === 6;
+    const holiday = holidays.some(h => h.date === dateStr);
+    if (weekend || holiday) {
+      setRoles([]);
+      setBookings([]);
+      return;
+    }
+    try {
+      const [roleData, bookingData] = await Promise.all([
+        getVolunteerRolesForVolunteer(token, dateStr),
+        getMyVolunteerBookings(token),
+      ]);
+      setRoles(roleData);
+      const filtered = bookingData.filter(
+        b => b.date === dateStr && ['approved', 'submitted'].includes(b.status)
+      );
+      setBookings(filtered);
+    } catch (err) {
+      console.error(err);
+    }
+  }, [currentDate, token, holidays]);
+
+  useEffect(() => {
+    getHolidays(token).then(setHolidays).catch(() => {});
+  }, [token]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  function changeDay(delta: number) {
+    setCurrentDate(d => new Date(d.getTime() + delta * 86400000));
+  }
+
+  async function submitRequest() {
+    if (!requestRole) return;
+    try {
+      await requestVolunteerBooking(
+        token,
+        requestRole.id,
+        formatDate(currentDate)
+      );
+      setRequestRole(null);
+      await loadData();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function cancelSelected() {
+    if (!decisionBooking) return;
+    try {
+      await updateVolunteerBookingStatus(
+        token,
+        decisionBooking.id,
+        'cancelled'
+      );
+      await loadData();
+    } catch {
+      setMessage('Failed to cancel booking');
+    } finally {
+      setDecisionBooking(null);
+      setDecisionReason('');
+    }
+  }
+
+  const dateStr = formatDate(currentDate);
+  const reginaDate = toZonedTime(currentDate, reginaTimeZone);
+  const dayName = formatInTimeZone(currentDate, reginaTimeZone, 'EEEE');
+  const holidayObj = holidays.find(h => h.date === dateStr);
+  const isHoliday = !!holidayObj;
+  const isWeekend = reginaDate.getDay() === 0 || reginaDate.getDay() === 6;
+  const isClosed = isHoliday || isWeekend;
+
+  const timeMap = new Map<string, VolunteerRole[]>();
+  for (const r of roles) {
+    const key = `${r.start_time}-${r.end_time}`;
+    if (!timeMap.has(key)) timeMap.set(key, []);
+    timeMap.get(key)!.push(r);
+  }
+  const maxSlots = Math.max(
+    0,
+    ...Array.from(timeMap.values(), arr => arr.length)
+  );
+  const rows = Array.from(timeMap.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([key, arr]) => {
+      const [start, end] = key.split('-');
+      return {
+        time: `${formatTime(start)} - ${formatTime(end)}`,
+        cells: arr.map(role => {
+          const booking = bookings.find(
+            b =>
+              b.role_id === role.role_id &&
+              b.start_time === role.start_time &&
+              b.date === role.date
+          );
+          if (booking) {
+            return {
+              content: role.name,
+              backgroundColor:
+                booking.status === 'submitted' ? '#ffe5b4' : '#e0f7e0',
+              onClick: () => {
+                setDecisionBooking(booking);
+                setDecisionReason('');
+              },
+            };
+          }
+          if (role.available <= 0) {
+            return {
+              content: `${role.name} (Full)`,
+              backgroundColor: '#f5f5f5',
+            };
+          }
+          return {
+            content: role.name,
+            onClick: () => {
+              if (!isClosed) {
+                setRequestRole(role);
+                setMessage('');
+              } else {
+                setMessage('Booking not allowed on weekends or holidays');
+              }
+            },
+          };
+        }),
+      };
+    });
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 16,
+        }}
+      >
+        <button onClick={() => changeDay(-1)}>Previous</button>
+        <h3>
+          {dateStr} - {dayName}
+          {isHoliday
+            ? ` (Holiday${holidayObj?.reason ? ': ' + holidayObj.reason : ''})`
+            : isWeekend
+              ? ' (Weekend)'
+              : ''}
+        </h3>
+        <button onClick={() => changeDay(1)}>Next</button>
+      </div>
+      {message && <p style={{ color: 'red' }}>{message}</p>}
+      {isClosed ? (
+        <p style={{ textAlign: 'center' }}>
+          Moose Jaw food bank is closed for {dayName}
+        </p>
+      ) : (
+        <VolunteerScheduleTable maxSlots={maxSlots} rows={rows} />
+      )}
+
+      {requestRole && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0,0,0,0.3)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div style={{ background: 'white', padding: 16, borderRadius: 4, width: 300 }}>
+            <h4>Request Booking</h4>
+            <p>Request booking for {requestRole.name}?</p>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                marginTop: 12,
+              }}
+            >
+              <button onClick={submitRequest}>Submit</button>
+              <button onClick={() => setRequestRole(null)}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {decisionBooking && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0,0,0,0.3)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div style={{ background: 'white', padding: 16, borderRadius: 4, width: 320 }}>
+            <h4>Cancel Booking</h4>
+            <p>Cancel booking for {decisionBooking.role_name}?</p>
+            <textarea
+              placeholder="Reason for cancellation"
+              value={decisionReason}
+              onChange={e => setDecisionReason(e.target.value)}
+              style={{ width: '100%', marginTop: 8 }}
+            />
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                marginTop: 12,
+              }}
+            >
+              <button onClick={cancelSelected}>Confirm</button>
+              <button
+                onClick={() => {
+                  setDecisionBooking(null);
+                  setDecisionReason('');
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add VolunteerSchedule component with volunteer-specific API calls and booking modals
- integrate schedule into VolunteerDashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892de6b5cb4832da5c7c42d76399d90