### PR TITLE
fix: include user email in Express request type

### DIFF
--- a/MJ_FB_Backend/src/types/express.d.ts
+++ b/MJ_FB_Backend/src/types/express.d.ts
@@ -3,6 +3,7 @@ declare namespace Express {
     user?: {
       id: string;
       role: 'shopper' | 'delivery' | 'staff' | 'volunteer_coordinator' | 'volunteer';
+      email?: string;
     };
   }
 }


### PR DESCRIPTION
## Summary
- add optional email field to Express Request user type so controllers can access user email without TypeScript errors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897773d889c832db9206c7ea1170f3f