### PR TITLE
Reset booking status to submitted on reschedule

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -203,9 +203,12 @@ export async function rescheduleBooking(req: Request, res: Response) {
     }
     await checkSlotCapacity(slotId, date);
     const newToken = randomUUID();
+    const isStaffReschedule =
+      req.user && ['staff', 'volunteer_coordinator'].includes(req.user.role);
+    const newStatus = isStaffReschedule ? booking.status : 'submitted';
     await pool.query(
-      'UPDATE bookings SET slot_id=$1, date=$2, reschedule_token=$3 WHERE id=$4',
-      [slotId, date, newToken, booking.id],
+      'UPDATE bookings SET slot_id=$1, date=$2, reschedule_token=$3, status=$4 WHERE id=$5',
+      [slotId, date, newToken, newStatus, booking.id],
     );
     await updateBookingsThisMonth(booking.user_id);
     res.json({ message: 'Booking rescheduled', rescheduleToken: newToken });

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -68,6 +68,72 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
   }
 }
 
+export async function optionalAuthMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || typeof authHeader !== 'string') {
+    return next();
+  }
+
+  const token = authHeader.startsWith('Bearer ')
+    ? authHeader.slice(7).trim()
+    : authHeader;
+
+  try {
+    const match = token.match(/^(staff|user)[:\-](\d+)$/);
+    if (!match) {
+      return res.status(401).json({ message: 'Invalid token format' });
+    }
+    const [, type, id] = match;
+    if (type === 'staff') {
+      const staffRes = await pool.query(
+        'SELECT id, first_name, last_name, email, role FROM staff WHERE id = $1',
+        [id],
+      );
+      if (staffRes.rowCount === 0) {
+        return res.status(401).json({ message: 'Invalid token' });
+      }
+      req.user = {
+        id: staffRes.rows[0].id.toString(),
+        type: 'staff',
+        role: staffRes.rows[0].role,
+        name: `${staffRes.rows[0].first_name} ${staffRes.rows[0].last_name}`,
+        email: staffRes.rows[0].email,
+      } as any;
+      return next();
+    }
+
+    if (type === 'user') {
+      const userRes = await pool.query(
+        'SELECT id, first_name, last_name, email, role, phone FROM users WHERE id = $1',
+        [id],
+      );
+      if (userRes.rowCount && userRes.rowCount > 0) {
+        req.user = {
+          id: userRes.rows[0].id.toString(),
+          type: 'user',
+          role: userRes.rows[0].role,
+          email: userRes.rows[0].email,
+          phone: userRes.rows[0].phone,
+          name: `${userRes.rows[0].first_name} ${userRes.rows[0].last_name}`,
+        } as any;
+        return next();
+      }
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+
+    return res.status(401).json({ message: 'Invalid token format' });
+  } catch (error) {
+    console.error('Auth error:', error);
+    res.status(500).json({
+      message: `Database error during authentication: ${(error as Error).message}`,
+    });
+  }
+}
+
 export function authorizeRoles(...allowedRoles: string[]) {
   return (req: Request, res: Response, next: NextFunction) => {
     if (!req.user) return res.status(401).json({ message: 'Unauthorized' });

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -1,5 +1,9 @@
 import express, { Request, Response } from 'express';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import {
+  authMiddleware,
+  authorizeRoles,
+  optionalAuthMiddleware,
+} from '../middleware/authMiddleware';
 import {
   createBooking,
   listBookings,
@@ -56,7 +60,7 @@ router.post(
 router.post('/:id/cancel', authMiddleware, cancelBooking);
 
 // Reschedule booking by token
-router.post('/reschedule/:token', rescheduleBooking);
+router.post('/reschedule/:token', optionalAuthMiddleware, rescheduleBooking);
 
 // Staff create preapproved booking for walk-in users
 router.post(

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -449,10 +449,13 @@ export async function rescheduleBookingByToken(
   token: string,
   slotId: string,
   date: string,
+  authToken?: string,
 ) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (authToken) headers.Authorization = authToken;
   const res = await fetch(`${API_BASE}/bookings/reschedule/${token}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify({ slotId, date }),
   });
   return handleResponse(res);


### PR DESCRIPTION
## Summary
- Added optional authentication middleware to detect staff on reschedule
- Reschedule API now resets booking status to `submitted` unless staff performs the change
- Frontend API updated to optionally send Authorization when rescheduling

## Testing
- `npm test` (backend)
- `npm run build` (backend)
- `npm test` (frontend) *(fails: Missing script 'test')*
- `npm run build` (frontend) *(fails: TS7006 in VolunteerSchedule.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6895461156ec832db093dcaaa3778e5a