### PR TITLE
Group volunteer roles by category and show all shifts

### DIFF
--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -36,6 +36,7 @@ export interface VolunteerRole {
   status: string;
   date: string;
   category_id: number;
+  category_name: string;
   is_wednesday_slot: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Ensure volunteer role dropdown lists unique roles per category by storing a category|role key
- Display all shifts for the selected role consecutively in the schedule view
- Add `category_name` field to `VolunteerRole` type

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: 3 problems (3 errors, 0 warnings))*
- `npx eslint src/components/VolunteerSchedule.tsx src/types.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897df8b4ee8832dab185752a83c062d