### PR TITLE
Use Material UI for schedule tables

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -1,3 +1,13 @@
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Paper,
+} from '@mui/material';
+
 interface Cell {
   content: string;
   backgroundColor?: string;
@@ -17,54 +27,52 @@ interface Props {
 
 export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   return (
-    <table style={{ borderCollapse: 'collapse', width: '100%' }}>
-      <thead>
-        <tr>
-          <th style={{ border: '1px solid #ccc', padding: 8, width: 120 }}>Time</th>
-          {Array.from({ length: maxSlots }).map((_, i) => (
-            <th key={i} style={{ border: '1px solid #ccc', padding: 8 }}>
-              Slot {i + 1}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, idx) => {
-          const used = row.cells.reduce((sum, c) => sum + (c.colSpan || 1), 0);
-          return (
-            <tr key={idx}>
-              <td style={{ border: '1px solid #ccc', padding: 8 }}>{row.time}</td>
-              {row.cells.map((cell, i) => (
-                <td
-                  key={i}
-                  colSpan={cell.colSpan}
-                  onClick={cell.onClick}
-                  style={{
-                    border: '1px solid #ccc',
-                    padding: 8,
-                    textAlign: 'center',
-                    backgroundColor: cell.backgroundColor,
-                    cursor: cell.onClick ? 'pointer' : 'default',
-                  }}
-                >
-                  {cell.content}
-                </td>
-              ))}
-              {Array.from({ length: maxSlots - used }).map((_, i) => (
-                <td key={`empty-${i}`} style={{ border: '1px solid #ccc', padding: 8 }} />
-              ))}
-            </tr>
-          );
-        })}
-        {rows.length === 0 && (
-          <tr>
-            <td colSpan={maxSlots + 1} style={{ textAlign: 'center', padding: 8 }}>
-              No bookings.
-            </td>
-          </tr>
-        )}
-      </tbody>
-    </table>
+    <TableContainer component={Paper}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ width: 120 }}>Time</TableCell>
+            {Array.from({ length: maxSlots }).map((_, i) => (
+              <TableCell key={i}>Slot {i + 1}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, idx) => {
+            const used = row.cells.reduce((sum, c) => sum + (c.colSpan || 1), 0);
+            return (
+              <TableRow key={idx}>
+                <TableCell>{row.time}</TableCell>
+                {row.cells.map((cell, i) => (
+                  <TableCell
+                    key={i}
+                    colSpan={cell.colSpan}
+                    onClick={cell.onClick}
+                    sx={{
+                      textAlign: 'center',
+                      backgroundColor: cell.backgroundColor,
+                      cursor: cell.onClick ? 'pointer' : 'default',
+                    }}
+                  >
+                    {cell.content}
+                  </TableCell>
+                ))}
+                {Array.from({ length: maxSlots - used }).map((_, i) => (
+                  <TableCell key={`empty-${i}`} />
+                ))}
+              </TableRow>
+            );
+          })}
+          {rows.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={maxSlots + 1} align="center">
+                No bookings.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
   );
 }
 


### PR DESCRIPTION
## Summary
- Refactor VolunteerScheduleTable to render with MUI Table components
- Enables Material Design styling for pantry and volunteer schedules

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden)*
- `npm test` (backend)
- `npm run lint` *(fails: StaffDashboard.tsx no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_6897b128de6c832da28e37161c600513