### PR TITLE
Improve schedule table responsiveness on small screens

### DIFF
--- a/MJ_FB_Frontend/src/components/ScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/ScheduleTable.tsx
@@ -1,5 +1,6 @@
 import type { Shift } from '../types';
 import { formatHHMM } from '../utils/time';
+import { useMediaQuery, useTheme } from '@mui/material';
 
 interface Props {
   shifts: Shift[];
@@ -10,32 +11,50 @@ export default function ScheduleTable({ shifts }: Props) {
     return <p>No shifts.</p>;
   }
 
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const cellStyle: React.CSSProperties = {
+    padding: isSmall ? 4 : 8,
+    fontSize: isSmall ? '0.75rem' : undefined,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  };
+
   const maxSlots = Math.max(...shifts.map((s) => s.maxVolunteers), 0);
 
   return (
-    <table>
+    <table
+      style={{
+        width: '100%',
+        tableLayout: 'fixed',
+        borderCollapse: 'collapse',
+      }}
+    >
       <thead>
         <tr>
-          <th>Shift</th>
+          <th style={cellStyle}>Shift</th>
           {Array.from({ length: maxSlots }).map((_, i) => (
-            <th key={i}>Slot {i + 1}</th>
+            <th key={i} style={cellStyle}>
+              Slot {i + 1}
+            </th>
           ))}
         </tr>
       </thead>
       <tbody>
         {shifts.map((shift) => (
           <tr key={shift.shiftId}>
-            <td>
+            <td style={cellStyle}>
               {formatHHMM(shift.startTime)}–{formatHHMM(shift.endTime)}
             </td>
             {Array.from({ length: maxSlots }).map((_, i) => (
               <td
                 key={i}
-                style={
-                  i >= shift.maxVolunteers
-                    ? { backgroundColor: '#eee' }
-                    : undefined
-                }
+                style={{
+                  ...cellStyle,
+                  backgroundColor:
+                    i >= shift.maxVolunteers ? '#eee' : undefined,
+                }}
               />
             ))}
           </tr>

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -6,6 +6,8 @@ import {
   TableCell,
   TableBody,
   Paper,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 
 interface Cell {
@@ -27,9 +29,24 @@ interface Props {
 
 export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   const slotWidth = `calc((100% - 160px) / ${maxSlots})`;
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   return (
     <TableContainer component={Paper}>
-      <Table size="small" sx={{ tableLayout: 'fixed', width: '100%' }}>
+      <Table
+        size="small"
+        sx={{
+          tableLayout: 'fixed',
+          width: '100%',
+          '& .MuiTableCell-root': {
+            p: isSmall ? 0.5 : 1,
+            fontSize: isSmall ? '0.75rem' : 'inherit',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          },
+        }}
+      >
         <colgroup>
           <col style={{ width: 160 }} />
           {Array.from({ length: maxSlots }).map((_, i) => (


### PR DESCRIPTION
## Summary
- shrink schedule table fonts on small viewports
- ensure table cells truncate overflow content

## Testing
- `npm test` (fails: jest-environment-jsdom cannot be found)

------
https://chatgpt.com/codex/tasks/task_e_6899518df638832da9ee364cf43fc801