### PR TITLE
Move profile menu into mobile navigation

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -37,4 +37,31 @@ describe('Navbar component', () => {
     expect(screen.queryByText(/Hello/)).toBeNull();
     expect(screen.getByRole('button', { name: /Logout/i })).toBeInTheDocument();
   });
+
+  it('moves greeting into hamburger menu on small screens', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = () => ({
+      matches: true,
+      addListener: () => {},
+      removeListener: () => {},
+    }) as any;
+
+    render(
+      <MemoryRouter>
+        <Navbar
+          groups={[{ label: 'Home', links: [{ label: 'Home', to: '/' }] }]}
+          onLogout={() => {}}
+          name="Tester"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/Hello, Tester/i)).toBeNull();
+    fireEvent.click(screen.getByLabelText(/open navigation menu/i));
+    expect(screen.getByText(/Hello, Tester/i)).toBeInTheDocument();
+    expect(screen.getByText(/Profile/i)).toBeInTheDocument();
+    expect(screen.getByText(/Logout/i)).toBeInTheDocument();
+
+    window.matchMedia = originalMatchMedia;
+  });
 });

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -95,7 +95,11 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
           <Box sx={{ flexGrow: 1 }} />
           {isSmall ? (
           <>
-            <IconButton color="inherit" onClick={(e) => setMobileAnchorEl(e.currentTarget)}>
+            <IconButton
+              color="inherit"
+              aria-label="open navigation menu"
+              onClick={(e) => setMobileAnchorEl(e.currentTarget)}
+            >
               <MenuIcon />
             </IconButton>
             <Menu
@@ -127,6 +131,45 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
                   ))}
                 </Box>
               ))}
+              {name ? (
+                <>
+                  <MenuItem disabled sx={navItemStyles}>
+                    Hello, {name}
+                  </MenuItem>
+                  <MenuItem
+                    component={RouterLink}
+                    to="/profile"
+                    onClick={() => {
+                      setMobileAnchorEl(null);
+                    }}
+                    disabled={loading}
+                    sx={navItemStyles}
+                  >
+                    Profile
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      setMobileAnchorEl(null);
+                      onLogout();
+                    }}
+                    disabled={loading}
+                    sx={navItemStyles}
+                  >
+                    Logout
+                  </MenuItem>
+                </>
+              ) : (
+                <MenuItem
+                  onClick={() => {
+                    setMobileAnchorEl(null);
+                    onLogout();
+                  }}
+                  disabled={loading}
+                  sx={navItemStyles}
+                >
+                  Logout
+                </MenuItem>
+              )}
             </Menu>
           </>
         ) : (
@@ -172,7 +215,7 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
           )
         )}
         <Box sx={{ flexGrow: 1 }} />
-        {name ? (
+        {name && !isSmall ? (
           <>
             <Button
               color="inherit"
@@ -208,11 +251,11 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
               </MenuItem>
             </Menu>
           </>
-        ) : (
+        ) : !name && !isSmall ? (
           <Button color="inherit" onClick={onLogout} disabled={loading} sx={navItemStyles}>
             Logout
           </Button>
-        )}
+        ) : null}
       </Toolbar>
     </AppBar>
   </Box>


### PR DESCRIPTION
## Summary
- move user greeting and profile actions into hamburger menu on small screens
- limit greeting button to larger screens and add accessible label
- test mobile navigation profile menu

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899394442e4832d9da186947f36eb0c