### PR TITLE
Add configurable color theme and Golos Text font

### DIFF
--- a/MJ_FB_Frontend/index.html
+++ b/MJ_FB_Frontend/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Golos+Text:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -1,5 +1,11 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --e-global-color-primary: #000000;
+  --e-global-color-secondary: #000000;
+  --e-global-color-text: #2E2E2E;
+  --e-global-color-accent: #941818;
+  --e-global-typography-text-font-family: 'Golos Text', sans-serif;
+
+  font-family: var(--e-global-typography-text-font-family);
   line-height: 1.5;
   font-weight: 400;
 
@@ -75,7 +81,7 @@ button:focus-visible {
   margin: 0 auto;
   padding: 1rem;
   box-sizing: border-box;
-  font-family: sans-serif;
+  font-family: var(--e-global-typography-text-font-family);
 }
 
 form {

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -2,22 +2,25 @@ import { createTheme } from '@mui/material/styles';
 import type { ThemeOptions } from '@mui/material/styles';
 import type { PaletteMode } from '@mui/material';
 import { createContext } from 'react';
+import themeConfig, { type ThemeConfig } from './themeConfig';
 
 export const ColorModeContext = createContext({ toggleColorMode: () => {} });
 
 export const getTheme = (
   mode: PaletteMode = 'light',
-  primary: string = '#1976d2',
-  secondary: string = '#9c27b0'
-) =>
-  createTheme({
+  config: ThemeConfig = themeConfig
+) => {
+  const theme = createTheme({
     palette: {
       mode,
-      primary: { main: primary },
-      secondary: { main: secondary },
+      primary: { main: config.primary },
+      secondary: { main: config.secondary },
+      text: { primary: config.text },
+      error: { main: config.accent },
+      background: { default: config.primary },
     },
     typography: {
-      fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
+      fontFamily: config.fontFamily,
     },
     components: {
       MuiButton: {
@@ -27,5 +30,17 @@ export const getTheme = (
       },
     },
   } as ThemeOptions);
+
+  if (typeof document !== 'undefined') {
+    const root = document.documentElement;
+    root.style.setProperty('--e-global-color-primary', config.primary);
+    root.style.setProperty('--e-global-color-secondary', config.secondary);
+    root.style.setProperty('--e-global-color-text', config.text);
+    root.style.setProperty('--e-global-color-accent', config.accent);
+    root.style.setProperty('--e-global-typography-text-font-family', config.fontFamily);
+  }
+
+  return theme;
+};
 
 export default getTheme;

--- a/MJ_FB_Frontend/src/themeConfig.ts
+++ b/MJ_FB_Frontend/src/themeConfig.ts
@@ -1,0 +1,17 @@
+export interface ThemeConfig {
+  primary: string;
+  secondary: string;
+  text: string;
+  accent: string;
+  fontFamily: string;
+}
+
+export const defaultTheme: ThemeConfig = {
+  primary: '#000000',
+  secondary: '#000000',
+  text: '#2E2E2E',
+  accent: '#941818',
+  fontFamily: '"Golos Text", sans-serif',
+};
+
+export default defaultTheme;


### PR DESCRIPTION
## Summary
- add Google Font and theme variables for primary/secondary/text/accent colors
- implement MUI theme that reads from a configurable theme config
- apply custom font via CSS variables for consistent typography

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68977dcd9a60832da634f8bc305fcfc7