### PR TITLE
Align navbar items to right

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -214,8 +214,6 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
             )
           )
         )}
-
-        <Box sx={{ flexGrow: 1 }} />
         {name && !isSmall ? (
           <>
             <Button


### PR DESCRIPTION
## Summary
- Remove spacer element so navigation links and profile/hamburger menu align flush to the right of the AppBar.

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; install blocked by 403 error)*

------
https://chatgpt.com/codex/tasks/task_e_689948a9c830832d8c7ae3232115729a