### PR TITLE
fix: show submitted appointments in pending

### DIFF
--- a/MJ_FB_Frontend/src/pages/UserDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/UserDashboard.tsx
@@ -19,7 +19,7 @@ import {
 } from '@mui/material';
 import { EventAvailable, Announcement, History } from '@mui/icons-material';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
-import { getBookings, getSlots, getHolidays, cancelBooking } from '../api/api';
+import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../api/api';
 import type { Slot, Holiday } from '../types';
 import { formatTime } from '../utils/time';
 
@@ -88,7 +88,9 @@ export default function UserDashboard({ token }: { token: string }) {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    getBookings(token).then(setBookings).catch(() => {});
+    getBookingHistory(token)
+      .then(setBookings)
+      .catch(() => {});
   }, [token]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- load user bookings via `getBookingHistory` so submitted requests appear on the pending list

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*


------
https://chatgpt.com/codex/tasks/task_e_6899633124a8832da2cdb0feebe776a7