### PR TITLE
Remove dark mode functionality

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -8,12 +8,10 @@ import {
   Menu,
   MenuItem,
 } from '@mui/material';
-import { Brightness4, Brightness7 } from '@mui/icons-material';
 import MenuIcon from '@mui/icons-material/Menu';
 import { useTheme } from '@mui/material/styles';
-import { useContext, useState } from 'react';
+import { useState } from 'react';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { ColorModeContext } from '../theme';
 
 export type NavLink = { label: string; id: string };
 export type NavGroup = { label: string; links: NavLink[] };
@@ -29,7 +27,6 @@ interface NavbarProps {
 
 export default function Navbar({ groups, active, onSelect, onLogout, name, loading }: NavbarProps) {
   const theme = useTheme();
-  const colorMode = useContext(ColorModeContext);
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [openGroup, setOpenGroup] = useState<string | null>(null);
@@ -127,9 +124,6 @@ export default function Navbar({ groups, active, onSelect, onLogout, name, loadi
         <Typography variant="body2" sx={{ mr: 1 }}>
           Hello, {name}
         </Typography>
-        <IconButton color="inherit" onClick={colorMode.toggleColorMode}>
-          {theme.palette.mode === 'dark' ? <Brightness7 /> : <Brightness4 />}
-        </IconButton>
         <Button color="inherit" onClick={onLogout} sx={{ ml: 1 }}>
           Logout
         </Button>

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -1,43 +1,26 @@
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { ThemeProvider, CssBaseline } from '@mui/material';
-import getTheme, { ColorModeContext } from './theme';
-import type { PaletteMode } from '@mui/material';
+import getTheme from './theme';
 
 function Main() {
-  const [mode, setMode] = useState<PaletteMode>(
-    (localStorage.getItem('mode') as PaletteMode) || 'light'
-  );
-  const colorMode = useMemo(
-    () => ({
-      toggleColorMode: () => {
-        setMode(prev => {
-          const next = prev === 'light' ? 'dark' : 'light';
-          localStorage.setItem('mode', next);
-          return next;
-        });
-      },
-    }),
-    []
-  );
-  const theme = useMemo(() => getTheme(mode), [mode]);
+  const theme = getTheme();
 
   return (
-    <ColorModeContext.Provider value={colorMode}>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <App />
-      </ThemeProvider>
-    </ColorModeContext.Provider>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   );
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Main />
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 
 export default Main;
+

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -1,26 +1,18 @@
 import { createTheme } from '@mui/material/styles';
 import type { ThemeOptions } from '@mui/material/styles';
-import type { PaletteMode } from '@mui/material';
-import { createContext } from 'react';
 import themeConfig, { type ThemeConfig } from './themeConfig';
 
-export const ColorModeContext = createContext({ toggleColorMode: () => {} });
-
-export const getTheme = (
-  mode: PaletteMode = 'light',
-  config: ThemeConfig = themeConfig
-) => {
-  const isDark = mode === 'dark';
+export const getTheme = (config: ThemeConfig = themeConfig) => {
   const theme = createTheme({
     palette: {
-      mode,
+      mode: 'light',
       primary: { main: config.primary },
-      secondary: { main: isDark ? '#FFFFFF' : config.secondary },
-      text: { primary: isDark ? '#FFFFFF' : config.text },
+      secondary: { main: config.secondary },
+      text: { primary: config.text },
       error: { main: config.accent },
       background: {
-        default: isDark ? '#121212' : config.background,
-        paper: isDark ? '#1e1e1e' : '#FFFFFF',
+        default: config.background,
+        paper: '#FFFFFF',
       },
     },
     typography: {
@@ -38,16 +30,10 @@ export const getTheme = (
   if (typeof document !== 'undefined') {
     const root = document.documentElement;
     root.style.setProperty('--e-global-color-primary', config.primary);
-    root.style.setProperty(
-      '--e-global-color-secondary',
-      isDark ? '#FFFFFF' : config.secondary
-    );
-    root.style.setProperty('--e-global-color-text', isDark ? '#FFFFFF' : config.text);
+    root.style.setProperty('--e-global-color-secondary', config.secondary);
+    root.style.setProperty('--e-global-color-text', config.text);
     root.style.setProperty('--e-global-color-accent', config.accent);
-    root.style.setProperty(
-      '--e-global-color-background',
-      isDark ? '#121212' : config.background
-    );
+    root.style.setProperty('--e-global-color-background', config.background);
     root.style.setProperty('--e-global-typography-text-font-family', config.fontFamily);
   }
 
@@ -55,3 +41,4 @@ export const getTheme = (
 };
 
 export default getTheme;
+


### PR DESCRIPTION
## Summary
- Remove dark mode support and related context, defaulting to a light theme
- Delete color scheme toggle from the navigation bar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68978409e794832db01f134c1b92a8d0