### PR TITLE
Fix slot selection clearing for shoppers

### DIFF
--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -129,7 +129,6 @@ export default function SlotBooking({ token, role }: Props) {
         setMessage('');
         return;
       }
-      setSelectedSlotId(null);
       setDayMessage('');
       setMessage('');
     }
@@ -237,7 +236,10 @@ export default function SlotBooking({ token, role }: Props) {
       </h3>
       <Calendar
         onChange={value => {
-          if (value instanceof Date) setSelectedDate(toReginaDate(value));
+          if (value instanceof Date) {
+            setSelectedDate(toReginaDate(value));
+            setSelectedSlotId(null);
+          }
         }}
         value={selectedDate ? toZonedTime(selectedDate, reginaTimeZone) : undefined}
         calendarType="gregory"


### PR DESCRIPTION
## Summary
- prevent slot deselection after choosing a time by clearing selection only when necessary
- reset slot selection when calendar date changes

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npx eslint src/components/SlotBooking.tsx -f json`


------
https://chatgpt.com/codex/tasks/task_e_6897e4703264832d8a8a138bd2801190