### PR TITLE
Adjust logo positioning for larger screens

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -81,9 +81,9 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
           alt="Food Bank logo"
           sx={{
             position: 'absolute',
-            top: { xs: 0, sm: 0 },
-            left: { xs: 0, sm: 0 },
-            width: { xs: 80, sm: 120 },
+            top: { xs: 0, sm: 36 },
+            left: { xs: 0, sm: 15 },
+            width: { xs: 80, sm: 200 },
           }}
         />
       </Box>


### PR DESCRIPTION
## Summary
- refine navbar logo layout so at widths 600px+ it sits 36px from top, 15px from left, sized to 200px

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689937151954832dbff7db7962a93c8a