### PR TITLE
Allow volunteers to view holidays and restrict holiday bookings

### DIFF
--- a/MJ_FB_Backend/src/routes/holidays.ts
+++ b/MJ_FB_Backend/src/routes/holidays.ts
@@ -8,7 +8,7 @@ const router = express.Router();
 router.get(
   '/',
   authMiddleware,
-  authorizeRoles('staff'),
+  authorizeRoles('staff', 'volunteer'),
   async (_, res) => {
     const result = await pool.query('SELECT date, reason FROM holidays ORDER BY date');
     res.json(


### PR DESCRIPTION
## Summary
- Permit volunteers to fetch holiday data
- Block volunteer bookings for pantry, warehouse, and administrative roles on holidays/weekends
- Filter volunteer schedule to hide restricted roles and show closed days

## Testing
- `npm test` in `MJ_FB_Backend`
- `npm test` in `MJ_FB_Frontend` *(fails: missing jest-environment-jsdom; attempted install but 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6899168397cc832dbde2f31b8fc11e4e