### PR TITLE
Add Jest testing scaffolding for backend and frontend

### DIFF
--- a/MJ_FB_Backend/jest.config.js
+++ b/MJ_FB_Backend/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
+};

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -17,6 +17,11 @@
     "@types/express": "^5.0.3",
     "@types/pg": "^8.15.4",
     "@types/jsonwebtoken": "^9.0.6",
+    "@types/jest": "^29.5.11",
+    "@types/supertest": "^2.0.16",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },
@@ -24,7 +29,7 @@
     "dev": "ts-node src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",

--- a/MJ_FB_Backend/tests/login.test.ts
+++ b/MJ_FB_Backend/tests/login.test.ts
@@ -1,0 +1,70 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+
+jest.mock('../src/db');
+jest.mock('bcrypt');
+jest.mock('jsonwebtoken');
+jest.mock('../src/utils/bookingUtils', () => ({
+  updateBookingsThisMonth: jest.fn().mockResolvedValue(0),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/users', usersRouter);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/users/login', () => {
+  it('returns 400 when missing credentials', async () => {
+    const res = await request(app).post('/api/users/login').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('logs in staff with valid credentials', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 1, first_name: 'John', last_name: 'Doe', password: 'hashed', role: 'staff' }],
+    });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    (jwt.sign as jest.Mock).mockReturnValue('token');
+
+    const res = await request(app)
+      .post('/api/users/login')
+      .send({ email: 'john@example.com', password: 'secret' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('token', 'token');
+    expect(res.body).toHaveProperty('role', 'staff');
+  });
+
+  it('returns 401 with invalid credentials', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ password: 'hashed' }],
+    });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+    const res = await request(app)
+      .post('/api/users/login')
+      .send({ email: 'john@example.com', password: 'wrong' });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/users/me', () => {
+  it('requires authentication', async () => {
+    const res = await request(app).get('/api/users/me');
+    expect(res.status).toBe(401);
+  });
+});

--- a/MJ_FB_Backend/tsconfig.test.json
+++ b/MJ_FB_Backend/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/MJ_FB_Frontend/jest.config.cjs
+++ b/MJ_FB_Frontend/jest.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  testMatch: ['<rootDir>/src/__tests__/**/*.test.tsx'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.test.json',
+    },
+  },
+};

--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "date-fns-tz": "^3.2.0",
@@ -34,6 +35,12 @@
     "react-calendar": "^6.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "@types/jest": "^29.5.11",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Login from '../components/Login';
+import { loginUser } from '../api/api';
+
+jest.mock('../api/api', () => ({
+  loginUser: jest.fn(),
+}));
+
+describe('Login component', () => {
+  it('submits login credentials and calls onLogin', async () => {
+    (loginUser as jest.Mock).mockResolvedValue({ token: 't', role: 'user', name: 'Test' });
+    const onLogin = jest.fn();
+    render(<Login onLogin={onLogin} onStaff={() => {}} onVolunteer={() => {}} />);
+    fireEvent.change(screen.getByLabelText(/client id/i), { target: { value: '123' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pass' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    await waitFor(() => expect(onLogin).toHaveBeenCalled());
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import Navbar from '../components/Navbar';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('Navbar component', () => {
+  it('renders with title and name', () => {
+    render(
+      <MemoryRouter>
+        <Navbar
+          groups={[{ label: 'Home', links: [{ label: 'Home', to: '/' }] }]}
+          onLogout={() => {}}
+          name="Tester"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Food Bank Portal/i)).toBeInTheDocument();
+    expect(screen.getByText(/Hello, Tester/i)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/tsconfig.test.json
+++ b/MJ_FB_Frontend/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src", "src/__tests__"]
+}


### PR DESCRIPTION
## Summary
- configure backend with Jest and Supertest
- wire up frontend with Jest and React Testing Library
- add sample login and navbar tests

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm test` (frontend) *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689794f59b8c832da5c1d8722b647289