### PR TITLE
fix: ensure logo container is positioned relatively

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -73,7 +73,7 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
         position: 'relative',
       }}
     >
-      <Box sx={{ height: 0 }}>
+      <Box sx={{ position: 'relative', height: 0 }}>
         <Box
           component="img"
           src="/images/mjfoodbank_logo.png"


### PR DESCRIPTION
## Summary
- position the navbar logo container relatively to anchor the logo image

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689948bfd69c832d8ba3e399681d8491