### PR TITLE
Handle empty API responses

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/api.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/api.test.tsx
@@ -1,0 +1,13 @@
+import { handleResponse } from '../api/api';
+
+describe('handleResponse', () => {
+  it('returns undefined for 204 responses', async () => {
+    const res = new Response(null, { status: 204 });
+    await expect(handleResponse(res)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined for zero Content-Length', async () => {
+    const res = new Response(null, { status: 200, headers: { 'Content-Length': '0' } });
+    await expect(handleResponse(res)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Avoid JSON parsing when responses have no content and return `undefined` instead
- Update API helpers to handle possible empty responses
- Add tests for 204 and zero-length responses

## Testing
- `npx jest --env=node` *(fails: TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_6897a4f1f0dc832d9e39ff04ba415073