### PR TITLE
Handle optional greeting in navbar

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -17,4 +17,19 @@ describe('Navbar component', () => {
     expect(screen.getByText(/Food Bank Portal/i)).toBeInTheDocument();
     expect(screen.getByText(/Hello, Tester/i)).toBeInTheDocument();
   });
+
+  it('renders without greeting when name is absent', () => {
+    render(
+      <MemoryRouter>
+        <Navbar
+          groups={[{ label: 'Home', links: [{ label: 'Home', to: '/' }] }]}
+          onLogout={() => {}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Food Bank Portal/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Hello/)).toBeNull();
+    expect(screen.getByRole('button', { name: /Logout/i })).toBeInTheDocument();
+  });
 });

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -122,10 +122,12 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
           )
         )}
         <Box sx={{ flexGrow: 1 }} />
-        <Typography variant="body2" sx={{ mr: 1 }}>
-          Hello, {name}
-        </Typography>
-        <Button color="inherit" onClick={onLogout} sx={{ ml: 1 }}>
+        {name && (
+          <Typography variant="body2" sx={{ mr: 1 }}>
+            Hello, {name}
+          </Typography>
+        )}
+        <Button color="inherit" onClick={onLogout} sx={{ ml: name ? 1 : 0 }}>
           Logout
         </Button>
       </Toolbar>


### PR DESCRIPTION
## Summary
- Show greeting in Navbar only when `name` is provided
- Cover missing-name scenario in Navbar tests

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68979d00b084832d96e802684ad52480