### PR TITLE
Limit form width for a centered layout

### DIFF
--- a/MJ_FB_Frontend/src/components/FormContainer.tsx
+++ b/MJ_FB_Frontend/src/components/FormContainer.tsx
@@ -9,7 +9,7 @@ interface FormContainerProps extends Omit<BoxProps, 'component' | 'onSubmit'> {
 
 export default function FormContainer({ onSubmit, submitLabel, children, ...boxProps }: FormContainerProps) {
   return (
-    <Box component="form" onSubmit={onSubmit} mt={2} {...boxProps}>
+    <Box component="form" onSubmit={onSubmit} mt={2} maxWidth={400} mx="auto" {...boxProps}>
       <Stack spacing={2}>
         {children}
         <Button type="submit" variant="contained" color="primary" fullWidth>


### PR DESCRIPTION
## Summary
- Center form containers and cap width at 400px to avoid full-screen forms

## Testing
- `npm test` (fails: Test environment jest-environment-jsdom cannot be found)
- `npm install --no-save jest-environment-jsdom@29.7.0` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68992b3ad264832daccc98faa871840f