### PR TITLE
Group volunteer role shifts in listing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,32 @@ CREATE TABLE IF NOT EXISTS volunteer_bookings (
 
 ### Slot API
 
+`GET /volunteer-roles` returns all volunteer roles with their shifts:
+
+```
+[
+  {
+    "id": <role_id>,
+    "role_id": <role_id>,
+    "category_id": <category_id>,
+    "name": "<role name>",
+    "max_volunteers": 3,
+    "category_name": "<category>",
+    "shifts": [
+      {
+        "id": <slot_id>,
+        "start_time": "09:00:00",
+        "end_time": "12:00:00",
+        "is_wednesday_slot": false,
+        "is_active": true
+      },
+      ...
+    ]
+  },
+  ...
+]
+```
+
 `GET /volunteer-roles/mine?date=YYYY-MM-DD` returns each slot the logged-in volunteer is trained for:
 
 ```

--- a/MJ_FB_Backend/src/controllers/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerRoleController.ts
@@ -95,7 +95,8 @@ export async function listVolunteerRoles(
 ) {
   try {
     const result = await pool.query(
-        `SELECT vr.id AS role_id, vr.category_id, vr.name, vr.max_volunteers,
+        `SELECT vr.id AS role_id, vr.category_id, vr.name,
+                MAX(vs.max_volunteers) AS max_volunteers,
                 vmr.name AS category_name,
                 json_agg(
                   json_build_object(
@@ -111,7 +112,7 @@ export async function listVolunteerRoles(
        JOIN volunteer_slots vs ON vs.role_id = vr.id
        JOIN volunteer_master_roles vmr ON vr.category_id = vmr.id
        WHERE vs.is_active
-       GROUP BY vr.id, vr.category_id, vr.name, vr.max_volunteers, vmr.name
+       GROUP BY vr.id, vr.category_id, vr.name, vmr.name
        ORDER BY vr.id`
     );
     res.json(


### PR DESCRIPTION
## Summary
- Group volunteer slot shifts by role so `/volunteer-roles` returns roles with nested shift arrays
- Document new `/volunteer-roles` API response format in AGENTS.md

## Testing
- `npm test 2>&1 | grep -A5 "Test Suites" | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6898dbb752c0832dada9eb6fa56b6783