### PR TITLE
Fix volunteer role selection for same category

### DIFF
--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -31,7 +31,8 @@ import {
 
 interface RoleOption {
   id: number; // unique slot id
-  category_id: number; // grouped role id
+  category_id: number; // category identifier
+  category_name: string; // category display name
   name: string;
   start_time: string;
   end_time: string;
@@ -137,10 +138,20 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
     return Array.from(groups.entries()).map(([category, roles]) => ({ category, roles }));
   }, [roles]);
 
-  const nameToCategoryId = useMemo(() => {
-    const map = new Map<string, number>();
+  const nameToRoleIds = useMemo(() => {
+    const map = new Map<string, number[]>();
     roles.forEach(r => {
-      if (!map.has(r.name)) map.set(r.name, r.category_id);
+      const arr = map.get(r.name) || [];
+      arr.push(r.id);
+      map.set(r.name, arr);
+    });
+    return map;
+  }, [roles]);
+
+  const idToName = useMemo(() => {
+    const map = new Map<number, string>();
+    roles.forEach(r => {
+      map.set(r.id, r.name);
     });
     return map;
   }, [roles]);
@@ -249,14 +260,14 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
     setSelectedVolunteer(u);
     setResults([]);
     setSearch(u.name);
-    const idToName = new Map<number, string>();
-    roles.forEach(r => {
-      if (!idToName.has(r.category_id)) idToName.set(r.category_id, r.name);
-    });
     setTrainedEdit(
-      (u.trainedAreas || [])
-        .map(id => idToName.get(id))
-        .filter(Boolean) as string[]
+      Array.from(
+        new Set(
+          (u.trainedAreas || [])
+            .map(id => idToName.get(id))
+            .filter(Boolean) as string[]
+        )
+      )
     );
     try {
       const data = await getVolunteerBookingHistory(token, u.id);
@@ -297,8 +308,8 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
     if (!selectedVolunteer) return;
     try {
       const ids = Array.from(
-        new Set(trainedEdit.map(name => nameToCategoryId.get(name) || 0))
-      ).filter(id => id !== 0);
+        new Set(trainedEdit.flatMap(name => nameToRoleIds.get(name) || []))
+      );
       await updateVolunteerTrainedAreas(token, selectedVolunteer.id, ids);
       setEditMsg('Roles updated');
     } catch (e) {
@@ -322,8 +333,10 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
     }
     try {
       const ids = Array.from(
-        new Set(selectedCreateRoles.map(name => nameToCategoryId.get(name) || 0))
-      ).filter(id => id !== 0);
+        new Set(
+          selectedCreateRoles.flatMap(name => nameToRoleIds.get(name) || [])
+        )
+      );
       await createVolunteer(
         token,
         firstName,


### PR DESCRIPTION
## Summary
- allow selecting multiple volunteer roles from a single category
- map role names to associated slot IDs so all relevant roles are sent to backend

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68980abd0a64832d97e3be83e47068a5