### PR TITLE
feat: remove iframe-style width constraint

### DIFF
--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -64,8 +64,8 @@ button:focus-visible {
 /* src/index.css */
 
 .app-container {
-  max-width: 900px; /* fits nicely in iframe, adjust as needed */
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: 1rem;
   box-sizing: border-box;
   font-family: var(--e-global-typography-text-font-family);


### PR DESCRIPTION
## Summary
- Let application layout span the full viewport width by removing the `.app-container` max-width.

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689928fc4850832dbb6208763cffd09a