### PR TITLE
Remove padding from app container

### DIFF
--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -66,7 +66,7 @@ button:focus-visible {
 .app-container {
   width: 100%;
   margin: 0;
-  padding: 1rem;
+  padding: 0;
   box-sizing: border-box;
   font-family: var(--e-global-typography-text-font-family);
 }
@@ -184,10 +184,6 @@ select {
 }
 
 @media (max-width: 600px) {
-  .app-container {
-    padding: 0.5rem;
-  }
-
   .navbar {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary
- eliminate default padding from `.app-container`
- drop mobile-specific padding override for the app container

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899318e0f38832d9403bcfcf5350313