### PR TITLE
style: refine button hover colors

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -60,6 +60,10 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
     fontSize: '20px',
     fontWeight: 700,
     textTransform: 'uppercase',
+    '&:hover': {
+      bgcolor: 'error.main',
+      color: 'common.white',
+    },
   };
 
   const menuItemStyles = {
@@ -67,6 +71,7 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
     color: 'common.black',
     '&:hover': {
       bgcolor: '#3f444b',
+      color: 'common.black',
     },
   };
 

--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -46,24 +46,6 @@ h1 {
   line-height: 1.1;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: var(--e-global-color-accent);
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
 
 
 /* src/index.css */
@@ -107,6 +89,11 @@ select {
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   border-radius: 4px;
+}
+
+.navbar button:hover {
+  background-color: var(--e-global-color-accent);
+  color: white;
 }
 
 .navbar button.active {

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -58,8 +58,18 @@ let theme = createTheme({
       defaultProps: { size: 'small' },
       styleOverrides: {
         root: { borderRadius: 12, textTransform: 'none', fontWeight: 600 },
-        containedPrimary: { color: '#fff' },
-        outlinedPrimary: { borderColor: `${BRAND_PRIMARY}33` }, // subtle outline
+        containedPrimary: {
+          color: '#fff',
+          '&:hover': { backgroundColor: BRAND_PRIMARY },
+        },
+        outlinedPrimary: {
+          borderColor: `${BRAND_PRIMARY}33`,
+          '&:hover': {
+            borderColor: BRAND_PRIMARY,
+            backgroundColor: `${BRAND_PRIMARY}14`,
+            color: BRAND_PRIMARY,
+          },
+        }, // subtle outline
       },
     },
     MuiChip: { styleOverrides: { root: { borderRadius: 10 } } },


### PR DESCRIPTION
## Summary
- keep contained and outlined buttons green on hover
- make navbar buttons show deep red background when hovered
- drop outdated global button styling

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899541c35d8832db833ca9247c48cf7