### PR TITLE
Add category ID to volunteer trained roles

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerController.ts
@@ -28,8 +28,8 @@ export async function updateTrainedArea(
     await pool.query('DELETE FROM volunteer_trained_roles WHERE volunteer_id = $1', [id]);
     if (roleIds.length > 0) {
       await pool.query(
-        `INSERT INTO volunteer_trained_roles (volunteer_id, role_id)
-         SELECT $1, UNNEST($2::int[])`,
+        `INSERT INTO volunteer_trained_roles (volunteer_id, role_id, category_id)
+         SELECT $1, vr.id, vr.category_id FROM volunteer_roles vr WHERE vr.id = ANY($2::int[])`,
         [id, roleIds]
       );
     }
@@ -155,8 +155,8 @@ export async function createVolunteer(
     );
     const volunteerId = result.rows[0].id;
     await pool.query(
-      `INSERT INTO volunteer_trained_roles (volunteer_id, role_id)
-       SELECT $1, UNNEST($2::int[])`,
+      `INSERT INTO volunteer_trained_roles (volunteer_id, role_id, category_id)
+       SELECT $1, vr.id, vr.category_id FROM volunteer_roles vr WHERE vr.id = ANY($2::int[])`,
       [volunteerId, roleIds]
     );
     res.status(201).json({ id: volunteerId });

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS volunteers (
 CREATE TABLE IF NOT EXISTS volunteer_trained_roles (
     volunteer_id integer NOT NULL,
     role_id integer NOT NULL,
+    category_id integer NOT NULL REFERENCES public.volunteer_master_roles(id),
     PRIMARY KEY (volunteer_id, role_id),
     FOREIGN KEY (volunteer_id) REFERENCES public.volunteers(id) ON DELETE CASCADE,
     FOREIGN KEY (role_id) REFERENCES public.volunteer_roles(id) ON DELETE CASCADE


### PR DESCRIPTION
## Summary
- track category_id on volunteer_trained_roles table
- populate category_id when volunteers' trained roles are created or updated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898085e61cc832da2077f7373bbde6f