### PR TITLE
Reset volunteer booking status on user reschedule

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
@@ -337,9 +337,11 @@ export async function rescheduleVolunteerBooking(
     }
 
     const newToken = randomUUID();
+    const isStaffReschedule = req.user && (req.user as any).role === 'staff';
+    const newStatus = isStaffReschedule ? booking.status : 'pending';
     await pool.query(
-      'UPDATE volunteer_bookings SET role_id=$1, date=$2, reschedule_token=$3 WHERE id=$4',
-      [roleId, date, newToken, booking.id],
+      'UPDATE volunteer_bookings SET role_id=$1, date=$2, reschedule_token=$3, status=$4 WHERE id=$5',
+      [roleId, date, newToken, newStatus, booking.id],
     );
     await sendEmail(
       'test@example.com',

--- a/MJ_FB_Backend/src/routes/volunteerBookings.ts
+++ b/MJ_FB_Backend/src/routes/volunteerBookings.ts
@@ -8,7 +8,11 @@ import {
   createVolunteerBookingForVolunteer,
   rescheduleVolunteerBooking,
 } from '../controllers/volunteerBookingController';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import {
+  authMiddleware,
+  authorizeRoles,
+  optionalAuthMiddleware,
+} from '../middleware/authMiddleware';
 
 const router = express.Router();
 
@@ -28,6 +32,10 @@ router.get(
 );
 router.get('/:role_id', authMiddleware, authorizeRoles('staff'), listVolunteerBookingsByRole);
 router.patch('/:id', authMiddleware, authorizeRoles('staff'), updateVolunteerBookingStatus);
-router.post('/reschedule/:token', rescheduleVolunteerBooking);
+router.post(
+  '/reschedule/:token',
+  optionalAuthMiddleware,
+  rescheduleVolunteerBooking,
+);
 
 export default router;

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -1,0 +1,64 @@
+import request from 'supertest';
+import express from 'express';
+import volunteerBookingsRouter from '../src/routes/volunteerBookings';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  optionalAuthMiddleware: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    if (req.headers['x-staff']) {
+      (req as any).user = { role: 'staff' };
+    }
+    next();
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/volunteer-bookings', volunteerBookingsRouter);
+
+describe('rescheduleVolunteerBooking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets status to pending when volunteer reschedules', async () => {
+    const booking = { id: 1, volunteer_id: 2, status: 'approved' };
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_volunteers: 5, category_id: 3 }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({});
+
+    const res = await request(app)
+      .post('/volunteer-bookings/reschedule/token123')
+      .send({ roleId: 4, date: '2025-09-01' });
+
+    expect(res.status).toBe(200);
+    const updateCall = (pool.query as jest.Mock).mock.calls[4];
+    expect(updateCall[1][3]).toBe('pending');
+  });
+
+  it('keeps status when staff reschedules', async () => {
+    const booking = { id: 1, volunteer_id: 2, status: 'approved' };
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_volunteers: 5, category_id: 3 }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({});
+
+    const res = await request(app)
+      .post('/volunteer-bookings/reschedule/token123')
+      .set('x-staff', 'true')
+      .send({ roleId: 4, date: '2025-09-01' });
+
+    expect(res.status).toBe(200);
+    const updateCall = (pool.query as jest.Mock).mock.calls[4];
+    expect(updateCall[1][3]).toBe('approved');
+  });
+});


### PR DESCRIPTION
## Summary
- Reset volunteer booking status to pending when a volunteer reschedules their own booking.
- Preserve original status when staff perform the reschedule.
- Enable optional authentication on volunteer booking reschedule endpoint and add tests for both scenarios.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b92f82f4832d817fa3233d628338