### PR TITLE
Add placeholder email notifications

### DIFF
--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -1,0 +1,5 @@
+export async function sendEmail(to: string, subject: string, body: string): Promise<void> {
+  // Placeholder for future Power Automate integration
+  console.log(`[Email placeholder] To: ${to}, Subject: ${subject}, Body: ${body}`);
+  // TODO: integrate with Power Automate or real email service
+}


### PR DESCRIPTION
## Summary
- stub email utility that logs intended messages for future Power Automate integration
- hook booking and volunteer booking controllers to call the stub on request, approval/rejection, cancellation, and reschedule events

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68954c180db8832d97768a41ae32a788