### PR TITLE
Group volunteer roles by category and role

### DIFF
--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -42,6 +42,7 @@ export interface VolunteerRole {
 }
 
 export interface VolunteerRoleGroup {
+  category_id: number;
   category: string;
   roles: {
     id: number;


### PR DESCRIPTION
## Summary
- group volunteer role query results by category_id and role_id
- expose category_id in volunteer role groups and update schedule UI to use it

## Testing
- `npm test` (backend)
- `npm test` *(frontend: fails - missing jest-environment-jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68980f737a80832da89388d44c1a073c