### PR TITLE
Align volunteer role dropdown checkbox with label

### DIFF
--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -520,17 +520,18 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
                         style={{
                           display: 'flex',
                           alignItems: 'center',
+                          justifyContent: 'space-between',
+                          width: '100%',
                           marginBottom: 4,
                         }}
                       >
+                        <span>{r.name}</span>
                         <input
                           type="checkbox"
                           value={r.id}
                           checked={selectedCreateRoles.includes(r.id)}
                           onChange={e => toggleCreateRole(r.id, e.target.checked)}
-                          style={{ marginRight: 6 }}
                         />
-                        {r.name}
                       </label>
                     ))}
                   </div>


### PR DESCRIPTION
## Summary
- Left-align volunteer subroles and right-align checkboxes in coordinator volunteer creation dropdown

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68977d027d90832d988546b5a06c8c2f