### PR TITLE
Group volunteer roles by role_id for scheduling

### DIFF
--- a/MJ_FB_Backend/src/routes/volunteerRoles.ts
+++ b/MJ_FB_Backend/src/routes/volunteerRoles.ts
@@ -5,12 +5,19 @@ import {
   updateVolunteerRole,
   deleteVolunteerRole,
   listVolunteerRolesForVolunteer,
+  listVolunteerRoleGroupsForVolunteer,
   updateVolunteerRoleStatus,
 } from '../controllers/volunteerRoleController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
+router.get(
+  '/mine/grouped',
+  authMiddleware,
+  authorizeRoles('volunteer'),
+  listVolunteerRoleGroupsForVolunteer,
+);
 router.get('/mine', authMiddleware, authorizeRoles('volunteer'), listVolunteerRolesForVolunteer);
 
 router.use(authMiddleware, authorizeRoles('staff'));

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -359,6 +359,13 @@ export async function getVolunteerRolesForVolunteer(token: string, date: string)
   return handleResponse(res);
 }
 
+export async function getVolunteerRoleGroups(token: string, date: string) {
+  const res = await apiFetch(`${API_BASE}/volunteer-roles/mine/grouped?date=${date}`, {
+    headers: { Authorization: bearer(token) },
+  });
+  return handleResponse(res);
+}
+
 export async function requestVolunteerBooking(
   token: string,
   roleId: number,

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -41,6 +41,15 @@ export interface VolunteerRole {
   is_wednesday_slot: boolean;
 }
 
+export interface VolunteerRoleGroup {
+  category: string;
+  roles: {
+    id: number;
+    name: string;
+    slots: VolunteerRole[];
+  }[];
+}
+
 export interface VolunteerBooking {
   id: number;
   status: string;


### PR DESCRIPTION
## Summary
- add backend endpoint to group volunteer roles by role_id and return slots per role
- expose new grouped roles query to frontend API and types
- update volunteer schedule view to use grouped roles and show all times for a selected role

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689806848818832d88d758cb17252712