### PR TITLE
fix: adjust nav submenu hover color

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -66,7 +66,7 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
     ...navItemStyles,
     color: 'common.black',
     '&:hover': {
-      bgcolor: '#3f44bb',
+      bgcolor: '#3f444b',
     },
   };
 


### PR DESCRIPTION
## Summary
- use #3f444b on nav submenu item hover

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found; install attempt returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899525df1b4832d9f0db143d61a0f4c