### PR TITLE
feat: enforce role hierarchy and route protections

### DIFF
--- a/MJ_FB_Backend/src/routes/blockedSlots.ts
+++ b/MJ_FB_Backend/src/routes/blockedSlots.ts
@@ -1,31 +1,46 @@
 import express from 'express';
-import { authMiddleware } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import pool from '../db';
 
 const router = express.Router();
 
-router.get('/', authMiddleware, async (req, res) => {
-  const date = req.query.date as string;
-  if (!date) return res.status(400).json({ message: 'Date required' });
-  const result = await pool.query('SELECT slot_id, reason FROM blocked_slots WHERE date = $1', [date]);
-  res.json(result.rows.map(r => ({ slotId: Number(r.slot_id), reason: r.reason ?? '' })));
-});
+router.get(
+  '/',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (req, res) => {
+    const date = req.query.date as string;
+    if (!date) return res.status(400).json({ message: 'Date required' });
+    const result = await pool.query('SELECT slot_id, reason FROM blocked_slots WHERE date = $1', [date]);
+    res.json(result.rows.map(r => ({ slotId: Number(r.slot_id), reason: r.reason ?? '' })));
+  },
+);
 
-router.post('/', authMiddleware, async (req, res) => {
-  const { date, slotId, reason } = req.body;
-  if (!date || !slotId) return res.status(400).json({ message: 'Date and slotId required' });
-  await pool.query(
-    'INSERT INTO blocked_slots (date, slot_id, reason) VALUES ($1, $2, $3) ON CONFLICT (date, slot_id) DO UPDATE SET reason = EXCLUDED.reason',
-    [date, slotId, reason ?? null]
-  );
-  res.json({ message: 'Added' });
-});
+router.post(
+  '/',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (req, res) => {
+    const { date, slotId, reason } = req.body;
+    if (!date || !slotId) return res.status(400).json({ message: 'Date and slotId required' });
+    await pool.query(
+      'INSERT INTO blocked_slots (date, slot_id, reason) VALUES ($1, $2, $3) ON CONFLICT (date, slot_id) DO UPDATE SET reason = EXCLUDED.reason',
+      [date, slotId, reason ?? null]
+    );
+    res.json({ message: 'Added' });
+  },
+);
 
-router.delete('/:date/:slotId', authMiddleware, async (req, res) => {
-  const { date, slotId } = req.params;
-  await pool.query('DELETE FROM blocked_slots WHERE date = $1 AND slot_id = $2', [date, slotId]);
-  res.json({ message: 'Removed' });
-});
+router.delete(
+  '/:date/:slotId',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (req, res) => {
+    const { date, slotId } = req.params;
+    await pool.query('DELETE FROM blocked_slots WHERE date = $1 AND slot_id = $2', [date, slotId]);
+    res.json({ message: 'Removed' });
+  },
+);
 
 export default router;
 

--- a/MJ_FB_Backend/src/routes/breaks.ts
+++ b/MJ_FB_Backend/src/routes/breaks.ts
@@ -1,37 +1,52 @@
 import express from 'express';
-import { authMiddleware } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import pool from '../db';
 
 const router = express.Router();
 
-router.get('/', authMiddleware, async (_, res) => {
-  const result = await pool.query('SELECT day_of_week, slot_id, reason FROM breaks');
-  res.json(
-    result.rows.map(r => ({
-      dayOfWeek: Number(r.day_of_week),
-      slotId: Number(r.slot_id),
-      reason: r.reason ?? '',
-    }))
-  );
-});
+router.get(
+  '/',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (_, res) => {
+    const result = await pool.query('SELECT day_of_week, slot_id, reason FROM breaks');
+    res.json(
+      result.rows.map(r => ({
+        dayOfWeek: Number(r.day_of_week),
+        slotId: Number(r.slot_id),
+        reason: r.reason ?? '',
+      }))
+    );
+  },
+);
 
-router.post('/', authMiddleware, async (req, res) => {
-  const { dayOfWeek, slotId, reason } = req.body;
-  if (dayOfWeek === undefined || slotId === undefined) {
-    return res.status(400).json({ message: 'dayOfWeek and slotId required' });
-  }
-  await pool.query(
-    'INSERT INTO breaks (day_of_week, slot_id, reason) VALUES ($1, $2, $3) ON CONFLICT (day_of_week, slot_id) DO UPDATE SET reason = EXCLUDED.reason',
-    [dayOfWeek, slotId, reason ?? null]
-  );
-  res.json({ message: 'Added' });
-});
+router.post(
+  '/',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (req, res) => {
+    const { dayOfWeek, slotId, reason } = req.body;
+    if (dayOfWeek === undefined || slotId === undefined) {
+      return res.status(400).json({ message: 'dayOfWeek and slotId required' });
+    }
+    await pool.query(
+      'INSERT INTO breaks (day_of_week, slot_id, reason) VALUES ($1, $2, $3) ON CONFLICT (day_of_week, slot_id) DO UPDATE SET reason = EXCLUDED.reason',
+      [dayOfWeek, slotId, reason ?? null]
+    );
+    res.json({ message: 'Added' });
+  },
+);
 
-router.delete('/:day/:slotId', authMiddleware, async (req, res) => {
-  const { day, slotId } = req.params;
-  await pool.query('DELETE FROM breaks WHERE day_of_week = $1 AND slot_id = $2', [day, slotId]);
-  res.json({ message: 'Removed' });
-});
+router.delete(
+  '/:day/:slotId',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (req, res) => {
+    const { day, slotId } = req.params;
+    await pool.query('DELETE FROM breaks WHERE day_of_week = $1 AND slot_id = $2', [day, slotId]);
+    res.json({ message: 'Removed' });
+  },
+);
 
 export default router;
 

