### PR TITLE
feat: add role schedule endpoints and UI

### DIFF
--- a/MJ_FB_Backend/src/routes/roles.ts
+++ b/MJ_FB_Backend/src/routes/roles.ts
@@ -1,0 +1,68 @@
+import { Router, Request, Response } from 'express';
+import pool from '../db';
+
+const router = Router();
+
+// GET /api/roles - returns unique roles grouped by category
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const query = `
+      SELECT
+        c.id            AS category_id,
+        c.name          AS category_name,
+        r.role_id,
+        MIN(r.name)     AS role_name
+      FROM volunteer_roles r
+      JOIN volunteer_master_roles c ON c.id = r.category_id
+      WHERE r.is_active = TRUE
+      GROUP BY c.id, c.name, r.role_id
+      ORDER BY c.name, role_name;
+    `;
+    const { rows } = await pool.query(query);
+    const result = rows.map((row) => ({
+      categoryId: row.category_id,
+      categoryName: row.category_name,
+      roleId: row.role_id,
+      roleName: row.role_name,
+    }));
+    res.json(result);
+  } catch (err) {
+    console.error('Failed to fetch roles', err);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
+// GET /api/roles/:roleId/shifts - returns all shifts for a role
+router.get('/:roleId/shifts', async (req: Request, res: Response) => {
+  const roleId = Number(req.params.roleId);
+  if (!Number.isInteger(roleId) || roleId <= 0) {
+    return res.status(400).json({ message: 'Invalid roleId' });
+  }
+  try {
+    const query = `
+      SELECT
+        r.id AS shift_id,
+        r.start_time,
+        r.end_time,
+        r.max_volunteers
+      FROM volunteer_roles r
+      WHERE r.is_active = TRUE
+        AND r.role_id = $1
+      ORDER BY r.start_time;
+    `;
+    const { rows } = await pool.query(query, [roleId]);
+    const result = rows.map((row) => ({
+      shiftId: row.shift_id,
+      startTime: row.start_time,
+      endTime: row.end_time,
+      maxVolunteers: row.max_volunteers,
+    }));
+    res.json(result);
+  } catch (err) {
+    console.error('Failed to fetch shifts', err);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
+export default router;
+

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -13,6 +13,7 @@ import volunteersRoutes from './routes/volunteers';
 import volunteerBookingsRoutes from './routes/volunteerBookings';
 import volunteerMasterRolesRoutes from './routes/volunteerMasterRoles';
 import authRoutes from './routes/auth';
+import rolesRoutes from './routes/roles';
 import { initializeSlots } from './data';
 import pool from './db';
 import { setupDatabase } from './setupDatabase';
@@ -43,6 +44,7 @@ app.use('/volunteer-master-roles', volunteerMasterRolesRoutes);
 app.use('/volunteers', volunteersRoutes);
 app.use('/volunteer-bookings', volunteerBookingsRoutes);
 app.use('/auth', authRoutes);
+app.use('/api/roles', rolesRoutes);
 
 const PORT = config.port;
 

--- a/MJ_FB_Frontend/src/components/RoleSelect.tsx
+++ b/MJ_FB_Frontend/src/components/RoleSelect.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import type { RoleOption } from '../types';
+
+interface Props {
+  onChange: (roleId: number) => void;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE || '';
+
+export default function RoleSelect({ onChange }: Props) {
+  const [roles, setRoles] = useState<RoleOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState('');
+
+  useEffect(() => {
+    const fetchRoles = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`${API_BASE}/api/roles`);
+        if (!res.ok) throw new Error('Failed to load roles');
+        const data: RoleOption[] = await res.json();
+        setRoles(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error fetching roles');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchRoles();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    setSelected(value);
+    const id = Number(value);
+    if (!Number.isNaN(id)) {
+      onChange(id);
+    }
+  };
+
+  const grouped: Record<string, RoleOption[]> = roles.reduce((acc, role) => {
+    acc[role.categoryName] = acc[role.categoryName] || [];
+    acc[role.categoryName].push(role);
+    return acc;
+  }, {} as Record<string, RoleOption[]>);
+
+  if (loading) return <p>Loading roles...</p>;
+  if (error) return <p>{error}</p>;
+
+  return (
+    <select value={selected} onChange={handleChange}>
+      <option value="">Select a role</option>
+      {Object.entries(grouped).map(([category, items]) => (
+        <optgroup key={category} label={category}>
+          {items.map((r) => (
+            <option key={r.roleId} value={r.roleId}>
+              {r.roleName}
+            </option>
+          ))}
+        </optgroup>
+      ))}
+    </select>
+  );
+}
+

--- a/MJ_FB_Frontend/src/components/ScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/ScheduleTable.tsx
@@ -1,0 +1,47 @@
+import type { Shift } from '../types';
+import { formatHHMM } from '../utils/time';
+
+interface Props {
+  shifts: Shift[];
+}
+
+export default function ScheduleTable({ shifts }: Props) {
+  if (shifts.length === 0) {
+    return <p>No shifts.</p>;
+  }
+
+  const maxSlots = Math.max(...shifts.map((s) => s.maxVolunteers), 0);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Shift</th>
+          {Array.from({ length: maxSlots }).map((_, i) => (
+            <th key={i}>Slot {i + 1}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {shifts.map((shift) => (
+          <tr key={shift.shiftId}>
+            <td>
+              {formatHHMM(shift.startTime)}–{formatHHMM(shift.endTime)}
+            </td>
+            {Array.from({ length: maxSlots }).map((_, i) => (
+              <td
+                key={i}
+                style={
+                  i >= shift.maxVolunteers
+                    ? { backgroundColor: '#eee' }
+                    : undefined
+                }
+              />
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/CoordinatorSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/CoordinatorSchedule.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import RoleSelect from '../components/RoleSelect';
+import ScheduleTable from '../components/ScheduleTable';
+import type { Shift } from '../types';
+
+const API_BASE = import.meta.env.VITE_API_BASE || '';
+
+export default function CoordinatorSchedule() {
+  const [roleId, setRoleId] = useState<number | null>(null);
+  const [shifts, setShifts] = useState<Shift[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (roleId === null) return;
+    const fetchShifts = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`${API_BASE}/api/roles/${roleId}/shifts`);
+        if (!res.ok) throw new Error('Failed to load shifts');
+        const data: Shift[] = await res.json();
+        setShifts(data);
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error fetching shifts');
+        setShifts([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchShifts();
+  }, [roleId]);
+
+  return (
+    <div>
+      <RoleSelect onChange={setRoleId} />
+      {loading && <p>Loading shifts...</p>}
+      {error && <p>{error}</p>}
+      {!loading && !error && roleId !== null && (
+        <ScheduleTable shifts={shifts} />
+      )}
+    </div>
+  );
+}
+

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -87,3 +87,17 @@ export interface UserProfile {
   role: Role;
   bookingsThisMonth: number;
 }
+
+export interface RoleOption {
+  categoryId: number;
+  categoryName: string;
+  roleId: number;
+  roleName: string;
+}
+
+export interface Shift {
+  shiftId: number;
+  startTime: string; // 'HH:MM:SS'
+  endTime: string;   // 'HH:MM:SS'
+  maxVolunteers: number;
+}

--- a/MJ_FB_Frontend/src/utils/time.ts
+++ b/MJ_FB_Frontend/src/utils/time.ts
@@ -7,3 +7,9 @@ export function formatTime(time: string): string {
   hour = hour % 12 || 12;
   return `${hour}:${minute} ${ampm}`;
 }
+
+export function formatHHMM(time: string): string {
+  if (!time) return '';
+  const [h, m] = time.split(':');
+  return `${h.padStart(2, '0')}:${m.padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Summary
- provide `/api/roles` and `/api/roles/:roleId/shifts` endpoints
- show unique roles in a grouped selector and render shift tables
- add HH:MM time formatting util and shared types

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6898141b18b8832db18cb721a9755b9f