### PR TITLE
feat: add reschedule token support

### DIFF
--- a/MJ_FB_Backend/src/models/booking.ts
+++ b/MJ_FB_Backend/src/models/booking.ts
@@ -12,4 +12,5 @@ interface Booking {
   is_staff_booking: boolean;
   created_at: string;
   reason?: string | null;
+  reschedule_token: string | null;
 }

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -7,7 +7,8 @@ import {
   createPreapprovedBooking,
   createBookingForUser,   // ✅ make sure to import this controller
   getBookingHistory,
-  cancelBooking
+  cancelBooking,
+  rescheduleBooking
 } from '../controllers/bookingController';
 
 const router = express.Router();
@@ -53,6 +54,9 @@ router.post(
 
 // Cancel booking (staff or user)
 router.post('/:id/cancel', authMiddleware, cancelBooking);
+
+// Reschedule booking by token
+router.post('/reschedule/:token', rescheduleBooking);
 
 // Staff create preapproved booking for walk-in users
 router.post(

--- a/MJ_FB_Backend/src/routes/volunteerBookings.ts
+++ b/MJ_FB_Backend/src/routes/volunteerBookings.ts
@@ -6,6 +6,7 @@ import {
   updateVolunteerBookingStatus,
   listVolunteerBookingsByVolunteer,
   createVolunteerBookingForVolunteer,
+  rescheduleVolunteerBooking,
 } from '../controllers/volunteerBookingController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { verifyVolunteerToken } from '../middleware/verifyVolunteerToken';
@@ -28,5 +29,6 @@ router.get(
 );
 router.get('/:role_id', authMiddleware, authorizeRoles('volunteer_coordinator'), listVolunteerBookingsByRole);
 router.patch('/:id', authMiddleware, authorizeRoles('volunteer_coordinator'), updateVolunteerBookingStatus);
+router.post('/reschedule/:token', rescheduleVolunteerBooking);
 
 export default router;

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS bookings (
     date date,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     is_staff_booking boolean DEFAULT false,
+    reschedule_token text,
     FOREIGN KEY (slot_id) REFERENCES public.slots(id),
     FOREIGN KEY (user_id) REFERENCES public.users(id)
 );
@@ -128,10 +129,16 @@ CREATE TABLE IF NOT EXISTS volunteer_bookings (
     date date NOT NULL,
     status text DEFAULT 'pending' NOT NULL CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled')),
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    reschedule_token text,
     FOREIGN KEY (role_id) REFERENCES public.volunteer_roles(id) ON DELETE CASCADE,
     FOREIGN KEY (volunteer_id) REFERENCES public.volunteers(id) ON DELETE CASCADE
 );
 `);
+
+  await client.query(`
+    ALTER TABLE bookings ADD COLUMN IF NOT EXISTS reschedule_token text;
+    ALTER TABLE volunteer_bookings ADD COLUMN IF NOT EXISTS reschedule_token text;
+  `);
 
   // Insert master data
   await client.query(`

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -445,3 +445,28 @@ export async function updateVolunteerTrainedAreas(
   return handleResponse(res);
 }
   
+export async function rescheduleBookingByToken(
+  token: string,
+  slotId: string,
+  date: string,
+) {
+  const res = await fetch(`${API_BASE}/bookings/reschedule/${token}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slotId, date }),
+  });
+  return handleResponse(res);
+}
+
+export async function rescheduleVolunteerBookingByToken(
+  token: string,
+  roleId: number,
+  date: string,
+) {
+  const res = await fetch(`${API_BASE}/volunteer-bookings/reschedule/${token}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ roleId, date }),
+  });
+  return handleResponse(res);
+}


### PR DESCRIPTION
## Summary
- add `reschedule_token` columns to booking tables and generation on creation
- implement token-based booking reschedule endpoints for clients and volunteers
- expose reschedule APIs in frontend

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Backend && npm run build`
- `cd MJ_FB_Frontend && npm test` *(fails: Missing script: "test")*
- `cd MJ_FB_Frontend && npm run build` *(fails: Parameter 'r' implicitly has an 'any' type.)*

------
https://chatgpt.com/codex/tasks/task_e_68954228ed28832dbb34fe9b84ad5fd5