### PR TITLE
Show pending volunteer bookings on schedule

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
@@ -55,7 +55,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
       setBaseRoles(Array.from(map, ([id, name]) => ({ id, name })));
       setSelectedRole(prev => (prev && map.has(Number(prev)) ? prev : ''));
       const filtered = bookingData.filter(
-        b => b.date === dateStr && ['approved', 'submitted'].includes(b.status)
+        b => b.date === dateStr && ['approved', 'pending'].includes(b.status)
       );
       setBookings(filtered);
     } catch (err) {
@@ -131,7 +131,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
       cells.push({
         content: 'My Booking',
         backgroundColor:
-          myBooking.status === 'submitted' ? '#ffe5b4' : '#e0f7e0',
+          myBooking.status === 'pending' ? '#ffe5b4' : '#e0f7e0',
         onClick: () => {
           setDecisionBooking(myBooking);
           setDecisionReason('');


### PR DESCRIPTION
## Summary
- Treat volunteer booking status `pending` as active so volunteers can see pending requests in the schedule
- Color pending volunteer bookings orange and approved bookings green

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6894c7eaa234832dbc04af3388483f2b