### PR TITLE
refactor: standardize page layout with reusable component

### DIFF
--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { loginUser } from '../api/api';
 import type { LoginResponse } from '../api/api';
-import { Box, Link, Typography, TextField, Stack } from '@mui/material';
+import { Link, TextField, Stack } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormContainer from './FormContainer';
+import Page from './Page';
 
 export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (user: LoginResponse) => void; onStaff: () => void; onVolunteer: () => void }) {
   const [clientId, setClientId] = useState('');
@@ -21,17 +22,20 @@ export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (use
   }
 
   return (
-    <Box>
-      <Stack direction="row" spacing={2} mb={2}>
-        <Link component="button" onClick={onStaff} underline="hover">Staff Login</Link>
-        <Link component="button" onClick={onVolunteer} underline="hover">Volunteer Login</Link>
-      </Stack>
-      <Typography variant="h4" gutterBottom>User Login</Typography>
+    <Page
+      title="User Login"
+      header={
+        <Stack direction="row" spacing={2} mb={2}>
+          <Link component="button" onClick={onStaff} underline="hover">Staff Login</Link>
+          <Link component="button" onClick={onVolunteer} underline="hover">Volunteer Login</Link>
+        </Stack>
+      }
+    >
       <FormContainer onSubmit={handleSubmit} submitLabel="Login">
         <TextField value={clientId} onChange={e => setClientId(e.target.value)} label="Client ID" fullWidth />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
       </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </Box>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/components/Page.tsx
+++ b/MJ_FB_Frontend/src/components/Page.tsx
@@ -1,0 +1,21 @@
+import { Box, Typography, type BoxProps } from '@mui/material';
+import type { ReactNode } from 'react';
+
+interface PageProps extends BoxProps {
+  title: string;
+  header?: ReactNode;
+  children: ReactNode;
+}
+
+export default function Page({ title, header, children, ...boxProps }: PageProps) {
+  return (
+    <Box {...boxProps}>
+      {header}
+      <Typography variant="h4" gutterBottom>
+        {title}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
+

--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
+import { Typography, List, ListItem } from '@mui/material';
 import type { Role, UserProfile } from '../types';
 import { getUserProfile } from '../api/api';
+import Page from './Page';
 
 export default function Profile({ token, role }: { token: string; role: Role }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
@@ -16,29 +18,25 @@ export default function Profile({ token, role }: { token: string; role: Role }) 
 
   if (role === 'staff') {
     return (
-      <div>
-        <h2>User Profile</h2>
-        <p>Profile view is only available for shoppers.</p>
-      </div>
+      <Page title="User Profile">
+        <Typography>Profile view is only available for shoppers.</Typography>
+      </Page>
     );
   }
 
   return (
-    <div>
-      <h2>User Profile</h2>
-      {error && <p>{error}</p>}
-      {!profile && !error && <p>Loading...</p>}
+    <Page title="User Profile">
+      {error && <Typography color="error">{error}</Typography>}
+      {!profile && !error && <Typography>Loading...</Typography>}
       {profile && (
-        <ul>
-          <li>
-            Name: {profile.firstName} {profile.lastName}
-          </li>
-          <li>Client ID: {profile.clientId}</li>
-          <li>Email: {profile.email || 'N/A'}</li>
-          <li>Phone: {profile.phone || 'N/A'}</li>
-          <li>Visits this month: {profile.bookingsThisMonth}</li>
-        </ul>
+        <List>
+          <ListItem>Name: {profile.firstName} {profile.lastName}</ListItem>
+          <ListItem>Client ID: {profile.clientId}</ListItem>
+          <ListItem>Email: {profile.email || 'N/A'}</ListItem>
+          <ListItem>Phone: {profile.phone || 'N/A'}</ListItem>
+          <ListItem>Visits this month: {profile.bookingsThisMonth}</ListItem>
+        </List>
       )}
-    </div>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/components/StaffDashboard/StaffDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/StaffDashboard.tsx
@@ -6,23 +6,6 @@ import ConfirmDialog from '../ConfirmDialog';
 import { TextField, Button } from '@mui/material';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  user_id: number;
-  user_name: string;
-  user_email: string;
-  user_phone: string;
-  client_id: number;
-  bookings_this_month: number;
-  slot_id: number;
-  start_time: string;
-  end_time: string;
-  is_staff_booking: boolean;
-  created_at: string;
-}
-
 export default function StaffDashboard({
   token,
   setError,

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { loginStaff, staffExists, createStaff } from '../api/api';
 import type { LoginResponse } from '../api/api';
-import { Box, Typography, TextField, Link } from '@mui/material';
+import { Typography, TextField, Link } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FeedbackModal from './FeedbackModal';
 import FormContainer from './FormContainer';
+import Page from './Page';
 
 export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
   const [checking, setChecking] = useState(true);
@@ -23,7 +24,7 @@ export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResp
       });
   }, []);
 
-  if (checking) return <div>Loading...</div>;
+  if (checking) return <Typography>Loading...</Typography>;
 
   return hasStaff ? (
     <StaffLoginForm onLogin={onLogin} error={error} onBack={onBack} />
@@ -52,15 +53,16 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
   }
 
   return (
-    <Box>
-      <Link component="button" onClick={onBack} underline="hover">User Login</Link>
-      <Typography variant="h4" gutterBottom>Staff Login</Typography>
+    <Page
+      title="Staff Login"
+      header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
+    >
       <FormContainer onSubmit={submit} submitLabel="Login">
         <TextField value={email} onChange={e => setEmail(e.target.value)} label="Email" fullWidth />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
       </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </Box>
+    </Page>
   );
 }
 
@@ -84,8 +86,7 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   }
 
   return (
-    <Box>
-      <Typography variant="h4" gutterBottom>Create Staff Account</Typography>
+    <Page title="Create Staff Account">
       <FormContainer onSubmit={submit} submitLabel="Create Staff">
         <TextField value={firstName} onChange={e => setFirstName(e.target.value)} label="First name" fullWidth />
         <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" fullWidth />
@@ -94,6 +95,6 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
       </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <FeedbackModal open={!!message} onClose={() => setMessage('')} message={message} />
-    </Box>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
@@ -4,10 +4,8 @@ import type { VolunteerBooking } from '../types';
 import { formatTime } from '../utils/time';
 import VolunteerSchedule from './VolunteerSchedule';
 import {
-  Box,
   Tabs,
   Tab,
-  Typography,
   TableContainer,
   Paper,
   Table,
@@ -16,6 +14,7 @@ import {
   TableCell,
   TableBody,
 } from '@mui/material';
+import Page from './Page';
 
 export default function VolunteerDashboard({ token }: { token: string }) {
   const [tab, setTab] = useState<'schedule' | 'history'>('schedule');
@@ -30,10 +29,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   }, [tab, token]);
 
   return (
-    <Box>
-      <Typography variant="h4" gutterBottom>
-        Volunteer Dashboard
-      </Typography>
+    <Page title="Volunteer Dashboard">
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="Schedule" value="schedule" />
         <Tab label="Booking History" value="history" />
@@ -74,7 +70,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
           </Table>
         </TableContainer>
       )}
-    </Box>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { loginVolunteer } from '../api/api';
 import type { LoginResponse } from '../api/api';
-import { Box, Typography, TextField, Link } from '@mui/material';
+import { TextField, Link } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormContainer from './FormContainer';
+import Page from './Page';
 
 export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
   const [username, setUsername] = useState('');
@@ -22,14 +23,15 @@ export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: Login
   }
 
   return (
-    <Box>
-      <Link component="button" onClick={onBack} underline="hover">User Login</Link>
-      <Typography variant="h4" gutterBottom>Volunteer Login</Typography>
+    <Page
+      title="Volunteer Login"
+      header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
+    >
       <FormContainer onSubmit={submit} submitLabel="Login">
         <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" fullWidth />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
       </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </Box>
+    </Page>
   );
 }


### PR DESCRIPTION
## Summary
- add Page layout component to provide consistent headers and spacing
- refactor login, profile, and volunteer dashboard screens to use Page component
- clean up unused booking type in staff dashboard

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897b4f7bb84832db8cd7d265fe8590f