### PR TITLE
Parse frontend origin env into array

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -15,7 +15,7 @@ Backend: https://github.com/Amrutha-A-J/MJ_FB_Backend
 
 `PG_DATABASE` – PostgreSQL database name.
 
-`FRONTEND_ORIGIN` – Origin URL of the frontend allowed for CORS. Defaults to `http://localhost:5173` if unset.
+`FRONTEND_ORIGIN` – Comma-separated list of frontend origin URLs allowed for CORS. Defaults to `http://localhost:5173,http://127.0.0.1:5173` if unset.
 
 `JWT_SECRET` – Secret key used to sign and verify JSON Web Tokens. **Required**.
 

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -16,6 +16,8 @@ const envSchema = z.object({
 
 const env = envSchema.parse(process.env);
 
+const frontendOrigins = env.FRONTEND_ORIGIN.split(',').map(o => o.trim());
+
 const requiredVars: Array<keyof typeof env> = [
   'PG_USER',
   'PG_PASSWORD',
@@ -39,6 +41,6 @@ export default {
   pgPort: env.PG_PORT,
   pgDatabase: env.PG_DATABASE,
   jwtSecret: env.JWT_SECRET,
-  frontendOrigin: env.FRONTEND_ORIGIN,
+  frontendOrigins,
   port: env.PORT,
 };

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -19,14 +19,9 @@ import logger from './utils/logger';
 const app = express();
 
 // ⭐ Add CORS middleware before routes
-// Allow a comma separated list of frontend origins so local hosts like
-// "http://127.0.0.1:5173" work in addition to "http://localhost:5173".
-const allowedOrigins = config.frontendOrigin
-  .split(',')
-  .map((o: string) => o.trim());
-
+// Origins are parsed from FRONTEND_ORIGIN env variable as a comma-separated list.
 app.use(cors({
-  origin: allowedOrigins,
+  origin: config.frontendOrigins,
   credentials: true,
 }));
 

--- a/MJ_FB_Backend/tests/config.test.ts
+++ b/MJ_FB_Backend/tests/config.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+describe('config FRONTEND_ORIGIN parsing', () => {
+  const original = process.env.FRONTEND_ORIGIN;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.FRONTEND_ORIGIN;
+    } else {
+      process.env.FRONTEND_ORIGIN = original;
+    }
+    jest.resetModules();
+  });
+
+  it('parses comma-separated origins into an array', () => {
+    process.env.FRONTEND_ORIGIN = 'http://localhost:3000,http://example.com';
+    jest.resetModules();
+    const config = require('../src/config').default;
+    expect(config.frontendOrigins).toEqual([
+      'http://localhost:3000',
+      'http://example.com',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- parse `FRONTEND_ORIGIN` into `frontendOrigins` array in config
- have server consume `config.frontendOrigins` for CORS setup
- document and test comma-separated frontend origins support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979d559b98832da63a3c7f6ceb77a2