### PR TITLE
Refactor volunteer dashboard navigation

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -12,6 +12,7 @@ import VolunteerLogin from './components/VolunteerLogin';
 import VolunteerDashboard from './components/VolunteerDashboard';
 import VolunteerManagement from './components/VolunteerManagement';
 import Dashboard from './pages/Dashboard';
+import VolunteerBookingHistory from './components/VolunteerBookingHistory';
 import type { Role } from './types';
 import Navbar, { type NavGroup } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
@@ -63,7 +64,13 @@ export default function App() {
       ],
     });
   } else if (role === 'volunteer') {
-    navGroups.push({ label: 'Volunteer', links: [{ label: 'Volunteer Dashboard', to: '/' }] });
+    navGroups.push({
+      label: 'Volunteer',
+      links: [
+        { label: 'Schedule', to: '/' },
+        { label: 'Booking History', to: '/volunteer/history' },
+      ],
+    });
   }
 
   return (
@@ -174,8 +181,8 @@ export default function App() {
                 )}
                 {role === 'volunteer' && (
                   <Route
-                    path="/volunteer-dashboard"
-                    element={<VolunteerDashboard token={token} />}
+                    path="/volunteer/history"
+                    element={<VolunteerBookingHistory token={token} />}
                   />
                 )}
                   <Route path="*" element={<Navigate to="/" replace />} />

--- a/MJ_FB_Frontend/src/components/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerBookingHistory.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { getMyVolunteerBookings } from '../api/api';
+import type { VolunteerBooking } from '../types';
+import { formatTime } from '../utils/time';
+import Page from './Page';
+import {
+  TableContainer,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@mui/material';
+
+export default function VolunteerBookingHistory({ token }: { token: string }) {
+  const [history, setHistory] = useState<VolunteerBooking[]>([]);
+
+  useEffect(() => {
+    getMyVolunteerBookings(token)
+      .then(setHistory)
+      .catch(() => {});
+  }, [token]);
+
+  return (
+    <Page title="Booking History">
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Role</TableCell>
+              <TableCell>Date</TableCell>
+              <TableCell>Time</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {history.map(h => (
+              <TableRow key={h.id}>
+                <TableCell>{h.role_name}</TableCell>
+                <TableCell>{h.date}</TableCell>
+                <TableCell>
+                  {formatTime(h.start_time)} - {formatTime(h.end_time)}
+                </TableCell>
+                <TableCell>{h.status}</TableCell>
+              </TableRow>
+            ))}
+            {history.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={4} align="center">
+                  No bookings.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Page>
+  );
+}
+

--- a/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
@@ -1,75 +1,10 @@
-import { useState, useEffect } from 'react';
-import { getMyVolunteerBookings } from '../api/api';
-import type { VolunteerBooking } from '../types';
-import { formatTime } from '../utils/time';
 import VolunteerSchedule from './VolunteerSchedule';
-import {
-  Tabs,
-  Tab,
-  TableContainer,
-  Paper,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
-} from '@mui/material';
 import Page from './Page';
 
 export default function VolunteerDashboard({ token }: { token: string }) {
-  const [tab, setTab] = useState<'schedule' | 'history'>('schedule');
-  const [history, setHistory] = useState<VolunteerBooking[]>([]);
-
-  useEffect(() => {
-    if (tab === 'history') {
-      getMyVolunteerBookings(token)
-        .then(setHistory)
-        .catch(() => {});
-    }
-  }, [tab, token]);
-
   return (
     <Page title="Volunteer Dashboard">
-      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
-        <Tab label="Schedule" value="schedule" />
-        <Tab label="Booking History" value="history" />
-      </Tabs>
-
-      {tab === 'schedule' && <VolunteerSchedule token={token} />}
-
-      {tab === 'history' && (
-        <TableContainer component={Paper}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Role</TableCell>
-                <TableCell>Date</TableCell>
-                <TableCell>Time</TableCell>
-                <TableCell>Status</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {history.map(h => (
-                <TableRow key={h.id}>
-                  <TableCell>{h.role_name}</TableCell>
-                  <TableCell>{h.date}</TableCell>
-                  <TableCell>
-                    {formatTime(h.start_time)} - {formatTime(h.end_time)}
-                  </TableCell>
-                  <TableCell>{h.status}</TableCell>
-                </TableRow>
-              ))}
-              {history.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={4} align="center">
-                    No bookings.
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      )}
+      <VolunteerSchedule token={token} />
     </Page>
   );
 }


### PR DESCRIPTION
## Summary
- Replace volunteer dashboard tabs with dedicated routes
- Add volunteer booking history page
- Update navigation to include volunteer schedule and history dropdown

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899162eb1b4832d95bd1755ad658922