### PR TITLE
Align navbar menu items to right

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -1,7 +1,6 @@
 import {
   AppBar,
   Toolbar,
-  Typography,
   Button,
   Box,
   IconButton,

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -91,8 +91,9 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
         position="static"
         sx={{ bgcolor: 'common.black', color: 'common.white' }}
       >
-        <Toolbar sx={{ gap: 2, flexWrap: 'wrap', minHeight: { xs: 48, sm: 56 } }}>
-          <Box sx={{ flexGrow: 1 }} />
+        <Toolbar
+          sx={{ gap: 2, flexWrap: 'wrap', minHeight: { xs: 48, sm: 56 }, justifyContent: 'flex-end' }}
+        >
           {isSmall ? (
           <>
             <IconButton color="inherit" onClick={(e) => setMobileAnchorEl(e.currentTarget)}>
@@ -171,7 +172,6 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
             )
           )
         )}
-        <Box sx={{ flexGrow: 1 }} />
         {name ? (
           <>
             <Button


### PR DESCRIPTION
## Summary
- Align Navbar menu and profile items to the right side using MUI toolbar `justifyContent: 'flex-end'`

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899396f8ae4832d8a3c57ae17ce4a07