### PR TITLE
Use min-height for root element background

### DIFF
--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -31,7 +31,7 @@ a:hover {
 body, html, #root {
   margin: 0;
   padding: 0;
-  height: 100%;
+  min-height: 100%;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- ensure `<body>`, `<html>`, and `#root` expand with content by replacing `height:100%` with `min-height:100%`

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ae2c8d28832dbec980184d9e0f21