### PR TITLE
Ensure CSS reset loads before other styles

### DIFF
--- a/MJ_FB_Frontend/index.html
+++ b/MJ_FB_Frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/reset.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Golos+Text:wght@400;500;700&display=swap"
       rel="stylesheet"

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import './reset.css';
 import './index.css';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import { theme } from './theme';


### PR DESCRIPTION
## Summary
- Link reset stylesheet in `index.html` so it loads before all other styles
- Remove reset import from `main.tsx` and keep app stylesheet import only

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_689958b26828832da1df61a6c148e98d