### PR TITLE
Use locale-aware date formatting and add timezone tests

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingUtils.ts
+++ b/MJ_FB_Backend/src/utils/bookingUtils.ts
@@ -1,11 +1,12 @@
 import pool from '../db';
 
-function getMonthRange(date: Date) {
+export function getMonthRange(date: Date) {
   const start = new Date(date.getFullYear(), date.getMonth(), 1);
   const end = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+  const format = (d: Date) => d.toLocaleDateString('en-CA');
   return {
-    start: start.toISOString().split('T')[0],
-    end: end.toISOString().split('T')[0],
+    start: format(start),
+    end: format(end),
   };
 }
 

--- a/MJ_FB_Backend/tests/bookingCapacity.test.ts
+++ b/MJ_FB_Backend/tests/bookingCapacity.test.ts
@@ -42,7 +42,7 @@ describe('POST /bookings capacity check', () => {
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1, max_capacity: 1 }] })
       .mockResolvedValueOnce({ rows: [{ count: '1' }] });
 
-    const today = new Date().toISOString().split('T')[0];
+    const today = new Date().toLocaleDateString('en-CA');
     const res = await request(app)
       .post('/bookings')
       .set('Authorization', 'Bearer token')

--- a/MJ_FB_Backend/tests/bookingUtils.test.ts
+++ b/MJ_FB_Backend/tests/bookingUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterAll } from '@jest/globals';
+
+const originalTZ = process.env.TZ;
+
+function loadUtils() {
+  // Reload the module after timezone change
+  jest.resetModules();
+  return require('../src/utils/bookingUtils');
+}
+
+describe('getMonthRange across time zones', () => {
+  afterAll(() => {
+    process.env.TZ = originalTZ;
+  });
+
+  it('returns correct range in UTC', () => {
+    process.env.TZ = 'UTC';
+    const { getMonthRange } = loadUtils();
+    const date = new Date('2024-03-31T00:00:00Z');
+    expect(getMonthRange(date)).toEqual({ start: '2024-03-01', end: '2024-03-31' });
+  });
+
+  it('returns correct range in Pacific/Auckland', () => {
+    process.env.TZ = 'Pacific/Auckland';
+    const { getMonthRange } = loadUtils();
+    const date = new Date('2024-03-31T00:00:00Z');
+    expect(getMonthRange(date)).toEqual({ start: '2024-03-01', end: '2024-03-31' });
+  });
+
+  it('handles leap year February correctly', () => {
+    process.env.TZ = 'Pacific/Auckland';
+    const { getMonthRange } = loadUtils();
+    const date = new Date('2024-02-15T00:00:00Z');
+    expect(getMonthRange(date)).toEqual({ start: '2024-02-01', end: '2024-02-29' });
+  });
+});


### PR DESCRIPTION
## Summary
- use `toLocaleDateString('en-CA')` for month range formatting
- test `getMonthRange` across multiple time zones including leap year boundaries
- adjust booking capacity test to use locale-safe dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a4eacd14832db4bab3ecd464f914