### PR TITLE
feat: improve dark mode styling

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -90,7 +90,7 @@ export default function Navbar({ groups, active, onSelect, onLogout, name, loadi
             group.links.length === 1 ? (
               <Button
                 key={group.links[0].id}
-                color={group.links[0].id === active ? 'secondary' : 'inherit'}
+                color="inherit"
                 onClick={() => onSelect(group.links[0].id)}
                 disabled={loading}
               >
@@ -99,7 +99,7 @@ export default function Navbar({ groups, active, onSelect, onLogout, name, loadi
             ) : (
               <Box key={group.label}>
                 <Button
-                  color={group.links.some((l) => l.id === active) ? 'secondary' : 'inherit'}
+                  color="inherit"
                   onClick={(e) => handleGroupClick(group.label, e)}
                 >
                   {group.label}

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -10,14 +10,18 @@ export const getTheme = (
   mode: PaletteMode = 'light',
   config: ThemeConfig = themeConfig
 ) => {
+  const isDark = mode === 'dark';
   const theme = createTheme({
     palette: {
       mode,
       primary: { main: config.primary },
-      secondary: { main: config.secondary },
-      text: { primary: config.text },
+      secondary: { main: isDark ? '#FFFFFF' : config.secondary },
+      text: { primary: isDark ? '#FFFFFF' : config.text },
       error: { main: config.accent },
-      background: { default: config.background },
+      background: {
+        default: isDark ? '#121212' : config.background,
+        paper: isDark ? '#1e1e1e' : '#FFFFFF',
+      },
     },
     typography: {
       fontFamily: config.fontFamily,
@@ -34,10 +38,16 @@ export const getTheme = (
   if (typeof document !== 'undefined') {
     const root = document.documentElement;
     root.style.setProperty('--e-global-color-primary', config.primary);
-    root.style.setProperty('--e-global-color-secondary', config.secondary);
-    root.style.setProperty('--e-global-color-text', config.text);
+    root.style.setProperty(
+      '--e-global-color-secondary',
+      isDark ? '#FFFFFF' : config.secondary
+    );
+    root.style.setProperty('--e-global-color-text', isDark ? '#FFFFFF' : config.text);
     root.style.setProperty('--e-global-color-accent', config.accent);
-    root.style.setProperty('--e-global-color-background', config.background);
+    root.style.setProperty(
+      '--e-global-color-background',
+      isDark ? '#121212' : config.background
+    );
     root.style.setProperty('--e-global-typography-text-font-family', config.fontFamily);
   }
 


### PR DESCRIPTION
## Summary
- adjust theme palette for dark mode, ensuring dark background and light text
- keep navbar links white to fix profile tab color

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68978198f3f0832d9cb92b54c9091b0e