### PR TITLE
feat: standardize form layout with reusable container

### DIFF
--- a/MJ_FB_Frontend/src/components/FormContainer.tsx
+++ b/MJ_FB_Frontend/src/components/FormContainer.tsx
@@ -1,0 +1,22 @@
+import { Box, Stack, Button, type BoxProps } from '@mui/material';
+import type { ReactNode, FormEvent } from 'react';
+
+interface FormContainerProps extends Omit<BoxProps, 'component' | 'onSubmit'> {
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void;
+  submitLabel: string;
+  children: ReactNode;
+}
+
+export default function FormContainer({ onSubmit, submitLabel, children, ...boxProps }: FormContainerProps) {
+  return (
+    <Box component="form" onSubmit={onSubmit} mt={2} {...boxProps}>
+      <Stack spacing={2}>
+        {children}
+        <Button type="submit" variant="contained" color="primary" fullWidth>
+          {submitLabel}
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { loginUser } from '../api/api';
 import type { LoginResponse } from '../api/api';
-import { Box, Link, Typography, TextField, Button, Stack } from '@mui/material';
+import { Box, Link, Typography, TextField, Stack } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
+import FormContainer from './FormContainer';
 
 export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (user: LoginResponse) => void; onStaff: () => void; onVolunteer: () => void }) {
   const [clientId, setClientId] = useState('');
@@ -26,13 +27,10 @@ export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (use
         <Link component="button" onClick={onVolunteer} underline="hover">Volunteer Login</Link>
       </Stack>
       <Typography variant="h4" gutterBottom>User Login</Typography>
-      <Box component="form" onSubmit={handleSubmit} mt={2}>
-        <Stack spacing={2}>
-          <TextField value={clientId} onChange={e => setClientId(e.target.value)} label="Client ID" />
-          <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-          <Button type="submit" variant="outlined" color="primary">Login</Button>
-        </Stack>
-      </Box>
+      <FormContainer onSubmit={handleSubmit} submitLabel="Login">
+        <TextField value={clientId} onChange={e => setClientId(e.target.value)} label="Client ID" fullWidth />
+        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
+      </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { loginStaff, staffExists, createStaff } from '../api/api';
 import type { LoginResponse } from '../api/api';
-import { Box, Typography, TextField, Button, Stack, Link } from '@mui/material';
+import { Box, Typography, TextField, Link } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FeedbackModal from './FeedbackModal';
+import FormContainer from './FormContainer';
 
 export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
   const [checking, setChecking] = useState(true);
@@ -54,13 +55,10 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
     <Box>
       <Link component="button" onClick={onBack} underline="hover">User Login</Link>
       <Typography variant="h4" gutterBottom>Staff Login</Typography>
-      <Box component="form" onSubmit={submit} mt={2}>
-        <Stack spacing={2}>
-          <TextField value={email} onChange={e => setEmail(e.target.value)} label="Email" />
-          <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-          <Button type="submit" variant="outlined" color="primary">Login</Button>
-        </Stack>
-      </Box>
+      <FormContainer onSubmit={submit} submitLabel="Login">
+        <TextField value={email} onChange={e => setEmail(e.target.value)} label="Email" fullWidth />
+        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
+      </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );
@@ -88,15 +86,12 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   return (
     <Box>
       <Typography variant="h4" gutterBottom>Create Staff Account</Typography>
-      <Box component="form" onSubmit={submit} mt={2}>
-        <Stack spacing={2}>
-          <TextField value={firstName} onChange={e => setFirstName(e.target.value)} label="First name" />
-          <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" />
-          <TextField type="email" value={email} onChange={e => setEmail(e.target.value)} label="Email" />
-          <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-          <Button type="submit" variant="contained" color="primary">Create Staff</Button>
-        </Stack>
-      </Box>
+      <FormContainer onSubmit={submit} submitLabel="Create Staff">
+        <TextField value={firstName} onChange={e => setFirstName(e.target.value)} label="First name" fullWidth />
+        <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" fullWidth />
+        <TextField type="email" value={email} onChange={e => setEmail(e.target.value)} label="Email" fullWidth />
+        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
+      </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <FeedbackModal open={!!message} onClose={() => setMessage('')} message={message} />
     </Box>

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { loginVolunteer } from '../api/api';
 import type { LoginResponse } from '../api/api';
-import { Box, Typography, TextField, Button, Stack, Link } from '@mui/material';
+import { Box, Typography, TextField, Link } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
+import FormContainer from './FormContainer';
 
 export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
   const [username, setUsername] = useState('');
@@ -24,13 +25,10 @@ export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: Login
     <Box>
       <Link component="button" onClick={onBack} underline="hover">User Login</Link>
       <Typography variant="h4" gutterBottom>Volunteer Login</Typography>
-      <Box component="form" onSubmit={submit} mt={2}>
-        <Stack spacing={2}>
-          <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" />
-          <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" />
-          <Button type="submit" variant="outlined" color="primary">Login</Button>
-        </Stack>
-      </Box>
+      <FormContainer onSubmit={submit} submitLabel="Login">
+        <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" fullWidth />
+        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
+      </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </Box>
   );


### PR DESCRIPTION
## Summary
- add a reusable `FormContainer` component to unify form structure and submit buttons
- update login-related forms to use `FormContainer` and full-width fields for consistent styling

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found; installation attempt returned 403)*
- `npm run lint` *(fails: 'Booking' is defined but never used in StaffDashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2dc7dc8832db1be2cf7fe1963f1