### PR TITLE
Ensure proper email input type in password reset dialog

### DIFF
--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -45,6 +45,7 @@ export default function PasswordResetDialog({
             autoFocus
             margin="dense"
             label={label}
+            type={type === 'staff' ? 'email' : 'text'}
             fullWidth
             value={identifier}
             onChange={e => setIdentifier(e.target.value)}


### PR DESCRIPTION
## Summary
- Set password reset dialog to use an email input when resetting staff accounts, enabling browser email validation

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*


------
https://chatgpt.com/codex/tasks/task_e_68990511ec8c832db2d2a0e692f8b043