### PR TITLE
refine navbar button colors

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -62,18 +62,23 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
     fontSize: { xs: 12, sm: 14, md: 16 },
     fontWeight: 700,
     textTransform: 'uppercase',
+    color: 'common.white',
     '&:hover': {
-      bgcolor: 'error.main',
-      color: 'common.white',
+      bgcolor: 'transparent',
+      color: 'error.main',
     },
   };
 
   const menuItemStyles = {
     ...navItemStyles,
     color: 'common.black',
-    '&:hover, &.Mui-selected:hover': {
-      bgcolor: '#3f444b',
-      color: 'common.black',
+    '&:hover': {
+      bgcolor: 'grey.800',
+      color: 'common.white',
+    },
+    '&.Mui-selected:hover': {
+      bgcolor: 'grey.800',
+      color: 'common.white',
     },
   };
 


### PR DESCRIPTION
## Summary
- keep nav buttons white by default and shift to deep red text on hover without a background
- ensure dropdown items use black text, turning white on a grey background when hovered

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689957658e24832d9fa7b08674ed93c6