### PR TITLE
fix: specify type for allowed origins

### DIFF
--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -23,7 +23,7 @@ const app = express();
 // "http://127.0.0.1:5173" work in addition to "http://localhost:5173".
 const allowedOrigins = config.frontendOrigin
   .split(',')
-  .map(o => o.trim());
+  .map((o: string) => o.trim());
 
 app.use(cors({
   origin: allowedOrigins,


### PR DESCRIPTION
## Summary
- type map callback in server startup so implicit any does not occur

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979bda23e0832da9e8bed3ed8dd0c4