### PR TITLE
refactor: restore light theme with red accent

### DIFF
--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -1,17 +1,17 @@
 :root {
-  --e-global-color-primary: #000000;
+  --e-global-color-primary: #941818;
   --e-global-color-secondary: #000000;
-  --e-global-color-text: #2E2E2E;
+  --e-global-color-text: #000000;
   --e-global-color-accent: #941818;
+  --e-global-color-background: #FFFFFF;
   --e-global-typography-text-font-family: 'Golos Text', sans-serif;
 
   font-family: var(--e-global-typography-text-font-family);
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: var(--e-global-color-text);
+  background-color: var(--e-global-color-background);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -21,11 +21,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--e-global-color-accent);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #7a1313;
 }
 
 body, html, #root {
@@ -53,24 +53,11 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--e-global-color-accent);
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }
 
 
@@ -118,13 +105,13 @@ select {
 }
 
 .navbar button.active {
-  background-color: #007bff;
+  background-color: var(--e-global-color-accent);
   color: white;
 }
 
 .navbar button.logout {
   margin-left: auto;
-  background-color: #dc3545;
+  background-color: var(--e-global-color-accent);
   color: white;
 }
 
@@ -155,8 +142,8 @@ select {
 }
 
 .slot-item.selected {
-  border: 2px solid blue;
-  background-color: #e0f0ff;
+  border: 2px solid var(--e-global-color-accent);
+  background-color: #fbeaea;
 }
 
 .slot-item.disabled {

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -17,7 +17,7 @@ export const getTheme = (
       secondary: { main: config.secondary },
       text: { primary: config.text },
       error: { main: config.accent },
-      background: { default: config.primary },
+      background: { default: config.background },
     },
     typography: {
       fontFamily: config.fontFamily,
@@ -37,6 +37,7 @@ export const getTheme = (
     root.style.setProperty('--e-global-color-secondary', config.secondary);
     root.style.setProperty('--e-global-color-text', config.text);
     root.style.setProperty('--e-global-color-accent', config.accent);
+    root.style.setProperty('--e-global-color-background', config.background);
     root.style.setProperty('--e-global-typography-text-font-family', config.fontFamily);
   }
 

--- a/MJ_FB_Frontend/src/themeConfig.ts
+++ b/MJ_FB_Frontend/src/themeConfig.ts
@@ -3,14 +3,16 @@ export interface ThemeConfig {
   secondary: string;
   text: string;
   accent: string;
+  background: string;
   fontFamily: string;
 }
 
 export const defaultTheme: ThemeConfig = {
-  primary: '#000000',
+  primary: '#941818',
   secondary: '#000000',
-  text: '#2E2E2E',
+  text: '#000000',
   accent: '#941818',
+  background: '#FFFFFF',
   fontFamily: '"Golos Text", sans-serif',
 };
 


### PR DESCRIPTION
## Summary
- Use white background and black text across app
- Introduce #941818 as primary accent color
- Update theme config and CSS variables for consistent styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68977fe2f4b8832d833b31c6c11793b6