### PR TITLE
Use cookie-based auth and drop token storage

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -46,8 +46,6 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
         maxAge: 7 * 24 * 60 * 60 * 1000,
       });
       return res.json({
-        token,
-        refreshToken,
         role: user.role,
         name: `${user.first_name} ${user.last_name}`,
         bookingsThisMonth,
@@ -86,8 +84,6 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
     res.json({
-      token,
-      refreshToken,
       role: staff.role,
       name: `${staff.first_name} ${staff.last_name}`,
     });

--- a/MJ_FB_Backend/src/controllers/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteerController.ts
@@ -81,8 +81,6 @@ export async function loginVolunteer(req: Request, res: Response, next: NextFunc
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
     res.json({
-      token,
-      refreshToken,
       role: 'volunteer',
       name: `${volunteer.first_name} ${volunteer.last_name}`,
     });

--- a/MJ_FB_Backend/tests/login.test.ts
+++ b/MJ_FB_Backend/tests/login.test.ts
@@ -43,8 +43,6 @@ describe('POST /api/users/login', () => {
       .send({ email: 'john@example.com', password: 'secret' });
 
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('token', 'token');
-    expect(res.body).toHaveProperty('refreshToken', 'token');
     expect(res.body).toHaveProperty('role', 'staff');
   });
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -22,9 +22,9 @@ import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
 
 export default function App() {
-  const [token, setToken] = useState(() => localStorage.getItem('token') || '');
-  const [role, setRole] = useState<Role>(() => (localStorage.getItem('role') as Role) || ('' as Role));
-  const [name, setName] = useState(() => localStorage.getItem('name') || '');
+  const [token, setToken] = useState('');
+  const [role, setRole] = useState<Role>('' as Role);
+  const [name, setName] = useState('');
   const [loading] = useState(false);
   const [error, setError] = useState('');
   const [loginMode, setLoginMode] = useState<'user' | 'staff' | 'volunteer'>('user');
@@ -34,9 +34,6 @@ export default function App() {
     setToken('');
     setRole('' as Role);
     setName('');
-    localStorage.removeItem('token');
-    localStorage.removeItem('role');
-    localStorage.removeItem('name');
   }
 
   const navGroups: NavGroup[] = [];
@@ -85,12 +82,9 @@ export default function App() {
         loginMode === 'user' ? (
           <Login
             onLogin={(u) => {
-              setToken(u.token);
+              setToken('loggedin');
               setRole(u.role);
               setName(u.name);
-              localStorage.setItem('token', u.token);
-              localStorage.setItem('role', u.role);
-              localStorage.setItem('name', u.name);
             }}
             onStaff={() => setLoginMode('staff')}
             onVolunteer={() => setLoginMode('volunteer')}
@@ -98,24 +92,18 @@ export default function App() {
         ) : loginMode === 'staff' ? (
           <StaffLogin
             onLogin={(u) => {
-              setToken(u.token);
+              setToken('loggedin');
               setRole(u.role);
               setName(u.name);
-              localStorage.setItem('token', u.token);
-              localStorage.setItem('role', u.role);
-              localStorage.setItem('name', u.name);
             }}
             onBack={() => setLoginMode('user')}
           />
         ) : (
           <VolunteerLogin
             onLogin={(u) => {
-              setToken(u.token);
+              setToken('loggedin');
               setRole(u.role);
               setName(u.name);
-              localStorage.setItem('token', u.token);
-              localStorage.setItem('role', u.role);
-              localStorage.setItem('name', u.name);
             }}
             onBack={() => setLoginMode('user')}
           />

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -9,8 +9,6 @@ jest.mock('../api/api', () => ({
 describe('Login component', () => {
   it('submits login credentials and calls onLogin', async () => {
     (loginUser as jest.Mock).mockResolvedValue({
-      token: 't',
-      refreshToken: 'rt',
       role: 'user',
       name: 'Test',
     });


### PR DESCRIPTION
## Summary
- Stop returning access and refresh tokens from user and volunteer login endpoints
- Remove localStorage token handling in the React app and rely on cookies for auth
- Simplify API helper to send credentialed requests with CSRF header

## Testing
- `npm test` *(failed: jest not found)*
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test` *(failed: jest not found)*
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68a48aa73488832db25504606807fbc5