### PR TITLE
feat: integrate power automate email flow

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -15,3 +15,7 @@ JWT_SECRET=change_me
 FRONTEND_ORIGIN=http://localhost:5173,http://127.0.0.1:5173
 # Server port
 PORT=4000
+# Power Automate HTTP trigger URL
+POWER_AUTOMATE_URL=https://your_flow_url
+# Optional key or code for the flow
+POWER_AUTOMATE_KEY=your_flow_key

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -12,6 +12,8 @@ const envSchema = z.object({
   JWT_SECRET: z.string().default('dev-secret'),
   FRONTEND_ORIGIN: z.string().default('http://localhost:5173,http://127.0.0.1:5173'),
   PORT: z.coerce.number().default(4000),
+  POWER_AUTOMATE_URL: z.string().optional(),
+  POWER_AUTOMATE_KEY: z.string().optional(),
 });
 
 const env = envSchema.parse(process.env);
@@ -43,4 +45,6 @@ export default {
   jwtSecret: env.JWT_SECRET,
   frontendOrigins,
   port: env.PORT,
+  powerAutomateUrl: env.POWER_AUTOMATE_URL ?? '',
+  powerAutomateKey: env.POWER_AUTOMATE_KEY ?? '',
 };

--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -1,5 +1,27 @@
+import config from '../config';
+
 export async function sendEmail(to: string, subject: string, body: string): Promise<void> {
-  // Placeholder for future Power Automate integration
-  console.log(`[Email placeholder] To: ${to}, Subject: ${subject}, Body: ${body}`);
-  // TODO: integrate with Power Automate or real email service
+  if (!config.powerAutomateUrl) {
+    console.warn('POWER_AUTOMATE_URL is not configured');
+    return;
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (config.powerAutomateKey) {
+    headers['x-functions-key'] = config.powerAutomateKey;
+  }
+
+  const response = await fetch(config.powerAutomateUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ to, subject, body }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    console.error(`Failed to send email: ${response.status} ${text}`);
+    throw new Error('Failed to send email');
+  }
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables:
 | `JWT_SECRET` | Secret used to sign JWT tokens |
 | `FRONTEND_ORIGIN` | Allowed origins for CORS (comma separated) |
 | `PORT` | Port for the backend server |
+| `POWER_AUTOMATE_URL` | HTTP endpoint for the Power Automate email flow |
+| `POWER_AUTOMATE_KEY` | Optional key or code for the Power Automate flow |
 
 ## Frontend setup (`MJ_FB_Frontend`)
 


### PR DESCRIPTION
## Summary
- post email content to Power Automate HTTP trigger instead of placeholder
- expose POWER_AUTOMATE_URL and POWER_AUTOMATE_KEY in config and docs

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a0042da4832d8486a0e3af4bee3a