### PR TITLE
feat: integrate breadcrumb navigation

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -15,6 +15,7 @@ import CoordinatorDashboard from './components/CoordinatorDashboard';
 import type { Role } from './types';
 import Navbar, { type NavGroup } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
+import Breadcrumbs from './components/Breadcrumbs';
 
 export default function App() {
   const [token, setToken] = useState(() => localStorage.getItem('token') || '');
@@ -124,6 +125,7 @@ export default function App() {
             />
 
             <main>
+              <Breadcrumbs />
               <Routes>
                 <Route
                   path="/"


### PR DESCRIPTION
## Summary
- add Breadcrumbs component to app layout for consistent page navigation

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f03f74b0832d96fa464787dcec85