### PR TITLE
Ensure UTC timezone and NTP sync for deployments

### DIFF
--- a/MJ_FB_Backend/Dockerfile
+++ b/MJ_FB_Backend/Dockerfile
@@ -1,5 +1,9 @@
 # Build stage
 FROM node:18-alpine AS build
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "UTC" > /etc/timezone
+ENV TZ=UTC
 WORKDIR /app
 COPY package*.json tsconfig.json ./
 COPY src ./src
@@ -7,6 +11,10 @@ RUN npm ci && npm run build
 
 # Production stage
 FROM node:18-alpine
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "UTC" > /etc/timezone
+ENV TZ=UTC
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev

--- a/MJ_FB_Frontend/Dockerfile
+++ b/MJ_FB_Frontend/Dockerfile
@@ -1,5 +1,9 @@
 # Build stage
 FROM node:18-alpine AS build
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "UTC" > /etc/timezone
+ENV TZ=UTC
 WORKDIR /app
 COPY package*.json tsconfig*.json vite.config.ts ./
 COPY public ./public
@@ -8,6 +12,10 @@ RUN npm ci && npm run build
 
 # Production stage
 FROM nginx:alpine
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "UTC" > /etc/timezone
+ENV TZ=UTC
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/ops/infra/time-sync.md
+++ b/ops/infra/time-sync.md
@@ -1,0 +1,10 @@
+# Time Synchronization
+
+All servers must maintain accurate system time to avoid authentication and scheduling issues.
+
+- Set the system timezone to **UTC**.
+- Ensure NTP synchronization is enabled (e.g., `timedatectl set-ntp true`).
+- Run the provisioning script `../setup-time-sync.sh` on new hosts.
+- Verify status with `timedatectl status` or `date`.
+
+Keeping time in sync prevents token expiry problems and misaligned schedules.

--- a/ops/setup-time-sync.sh
+++ b/ops/setup-time-sync.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configure the server timezone and enable NTP synchronization
+
+# Set timezone to UTC
+if command -v timedatectl >/dev/null 2>&1; then
+  sudo timedatectl set-timezone UTC
+  sudo timedatectl set-ntp true
+  timedatectl status
+else
+  echo "timedatectl not found. Install systemd or configure timezone/NTP manually." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- install tzdata and set UTC in backend and frontend Dockerfiles
- add provisioning script to set UTC timezone and enable NTP
- document time synchronization requirements for ops

## Testing
- `npm test` *(fails: jest: not found)*
- `npm ci` *(fails: lock file out of sync)*
- `npm test` (frontend) *(fails: jest: not found)*
- `npm ci` (frontend) *(fails: lock file out of sync)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f7b8d44832dbb3b557a94994c7c