### PR TITLE
Fix ThemeOptions import

### DIFF
--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -1,4 +1,5 @@
-import { createTheme, ThemeOptions } from '@mui/material/styles';
+import { createTheme } from '@mui/material/styles';
+import type { ThemeOptions } from '@mui/material/styles';
 import type { PaletteMode } from '@mui/material';
 import { createContext } from 'react';
 


### PR DESCRIPTION
## Summary
- import ThemeOptions as a type-only import to resolve runtime SyntaxError

## Testing
- `npm run lint`
- `npm run build` *(fails: Parameter implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_6894d60b129c832d82f5ce88205a5156