### PR TITLE
Align staff schedule with volunteer schedule

### DIFF
--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -1,6 +1,6 @@
 // src/api/api.ts
 // Read API base URL from environment or fall back to localhost
-import type { Role, UserRole, StaffRole, UserProfile } from '../types';
+import type { Role, UserRole, StaffRole, UserProfile, Slot } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
 
@@ -130,14 +130,21 @@ export async function createStaff(
   await handleResponse(res);
 }
 
+
 export async function getSlots(token: string, date?: string) {
-    let url = `${API_BASE}/slots`;
-    if (date) url += `?date=${encodeURIComponent(date)}`;
-    const res = await apiFetch(url, {
-      headers: { Authorization: bearer(token) }
-    });
-    return handleResponse(res);
-  }
+  let url = `${API_BASE}/slots`;
+  if (date) url += `?date=${encodeURIComponent(date)}`;
+  const res = await apiFetch(url, {
+    headers: { Authorization: bearer(token) },
+  });
+  const data = await handleResponse(res);
+  return data.map((s: any) => ({
+    id: String(s.id),
+    startTime: s.startTime ?? s.start_time,
+    endTime: s.endTime ?? s.end_time,
+    available: s.available,
+  })) as Slot[];
+}
 
 // api.ts
 export async function addUser(
@@ -236,7 +243,13 @@ export async function getAllSlots(token: string) {
   const res = await apiFetch(`${API_BASE}/slots/all`, {
     headers: { Authorization: bearer(token) },
   });
-  return handleResponse(res);
+  const data = await handleResponse(res);
+  return data.map((s: any) => ({
+    id: String(s.id),
+    startTime: s.startTime ?? s.start_time,
+    endTime: s.endTime ?? s.end_time,
+    available: s.available,
+  })) as Slot[];
 }
 
 export async function getBlockedSlots(token: string, date: string) {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
@@ -214,7 +214,7 @@ export default function PantrySchedule({ token }: { token: string }) {
       cells: Array.from({ length: 4 }).map((_, i) => {
         const booking = slotBookings[i];
         return {
-          content: booking ? booking.user_name : '',
+          content: booking ? booking.user_name : 'Available',
           backgroundColor: booking
             ? booking.status === 'submitted'
               ? '#ffe5b4'


### PR DESCRIPTION
## Summary
- Map slot responses to camelCase so times render in staff schedule
- Show volunteer names for booked slots and "Available" for open slots in staff schedule

## Testing
- `npm test` *(fails: jest-environment-jsdom module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6898c8bdfc28832d92fa4a0ffc2f0f06