### PR TITLE
feat(frontend): restore staff pending requests page

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -6,6 +6,7 @@ import UserHistory from './components/StaffDashboard/UserHistory';
 import SlotBooking from './components/SlotBooking';
 import AddUser from './components/StaffDashboard/AddUser';
 import PantrySchedule from './components/StaffDashboard/PantrySchedule';
+import Pending from './components/StaffDashboard/Pending';
 import Login from './components/Login';
 import StaffLogin from './components/StaffLogin';
 import VolunteerLogin from './components/VolunteerLogin';
@@ -45,6 +46,7 @@ export default function App() {
         { label: 'Pantry Schedule', to: '/pantry-schedule' },
         { label: 'Add User', to: '/add-user' },
         { label: 'User History', to: '/user-history' },
+        { label: 'Pending', to: '/pending' },
       ];
     navGroups.push({ label: 'Staff', links: staffLinks });
       navGroups.push({
@@ -172,6 +174,7 @@ export default function App() {
                 )}
                 {isStaff && <Route path="/add-user" element={<AddUser token={token} />} />}
                 {isStaff && <Route path="/user-history" element={<UserHistory token={token} />} />}
+                {isStaff && <Route path="/pending" element={<Pending token={token} />} />}
                 {isStaff && (
                   <>
                     <Route

--- a/MJ_FB_Frontend/src/components/StaffDashboard/Pending.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/Pending.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { Grid, Card, CardContent, CardActions, Typography, TextField, Button } from '@mui/material';
+import { getBookingHistory, decideBooking } from '../../api/api';
+import FeedbackSnackbar from '../FeedbackSnackbar';
+import { formatTime } from '../../utils/time';
+
+interface Booking {
+  id: number;
+  user_name?: string;
+  date: string;
+  start_time?: string;
+  end_time?: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+export default function Pending({ token }: { token: string }) {
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [reasons, setReasons] = useState<Record<number, string>>({});
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<'success' | 'error'>('success');
+
+  function loadBookings() {
+    getBookingHistory(token, { status: 'submitted' })
+      .then(setBookings)
+      .catch(() => {});
+  }
+
+  useEffect(() => {
+    loadBookings();
+  }, [token]);
+
+  async function handleDecision(id: number, decision: 'approve' | 'reject') {
+    try {
+      await decideBooking(token, String(id), decision, reasons[id] || '');
+      setSeverity('success');
+      setMessage(`Booking ${decision === 'approve' ? 'approved' : 'rejected'}`);
+      setReasons(r => {
+        const copy = { ...r };
+        delete copy[id];
+        return copy;
+      });
+      loadBookings();
+    } catch (e) {
+      setSeverity('error');
+      setMessage(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  return (
+    <>
+      <Typography variant="h5" gutterBottom>
+        Pending Requests
+      </Typography>
+      <Grid container spacing={2}>
+        {bookings.map(b => (
+          <Grid item xs={12} sm={6} md={4} key={b.id}>
+            <Card variant="outlined" sx={{ borderRadius: 1 }}>
+              <CardContent>
+                <Typography variant="subtitle1">{b.user_name || 'Unknown'}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {new Date(b.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}{' '}
+                  {formatTime(b.start_time || b.startTime || '')} - {formatTime(b.end_time || b.endTime || '')}
+                </Typography>
+                <TextField
+                  label="Reason (optional)"
+                  size="small"
+                  fullWidth
+                  sx={{ mt: 2 }}
+                  value={reasons[b.id] || ''}
+                  onChange={e => setReasons(r => ({ ...r, [b.id]: e.target.value }))}
+                />
+              </CardContent>
+              <CardActions>
+                <Button
+                  size="small"
+                  variant="contained"
+                  sx={{ textTransform: 'none' }}
+                  onClick={() => handleDecision(b.id, 'approve')}
+                >
+                  Approve
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  sx={{ textTransform: 'none' }}
+                  onClick={() => handleDecision(b.id, 'reject')}
+                >
+                  Reject
+                </Button>
+              </CardActions>
+            </Card>
+          </Grid>
+        ))}
+        {bookings.length === 0 && (
+          <Grid item xs={12}>
+            <Typography>No pending bookings.</Typography>
+          </Grid>
+        )}
+      </Grid>
+      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity={severity} />
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Pending link to staff navigation
- implement Pending component to review and approve or reject booking requests

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899747ffacc832d9ac84c217d2c6c42