### PR TITLE
feat: add reusable entity search component

### DIFF
--- a/MJ_FB_Frontend/src/components/EntitySearch.tsx
+++ b/MJ_FB_Frontend/src/components/EntitySearch.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { TextField, Button } from '@mui/material';
+import { searchUsers, searchVolunteers } from '../api/api';
+
+interface EntitySearchProps {
+  token: string;
+  type: 'user' | 'volunteer';
+  placeholder?: string;
+  onSelect: (result: any) => void;
+  renderResult?: (result: any, select: () => void) => ReactNode;
+}
+
+export default function EntitySearch({
+  token,
+  type,
+  placeholder,
+  onSelect,
+  renderResult,
+}: EntitySearchProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (query.length < 3) {
+      setResults([]);
+      return;
+    }
+    let active = true;
+    const fn = type === 'user' ? searchUsers : searchVolunteers;
+    fn(token, query)
+      .then(data => {
+        if (active) setResults(data);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [query, token, type]);
+
+  const getLabel = (r: any) =>
+    type === 'user' ? `${r.name} (${r.client_id})` : r.name;
+
+  function handleSelect(res: any) {
+    setQuery(getLabel(res));
+    setResults([]);
+    onSelect(res);
+  }
+
+  return (
+    <div>
+      <TextField
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder={placeholder}
+        label="Search"
+        size="small"
+        fullWidth
+        sx={{ mb: 1 }}
+      />
+      {results.length > 0 ? (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {results.map(r => (
+            <li key={r.id}>
+              {renderResult ? (
+                renderResult(r, () => handleSelect(r))
+              ) : (
+                <Button
+                  onClick={() => handleSelect(r)}
+                  variant="outlined"
+                  color="primary"
+                >
+                  {getLabel(r)}
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        query.length >= 3 && <p>No search results.</p>
+      )}
+    </div>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Grid,
   Card,
@@ -10,16 +11,13 @@ import {
   List,
   ListItem,
   ListItemText,
-  TextField,
   Chip,
-  IconButton,
 } from '@mui/material';
 import {
   CalendarToday,
   People,
   WarningAmber,
   Cancel as CancelIcon,
-  Search,
   EventAvailable,
   Announcement,
 } from '@mui/icons-material';
@@ -31,6 +29,7 @@ import {
 } from '../api/api';
 import type { Role, Slot } from '../types';
 import { formatTime } from '../utils/time';
+import EntitySearch from '../components/EntitySearch';
 
 export interface DashboardProps {
   role: Role;
@@ -92,6 +91,8 @@ function StaffDashboard({ token }: { token: string }) {
     { role: string; filled: number; total: number }[]
   >([]);
   const [schedule, setSchedule] = useState<{ day: string; open: number }[]>([]);
+  const [searchType, setSearchType] = useState<'user' | 'volunteer'>('user');
+  const navigate = useNavigate();
 
   useEffect(() => {
     getBookings(token).then(setBookings).catch(() => {});
@@ -241,17 +242,41 @@ function StaffDashboard({ token }: { token: string }) {
           <Grid item xs={12}>
             <SectionCard title="Quick Search">
               <Stack spacing={2}>
+                <EntitySearch
+                  token={token}
+                  type={searchType}
+                  placeholder="Search"
+                  onSelect={res => {
+                    if (searchType === 'user') {
+                      navigate(
+                        `/user-history?id=${res.id}&name=${encodeURIComponent(
+                          res.name,
+                        )}&clientId=${res.client_id}`,
+                      );
+                    } else {
+                      navigate(
+                        `/volunteer-management/search?id=${res.id}&name=${encodeURIComponent(
+                          res.name,
+                        )}`,
+                      );
+                    }
+                  }}
+                />
                 <Stack direction="row" spacing={1}>
-                  <TextField size="small" placeholder="Search" fullWidth />
-                  <IconButton color="primary" size="small">
-                    <Search />
-                  </IconButton>
-                </Stack>
-                <Stack direction="row" spacing={1}>
-                  <Button size="small" variant="contained" sx={{ textTransform: 'none' }}>
+                  <Button
+                    size="small"
+                    variant={searchType === 'user' ? 'contained' : 'outlined'}
+                    sx={{ textTransform: 'none' }}
+                    onClick={() => setSearchType('user')}
+                  >
                     Find Client
                   </Button>
-                  <Button size="small" variant="outlined" sx={{ textTransform: 'none' }}>
+                  <Button
+                    size="small"
+                    variant={searchType === 'volunteer' ? 'contained' : 'outlined'}
+                    sx={{ textTransform: 'none' }}
+                    onClick={() => setSearchType('volunteer')}
+                  >
                     Find Volunteer
                   </Button>
                 </Stack>


### PR DESCRIPTION
## Summary
- extract reusable EntitySearch for users and volunteers
- integrate EntitySearch into user history, volunteer management, and staff dashboard quick search
- support quick navigation via query parameters

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689a0d158a18832d989ea0fbd459c09d