### PR TITLE
Replace Stack form containers with MUI Box forms

### DIFF
--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -35,11 +35,13 @@ export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (use
         <Link component="button" onClick={onVolunteer} underline="hover">Volunteer Login</Link>
       </Stack>
       <Typography variant="h4" gutterBottom>User Login</Typography>
-      <Stack component="form" spacing={2} onSubmit={handleSubmit} mt={2}>
-        <TextField value={clientId} onChange={e => setClientId(e.target.value)} label="Client ID" />
-        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-        <Button type="submit" variant="outlined" color="primary">Login</Button>
-      </Stack>
+      <Box component="form" onSubmit={handleSubmit} mt={2}>
+        <Stack spacing={2}>
+          <TextField value={clientId} onChange={e => setClientId(e.target.value)} label="Client ID" />
+          <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
+          <Button type="submit" variant="outlined" color="primary">Login</Button>
+        </Stack>
+      </Box>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -54,11 +54,13 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
     <Box>
       <Link component="button" onClick={onBack} underline="hover">User Login</Link>
       <Typography variant="h4" gutterBottom>Staff Login</Typography>
-      <Stack component="form" onSubmit={submit} spacing={2} mt={2}>
-        <TextField value={email} onChange={e => setEmail(e.target.value)} label="Email" />
-        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-        <Button type="submit" variant="outlined" color="primary">Login</Button>
-      </Stack>
+      <Box component="form" onSubmit={submit} mt={2}>
+        <Stack spacing={2}>
+          <TextField value={email} onChange={e => setEmail(e.target.value)} label="Email" />
+          <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
+          <Button type="submit" variant="outlined" color="primary">Login</Button>
+        </Stack>
+      </Box>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );
@@ -86,13 +88,15 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   return (
     <Box>
       <Typography variant="h4" gutterBottom>Create Staff Account</Typography>
-      <Stack component="form" onSubmit={submit} spacing={2} mt={2}>
-        <TextField value={firstName} onChange={e => setFirstName(e.target.value)} label="First name" />
-        <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" />
-        <TextField type="email" value={email} onChange={e => setEmail(e.target.value)} label="Email" />
-        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-        <Button type="submit" variant="outlined" color="primary">Create Staff</Button>
-      </Stack>
+      <Box component="form" onSubmit={submit} mt={2}>
+        <Stack spacing={2}>
+          <TextField value={firstName} onChange={e => setFirstName(e.target.value)} label="First name" />
+          <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" />
+          <TextField type="email" value={email} onChange={e => setEmail(e.target.value)} label="Email" />
+          <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
+          <Button type="submit" variant="outlined" color="primary">Create Staff</Button>
+        </Stack>
+      </Box>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <FeedbackModal open={!!message} onClose={() => setMessage('')} message={message} />
     </Box>

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -27,11 +27,13 @@ export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: Login
     <Box>
       <Link component="button" onClick={onBack} underline="hover">User Login</Link>
       <Typography variant="h4" gutterBottom>Volunteer Login</Typography>
-      <Stack component="form" onSubmit={submit} spacing={2} mt={2}>
-        <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" />
-        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-        <Button type="submit" variant="outlined" color="primary">Login</Button>
-      </Stack>
+      <Box component="form" onSubmit={submit} mt={2}>
+        <Stack spacing={2}>
+          <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" />
+          <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
+          <Button type="submit" variant="outlined" color="primary">Login</Button>
+        </Stack>
+      </Box>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );


### PR DESCRIPTION
## Summary
- Switch login-related forms from Stack components to Material UI Box with `component="form"`
- Maintain Stack layout within the Box for spacing and submit handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689786cdc7c8832d9a6a6c37ed862201