--- a/MJ_FB_Backend/src/routes/holidays.ts
+++ b/MJ_FB_Backend/src/routes/holidays.ts
@@ -1,33 +1,48 @@
 // src/routes/holidays.ts
 import express from 'express';
-import { authMiddleware } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import pool from '../db';
 
 const router = express.Router();
 
-router.get('/', authMiddleware, async (_, res) => {
-  const result = await pool.query('SELECT date, reason FROM holidays ORDER BY date');
-  res.json(
-    result.rows.map(r => ({
-      date: r.date.toISOString().split('T')[0],
-      reason: r.reason ?? '',
-    }))
-  );
-});
+router.get(
+  '/',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (_, res) => {
+    const result = await pool.query('SELECT date, reason FROM holidays ORDER BY date');
+    res.json(
+      result.rows.map(r => ({
+        date: r.date.toISOString().split('T')[0],
+        reason: r.reason ?? '',
+      }))
+    );
+  },
+);
 
-router.post('/', authMiddleware, async (req, res) => {
-  const { date, reason } = req.body;
-  if (!date) return res.status(400).json({ message: 'Date required' });
-  await pool.query(
-    'INSERT INTO holidays (date, reason) VALUES ($1, $2) ON CONFLICT (date) DO UPDATE SET reason = EXCLUDED.reason',
-    [date, reason ?? null]
-  );
-  res.json({ message: 'Added' });
-});
+router.post(
+  '/',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (req, res) => {
+    const { date, reason } = req.body;
+    if (!date) return res.status(400).json({ message: 'Date required' });
+    await pool.query(
+      'INSERT INTO holidays (date, reason) VALUES ($1, $2) ON CONFLICT (date) DO UPDATE SET reason = EXCLUDED.reason',
+      [date, reason ?? null]
+    );
+    res.json({ message: 'Added' });
+  },
+);
 
-router.delete('/:date', authMiddleware, async (req, res) => {
-  await pool.query('DELETE FROM holidays WHERE date = $1', [req.params.date]);
-  res.json({ message: 'Removed' });
-});
+router.delete(
+  '/:date',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  async (req, res) => {
+    await pool.query('DELETE FROM holidays WHERE date = $1', [req.params.date]);
+    res.json({ message: 'Removed' });
+  },
+);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/slots.ts
+++ b/MJ_FB_Backend/src/routes/slots.ts
@@ -1,10 +1,20 @@
 import express from 'express';
 import { listSlots, listAllSlots } from '../controllers/slotController';
-import { authMiddleware } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
-router.get('/all', authMiddleware, listAllSlots);
-router.get('/', authMiddleware, listSlots);
+router.get(
+  '/all',
+  authMiddleware,
+  authorizeRoles('staff', 'volunteer_coordinator'),
+  listAllSlots,
+);
+router.get(
+  '/',
+  authMiddleware,
+  authorizeRoles('shopper', 'delivery', 'staff', 'volunteer_coordinator'),
+  listSlots,
+);
 
 export default router;

--- a/MJ_FB_Backend/tests/authorization.test.ts
+++ b/MJ_FB_Backend/tests/authorization.test.ts
@@ -1,0 +1,79 @@
+import request from 'supertest';
+import express from 'express';
+import blockedSlotsRouter from '../src/routes/blockedSlots';
+import slotsRouter from '../src/routes/slots';
+import { authMiddleware, authorizeRoles } from '../src/middleware/authMiddleware';
+import pool from '../src/db';
+import jwt from 'jsonwebtoken';
+
+jest.mock('../src/db');
+jest.mock('jsonwebtoken');
+
+const app = express();
+app.use(express.json());
+app.use('/blocked-slots', blockedSlotsRouter);
+app.use('/slots', slotsRouter);
+app.get('/volunteer-area', authMiddleware, authorizeRoles('volunteer'), (_req, res) => res.json({ ok: true }));
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Authorization middleware', () => {
+  it('returns 403 when shopper accesses blocked slots', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'shopper', type: 'user' });
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [{ id: 1, first_name: 'Test', last_name: 'User', email: 'test@example.com', role: 'shopper', phone: '123' }],
+    });
+
+    const res = await request(app)
+      .post('/blocked-slots')
+      .set('Authorization', 'Bearer token')
+      .send({ date: '2024-01-01', slotId: 1 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when shopper accesses all slots', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'shopper', type: 'user' });
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [{ id: 1, first_name: 'Test', last_name: 'User', email: 'test@example.com', role: 'shopper', phone: '123' }],
+    });
+
+    const res = await request(app)
+      .get('/slots/all')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(403);
+  });
+
+  it('allows coordinator to access volunteer endpoint', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 2, role: 'volunteer_coordinator', type: 'staff' });
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [{ id: 2, first_name: 'Coord', last_name: 'inator', email: 'coord@example.com', role: 'volunteer_coordinator' }],
+    });
+
+    const res = await request(app)
+      .get('/volunteer-area')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 when shopper accesses volunteer endpoint', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'shopper', type: 'user' });
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [{ id: 1, first_name: 'Test', last_name: 'User', email: 'test@example.com', role: 'shopper', phone: '123' }],
+    });
+
+    const res = await request(app)
+      .get('/volunteer-area')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add role hierarchy so coordinators inherit volunteer permissions
- restrict schedule management routes to staff and volunteer coordinators
- add integration tests for unauthorized role access

## Testing
- `cd MJ_FB_Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897966cbdd0832d81bea3f66a0e7bdd