### PR TITLE
Align staff volunteer schedule with volunteer view

### DIFF
--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -1,6 +1,6 @@
 // src/api/api.ts
 // Read API base URL from environment or fall back to localhost
-import type { Role, UserRole, StaffRole, UserProfile } from '../types';
+import type { Role, UserRole, StaffRole, UserProfile, Slot } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
 
@@ -130,14 +130,21 @@ export async function createStaff(
   await handleResponse(res);
 }
 
+
 export async function getSlots(token: string, date?: string) {
-    let url = `${API_BASE}/slots`;
-    if (date) url += `?date=${encodeURIComponent(date)}`;
-    const res = await apiFetch(url, {
-      headers: { Authorization: bearer(token) }
-    });
-    return handleResponse(res);
-  }
+  let url = `${API_BASE}/slots`;
+  if (date) url += `?date=${encodeURIComponent(date)}`;
+  const res = await apiFetch(url, {
+    headers: { Authorization: bearer(token) },
+  });
+  const data = await handleResponse(res);
+  return data.map((s: any) => ({
+    id: String(s.id),
+    startTime: s.startTime ?? s.start_time,
+    endTime: s.endTime ?? s.end_time,
+    available: s.available,
+  })) as Slot[];
+}
 
 // api.ts
 export async function addUser(
@@ -236,7 +243,13 @@ export async function getAllSlots(token: string) {
   const res = await apiFetch(`${API_BASE}/slots/all`, {
     headers: { Authorization: bearer(token) },
   });
-  return handleResponse(res);
+  const data = await handleResponse(res);
+  return data.map((s: any) => ({
+    id: String(s.id),
+    startTime: s.startTime ?? s.start_time,
+    endTime: s.endTime ?? s.end_time,
+    available: s.available,
+  })) as Slot[];
 }
 
 export async function getBlockedSlots(token: string, date: string) {

--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -412,7 +412,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
                     (booking.status.toLowerCase() === 'pending' && !canBook
                       ? ' (Full)'
                       : '')
-                : '',
+                : 'Available',
               backgroundColor: booking
                 ? booking.status.toLowerCase() === 'approved'
                   ? '#c8e6c9'


### PR DESCRIPTION
## Summary
- Convert slot API responses to camelCase start/end times for consistent schedule rendering
- Label open slots as "Available" on the staff volunteer schedule while showing volunteer names for booked slots

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c8bdfc28832d92fa4a0ffc2f0f06