### PR TITLE
Use proper input types for form fields

### DIFF
--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -855,6 +855,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
             />
             <TextField
               label="Phone (optional)"
+              type="tel"
               value={phone}
               onChange={e => setPhone(e.target.value)}
               size="small"

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -87,7 +87,12 @@ export default function AddUser({ token }: { token: string }) {
           <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
           <TextField label="Client ID" value={clientId} onChange={e => setClientId(e.target.value)} />
           <TextField label="Email (optional)" type="email" value={email} onChange={e => setEmail(e.target.value)} />
-          <TextField label="Phone (optional)" value={phone} onChange={e => setPhone(e.target.value)} />
+          <TextField
+            label="Phone (optional)"
+            type="tel"
+            value={phone}
+            onChange={e => setPhone(e.target.value)}
+          />
           <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
           <TextField select label="Role" value={role} onChange={e => setRole(e.target.value as UserRole)}>
             <MenuItem value="shopper">Shopper</MenuItem>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -60,7 +60,13 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
       header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
     >
       <FormContainer onSubmit={submit} submitLabel="Login">
-        <TextField value={email} onChange={e => setEmail(e.target.value)} label="Email" fullWidth />
+        <TextField
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          label="Email"
+          fullWidth
+        />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">Forgot password?</Link>
       </FormContainer>


### PR DESCRIPTION
## Summary
- ensure staff login uses an email-type field
- specify telephone input types when adding users and coordinators

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*


------
https://chatgpt.com/codex/tasks/task_e_689903a74070832db85f03c6bf7d0553