### PR TITLE
refactor: use snackbar and modal for app feedback

### DIFF
--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -13,6 +13,7 @@ import type { VolunteerBookingDetail } from '../types';
 import { formatTime } from '../utils/time';
 import VolunteerScheduleTable from './VolunteerScheduleTable';
 import { fromZonedTime, formatInTimeZone } from 'date-fns-tz';
+import FeedbackSnackbar from './FeedbackSnackbar';
 
 interface RoleOption {
   id: number; // unique slot id
@@ -493,7 +494,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
         </div>
       )}
 
-      {message && <p style={{ color: 'red' }}>{message}</p>}
+      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity="error" />
 
       {assignModal && (
         <div

--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -3,6 +3,7 @@ import { loginUser } from '../api/api';
 import type { LoginResponse } from '../api/api';
 import { formatInTimeZone } from 'date-fns-tz';
 import { Box, Link, Typography, TextField, Button, Stack } from '@mui/material';
+import FeedbackSnackbar from './FeedbackSnackbar';
 
 export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (user: LoginResponse) => void; onStaff: () => void; onVolunteer: () => void }) {
   const [clientId, setClientId] = useState('');
@@ -34,12 +35,12 @@ export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (use
         <Link component="button" onClick={onVolunteer} underline="hover">Volunteer Login</Link>
       </Stack>
       <Typography variant="h4" gutterBottom>User Login</Typography>
-      {error && <Typography color="error">{error}</Typography>}
       <Stack component="form" spacing={2} onSubmit={handleSubmit} mt={2}>
         <TextField value={clientId} onChange={e => setClientId(e.target.value)} label="Client ID" />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
         <Button type="submit" variant="contained">Login</Button>
       </Stack>
+      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );
 }

--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -5,6 +5,7 @@ import { searchUsers, createBookingForUser, createBooking, getSlots, getHolidays
 import { toZonedTime, fromZonedTime, formatInTimeZone } from 'date-fns-tz';
 import type { Slot, Holiday } from '../types';
 import { formatTime } from '../utils/time';
+import FeedbackSnackbar from './FeedbackSnackbar';
 
 const reginaTimeZone = 'America/Regina';
 const LIMIT_MESSAGE =
@@ -211,7 +212,7 @@ export default function SlotBooking({ token, role }: Props) {
             </li>
           ))}
         </ul>
-        {message && <p className="error-message">{message}</p>}
+        <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity="error" />
       </div>
     );
   }
@@ -274,9 +275,12 @@ export default function SlotBooking({ token, role }: Props) {
       )}
 
       {role === 'staff' && <button onClick={() => setSelectedUser(null)}>Back to Search</button>}
-      {message && (
-        <p className={message.startsWith('Booking') ? 'success-message' : 'error-message'}>{message}</p>
-      )}
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity={message.startsWith('Booking') ? 'success' : 'error'}
+      />
     </div>
   );
 }

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
 import { addUser, createStaff } from '../../api/api';
 import type { UserRole, StaffRole } from '../../types';
