### PR TITLE
feat: centralize environment configuration

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -8,6 +8,8 @@ PG_HOST=localhost
 PG_PORT=5432
 # Database name
 PG_DATABASE=mj_fb_db
+# Secret used for signing JWT tokens
+JWT_SECRET=change_me
 # Allowed frontend origins for CORS (comma separated)
 # Include both localhost and 127.0.0.1 for local development
 FRONTEND_ORIGIN=http://localhost:5173,http://127.0.0.1:5173

--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -5,9 +5,21 @@ Backend: https://github.com/Amrutha-A-J/MJ_FB_Backend
 
 ## Environment Variables
 
+`PG_HOST` – PostgreSQL host.
+
+`PG_PORT` – PostgreSQL port.
+
+`PG_USER` – PostgreSQL username.
+
+`PG_PASSWORD` – PostgreSQL password.
+
+`PG_DATABASE` – PostgreSQL database name.
+
 `FRONTEND_ORIGIN` – Origin URL of the frontend allowed for CORS. Defaults to `http://localhost:5173` if unset.
 
 `JWT_SECRET` – Secret key used to sign and verify JSON Web Tokens. **Required**.
+
+`PORT` – Port for the backend server.
 
 ## Authentication Tokens
 

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -1,0 +1,44 @@
+import dotenv from 'dotenv';
+import { z } from 'zod';
+
+dotenv.config();
+
+const envSchema = z.object({
+  PG_USER: z.string().default('postgres'),
+  PG_PASSWORD: z.string().default('password'),
+  PG_HOST: z.string().default('localhost'),
+  PG_PORT: z.coerce.number().default(5432),
+  PG_DATABASE: z.string().default('mj_fb_db'),
+  JWT_SECRET: z.string().default('dev-secret'),
+  FRONTEND_ORIGIN: z.string().default('http://localhost:5173,http://127.0.0.1:5173'),
+  PORT: z.coerce.number().default(4000),
+});
+
+const env = envSchema.parse(process.env);
+
+const requiredVars: Array<keyof typeof env> = [
+  'PG_USER',
+  'PG_PASSWORD',
+  'PG_HOST',
+  'PG_PORT',
+  'PG_DATABASE',
+  'JWT_SECRET',
+  'FRONTEND_ORIGIN',
+];
+
+const missing = requiredVars.filter(key => !process.env[key]);
+if (missing.length > 0) {
+  // eslint-disable-next-line no-console
+  console.warn(`Missing environment variables: ${missing.join(', ')}`);
+}
+
+export default {
+  pgUser: env.PG_USER,
+  pgPassword: env.PG_PASSWORD,
+  pgHost: env.PG_HOST,
+  pgPort: env.PG_PORT,
+  pgDatabase: env.PG_DATABASE,
+  jwtSecret: env.JWT_SECRET,
+  frontendOrigin: env.FRONTEND_ORIGIN,
+  port: env.PORT,
+};

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -4,7 +4,7 @@ import { UserRole } from '../models/user';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { updateBookingsThisMonth } from '../utils/bookingUtils';
-import { JWT_SECRET } from '../utils/env';
+import config from '../config';
 import logger from '../utils/logger';
 
 export async function loginUser(req: Request, res: Response, next: NextFunction) {
@@ -32,7 +32,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       const bookingsThisMonth = await updateBookingsThisMonth(user.id);
       const token = jwt.sign(
         { id: user.id, role: user.role, type: 'user' },
-        JWT_SECRET,
+        config.jwtSecret,
         { expiresIn: '1h' },
       );
       res.cookie('token', token, {
@@ -66,7 +66,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
     }
     const token = jwt.sign(
       { id: staff.id, role: staff.role, type: 'staff' },
-      JWT_SECRET,
+      config.jwtSecret,
       { expiresIn: '1h' },
     );
     res.cookie('token', token, {

--- a/MJ_FB_Backend/src/db.ts
+++ b/MJ_FB_Backend/src/db.ts
@@ -1,12 +1,11 @@
 import { Pool } from 'pg';
-import dotenv from 'dotenv';
-dotenv.config();
+import config from './config';
 
 const pool = new Pool({
-  user: process.env.PG_USER,
-  password: process.env.PG_PASSWORD,
-  host: process.env.PG_HOST,
-  port: Number(process.env.PG_PORT),
-  database: process.env.PG_DATABASE,
+  user: config.pgUser,
+  password: config.pgPassword,
+  host: config.pgHost,
+  port: config.pgPort,
+  database: config.pgDatabase,
 });
 export default pool;

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import pool from '../db';
 import jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../utils/env';
+import config from '../config';
 import logger from '../utils/logger';
 
 function getTokenFromCookies(req: Request) {
@@ -31,7 +31,7 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
   }
 
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as {
+    const decoded = jwt.verify(token, config.jwtSecret) as {
       id: number | string;
       role: string;
       type: string;
@@ -104,7 +104,7 @@ export async function optionalAuthMiddleware(
   }
 
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as {
+    const decoded = jwt.verify(token, config.jwtSecret) as {
       id: number | string;
       role: string;
       type: string;

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
-import dotenv from 'dotenv';
+import config from './config';
 import usersRoutes from './routes/users';
 import slotsRoutes from './routes/slots';
 import bookingsRoutes from './routes/bookings';
@@ -16,15 +16,12 @@ import pool from './db';
 import { setupDatabase } from './setupDatabase';
 import logger from './utils/logger';
 
-dotenv.config();
-
 const app = express();
 
 // ⭐ Add CORS middleware before routes
 // Allow a comma separated list of frontend origins so local hosts like
 // "http://127.0.0.1:5173" work in addition to "http://localhost:5173".
-const allowedOrigins = (process.env.FRONTEND_ORIGIN ||
-  'http://localhost:5173,http://127.0.0.1:5173')
+const allowedOrigins = config.frontendOrigin
   .split(',')
   .map(o => o.trim());
 
@@ -48,7 +45,7 @@ app.use('/volunteer-roles', volunteerRolesRoutes);
 app.use('/volunteers', volunteersRoutes);
 app.use('/volunteer-bookings', volunteerBookingsRoutes);
 
-const PORT = Number(process.env.PORT) || 4000;
+const PORT = config.port;
 
 async function init() {
   try {

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -1,19 +1,17 @@
 import { Client } from 'pg';
-import dotenv from 'dotenv';
-
-dotenv.config();
+import config from './config';
 
 export async function setupDatabase() {
-  const dbName = process.env.PG_DATABASE || 'mj_fb_db';
-  const config = {
-    user: process.env.PG_USER,
-    password: process.env.PG_PASSWORD,
-    host: process.env.PG_HOST,
-    port: Number(process.env.PG_PORT),
+  const dbName = config.pgDatabase;
+  const dbConfig = {
+    user: config.pgUser,
+    password: config.pgPassword,
+    host: config.pgHost,
+    port: config.pgPort,
   };
 
   // Connect to default database to ensure target database exists
-  const adminClient = new Client({ ...config, database: 'postgres' });
+  const adminClient = new Client({ ...dbConfig, database: 'postgres' });
   await adminClient.connect();
   const dbExists = await adminClient.query('SELECT 1 FROM pg_database WHERE datname = $1', [dbName]);
   if (dbExists.rowCount === 0) {
@@ -23,7 +21,7 @@ export async function setupDatabase() {
   await adminClient.end();
 
   // Now connect to the target database
-  const client = new Client({ ...config, database: dbName });
+  const client = new Client({ ...dbConfig, database: dbName });
   await client.connect();
 
   // Create tables if they do not exist

--- a/MJ_FB_Backend/src/utils/env.ts
+++ b/MJ_FB_Backend/src/utils/env.ts
@@ -1,6 +1,0 @@
-export const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
-
-if (!process.env.JWT_SECRET) {
-  // eslint-disable-next-line no-console
-  console.warn('JWT_SECRET not set, using default development secret');
-}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ npm install
 npm start   # or npm run dev
 ```
 
+### Required environment variables
+
+Create a `.env` file in `MJ_FB_Backend` with the following variables:
+
+| Variable | Description |
+| --- | --- |
+| `PG_HOST` | PostgreSQL host |
+| `PG_PORT` | PostgreSQL port |
+| `PG_USER` | PostgreSQL username |
+| `PG_PASSWORD` | PostgreSQL password |
+| `PG_DATABASE` | PostgreSQL database name |
+| `JWT_SECRET` | Secret used to sign JWT tokens |
+| `FRONTEND_ORIGIN` | Allowed origins for CORS (comma separated) |
+| `PORT` | Port for the backend server |
+
 ## Frontend setup (`MJ_FB_Frontend`)
 
 Prerequisites:


### PR DESCRIPTION
## Summary
- add config module with schema-based `.env` loading
- use centralized config in server startup and database utilities
- document required environment variables in repo READMEs

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689796746308832da1aea3e13922cad4