### PR TITLE
feat: add reusable feedback modal

### DIFF
--- a/MJ_FB_Frontend/src/components/FeedbackModal.tsx
+++ b/MJ_FB_Frontend/src/components/FeedbackModal.tsx
@@ -1,0 +1,22 @@
+import type { AlertColor } from '@mui/material';
+import { Dialog, DialogContent, DialogActions, Button, Alert } from '@mui/material';
+
+interface FeedbackModalProps {
+  open: boolean;
+  onClose: () => void;
+  message: string;
+  severity?: AlertColor;
+}
+
+export default function FeedbackModal({ open, onClose, message, severity = 'success' }: FeedbackModalProps) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogContent>
+        <Alert severity={severity}>{message}</Alert>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add FeedbackModal component using MUI Dialog and Alert

## Testing
- `npm run lint`
- `npm run build` *(fails: src/components/VolunteerSchedule.tsx(54,24): Parameter 'r' implicitly has an 'any' type.)*

------
https://chatgpt.com/codex/tasks/task_e_68954f0da524832d9304e9810fca560f