### PR TITLE
Use contained style for major form submit buttons

### DIFF
--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -608,7 +608,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
               </div>
             )}
           </div>
-          <Button onClick={submitVolunteer} variant="outlined" color="primary">Add Volunteer</Button>
+          <Button onClick={submitVolunteer} variant="contained" color="primary">Add Volunteer</Button>
           <FeedbackSnackbar
             open={!!createMsg}
             onClose={() => setCreateMsg('')}

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -93,7 +93,7 @@ export default function AddUser({ token }: { token: string }) {
             <MenuItem value="shopper">Shopper</MenuItem>
             <MenuItem value="delivery">Delivery</MenuItem>
           </TextField>
-          <Button variant="outlined" color="primary" onClick={submitUser}>
+          <Button variant="contained" color="primary" onClick={submitUser}>
             Add User
           </Button>
         </Stack>
@@ -112,7 +112,7 @@ export default function AddUser({ token }: { token: string }) {
           </TextField>
           <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} />
           <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
-          <Button variant="outlined" color="primary" onClick={submitStaff}>
+          <Button variant="contained" color="primary" onClick={submitStaff}>
             Add Staff
           </Button>
         </Stack>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -94,7 +94,7 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
           <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" />
           <TextField type="email" value={email} onChange={e => setEmail(e.target.value)} label="Email" />
           <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-          <Button type="submit" variant="outlined" color="primary">Create Staff</Button>
+          <Button type="submit" variant="contained" color="primary">Create Staff</Button>
         </Stack>
       </Box>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />


### PR DESCRIPTION
## Summary
- Use contained (solid) Material UI buttons for Create Staff form
- Use contained buttons for Add User and Add Staff actions
- Use contained button for Add Volunteer action

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: 'Booking' is defined but never used in StaffDashboard.tsx)*
- `npx eslint src/components/CoordinatorDashboard.tsx src/components/StaffDashboard/AddUser.tsx src/components/StaffLogin.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6897aef1ea00832d8a8ba5d327e65fef