### PR TITLE
Add reusable snackbar for brief feedback messages

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -13,6 +13,7 @@ import VolunteerDashboard from './components/VolunteerDashboard';
 import CoordinatorDashboard from './components/CoordinatorDashboard';
 import type { Role } from './types';
 import Navbar, { type NavGroup } from './components/Navbar';
+import FeedbackSnackbar from './components/FeedbackSnackbar';
 
 export default function App() {
   const [token, setToken] = useState(localStorage.getItem('token') || '');
@@ -124,11 +125,12 @@ export default function App() {
             loading={loading}
           />
 
-          {error && (
-            <div role="alert" className="error-message">
-              {error}
-            </div>
-          )}
+          <FeedbackSnackbar
+            open={!!error}
+            onClose={() => setError('')}
+            message={error}
+            severity="error"
+          />
 
           <main>
             {activePage === 'profile' && <Profile />}

--- a/MJ_FB_Frontend/src/components/FeedbackSnackbar.tsx
+++ b/MJ_FB_Frontend/src/components/FeedbackSnackbar.tsx
@@ -1,0 +1,38 @@
+import type { AlertColor } from '@mui/material';
+import { Snackbar, Alert } from '@mui/material';
+import type { SyntheticEvent } from 'react';
+
+interface FeedbackSnackbarProps {
+  open: boolean;
+  onClose: () => void;
+  message: string;
+  severity?: AlertColor;
+  duration?: number;
+}
+
+export default function FeedbackSnackbar({
+  open,
+  onClose,
+  message,
+  severity = 'success',
+  duration = 6000,
+}: FeedbackSnackbarProps) {
+  function handleClose(_?: SyntheticEvent | Event, reason?: string) {
+    if (reason === 'clickaway') return;
+    onClose();
+  }
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={duration}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    >
+      <Alert onClose={handleClose} severity={severity} variant="filled" sx={{ width: '100%' }}>
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+}
+

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ npm start   # or npm run dev
 ```
 
 Refer to the submodule repositories for detailed configuration and environment variables.
+
+### Frontend features
+
+- Includes a reusable `FeedbackSnackbar` component for concise user notifications.


### PR DESCRIPTION
## Summary
- add generic FeedbackSnackbar component leveraging MUI's Snackbar & Alert
- surface app errors through FeedbackSnackbar instead of inline alerts
- document FeedbackSnackbar in README

## Testing
- `npm test` (frontend fails: Missing script "test")
- `npm run lint`
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68955302b18c832da7aa1e0139b3be73