### PR TITLE
Fix volunteer trained roles update logic

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerController.ts
@@ -19,7 +19,7 @@ export async function updateTrainedArea(
   }
   try {
     const validRoles = await pool.query<{ id: number }>(
-      `SELECT id FROM volunteer_roles WHERE id = ANY($1::int[])`,
+      `SELECT id FROM volunteer_master_roles WHERE id = ANY($1::int[])`,
       [roleIds]
     );
     if (validRoles.rowCount !== roleIds.length) {
@@ -139,7 +139,7 @@ export async function createVolunteer(
     }
 
     const validRoles = await pool.query<{ id: number }>(
-      `SELECT id FROM volunteer_roles WHERE id = ANY($1::int[])`,
+      `SELECT id FROM volunteer_master_roles WHERE id = ANY($1::int[])`,
       [roleIds]
     );
     if (validRoles.rowCount !== roleIds.length) {

--- a/MJ_FB_Backend/src/controllers/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerRoleController.ts
@@ -225,7 +225,7 @@ export async function listVolunteerRolesForVolunteer(
          WHERE status IN ('pending','approved') AND date = $1
          GROUP BY role_id
        ) b ON vr.id = b.role_id
-       WHERE vr.id = ANY($2::int[])
+       WHERE vr.category_id = ANY($2::int[])
         AND vr.is_active
         AND (vr.is_wednesday_slot = false OR EXTRACT(DOW FROM $1::date) = 3)
        ORDER BY vr.start_time`,

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS volunteer_trained_roles (
     role_id integer NOT NULL,
     PRIMARY KEY (volunteer_id, role_id),
     FOREIGN KEY (volunteer_id) REFERENCES public.volunteers(id) ON DELETE CASCADE,
-    FOREIGN KEY (role_id) REFERENCES public.volunteer_roles(id) ON DELETE CASCADE
+    FOREIGN KEY (role_id) REFERENCES public.volunteer_master_roles(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS bookings (

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -41,7 +41,7 @@ describe('Volunteer routes with valid role IDs', () => {
 
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ id: 5 });
-    expect((pool.query as jest.Mock).mock.calls[2][0]).toMatch(/SELECT id FROM volunteer_roles/);
+    expect((pool.query as jest.Mock).mock.calls[2][0]).toMatch(/SELECT id FROM volunteer_master_roles/);
   });
 
   it('updates trained areas when role IDs are valid', async () => {
@@ -56,6 +56,6 @@ describe('Volunteer routes with valid role IDs', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ id: 1, roleIds: [1, 2] });
-    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/SELECT id FROM volunteer_roles/);
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/SELECT id FROM volunteer_master_roles/);
   });
 });


### PR DESCRIPTION
## Summary
- Validate volunteer role updates against master roles
- Query volunteer roles for volunteers by category
- Ensure volunteer_trained_roles references master roles
- Update tests for new master role logic

## Testing
- `cd MJ_FB_Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ecdf8dc0832da7b9789d55c5116d