### PR TITLE
Default to development JWT secret when env var missing

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -4,6 +4,7 @@ import { UserRole } from '../models/user';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { updateBookingsThisMonth } from '../utils/bookingUtils';
+import { JWT_SECRET } from '../utils/env';
 
 export async function loginUser(req: Request, res: Response) {
   const { email, password, clientId } = req.body;
@@ -28,13 +29,9 @@ export async function loginUser(req: Request, res: Response) {
         return res.status(401).json({ message: 'Invalid credentials' });
       }
       const bookingsThisMonth = await updateBookingsThisMonth(user.id);
-      const secret = process.env.JWT_SECRET;
-      if (!secret) {
-        throw new Error('JWT_SECRET not set');
-      }
       const token = jwt.sign(
         { id: user.id, role: user.role, type: 'user' },
-        secret,
+        JWT_SECRET,
         { expiresIn: '1h' },
       );
       return res.json({
@@ -61,13 +58,9 @@ export async function loginUser(req: Request, res: Response) {
     if (!match) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      throw new Error('JWT_SECRET not set');
-    }
     const token = jwt.sign(
       { id: staff.id, role: staff.role, type: 'staff' },
-      secret,
+      JWT_SECRET,
       { expiresIn: '1h' },
     );
     res.json({

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import pool from '../db';
 import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../utils/env';
 
 export async function authMiddleware(req: Request, res: Response, next: NextFunction) {
   const authHeader = req.headers['authorization'];
@@ -14,11 +15,7 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     : authHeader;
 
   try {
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      throw new Error('JWT_SECRET not set');
-    }
-    const decoded = jwt.verify(token, secret) as {
+    const decoded = jwt.verify(token, JWT_SECRET) as {
       id: number | string;
       role: string;
       type: string;
@@ -89,11 +86,7 @@ export async function optionalAuthMiddleware(
     : authHeader;
 
   try {
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      throw new Error('JWT_SECRET not set');
-    }
-    const decoded = jwt.verify(token, secret) as {
+    const decoded = jwt.verify(token, JWT_SECRET) as {
       id: number | string;
       role: string;
       type: string;

--- a/MJ_FB_Backend/src/utils/env.ts
+++ b/MJ_FB_Backend/src/utils/env.ts
@@ -1,0 +1,6 @@
+export const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+if (!process.env.JWT_SECRET) {
+  // eslint-disable-next-line no-console
+  console.warn('JWT_SECRET not set, using default development secret');
+}


### PR DESCRIPTION
## Summary
- avoid runtime failures when JWT_SECRET env var isn't configured by using a default development secret
- centralize JWT secret lookup and update login/auth middleware to use it

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68978fbb47bc832da2e5bebde9293160