+import FeedbackSnackbar from '../FeedbackSnackbar';
+import FeedbackModal from '../FeedbackModal';
 
 export default function AddUser({ token }: { token: string }) {
   const [mode, setMode] = useState<'user' | 'staff'>('user');
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<UserRole>('shopper');
   const [phone, setPhone] = useState('');
-  const [message, setMessage] = useState('');
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
 
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
@@ -17,7 +20,7 @@ export default function AddUser({ token }: { token: string }) {
 
   async function submitUser() {
     if (!firstName || !lastName || !clientId || !password) {
-      setMessage('First name, last name, client ID and password required');
+      setError('First name, last name, client ID and password required');
       return;
     }
     try {
@@ -31,7 +34,7 @@ export default function AddUser({ token }: { token: string }) {
         email || undefined,
         phone || undefined
       );
-      setMessage('User added successfully');
+      setSuccess('User added successfully');
       setFirstName('');
       setLastName('');
       setClientId('');
@@ -40,25 +43,25 @@ export default function AddUser({ token }: { token: string }) {
       setPassword('');
       setRole('shopper');
     } catch (err: unknown) {
-      setMessage(err instanceof Error ? err.message : String(err));
+      setError(err instanceof Error ? err.message : String(err));
     }
   }
 
   async function submitStaff() {
     if (!firstName || !lastName || !email || !password) {
-      setMessage('All fields required');
+      setError('All fields required');
       return;
     }
     try {
       await createStaff(firstName, lastName, staffRole, email, password, token);
-      setMessage('Staff added successfully');
+      setSuccess('Staff added successfully');
       setFirstName('');
       setLastName('');
       setEmail('');
       setPassword('');
       setStaffRole('staff');
     } catch (err: unknown) {
-      setMessage(err instanceof Error ? err.message : String(err));
+      setError(err instanceof Error ? err.message : String(err));
     }
   }
 
@@ -69,7 +72,8 @@ export default function AddUser({ token }: { token: string }) {
         <button onClick={() => setMode('user')}>Create User</button>
         <button onClick={() => setMode('staff')} style={{ marginLeft: 8 }}>Create Staff</button>
       </div>
-      {message && <p>{message}</p>}
+      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+      <FeedbackModal open={!!success} onClose={() => setSuccess('')} message={success} />
       {mode === 'user' ? (
         <>
           <div style={{ marginBottom: 8 }}>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/ManageAvailability.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../api/api';
 import type { Slot, Holiday, Break, BlockedSlot } from '../../types';
 import { formatTime } from '../../utils/time';
+import FeedbackSnackbar from '../FeedbackSnackbar';
 
 const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
@@ -157,7 +158,7 @@ export default function ManageAvailability({ token }: { token: string }) {
   return (
     <div>
       <h2>Manage Availability</h2>
-      {message && <p>{message}</p>}
+      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} />
 
       <div style={{ marginBottom: 16 }}>
         <label>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
@@ -4,6 +4,7 @@ import type { Slot, Break, Holiday, BlockedSlot } from '../../types';
 import { fromZonedTime, toZonedTime, formatInTimeZone } from 'date-fns-tz';
 import { formatTime } from '../../utils/time';
 import VolunteerScheduleTable from '../VolunteerScheduleTable';
+import FeedbackSnackbar from '../FeedbackSnackbar';
 
 interface Booking {
   id: number;
@@ -240,7 +241,7 @@ export default function PantrySchedule({ token }: { token: string }) {
         </h3>
         <button onClick={() => changeDay(1)}>Next</button>
       </div>
-      {message && <p style={{ color: 'red' }}>{message}</p>}
+      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity="error" />
       {isClosed ? (
         <p style={{ textAlign: 'center' }}>Moose Jaw food bank is closed for {dayName}</p>
       ) : (
@@ -280,7 +281,7 @@ export default function PantrySchedule({ token }: { token: string }) {
                 </li>
               ))}
             </ul>
-            {assignMessage && <p style={{ color: 'red' }}>{assignMessage}</p>}
+            <FeedbackSnackbar open={!!assignMessage} onClose={() => setAssignMessage('')} message={assignMessage} severity="error" />
             <button onClick={() => { setAssignSlot(null); setSearchTerm(''); setAssignMessage(''); }}>Close</button>
           </div>
         </div>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { loginStaff, staffExists, createStaff } from '../api/api';
 import type { LoginResponse } from '../api/api';
 import { Box, Typography, TextField, Button, Stack, Link } from '@mui/material';
+import FeedbackSnackbar from './FeedbackSnackbar';
+import FeedbackModal from './FeedbackModal';
 
 export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
   const [checking, setChecking] = useState(true);
@@ -52,12 +54,12 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
     <Box>
       <Link component="button" onClick={onBack} underline="hover">User Login</Link>
       <Typography variant="h4" gutterBottom>Staff Login</Typography>
-      {error && <Typography color="error">{error}</Typography>}
       <Stack component="form" onSubmit={submit} spacing={2} mt={2}>
         <TextField value={email} onChange={e => setEmail(e.target.value)} label="Email" />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
         <Button type="submit" variant="contained">Login</Button>
       </Stack>
+      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );
 }
@@ -84,8 +86,6 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   return (
     <Box>
       <Typography variant="h4" gutterBottom>Create Staff Account</Typography>
-      {error && <Typography color="error">{error}</Typography>}
-      {message && <Typography color="success.main">{message}</Typography>}
       <Stack component="form" onSubmit={submit} spacing={2} mt={2}>
         <TextField value={firstName} onChange={e => setFirstName(e.target.value)} label="First name" />
         <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" />
@@ -93,6 +93,8 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
         <Button type="submit" variant="contained">Create Staff</Button>
       </Stack>
+      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+      <FeedbackModal open={!!message} onClose={() => setMessage('')} message={message} />
     </Box>
   );
 }

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { loginVolunteer } from '../api/api';
 import type { LoginResponse } from '../api/api';
 import { Box, Typography, TextField, Button, Stack, Link } from '@mui/material';
+import FeedbackSnackbar from './FeedbackSnackbar';
 
 export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
   const [username, setUsername] = useState('');
@@ -26,12 +27,12 @@ export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: Login
     <Box>
       <Link component="button" onClick={onBack} underline="hover">User Login</Link>
       <Typography variant="h4" gutterBottom>Volunteer Login</Typography>
-      {error && <Typography color="error">{error}</Typography>}
       <Stack component="form" onSubmit={submit} spacing={2} mt={2}>
         <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
         <Button type="submit" variant="contained">Login</Button>
       </Stack>
+      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );
 }

--- a/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
@@ -10,6 +10,7 @@ import type { VolunteerRole, Holiday, VolunteerBooking } from '../types';
 import { fromZonedTime, toZonedTime, formatInTimeZone } from 'date-fns-tz';
 import { formatTime } from '../utils/time';
 import VolunteerScheduleTable from './VolunteerScheduleTable';
+import FeedbackSnackbar from './FeedbackSnackbar';
 
 const reginaTimeZone = 'America/Regina';
 
@@ -200,7 +201,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
             </h3>
             <button onClick={() => changeDay(1)}>Next</button>
           </div>
-          {message && <p style={{ color: 'red' }}>{message}</p>}
+          <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity="error" />
           {isClosed ? (
             <p style={{ textAlign: 'center' }}>
               Moose Jaw food bank is closed for {dayName}


### PR DESCRIPTION
## Summary
- replace inline feedback messages with shared `FeedbackSnackbar`
- add `FeedbackModal` and confirmation dialog where stronger user action is needed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895580cd1ac832da84bf13711d9cca1