### PR TITLE
Show requested role on pending volunteer bookings

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
@@ -127,7 +127,7 @@ export async function listVolunteerBookingsByRole(req: Request, res: Response) {
   try {
     const result = await pool.query(
       `SELECT vb.id, vb.status, vb.role_id, vb.volunteer_id, vb.date,
-              vr.start_time, vr.end_time,
+              vr.start_time, vr.end_time, vr.name AS role_name,
               v.first_name || ' ' || v.last_name AS volunteer_name
        FROM volunteer_bookings vb
        JOIN volunteer_roles vr ON vb.role_id = vr.id

--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -127,7 +127,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
           if (b.status.toLowerCase() === 'pending') {
             const approvedCount = approvedByDate[b.date] || 0;
             const canBook = approvedCount < r.max_volunteers;
-            all.push({ ...b, can_book: canBook });
+            all.push({ ...b, role_name: b.role_name || r.name, can_book: canBook });
           }
         });
       } catch {
@@ -470,6 +470,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
             {pending.map(p => (
               <li key={p.id} style={{ marginBottom: 12, border: '1px solid #ccc', padding: 8 }}>
                 <div><strong>Volunteer:</strong> {p.volunteer_name}</div>
+                <div><strong>Role:</strong> {p.role_name}</div>
                 <div><strong>Date:</strong> {p.date}</div>
                 <div><strong>Time:</strong> {formatTime(p.start_time)} - {formatTime(p.end_time)}</div>
                 <div><strong>Slot Availability:</strong> {p.can_book ? 'Available' : 'Full'}</div>


### PR DESCRIPTION
## Summary
- expose volunteer role name in backend pending-bookings query
- show each booking's role in coordinator dashboard

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894d33d3e8c832d9a93e3e497abb8d2