### PR TITLE
Fix volunteer trained roles update logic

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
@@ -29,18 +29,17 @@ export async function createVolunteerBooking(
 
   try {
     const roleRes = await pool.query(
-      'SELECT max_volunteers, category_id FROM volunteer_roles WHERE id = $1 AND is_active',
+      'SELECT max_volunteers FROM volunteer_roles WHERE id = $1 AND is_active',
       [roleId]
     );
     if (roleRes.rowCount === 0) {
       return res.status(404).json({ message: 'Role not found' });
     }
     const role = roleRes.rows[0];
-    const masterRoleId = role.category_id;
 
     const volRes = await pool.query(
       'SELECT 1 FROM volunteer_trained_roles WHERE volunteer_id = $1 AND role_id = $2',
-      [user.id, masterRoleId]
+      [user.id, roleId]
     );
     if (volRes.rowCount === 0) {
       return res.status(400).json({ message: 'Not trained for this role' });
@@ -96,18 +95,17 @@ export async function createVolunteerBookingForVolunteer(
 
   try {
     const roleRes = await pool.query(
-      'SELECT max_volunteers, category_id FROM volunteer_roles WHERE id = $1 AND is_active',
+      'SELECT max_volunteers FROM volunteer_roles WHERE id = $1 AND is_active',
       [roleId]
     );
     if (roleRes.rowCount === 0) {
       return res.status(404).json({ message: 'Role not found' });
     }
     const role = roleRes.rows[0];
-    const masterRoleId = role.category_id;
 
     const trainedRes = await pool.query(
       'SELECT 1 FROM volunteer_trained_roles WHERE volunteer_id = $1 AND role_id = $2',
-      [volunteerId, masterRoleId]
+      [volunteerId, roleId]
     );
     if (trainedRes.rowCount === 0) {
       return res.status(400).json({ message: 'Volunteer not trained for this role' });
@@ -309,7 +307,7 @@ export async function rescheduleVolunteerBooking(
     const booking = bookingRes.rows[0];
 
     const roleRes = await pool.query(
-      'SELECT max_volunteers, category_id FROM volunteer_roles WHERE id = $1 AND is_active',
+      'SELECT max_volunteers FROM volunteer_roles WHERE id = $1 AND is_active',
       [roleId],
     );
     if (roleRes.rowCount === 0) {
@@ -319,7 +317,7 @@ export async function rescheduleVolunteerBooking(
 
     const trainedRes = await pool.query(
       'SELECT 1 FROM volunteer_trained_roles WHERE volunteer_id = $1 AND role_id = $2',
-      [booking.volunteer_id, role.category_id],
+      [booking.volunteer_id, roleId],
     );
     if (trainedRes.rowCount === 0) {
       return res.status(400).json({ message: 'Volunteer not trained for this role' });

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -29,7 +29,7 @@ describe('rescheduleVolunteerBooking', () => {
     const booking = { id: 1, volunteer_id: 2, status: 'approved' };
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_volunteers: 5, category_id: 3 }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_volunteers: 5 }] })
       .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ count: 0 }] })
       .mockResolvedValueOnce({});
@@ -47,7 +47,7 @@ describe('rescheduleVolunteerBooking', () => {
     const booking = { id: 1, volunteer_id: 2, status: 'approved' };
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_volunteers: 5, category_id: 3 }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_volunteers: 5 }] })
       .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ count: 0 }] })
       .mockResolvedValueOnce({});


### PR DESCRIPTION
## Summary
- Use volunteer role IDs instead of categories when validating and listing trained roles
- Verify bookings and reschedules against volunteers' trained role IDs
- Restore trained role table to reference volunteer_roles and update tests

## Testing
- `cd MJ_FB_Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ecdf8dc0832da7b9789d55c5116d