### PR TITLE
Fix navbar button visibility after outline style change

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -87,8 +87,7 @@ export default function Navbar({ groups, active, onSelect, onLogout, name, loadi
             group.links.length === 1 ? (
               <Button
                 key={group.links[0].id}
-                variant="outlined"
-                color="primary"
+                color="inherit"
                 onClick={() => onSelect(group.links[0].id)}
                 disabled={loading}
               >
@@ -97,8 +96,7 @@ export default function Navbar({ groups, active, onSelect, onLogout, name, loadi
             ) : (
               <Box key={group.label}>
                 <Button
-                  variant="outlined"
-                  color="primary"
+                  color="inherit"
                   onClick={(e) => handleGroupClick(group.label, e)}
                 >
                   {group.label}


### PR DESCRIPTION
## Summary
- ensure navbar buttons inherit AppBar color instead of using outlined variant so they remain visible

## Testing
- `npm test --prefix MJ_FB_Frontend` *(fails: Missing script "test")*
- `npm run lint --prefix MJ_FB_Frontend`
- `npm test --prefix MJ_FB_Backend`


------
https://chatgpt.com/codex/tasks/task_e_689785fd50f0832d8df4401ba9993813