### PR TITLE
Ensure schedule slots share equal width

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -26,12 +26,19 @@ interface Props {
 }
 
 export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
+  const slotWidth = `calc((100% - 160px) / ${maxSlots})`;
   return (
     <TableContainer component={Paper}>
-      <Table size="small">
+      <Table size="small" sx={{ tableLayout: 'fixed', width: '100%' }}>
+        <colgroup>
+          <col style={{ width: 160 }} />
+          {Array.from({ length: maxSlots }).map((_, i) => (
+            <col key={i} style={{ width: slotWidth }} />
+          ))}
+        </colgroup>
         <TableHead>
           <TableRow>
-            <TableCell sx={{ width: 160 }}>Time</TableCell>
+            <TableCell>Time</TableCell>
             {Array.from({ length: maxSlots }).map((_, i) => (
               <TableCell key={i}>Slot {i + 1}</TableCell>
             ))}


### PR DESCRIPTION
## Summary
- Fix uneven slot sizing by using a fixed table layout and calculated column widths
- Apply equal slot widths across pantry and volunteer schedules via shared table component

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm install --no-save jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68992ba7a71c832dafa79e6d36cd85cc