### PR TITLE
feat: enable volunteer booking access

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -16,7 +16,7 @@ import Dashboard from './pages/Dashboard';
 import UserDashboard from './pages/UserDashboard';
 import VolunteerBookingHistory from './components/VolunteerBookingHistory';
 import VolunteerSchedule from './components/VolunteerSchedule';
-import type { Role } from './types';
+import type { Role, UserRole } from './types';
 import Navbar, { type NavGroup } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
@@ -25,6 +25,9 @@ export default function App() {
   const [token, setToken] = useState('');
   const [role, setRole] = useState<Role>('' as Role);
   const [name, setName] = useState('');
+  const [userRole, setUserRole] = useState<UserRole | ''>(
+    () => (localStorage.getItem('userRole') as UserRole) || ''
+  );
   const [loading] = useState(false);
   const [error, setError] = useState('');
   const [loginMode, setLoginMode] = useState<'user' | 'staff' | 'volunteer'>('user');
@@ -34,6 +37,8 @@ export default function App() {
     setToken('');
     setRole('' as Role);
     setName('');
+    setUserRole('');
+    localStorage.removeItem('userRole');
   }
 
   const navGroups: NavGroup[] = [];
@@ -73,6 +78,15 @@ export default function App() {
         { label: 'Booking History', to: '/volunteer/history' },
       ],
     });
+    if (userRole === 'shopper') {
+      navGroups.push({
+        label: 'Booking',
+        links: [
+          { label: 'Booking Slots', to: '/slots' },
+          { label: 'Booking History', to: '/booking-history' },
+        ],
+      });
+    }
   }
 
   return (
@@ -85,6 +99,9 @@ export default function App() {
               setToken('loggedin');
               setRole(u.role);
               setName(u.name);
+              setUserRole(u.userRole || '');
+              if (u.userRole) localStorage.setItem('userRole', u.userRole);
+              else localStorage.removeItem('userRole');
             }}
             onStaff={() => setLoginMode('staff')}
             onVolunteer={() => setLoginMode('volunteer')}
@@ -95,6 +112,9 @@ export default function App() {
               setToken('loggedin');
               setRole(u.role);
               setName(u.name);
+              setUserRole(u.userRole || '');
+              if (u.userRole) localStorage.setItem('userRole', u.userRole);
+              else localStorage.removeItem('userRole');
             }}
             onBack={() => setLoginMode('user')}
           />
@@ -104,6 +124,9 @@ export default function App() {
               setToken('loggedin');
               setRole(u.role);
               setName(u.name);
+              setUserRole(u.userRole || '');
+              if (u.userRole) localStorage.setItem('userRole', u.userRole);
+              else localStorage.removeItem('userRole');
             }}
             onBack={() => setLoginMode('user')}
           />
@@ -150,6 +173,20 @@ export default function App() {
                   <Route path="/slots" element={<SlotBooking token={token} role="shopper" />} />
                 )}
                 {role === 'shopper' && (
+                  <Route
+                    path="/booking-history"
+                    element={
+                      <UserHistory
+                        token={token}
+                        initialUser={{ id: 0, name, client_id: 0 }}
+                      />
+                    }
+                  />
+                )}
+                {role === 'volunteer' && userRole === 'shopper' && (
+                  <Route path="/slots" element={<SlotBooking token={token} role="shopper" />} />
+                )}
+                {role === 'volunteer' && userRole === 'shopper' && (
                   <Route
                     path="/booking-history"
                     element={

--- a/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import App from '../App';
+import { loginVolunteer } from '../api/api';
+
+jest.mock('../api/api', () => ({
+  loginVolunteer: jest.fn(),
+}));
+
+jest.mock('../components/VolunteerDashboard', () => () => <div>VolunteerDashboard</div>);
+jest.mock('../components/VolunteerSchedule', () => () => <div>VolunteerSchedule</div>);
+jest.mock('../components/VolunteerBookingHistory', () => () => <div>VolunteerHistory</div>);
+jest.mock('../components/SlotBooking', () => () => <div>SlotBooking Component</div>);
+jest.mock('../components/StaffDashboard/UserHistory', () => () => <div>BookingHistory Component</div>);
+
+
+describe('Volunteer with shopper profile', () => {
+  it('shows booking links and allows access to booking routes', async () => {
+    localStorage.clear();
+    (loginVolunteer as jest.Mock).mockResolvedValue({
+      role: 'volunteer',
+      name: 'Test',
+      userRole: 'shopper',
+    });
+
+    render(<App />);
+
+    fireEvent.click(screen.getByText(/volunteer login/i));
+
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'vol' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pass' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => expect(screen.getByRole('link', { name: /Booking Slots/i })).toBeInTheDocument());
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('link', { name: /Booking Slots/i }));
+    expect(screen.getByText(/SlotBooking Component/i)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -48,6 +48,7 @@ export interface LoginResponse {
   role: Role;
   name: string;
   bookingsThisMonth?: number;
+  userRole?: UserRole;
 }
 
 export async function handleResponse(res: Response) {
@@ -104,7 +105,8 @@ export async function loginVolunteer(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password }),
   });
-  return handleResponse(res);
+  const data = await handleResponse(res);
+  return data;
 }
 
 export async function requestPasswordReset(data: {

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -18,7 +18,6 @@ export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: Login
     try {
       const user = await loginVolunteer(username, password);
       onLogin(user);
-      window.location.href = '/volunteer-dashboard';
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     }


### PR DESCRIPTION
## Summary
- propagate optional `userRole` through login API
- persist volunteer shopper role and expose booking nav/routes
- streamline volunteer login and add tests for volunteer bookings

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49fbcbd78832db4df0582c40dd36a