### PR TITLE
Redirect staff to pantry schedule and move profile access

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
     setName('');
   }
 
-  const navGroups: NavGroup[] = [{ label: 'Profile', links: [{ label: 'Profile', to: '/profile' }] }];
+  const navGroups: NavGroup[] = [];
   if (isStaff) {
     const staffLinks = [
       { label: 'Staff Dashboard', to: '/staff-dashboard' },
@@ -116,7 +116,15 @@ export default function App() {
                 <Route
                   path="/"
                   element={
-                    <Navigate to={role === 'volunteer' ? '/volunteer-dashboard' : '/profile'} />
+                    <Navigate
+                      to={
+                        role === 'volunteer'
+                          ? '/volunteer-dashboard'
+                          : role === 'staff'
+                          ? '/pantry-schedule'
+                          : '/profile'
+                      }
+                    />
                   }
                 />
                 <Route path="/profile" element={<Profile token={token} role={role} />} />
@@ -169,7 +177,15 @@ export default function App() {
                 <Route
                   path="*"
                   element={
-                    <Navigate to={role === 'volunteer' ? '/volunteer-dashboard' : '/profile'} />
+                    <Navigate
+                      to={
+                        role === 'volunteer'
+                          ? '/volunteer-dashboard'
+                          : role === 'staff'
+                          ? '/pantry-schedule'
+                          : '/profile'
+                      }
+                    />
                   }
                 />
               </Routes>

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import Navbar from '../components/Navbar';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -16,6 +16,8 @@ describe('Navbar component', () => {
 
     expect(screen.getByText(/Food Bank Portal/i)).toBeInTheDocument();
     expect(screen.getByText(/Hello, Tester/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/Hello, Tester/i));
+    expect(screen.getByText(/Profile/i)).toBeInTheDocument();
   });
 
   it('renders without greeting when name is absent', () => {

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -30,6 +30,7 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [openGroup, setOpenGroup] = useState<string | null>(null);
   const [mobileAnchorEl, setMobileAnchorEl] = useState<null | HTMLElement>(null);
+  const [profileAnchorEl, setProfileAnchorEl] = useState<null | HTMLElement>(null);
   const location = useLocation();
 
   function handleGroupClick(label: string, event: React.MouseEvent<HTMLElement>) {
@@ -42,7 +43,16 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
     setOpenGroup(null);
   }
 
+  function handleProfileClick(event: React.MouseEvent<HTMLElement>) {
+    setProfileAnchorEl(event.currentTarget);
+  }
+
+  function closeProfileMenu() {
+    setProfileAnchorEl(null);
+  }
+
   const mobileMenuOpen = Boolean(mobileAnchorEl);
+  const profileMenuOpen = Boolean(profileAnchorEl);
 
   return (
     <AppBar position="static">
@@ -123,9 +133,25 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
         )}
         <Box sx={{ flexGrow: 1 }} />
         {name && (
-          <Typography variant="body2" sx={{ mr: 1 }}>
-            Hello, {name}
-          </Typography>
+          <>
+            <Button color="inherit" onClick={handleProfileClick}>
+              Hello, {name}
+            </Button>
+            <Menu
+              anchorEl={profileAnchorEl}
+              open={profileMenuOpen}
+              onClose={closeProfileMenu}
+            >
+              <MenuItem
+                component={RouterLink}
+                to="/profile"
+                onClick={closeProfileMenu}
+                disabled={loading}
+              >
+                Profile
+              </MenuItem>
+            </Menu>
+          </>
         )}
         <Button color="inherit" onClick={onLogout} sx={{ ml: name ? 1 : 0 }}>
           Logout


### PR DESCRIPTION
## Summary
- Redirect staff to pantry schedule by default after login
- Move profile navigation into greeting menu for a cleaner navbar
- Cover profile menu in navbar tests

## Testing
- `npm test --prefix MJ_FB_Frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm test --prefix MJ_FB_Backend`

------
https://chatgpt.com/codex/tasks/task_e_6897d946f448832d9d421eda7f2f0e47