### PR TITLE
Persist auth session across refresh

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -22,9 +22,11 @@ import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
 
 export default function App() {
-  const [token, setToken] = useState('');
-  const [role, setRole] = useState<Role>('' as Role);
-  const [name, setName] = useState('');
+  const [token, setToken] = useState(() => localStorage.getItem('token') || '');
+  const [role, setRole] = useState<Role>(
+    () => (localStorage.getItem('role') as Role) || ('' as Role)
+  );
+  const [name, setName] = useState(() => localStorage.getItem('name') || '');
   const [userRole, setUserRole] = useState<UserRole | ''>(
     () => (localStorage.getItem('userRole') as UserRole) || ''
   );
@@ -38,6 +40,9 @@ export default function App() {
     setRole('' as Role);
     setName('');
     setUserRole('');
+    localStorage.removeItem('token');
+    localStorage.removeItem('role');
+    localStorage.removeItem('name');
     localStorage.removeItem('userRole');
   }
 
@@ -100,6 +105,9 @@ export default function App() {
               setRole(u.role);
               setName(u.name);
               setUserRole(u.userRole || '');
+              localStorage.setItem('token', 'loggedin');
+              localStorage.setItem('role', u.role);
+              localStorage.setItem('name', u.name);
               if (u.userRole) localStorage.setItem('userRole', u.userRole);
               else localStorage.removeItem('userRole');
             }}
@@ -113,6 +121,9 @@ export default function App() {
               setRole(u.role);
               setName(u.name);
               setUserRole(u.userRole || '');
+              localStorage.setItem('token', 'loggedin');
+              localStorage.setItem('role', u.role);
+              localStorage.setItem('name', u.name);
               if (u.userRole) localStorage.setItem('userRole', u.userRole);
               else localStorage.removeItem('userRole');
             }}
@@ -125,6 +136,9 @@ export default function App() {
               setRole(u.role);
               setName(u.name);
               setUserRole(u.userRole || '');
+              localStorage.setItem('token', 'loggedin');
+              localStorage.setItem('role', u.role);
+              localStorage.setItem('name', u.name);
               if (u.userRole) localStorage.setItem('userRole', u.userRole);
               else localStorage.removeItem('userRole');
             }}

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import App from '../App';
+
+jest.mock('../api/api', () => ({
+  getBookingHistory: jest.fn().mockResolvedValue([]),
+  getSlots: jest.fn().mockResolvedValue([]),
+  getHolidays: jest.fn().mockResolvedValue([]),
+}));
+
+describe('App authentication persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows login when not authenticated', () => {
+    render(<App />);
+    expect(screen.getByText(/user login/i)).toBeInTheDocument();
+  });
+
+  it('keeps user logged in when token exists', () => {
+    localStorage.setItem('token', 'loggedin');
+    localStorage.setItem('role', 'shopper');
+    localStorage.setItem('name', 'Test User');
+    render(<App />);
+    expect(screen.queryByText(/user login/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- store login token, role, and name in localStorage so refreshing the tab no longer logs out users
- clear stored auth data on logout
- add unit test ensuring App loads logged-in state from localStorage

## Testing
- `npm test` *(fails: jest-environment-jsdom missing; attempted install but 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b34dcc20832db0f5d7495531c897