### PR TITLE
Center login form headings inside container

### DIFF
--- a/MJ_FB_Frontend/src/components/FormContainer.tsx
+++ b/MJ_FB_Frontend/src/components/FormContainer.tsx
@@ -5,14 +5,22 @@ interface FormContainerProps extends Omit<BoxProps, 'component' | 'onSubmit'> {
   onSubmit: (e: FormEvent<HTMLFormElement>) => void;
   submitLabel: string;
   children: ReactNode;
+  title?: string;
+  header?: ReactNode;
 }
 
-export default function FormContainer({ onSubmit, submitLabel, children, ...boxProps }: FormContainerProps) {
+export default function FormContainer({ onSubmit, submitLabel, children, title, header, ...boxProps }: FormContainerProps) {
   return (
     <Box display="flex" flexDirection="column" minHeight="100vh">
       <Box flexGrow={1} display="flex" justifyContent="center" alignItems="center" px={2}>
         <Box component="form" onSubmit={onSubmit} maxWidth={400} width="100%" mx="auto" {...boxProps}>
           <Stack spacing={2}>
+            {header && <Box textAlign="center">{header}</Box>}
+            {title && (
+              <Typography variant="h5" textAlign="center">
+                {title}
+              </Typography>
+            )}
             {children}
             <Button type="submit" variant="contained" color="primary" fullWidth>
               {submitLabel}

--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -4,7 +4,6 @@ import type { LoginResponse } from '../api/api';
 import { Link, TextField, Stack } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormContainer from './FormContainer';
-import Page from './Page';
 import PasswordResetDialog from './PasswordResetDialog';
 
 export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (user: LoginResponse) => void; onStaff: () => void; onVolunteer: () => void }) {
@@ -24,16 +23,22 @@ export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (use
   }
 
   return (
-    <Page
-      title="User Login"
-      header={
-        <Stack direction="row" spacing={2} mb={2}>
-          <Link component="button" onClick={onStaff} underline="hover">Staff Login</Link>
-          <Link component="button" onClick={onVolunteer} underline="hover">Volunteer Login</Link>
-        </Stack>
-      }
-    >
-      <FormContainer onSubmit={handleSubmit} submitLabel="Login">
+    <>
+      <FormContainer
+        onSubmit={handleSubmit}
+        submitLabel="Login"
+        title="User Login"
+        header={
+          <Stack direction="row" spacing={2} justifyContent="center">
+            <Link component="button" onClick={onStaff} underline="hover">
+              Staff Login
+            </Link>
+            <Link component="button" onClick={onVolunteer} underline="hover">
+              Volunteer Login
+            </Link>
+          </Stack>
+        }
+      >
         <TextField value={clientId} onChange={e => setClientId(e.target.value)} label="Client ID" fullWidth />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">
@@ -42,6 +47,6 @@ export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (use
       </FormContainer>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="user" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </Page>
+    </>
   );
 }

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -5,7 +5,6 @@ import { Typography, TextField, Link } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FeedbackModal from './FeedbackModal';
 import FormContainer from './FormContainer';
-import Page from './Page';
 import PasswordResetDialog from './PasswordResetDialog';
 
 export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
@@ -55,11 +54,13 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
   }
 
   return (
-    <Page
-      title="Staff Login"
-      header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
-    >
-      <FormContainer onSubmit={submit} submitLabel="Login">
+    <>
+      <FormContainer
+        onSubmit={submit}
+        submitLabel="Login"
+        title="Staff Login"
+        header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
+      >
         <TextField
           type="email"
           value={email}
@@ -72,7 +73,7 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
       </FormContainer>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="staff" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </Page>
+    </>
   );
 }
 
@@ -96,8 +97,8 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   }
 
   return (
-    <Page title="Create Staff Account">
-      <FormContainer onSubmit={submit} submitLabel="Create Staff">
+    <>
+      <FormContainer onSubmit={submit} submitLabel="Create Staff" title="Create Staff Account">
         <TextField value={firstName} onChange={e => setFirstName(e.target.value)} label="First name" fullWidth />
         <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" fullWidth />
         <TextField type="email" value={email} onChange={e => setEmail(e.target.value)} label="Email" fullWidth />
@@ -105,6 +106,6 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
       </FormContainer>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <FeedbackModal open={!!message} onClose={() => setMessage('')} message={message} />
-    </Page>
+    </>
   );
 }

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -4,7 +4,6 @@ import type { LoginResponse } from '../api/api';
 import { TextField, Link } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormContainer from './FormContainer';
-import Page from './Page';
 import PasswordResetDialog from './PasswordResetDialog';
 
 export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
@@ -24,17 +23,19 @@ export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: Login
   }
 
   return (
-    <Page
-      title="Volunteer Login"
-      header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
-    >
-      <FormContainer onSubmit={submit} submitLabel="Login">
+    <>
+      <FormContainer
+        onSubmit={submit}
+        submitLabel="Login"
+        title="Volunteer Login"
+        header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
+      >
         <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" fullWidth />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">Forgot password?</Link>
       </FormContainer>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="volunteer" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </Page>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Allow FormContainer to render optional headers and titles inside the centered form
- Use enhanced FormContainer in user, staff, and volunteer login flows so headings align with forms

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b02c59b0832d9ed1b0d0d47da8ea