### PR TITLE
feat: allow coordinator to edit volunteer roles

### DIFF
--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -467,15 +467,27 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
           {results.length > 0 && (
             <ul style={{ listStyle: 'none', padding: 0 }}>
               {results.map(r => (
-                <li key={r.id}>
-                  <Button onClick={() => selectVolunteer(r)} variant="outlined" color="primary">{r.name}</Button>
+                <li
+                  key={r.id}
+                  style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}
+                >
+                  <span>{r.name}</span>
+                  <Button
+                    onClick={() => selectVolunteer(r)}
+                    variant="outlined"
+                    color="primary"
+                    size="small"
+                    sx={{ ml: 1 }}
+                  >
+                    Edit
+                  </Button>
                 </li>
               ))}
             </ul>
           )}
           {selectedVolunteer && (
             <div>
-              <h3>Roles for {selectedVolunteer.name}</h3>
+              <h3>Edit Roles for {selectedVolunteer.name}</h3>
               <div style={{ marginBottom: 8 }}>
                 {baseRoles.map(r => (
                   <label


### PR DESCRIPTION
## Summary
- add explicit edit option for volunteers so coordinators can modify their role assignments

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b9fde4a8832dbf9955515b991a82