### PR TITLE
Fix volunteer roles query

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerRoleController.ts
@@ -266,7 +266,7 @@ export async function listVolunteerRolesForVolunteer(
     const roleIds = volunteerRes.rows.map(r => r.role_id);
     const result = await pool.query(
         `SELECT vs.slot_id AS id, vs.role_id, vr.name, vs.start_time, vs.end_time,
-                vs.max_volunteers AS max_volunteers, vr.category_id, vs.is_wednesday_slot, vs.is_active,
+                vr.max_volunteers AS max_volunteers, vr.category_id, vs.is_wednesday_slot, vs.is_active,
                 vmr.name AS category_name,
                 COALESCE(b.count,0) AS booked, $1::date AS date
          FROM volunteer_slots vs


### PR DESCRIPTION
## Summary
- correct volunteer roles listing query to pull `max_volunteers` from `volunteer_roles`

## Testing
- `cd MJ_FB_Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991b7802e8832d9dafaff7588bdd1c