### PR TITLE
Connect dashboards to live booking data

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -133,7 +133,7 @@ export default function App() {
                       role === 'volunteer' ? (
                         <VolunteerDashboard token={token} />
                       ) : (
-                        <Dashboard role={isStaff ? 'staff' : 'user'} />
+                        <Dashboard role={isStaff ? 'staff' : 'user'} token={token} />
                       )
                     }
                   />

--- a/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/CoordinatorDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   getVolunteerRoles,
@@ -26,86 +26,10 @@ import {
   ListSubheader,
   Checkbox,
   FormControlLabel,
-  Grid,
-  Card,
-  CardHeader,
-  CardContent,
-  Typography,
-  Stack,
-  List,
-  ListItem,
-  ListItemText,
-  Chip,
-  IconButton,
 } from '@mui/material';
-import {
-  CalendarToday,
-  People,
-  WarningAmber,
-  Cancel as CancelIcon,
-  Search,
-  Announcement,
-} from '@mui/icons-material';
+import Dashboard from '../pages/Dashboard';
 
-interface SectionCardProps {
-  title: string;
-  icon?: ReactNode;
-  children: ReactNode;
-}
 
-const SectionCard = ({ title, icon, children }: SectionCardProps) => (
-  <Card variant="outlined" sx={{ borderRadius: 2, boxShadow: 1 }}>
-    <CardHeader title={title} avatar={icon} />
-    <CardContent>{children}</CardContent>
-  </Card>
-);
-
-interface StatProps {
-  icon: ReactNode;
-  label: string;
-  value: string | number;
-}
-
-const Stat = ({ icon, label, value }: StatProps) => (
-  <Stack direction="row" spacing={1} alignItems="center">
-    {icon}
-    <Stack>
-      <Typography variant="body2" color="text.secondary">
-        {label}
-      </Typography>
-      <Typography variant="h6">{value}</Typography>
-    </Stack>
-  </Stack>
-);
-
-const mockStaff = {
-  stats: {
-    appointments: 24,
-    volunteers: 8,
-    approvals: 5,
-    cancellations: 2,
-  },
-  approvals: [
-    { name: 'Alice Johnson', type: 'User' },
-    { name: 'Bob Lee', type: 'Volunteer' },
-  ],
-  coverage: [
-    { role: 'Pantry', filled: 4, total: 5 },
-    { role: 'Warehouse', filled: 2, total: 3 },
-    { role: 'Driver', filled: 1, total: 2 },
-  ],
-  schedule: [
-    { day: 'Mon', open: 12 },
-    { day: 'Tue', open: 8 },
-    { day: 'Wed', open: 10 },
-    { day: 'Thu', open: 14 },
-    { day: 'Fri', open: 6 },
-    { day: 'Sat', open: 4 },
-    { day: 'Sun', open: 0 },
-  ],
-  cancellations: ['Jones - 9:00 AM', 'Smith - 11:30 AM'],
-  notices: ['Food drive Saturday', 'Team meeting Thursday'],
-};
 
 
 interface RoleOption {
@@ -534,135 +458,7 @@ export default function CoordinatorDashboard({ token }: { token: string }) {
   return (
     <div>
       <h2>{title}</h2>
-      {tab === 'dashboard' && (
-        <Grid container spacing={2}>
-          <Grid item xs={12} md={6}>
-            <SectionCard title="Today at a Glance">
-              <Grid container spacing={2}>
-                <Grid item xs={6}>
-                  <Stat
-                    icon={<CalendarToday color="primary" />}
-                    label="Appointments Today"
-                    value={mockStaff.stats.appointments}
-                  />
-                </Grid>
-                <Grid item xs={6}>
-                  <Stat
-                    icon={<People color="primary" />}
-                    label="Volunteers Scheduled"
-                    value={mockStaff.stats.volunteers}
-                  />
-                </Grid>
-                <Grid item xs={6}>
-                  <Stat
-                    icon={<WarningAmber color="warning" />}
-                    label="Pending Approvals"
-                    value={mockStaff.stats.approvals}
-                  />
-                </Grid>
-                <Grid item xs={6}>
-                  <Stat
-                    icon={<CancelIcon color="error" />}
-                    label="Cancellations"
-                    value={mockStaff.stats.cancellations}
-                  />
-                </Grid>
-              </Grid>
-            </SectionCard>
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <SectionCard title="Pending Approvals">
-              <List>
-                {mockStaff.approvals.map((item, i) => (
-                  <ListItem key={i} secondaryAction={<Chip label={item.type} />}>
-                    <ListItemText primary={item.name} />
-                  </ListItem>
-                ))}
-              </List>
-            </SectionCard>
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <SectionCard title="Volunteer Coverage">
-              <List>
-                {mockStaff.coverage.map((item, i) => {
-                  const ratio = item.filled / item.total;
-                  let color: 'success' | 'warning' | 'error' | 'default' = 'default';
-                  if (ratio >= 1) color = 'success';
-                  else if (ratio >= 0.5) color = 'warning';
-                  else color = 'error';
-                  return (
-                    <ListItem
-                      key={i}
-                      secondaryAction={<Chip color={color} label={`${item.filled}/${item.total}`} />}
-                    >
-                      <ListItemText primary={item.role} />
-                    </ListItem>
-                  );
-                })}
-              </List>
-            </SectionCard>
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <SectionCard title="Pantry Schedule (This Week)">
-              <Grid container columns={7} spacing={2}>
-                {mockStaff.schedule.map((day, i) => (
-                  <Grid item xs={1} key={i}>
-                    <Stack alignItems="center" spacing={1}>
-                      <Typography variant="body2">{day.day}</Typography>
-                      <Chip
-                        label={`Open: ${day.open}`}
-                        color={day.open > 0 ? 'success' : 'default'}
-                      />
-                    </Stack>
-                  </Grid>
-                ))}
-              </Grid>
-            </SectionCard>
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <SectionCard title="Quick Search">
-              <Stack spacing={2}>
-                <Stack direction="row" spacing={1}>
-                  <TextField size="small" placeholder="Search" fullWidth />
-                  <IconButton color="primary" size="small">
-                    <Search />
-                  </IconButton>
-                </Stack>
-                <Stack direction="row" spacing={1}>
-                  <Button size="small" variant="contained" sx={{ textTransform: 'none' }}>
-                    Find Client
-                  </Button>
-                  <Button size="small" variant="outlined" sx={{ textTransform: 'none' }}>
-                    Find Volunteer
-                  </Button>
-                </Stack>
-              </Stack>
-            </SectionCard>
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <SectionCard title="Recent Cancellations">
-              <List>
-                {mockStaff.cancellations.map((c, i) => (
-                  <ListItem key={i}>
-                    <ListItemText primary={c} />
-                  </ListItem>
-                ))}
-              </List>
-            </SectionCard>
-          </Grid>
-          <Grid item xs={12}>
-            <SectionCard title="Notices & Events" icon={<Announcement color="primary" />}>
-              <List>
-                {mockStaff.notices.map((n, i) => (
-                  <ListItem key={i}>
-                    <ListItemText primary={n} />
-                  </ListItem>
-                ))}
-              </List>
-            </SectionCard>
-          </Grid>
-        </Grid>
-      )}
+      {tab === 'dashboard' && <Dashboard role="staff" token={token} />}
       {tab === 'schedule' && (
         <div>
           <FormControl size="small" sx={{ minWidth: 200 }}>


### PR DESCRIPTION
## Summary
- Pass auth token to Dashboard and fetch bookings for staff and shoppers
- Populate dashboard cards with live booking, coverage, and slot data
- Reuse shared Dashboard inside CoordinatorDashboard instead of mock widgets

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm install -D jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689906c94020832d9230d0364637bc09