### PR TITLE
Switch to JWT-based auth

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -7,4 +7,16 @@ Backend: https://github.com/Amrutha-A-J/MJ_FB_Backend
 
 `FRONTEND_ORIGIN` – Origin URL of the frontend allowed for CORS. Defaults to `http://localhost:5173` if unset.
 
+`JWT_SECRET` – Secret key used to sign and verify JSON Web Tokens. **Required**.
+
+## Authentication Tokens
+
+Login responses now return a JSON Web Token (JWT) instead of a simple `type:id` string. Clients must send this token in the `Authorization` header using the standard Bearer format:
+
+```
+Authorization: Bearer <token>
+```
+
+The token payload includes the user's `id`, `role`, and `type` and expires after one hour.
+
 

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -7,13 +7,15 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
-    "pg": "^8.16.3"
+    "pg": "^8.16.3",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/pg": "^8.15.4",
+    "@types/jsonwebtoken": "^9.0.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -4,6 +4,8 @@ import type { Role, UserRole, StaffRole, UserProfile } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
 
+const bearer = (token: string) => `Bearer ${token}`;
+
 export interface LoginResponse {
   token: string;
   role: Role;
@@ -63,7 +65,7 @@ export async function loginVolunteer(
 
 export async function getUserProfile(token: string): Promise<UserProfile> {
   const res = await fetch(`${API_BASE}/users/me`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
@@ -85,7 +87,7 @@ export async function createStaff(
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
-  if (token) headers.Authorization = token;
+  if (token) headers.Authorization = bearer(token);
   const res = await fetch(`${API_BASE}/staff`, {
     method: 'POST',
     headers,
@@ -98,7 +100,7 @@ export async function getSlots(token: string, date?: string) {
     let url = `${API_BASE}/slots`;
     if (date) url += `?date=${encodeURIComponent(date)}`;
     const res = await fetch(url, {
-      headers: { Authorization: token }
+      headers: { Authorization: bearer(token) }
     });
     return handleResponse(res);
   }
@@ -118,7 +120,7 @@ export async function addUser(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify({
       firstName,
@@ -138,7 +140,7 @@ export async function addUser(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: token,
+        Authorization: bearer(token),
       },
       body: JSON.stringify({ slotId, date, requestData: '' }),
     });
@@ -147,7 +149,7 @@ export async function addUser(
 
 export async function getBookings(token: string) {
   const res = await fetch(`${API_BASE}/bookings`, {
-    headers: { Authorization: token }
+    headers: { Authorization: bearer(token) }
   });
   return handleResponse(res);
 }
@@ -163,7 +165,7 @@ export async function getBookingHistory(
   const res = await fetch(
     `${API_BASE}/bookings/history?${params.toString()}`,
     {
-      headers: { Authorization: token },
+      headers: { Authorization: bearer(token) },
     }
   );
   return handleResponse(res);
@@ -171,7 +173,7 @@ export async function getBookingHistory(
 
 export async function getHolidays(token: string) {
     const res = await fetch(`${API_BASE}/holidays`, {
-      headers: { Authorization: token }
+      headers: { Authorization: bearer(token) }
     });
     return handleResponse(res); // returns Holiday[]
   }
@@ -181,7 +183,7 @@ export async function getHolidays(token: string) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: token
+        Authorization: bearer(token)
       },
       body: JSON.stringify({ date, reason })
     });
@@ -191,21 +193,21 @@ export async function getHolidays(token: string) {
   export async function removeHoliday(token: string, date: string) {
     const res = await fetch(`${API_BASE}/holidays/${encodeURIComponent(date)}`, {
       method: 'DELETE',
-      headers: { Authorization: token }
+      headers: { Authorization: bearer(token) }
     });
     return handleResponse(res);
   }
 
 export async function getAllSlots(token: string) {
   const res = await fetch(`${API_BASE}/slots/all`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
 
 export async function getBlockedSlots(token: string, date: string) {
   const res = await fetch(`${API_BASE}/blocked-slots?date=${encodeURIComponent(date)}`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res); // returns BlockedSlot[]
 }
@@ -215,7 +217,7 @@ export async function addBlockedSlot(token: string, date: string, slotId: number
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify({ date, slotId, reason }),
   });
@@ -225,14 +227,14 @@ export async function addBlockedSlot(token: string, date: string, slotId: number
 export async function removeBlockedSlot(token: string, date: string, slotId: number) {
   const res = await fetch(`${API_BASE}/blocked-slots/${encodeURIComponent(date)}/${slotId}`, {
     method: 'DELETE',
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
 
 export async function getBreaks(token: string) {
   const res = await fetch(`${API_BASE}/breaks`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res); // returns Break[]
 }
@@ -242,7 +244,7 @@ export async function addBreak(token: string, dayOfWeek: number, slotId: number,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify({ dayOfWeek, slotId, reason }),
   });
@@ -252,7 +254,7 @@ export async function addBreak(token: string, dayOfWeek: number, slotId: number,
 export async function removeBreak(token: string, dayOfWeek: number, slotId: number) {
   const res = await fetch(`${API_BASE}/breaks/${dayOfWeek}/${slotId}`, {
     method: 'DELETE',
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
@@ -262,7 +264,7 @@ export async function decideBooking(token: string, bookingId: string, decision: 
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token
+      Authorization: bearer(token)
     },
     body: JSON.stringify({ decision, reason }),
   });
@@ -274,7 +276,7 @@ export async function cancelBooking(token: string, bookingId: string, reason?: s
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify(reason ? { reason } : {}),
   });
@@ -283,7 +285,7 @@ export async function cancelBooking(token: string, bookingId: string, reason?: s
 
 export async function searchUsers(token: string, search: string) {
     const res = await fetch(`${API_BASE}/users/search?search=${encodeURIComponent(search)}`, {
-      headers: { Authorization: token }
+      headers: { Authorization: bearer(token) }
     });
     return handleResponse(res); // returns array of users
   }
@@ -292,7 +294,7 @@ export async function searchVolunteers(token: string, search: string) {
   const res = await fetch(
     `${API_BASE}/volunteers/search?search=${encodeURIComponent(search)}`,
     {
-      headers: { Authorization: token },
+      headers: { Authorization: bearer(token) },
     }
   );
   return handleResponse(res);
@@ -309,7 +311,7 @@ export async function searchVolunteers(token: string, search: string) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: token
+        Authorization: bearer(token)
       },
       body: JSON.stringify({ userId, slotId, date, isStaffBooking })
     });
@@ -318,7 +320,7 @@ export async function searchVolunteers(token: string, search: string) {
 
 export async function getVolunteerRolesForVolunteer(token: string, date: string) {
   const res = await fetch(`${API_BASE}/volunteer-roles/mine?date=${date}`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
@@ -332,7 +334,7 @@ export async function requestVolunteerBooking(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify({ roleId, date }),
   });
@@ -341,21 +343,21 @@ export async function requestVolunteerBooking(
 
 export async function getMyVolunteerBookings(token: string) {
   const res = await fetch(`${API_BASE}/volunteer-bookings/mine`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
 
 export async function getVolunteerRoles(token: string) {
   const res = await fetch(`${API_BASE}/volunteer-roles`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
 
 export async function getVolunteerBookingsByRole(token: string, roleId: number) {
   const res = await fetch(`${API_BASE}/volunteer-bookings/${roleId}`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
@@ -369,7 +371,7 @@ export async function updateVolunteerBookingStatus(
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify({ status }),
   });
@@ -386,7 +388,7 @@ export async function createVolunteerBookingForVolunteer(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify({ volunteerId, roleId, date }),
   });
@@ -395,7 +397,7 @@ export async function createVolunteerBookingForVolunteer(
 
 export async function getVolunteerBookingHistory(token: string, volunteerId: number) {
   const res = await fetch(`${API_BASE}/volunteer-bookings/volunteer/${volunteerId}`, {
-    headers: { Authorization: token },
+    headers: { Authorization: bearer(token) },
   });
   return handleResponse(res);
 }
@@ -414,7 +416,7 @@ export async function createVolunteer(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify({
       firstName,
@@ -438,7 +440,7 @@ export async function updateVolunteerTrainedAreas(
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token,
+      Authorization: bearer(token),
     },
     body: JSON.stringify({ roleIds }),
   });
@@ -452,7 +454,7 @@ export async function rescheduleBookingByToken(
   authToken?: string,
 ) {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (authToken) headers.Authorization = authToken;
+  if (authToken) headers.Authorization = bearer(authToken);
   const res = await fetch(`${API_BASE}/bookings/reschedule/${token}`, {
     method: 'POST',
     headers,


### PR DESCRIPTION
## Summary
- add jsonwebtoken dependency
- issue JWTs in userController using env secret and expiration
- verify JWTs in auth middleware
- document token format and use Bearer auth in frontend api utilities

## Testing
- `npm test` (backend)
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68978d598708832d9801066ac7508b9e