### PR TITLE
Add checkboxes to volunteer role selection

### DIFF
--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -14,7 +14,14 @@ import { formatTime } from '../utils/time';
 import VolunteerScheduleTable from './VolunteerScheduleTable';
 import { fromZonedTime, formatInTimeZone } from 'date-fns-tz';
 import FeedbackSnackbar from './FeedbackSnackbar';
-import { Button, TextField, MenuItem, ListSubheader } from '@mui/material';
+import {
+  Button,
+  TextField,
+  MenuItem,
+  ListSubheader,
+  Checkbox,
+  ListItemText,
+} from '@mui/material';
 
 interface RoleOption {
   id: number; // unique slot id
@@ -502,7 +509,8 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
                   <ListSubheader>{g.category}</ListSubheader>
                   {g.roles.map(r => (
                     <MenuItem key={r.id} value={r.id}>
-                      {r.name}
+                      <Checkbox checked={selectedCreateRoles.indexOf(r.id) > -1} />
+                      <ListItemText primary={r.name} />
                     </MenuItem>
                   ))}
                 </Fragment>


### PR DESCRIPTION
## Summary
- allow selecting multiple volunteer roles when creating volunteers
- show checkboxes in dropdown menu for clearer selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689789984918832dbf88407b465b07fe