### PR TITLE
Add footer to form pages to avoid bottom bar overlap

### DIFF
--- a/MJ_FB_Frontend/src/components/FormContainer.tsx
+++ b/MJ_FB_Frontend/src/components/FormContainer.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack, Button, type BoxProps } from '@mui/material';
+import { Box, Stack, Button, Typography, type BoxProps } from '@mui/material';
 import type { ReactNode, FormEvent } from 'react';
 
 interface FormContainerProps extends Omit<BoxProps, 'component' | 'onSubmit'> {
@@ -9,14 +9,21 @@ interface FormContainerProps extends Omit<BoxProps, 'component' | 'onSubmit'> {
 
 export default function FormContainer({ onSubmit, submitLabel, children, ...boxProps }: FormContainerProps) {
   return (
-    <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
-      <Box component="form" onSubmit={onSubmit} maxWidth={400} width="100%" mx="auto" {...boxProps}>
-        <Stack spacing={2}>
-          {children}
-          <Button type="submit" variant="contained" color="primary" fullWidth>
-            {submitLabel}
-          </Button>
-        </Stack>
+    <Box display="flex" flexDirection="column" minHeight="100vh">
+      <Box flexGrow={1} display="flex" justifyContent="center" alignItems="center" px={2}>
+        <Box component="form" onSubmit={onSubmit} maxWidth={400} width="100%" mx="auto" {...boxProps}>
+          <Stack spacing={2}>
+            {children}
+            <Button type="submit" variant="contained" color="primary" fullWidth>
+              {submitLabel}
+            </Button>
+          </Stack>
+        </Box>
+      </Box>
+      <Box component="footer" py={2}>
+        <Typography variant="body2" color="text.secondary" align="center">
+          copyright@Moose Jaw & District food bank
+        </Typography>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- update FormContainer to include bottom footer spacing and copyright notice

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ad398160832da1ee56acfc75e803