### PR TITLE
fix submenu hover text color to white

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -65,8 +65,9 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
   const menuItemStyles = {
     ...navItemStyles,
     color: 'common.black',
-    '&:hover': {
+    '&:hover, &.Mui-selected:hover': {
       bgcolor: '#3f444b',
+      color: 'common.white',
     },
   };
 


### PR DESCRIPTION
## Summary
- ensure navbar submenu items turn white on hover

## Testing
- `npm test` (fails: jest-environment-jsdom cannot be found)
- `npm install jest-environment-jsdom --no-save` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689953465e84832daebfe10ce8534937