### PR TITLE
feat: integrate react-query for API calls

### DIFF
--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -16,6 +16,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.26.1",
+    "@tanstack/react-query": "^5.62.0",
     "@mui/material": "^6.2.0",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -4,15 +4,19 @@ import App from './App';
 import './index.css';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import getTheme from './theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 function Main() {
   const theme = getTheme();
+  const queryClient = new QueryClient();
 
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <App />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <App />
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- add @tanstack/react-query to frontend and wrap app with QueryClientProvider
- refactor SlotBooking to use useQuery/useMutation for holidays, slots, and bookings
- refactor StaffDashboard to load and update bookings with react-query

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689799b76394832d8a618072b1b6db76