### PR TITLE
Fix React Query mutation usage in slot booking

### DIFF
--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -146,12 +146,14 @@ export default function SlotBooking({ token, role }: Props) {
   });
 
   const queryClient = useQueryClient();
-  const bookingMutation = useMutation((vars: { slotId: string; date: string }) =>
-    createBooking(token, vars.slotId, vars.date),
-  );
-  const staffBookingMutation = useMutation((vars: { userId: number; slotId: number; date: string }) =>
-    createBookingForUser(token, vars.userId, vars.slotId, vars.date, true),
-  );
+  const bookingMutation = useMutation({
+    mutationFn: (vars: { slotId: string; date: string }) =>
+      createBooking(token, vars.slotId, vars.date),
+  });
+  const staffBookingMutation = useMutation({
+    mutationFn: (vars: { userId: number; slotId: number; date: string }) =>
+      createBookingForUser(token, vars.userId, vars.slotId, vars.date, true),
+  });
 
   async function submitBooking() {
     if (!selectedSlotId || !selectedDate) {


### PR DESCRIPTION
## Summary
- fix missing mutationFn in useMutation when booking slots

## Testing
- `npm test` (fails: jest-environment-jsdom cannot be found)


------
https://chatgpt.com/codex/tasks/task_e_68992eb08ce0832db6d4770e62134477