### PR TITLE
Group nav links and add responsive menu

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -12,7 +12,7 @@ import VolunteerLogin from './components/VolunteerLogin';
 import VolunteerDashboard from './components/VolunteerDashboard';
 import CoordinatorDashboard from './components/CoordinatorDashboard';
 import type { Role } from './types';
-import Navbar from './components/Navbar';
+import Navbar, { type NavGroup } from './components/Navbar';
 
 export default function App() {
   const [token, setToken] = useState(localStorage.getItem('token') || '');
@@ -46,25 +46,29 @@ export default function App() {
     setActivePage(id);
   }
 
-  let navLinks: { label: string; id: string }[] = [{ label: 'Profile', id: 'profile' }];
+  const navGroups: NavGroup[] = [{ label: 'Profile', links: [{ label: 'Profile', id: 'profile' }] }];
   if (isStaff) {
-    navLinks = navLinks.concat([
+    const staffLinks = [
       { label: 'Staff Dashboard', id: 'staffDashboard' },
       { label: 'Manage Availability', id: 'manageAvailability' },
       { label: 'Pantry Schedule', id: 'pantrySchedule' },
       { label: 'Add User', id: 'addUser' },
       { label: 'User History', id: 'userHistory' },
-    ]);
+    ];
     if (isCoordinator) {
-      navLinks.push({ label: 'Coordinator Dashboard', id: 'coordinatorDashboard' });
+      staffLinks.push({ label: 'Coordinator Dashboard', id: 'coordinatorDashboard' });
     }
+    navGroups.push({ label: 'Staff', links: staffLinks });
   } else if (role === 'shopper') {
-    navLinks = navLinks.concat([
-      { label: 'Booking Slots', id: 'slots' },
-      { label: 'Booking History', id: 'bookingHistory' },
-    ]);
+    navGroups.push({
+      label: 'Booking',
+      links: [
+        { label: 'Booking Slots', id: 'slots' },
+        { label: 'Booking History', id: 'bookingHistory' },
+      ],
+    });
   } else if (role === 'volunteer') {
-    navLinks = navLinks.concat([{ label: 'Volunteer Dashboard', id: 'volunteerDashboard' }]);
+    navGroups.push({ label: 'Volunteer', links: [{ label: 'Volunteer Dashboard', id: 'volunteerDashboard' }] });
   }
 
   return (
@@ -112,7 +116,7 @@ export default function App() {
       ) : (
         <>
           <Navbar
-            links={navLinks}
+            groups={navGroups}
             active={activePage}
             onSelect={handleNavClick}
             onLogout={logout}

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -1,13 +1,25 @@
-import { AppBar, Toolbar, Typography, Button, Box, IconButton } from '@mui/material';
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Button,
+  Box,
+  IconButton,
+  Menu,
+  MenuItem,
+} from '@mui/material';
 import { Brightness4, Brightness7 } from '@mui/icons-material';
+import MenuIcon from '@mui/icons-material/Menu';
 import { useTheme } from '@mui/material/styles';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { ColorModeContext } from '../theme';
 
-type NavLink = { label: string; id: string };
+export type NavLink = { label: string; id: string };
+export type NavGroup = { label: string; links: NavLink[] };
 
 interface NavbarProps {
-  links: NavLink[];
+  groups: NavGroup[];
   active: string;
   onSelect: (id: string) => void;
   onLogout: () => void;
@@ -15,9 +27,25 @@ interface NavbarProps {
   loading?: boolean;
 }
 
-export default function Navbar({ links, active, onSelect, onLogout, name, loading }: NavbarProps) {
+export default function Navbar({ groups, active, onSelect, onLogout, name, loading }: NavbarProps) {
   const theme = useTheme();
   const colorMode = useContext(ColorModeContext);
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [openGroup, setOpenGroup] = useState<string | null>(null);
+  const [mobileAnchorEl, setMobileAnchorEl] = useState<null | HTMLElement>(null);
+
+  function handleGroupClick(label: string, event: React.MouseEvent<HTMLElement>) {
+    setAnchorEl(event.currentTarget);
+    setOpenGroup(label);
+  }
+
+  function closeGroup() {
+    setAnchorEl(null);
+    setOpenGroup(null);
+  }
+
+  const mobileMenuOpen = Boolean(mobileAnchorEl);
 
   return (
     <AppBar position="static">
@@ -25,16 +53,76 @@ export default function Navbar({ links, active, onSelect, onLogout, name, loadin
         <Typography variant="h6" sx={{ flexGrow: 1 }}>
           Food Bank Portal
         </Typography>
-        {links.map(({ label, id }) => (
-          <Button
-            key={id}
-            color={active === id ? 'secondary' : 'inherit'}
-            onClick={() => onSelect(id)}
-            disabled={loading}
-          >
-            {label}
-          </Button>
-        ))}
+        {isSmall ? (
+          <>
+            <IconButton color="inherit" onClick={(e) => setMobileAnchorEl(e.currentTarget)}>
+              <MenuIcon />
+            </IconButton>
+            <Menu
+              anchorEl={mobileAnchorEl}
+              open={mobileMenuOpen}
+              onClose={() => setMobileAnchorEl(null)}
+            >
+              {groups.map((group) => (
+                <Box key={group.label}>
+                  {!(group.links.length === 1 && group.links[0].label === group.label) && (
+                    <MenuItem disabled>{group.label}</MenuItem>
+                  )}
+                  {group.links.map(({ label, id }) => (
+                    <MenuItem
+                      key={id}
+                      selected={active === id}
+                      onClick={() => {
+                        setMobileAnchorEl(null);
+                        onSelect(id);
+                      }}
+                      disabled={loading}
+                    >
+                      {label}
+                    </MenuItem>
+                  ))}
+                </Box>
+              ))}
+            </Menu>
+          </>
+        ) : (
+          groups.map((group) =>
+            group.links.length === 1 ? (
+              <Button
+                key={group.links[0].id}
+                color={group.links[0].id === active ? 'secondary' : 'inherit'}
+                onClick={() => onSelect(group.links[0].id)}
+                disabled={loading}
+              >
+                {group.links[0].label}
+              </Button>
+            ) : (
+              <Box key={group.label}>
+                <Button
+                  color={group.links.some((l) => l.id === active) ? 'secondary' : 'inherit'}
+                  onClick={(e) => handleGroupClick(group.label, e)}
+                >
+                  {group.label}
+                </Button>
+                <Menu anchorEl={anchorEl} open={openGroup === group.label} onClose={closeGroup}>
+                  {group.links.map(({ label, id }) => (
+                    <MenuItem
+                      key={id}
+                      selected={active === id}
+                      onClick={() => {
+                        closeGroup();
+                        onSelect(id);
+                      }}
+                      disabled={loading}
+                    >
+                      {label}
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </Box>
+            )
+          )
+        )}
         <Box sx={{ flexGrow: 1 }} />
         <Typography variant="body2" sx={{ mr: 1 }}>
           Hello, {name}


### PR DESCRIPTION
## Summary
- group navigation options into role-based menu sections
- add hamburger menu for small screens

## Testing
- `npm run lint`
- `npm run build` *(fails: `src/components/VolunteerSchedule.tsx` parameters 'r' and 'b' implicitly have 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_6894d9c9be00832d87bb302679b28e39