### PR TITLE
Allow calendar-based rescheduling

### DIFF
--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  MenuItem,
+} from '@mui/material';
+import { getSlots, rescheduleBookingByToken } from '../api/api';
+import { formatTime } from '../utils/time';
+import FeedbackSnackbar from './FeedbackSnackbar';
+import type { Slot } from '../types';
+
+interface RescheduleDialogProps {
+  open: boolean;
+  token: string;
+  rescheduleToken: string;
+  onClose: () => void;
+  onRescheduled: () => void;
+}
+
+export default function RescheduleDialog({
+  open,
+  token,
+  rescheduleToken,
+  onClose,
+  onRescheduled,
+}: RescheduleDialogProps) {
+  const [date, setDate] = useState('');
+  const [slots, setSlots] = useState<Slot[]>([]);
+  const [slotId, setSlotId] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (open && date) {
+      getSlots(token, date)
+        .then(setSlots)
+        .catch(() => setSlots([]));
+    } else {
+      setSlots([]);
+      setSlotId('');
+    }
+  }, [open, date, token]);
+
+  async function submit() {
+    if (!date || !slotId) {
+      setMessage('Please select date and time');
+      return;
+    }
+    try {
+      await rescheduleBookingByToken(rescheduleToken, slotId, date, token);
+      onRescheduled();
+      onClose();
+      setDate('');
+      setSlotId('');
+    } catch {
+      setMessage('Failed to reschedule booking');
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Reschedule Booking</DialogTitle>
+      <DialogContent>
+        <TextField
+          type="date"
+          label="Date"
+          value={date}
+          onChange={e => setDate(e.target.value)}
+          fullWidth
+          margin="normal"
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          select
+          label="Time"
+          value={slotId}
+          onChange={e => setSlotId(e.target.value)}
+          fullWidth
+          margin="normal"
+          disabled={!date || slots.length === 0}
+        >
+          {slots.map(s => (
+            <MenuItem key={s.id} value={s.id}>
+              {formatTime(s.startTime)} - {formatTime(s.endTime)}
+            </MenuItem>
+          ))}
+        </TextField>
+        <FeedbackSnackbar
+          open={!!message}
+          message={message}
+          onClose={() => setMessage('')}
+          severity="error"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="outlined" color="primary">
+          Cancel
+        </Button>
+        <Button onClick={submit} variant="outlined" color="primary">
+          Reschedule
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable dialog that lists available slots for a chosen date
- integrate calendar-based rescheduling in staff schedule and user history views

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6897ef5b0ccc832d9fbc17e77b1546f8