### PR TITLE
feat: add breadcrumb component

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Breadcrumbs.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Breadcrumbs from '../components/Breadcrumbs';
+
+describe('Breadcrumbs component', () => {
+  it('renders path segments', () => {
+    render(
+      <MemoryRouter initialEntries={['/foo/bar']}>
+        <Breadcrumbs />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Foo')).toHaveAttribute('href', '/foo');
+    expect(screen.getByText('Bar')).toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/components/Breadcrumbs.tsx
+++ b/MJ_FB_Frontend/src/components/Breadcrumbs.tsx
@@ -1,0 +1,35 @@
+import { Breadcrumbs as MuiBreadcrumbs, Link, Typography } from '@mui/material';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
+
+function formatSegment(segment: string) {
+  return segment
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export default function Breadcrumbs() {
+  const location = useLocation();
+  const pathnames = location.pathname.split('/').filter((x) => x);
+
+  return (
+    <MuiBreadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
+      <Link component={RouterLink} underline="hover" color="inherit" to="/">
+        Home
+      </Link>
+      {pathnames.map((value, index) => {
+        const to = `/${pathnames.slice(0, index + 1).join('/')}`;
+        const label = formatSegment(value);
+        return index === pathnames.length - 1 ? (
+          <Typography color="text.primary" key={to}>
+            {label}
+          </Typography>
+        ) : (
+          <Link component={RouterLink} underline="hover" color="inherit" to={to} key={to}>
+            {label}
+          </Link>
+        );
+      })}
+    </MuiBreadcrumbs>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Breadcrumbs component for navigation paths
- test breadcrumb rendering

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: Unexpected any in PasswordResetDialog.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6897ed871430832db2f5e3868cc42fc9