### PR TITLE
Show no-results message for empty searches

### DIFF
--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -702,7 +702,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
             size="small"
             sx={{ mb: 1 }}
           />
-          {results.length > 0 && (
+          {results.length > 0 ? (
             <ul style={{ listStyle: 'none', padding: 0 }}>
               {results.map(r => (
                 <li
@@ -722,6 +722,8 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
                 </li>
               ))}
             </ul>
+          ) : (
+            search.length >= 3 && <p>No search results.</p>
           )}
           {selectedVolunteer && (
             <div>
@@ -984,11 +986,19 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
               {assignResults.map(v => (
                 <li key={v.id} style={{ marginBottom: 4 }}>
                   {v.name}
-                  <Button style={{ marginLeft: 4 }} onClick={() => assignVolunteer(v)} variant="outlined" color="primary">
+                  <Button
+                    style={{ marginLeft: 4 }}
+                    onClick={() => assignVolunteer(v)}
+                    variant="outlined"
+                    color="primary"
+                  >
                     Assign
                   </Button>
                 </li>
               ))}
+              {assignSearch.length >= 3 && assignResults.length === 0 && (
+                <li>No search results.</li>
+              )}
             </ul>
             <Button
               onClick={() => {

--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -104,7 +104,10 @@ export default function SlotBooking({ token, role }: Props) {
     }
   }, [selectedDate, holidays, isWeekend, isHoliday, getNextAvailableDate]);
 
-  const { data: userResults = [] } = useQuery({
+  const {
+    data: userResults = [],
+    isFetching: userFetching,
+  } = useQuery({
     queryKey: ['userSearch', searchTerm],
     queryFn: () => searchUsers(token, searchTerm),
     enabled: role === 'staff' && searchTerm.length >= 3,
@@ -218,11 +221,20 @@ export default function SlotBooking({ token, role }: Props) {
           {userResults.slice(0, 5).map(user => (
             <li key={user.id} className="user-item">
               {user.name} ({user.email})
-              <Button size="small" variant="outlined" color="primary" sx={{ ml: 1 }} onClick={() => setSelectedUser(user)}>
+              <Button
+                size="small"
+                variant="outlined"
+                color="primary"
+                sx={{ ml: 1 }}
+                onClick={() => setSelectedUser(user)}
+              >
                 Book Appointment
               </Button>
             </li>
           ))}
+          {!userFetching && searchTerm.length >= 3 && userResults.length === 0 && (
+            <li>No search results.</li>
+          )}
         </ul>
         <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity="error" />
       </div>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
@@ -286,11 +286,19 @@ export default function PantrySchedule({ token }: { token: string }) {
               {userResults.map(u => (
                 <li key={u.id} style={{ marginBottom: 4 }}>
                   {u.name} ({u.email})
-                  <Button style={{ marginLeft: 4 }} onClick={() => assignUser(u)} variant="outlined" color="primary">
+                  <Button
+                    style={{ marginLeft: 4 }}
+                    onClick={() => assignUser(u)}
+                    variant="outlined"
+                    color="primary"
+                  >
                     Assign
                   </Button>
                 </li>
               ))}
+              {assignSlot && searchTerm.length >= 3 && userResults.length === 0 && (
+                <li>No search results.</li>
+              )}
             </ul>
             <FeedbackSnackbar open={!!assignMessage} onClose={() => setAssignMessage('')} message={assignMessage} severity="error" />
             <Button onClick={() => { setAssignSlot(null); setSearchTerm(''); setAssignMessage(''); }} variant="outlined" color="primary">Close</Button>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -96,7 +96,7 @@ export default function UserHistory({
             size="small"
             sx={{ mb: 1 }}
           />
-          {results.length > 0 && (
+          {results.length > 0 ? (
             <ul style={{ listStyle: 'none', padding: 0 }}>
               {results.map(u => (
                 <li key={u.id}>
@@ -114,6 +114,8 @@ export default function UserHistory({
                 </li>
               ))}
             </ul>
+          ) : (
+            search.length >= 3 && <p>No search results.</p>
           )}
         </>
       )}


### PR DESCRIPTION
## Summary
- Display "No search results" in SlotBooking when staff user search finds nothing
- Show empty-result message in UserHistory user search
- Add no-results feedback for volunteer search and assignment in CoordinatorDashboard
- Notify staff when user search within PantrySchedule returns no matches

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689903dbd768832dbbb33121ccbcbba5