### PR TITLE
Expose max volunteers in volunteer bookings list

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerBookingController.ts
@@ -154,7 +154,7 @@ export async function listVolunteerBookings(
     const result = await pool.query(
       `SELECT vb.id, vb.status, vb.slot_id AS role_id, vb.volunteer_id, vb.date,
               vb.reschedule_token,
-              vs.start_time, vs.end_time, vr.name AS role_name, vmr.name AS category_name,
+              vs.start_time, vs.end_time, vs.max_volunteers, vr.name AS role_name, vmr.name AS category_name,
               v.first_name || ' ' || v.last_name AS volunteer_name
        FROM volunteer_bookings vb
        JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id
@@ -184,7 +184,7 @@ export async function listVolunteerBookingsByRole(
     const result = await pool.query(
       `SELECT vb.id, vb.status, vb.slot_id AS role_id, vb.volunteer_id, vb.date,
               vb.reschedule_token,
-              vs.start_time, vs.end_time, vr.name AS role_name, vmr.name AS category_name,
+              vs.start_time, vs.end_time, vs.max_volunteers, vr.name AS role_name, vmr.name AS category_name,
               v.first_name || ' ' || v.last_name AS volunteer_name
        FROM volunteer_bookings vb
        JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id
@@ -247,7 +247,7 @@ export async function listVolunteerBookingsByVolunteer(
     const result = await pool.query(
       `SELECT vb.id, vb.status, vb.slot_id AS role_id, vb.volunteer_id, vb.date,
               vb.reschedule_token,
-              vs.start_time, vs.end_time, vr.name AS role_name, vmr.name AS category_name
+              vs.start_time, vs.end_time, vs.max_volunteers, vr.name AS role_name, vmr.name AS category_name
        FROM volunteer_bookings vb
        JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id
        JOIN volunteer_roles vr ON vs.role_id = vr.id

--- a/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import express from 'express';
+import volunteerBookingsRouter from '../src/routes/volunteerBookings';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  optionalAuthMiddleware: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/volunteer-bookings', volunteerBookingsRouter);
+
+describe('listVolunteerBookings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('includes max_volunteers in the response', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          status: 'pending',
+          role_id: 2,
+          volunteer_id: 3,
+          date: '2025-01-01',
+          reschedule_token: 'abc',
+          start_time: '09:00:00',
+          end_time: '12:00:00',
+          max_volunteers: 5,
+          role_name: 'Pantry',
+          category_name: 'Food',
+          volunteer_name: 'John Doe',
+        },
+      ],
+    });
+
+    const res = await request(app).get('/volunteer-bookings');
+    expect(res.status).toBe(200);
+    expect(res.body[0].max_volunteers).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- include `max_volunteers` in volunteer booking listing queries so the endpoint has capacity info
- add regression test to ensure listings return `max_volunteers`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689915a3c3d4832d90b1cb5e0ac5b36d