### PR TITLE
Add navbar and login routes for auth screens

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -17,6 +17,7 @@ import UserDashboard from './pages/UserDashboard';
 import VolunteerBookingHistory from './components/VolunteerBookingHistory';
 import VolunteerSchedule from './components/VolunteerSchedule';
 import type { Role, UserRole } from './types';
+import type { LoginResponse } from './api/api';
 import Navbar, { type NavGroup } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
@@ -30,8 +31,16 @@ export default function App() {
   );
   const [loading] = useState(false);
   const [error, setError] = useState('');
-  const [loginMode, setLoginMode] = useState<'user' | 'staff' | 'volunteer'>('user');
   const isStaff = role === 'staff';
+
+  function handleLogin(u: LoginResponse) {
+    setToken('loggedin');
+    setRole(u.role);
+    setName(u.name);
+    setUserRole(u.userRole || '');
+    if (u.userRole) localStorage.setItem('userRole', u.userRole);
+    else localStorage.removeItem('userRole');
+  }
 
   function logout() {
     setToken('');
@@ -42,25 +51,31 @@ export default function App() {
   }
 
   const navGroups: NavGroup[] = [];
-  if (isStaff) {
-      const staffLinks = [
-        { label: 'Manage Availability', to: '/manage-availability' },
-        { label: 'Pantry Schedule', to: '/pantry-schedule' },
-        { label: 'Add User', to: '/add-user' },
-        { label: 'User History', to: '/user-history' },
-        { label: 'Pending', to: '/pending' },
-      ];
+  if (!token) {
+    navGroups.push(
+      { label: 'User Login', links: [{ label: 'User Login', to: '/login/user' }] },
+      { label: 'Volunteer Login', links: [{ label: 'Volunteer Login', to: '/login/volunteer' }] },
+      { label: 'Staff Login', links: [{ label: 'Staff Login', to: '/login/staff' }] },
+    );
+  } else if (isStaff) {
+    const staffLinks = [
+      { label: 'Manage Availability', to: '/manage-availability' },
+      { label: 'Pantry Schedule', to: '/pantry-schedule' },
+      { label: 'Add User', to: '/add-user' },
+      { label: 'User History', to: '/user-history' },
+      { label: 'Pending', to: '/pending' },
+    ];
     navGroups.push({ label: 'Staff', links: staffLinks });
-      navGroups.push({
-        label: 'Volunteer Management',
-        links: [
-          { label: 'Dashboard', to: '/volunteer-management' },
-          { label: 'Schedule', to: '/volunteer-management/schedule' },
-          { label: 'Search', to: '/volunteer-management/search' },
-          { label: 'Create', to: '/volunteer-management/create' },
-          { label: 'Pending', to: '/volunteer-management/pending' },
-        ],
-      });
+    navGroups.push({
+      label: 'Volunteer Management',
+      links: [
+        { label: 'Dashboard', to: '/volunteer-management' },
+        { label: 'Schedule', to: '/volunteer-management/schedule' },
+        { label: 'Search', to: '/volunteer-management/search' },
+        { label: 'Create', to: '/volunteer-management/create' },
+        { label: 'Pending', to: '/volunteer-management/pending' },
+      ],
+    });
   } else if (role === 'shopper') {
     navGroups.push({
       label: 'Booking',
@@ -92,142 +107,111 @@ export default function App() {
   return (
     <BrowserRouter>
       <div className="app-container">
-        {!token ? (
-        loginMode === 'user' ? (
-          <Login
-            onLogin={(u) => {
-              setToken('loggedin');
-              setRole(u.role);
-              setName(u.name);
-              setUserRole(u.userRole || '');
-              if (u.userRole) localStorage.setItem('userRole', u.userRole);
-              else localStorage.removeItem('userRole');
-            }}
-            onStaff={() => setLoginMode('staff')}
-            onVolunteer={() => setLoginMode('volunteer')}
-          />
-        ) : loginMode === 'staff' ? (
-          <StaffLogin
-            onLogin={(u) => {
-              setToken('loggedin');
-              setRole(u.role);
-              setName(u.name);
-              setUserRole(u.userRole || '');
-              if (u.userRole) localStorage.setItem('userRole', u.userRole);
-              else localStorage.removeItem('userRole');
-            }}
-            onBack={() => setLoginMode('user')}
-          />
-        ) : (
-          <VolunteerLogin
-            onLogin={(u) => {
-              setToken('loggedin');
-              setRole(u.role);
-              setName(u.name);
-              setUserRole(u.userRole || '');
-              if (u.userRole) localStorage.setItem('userRole', u.userRole);
-              else localStorage.removeItem('userRole');
-            }}
-            onBack={() => setLoginMode('user')}
-          />
-        )
-        ) : (
-          <>
-            <Navbar
-              groups={navGroups}
-              onLogout={logout}
-              name={name || undefined}
-              loading={loading}
-            />
+        <Navbar
+          groups={navGroups}
+          onLogout={token ? logout : undefined}
+          name={token ? name || undefined : undefined}
+          loading={loading}
+        />
 
-            <FeedbackSnackbar
-              open={!!error}
-              onClose={() => setError('')}
-              message={error}
-              severity="error"
-            />
+        <FeedbackSnackbar
+          open={!!error}
+          onClose={() => setError('')}
+          message={error}
+          severity="error"
+        />
 
-            <main>
-              <Breadcrumbs />
-              <Routes>
+        {token ? (
+          <main>
+            <Breadcrumbs />
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  role === 'volunteer' ? (
+                    <VolunteerDashboard token={token} />
+                  ) : isStaff ? (
+                    <Dashboard role="staff" token={token} />
+                  ) : (
+                    <UserDashboard token={token} />
+                  )
+                }
+              />
+              <Route path="/profile" element={<Profile token={token} role={role} />} />
+              {isStaff && (
+                <Route path="/manage-availability" element={<ManageAvailability token={token} />} />
+              )}
+              {isStaff && (
+                <Route path="/pantry-schedule" element={<PantrySchedule token={token} />} />
+              )}
+              {role === 'shopper' && (
+                <Route path="/slots" element={<SlotBooking token={token} role="shopper" />} />
+              )}
+              {role === 'shopper' && (
+                <Route
+                  path="/booking-history"
+                  element={
+                    <UserHistory
+                      token={token}
+                      initialUser={{ id: 0, name, client_id: 0 }}
+                    />
+                  }
+                />
+              )}
+              {role === 'volunteer' && userRole === 'shopper' && (
+                <Route path="/slots" element={<SlotBooking token={token} role="shopper" />} />
+              )}
+              {role === 'volunteer' && userRole === 'shopper' && (
+                <Route
+                  path="/booking-history"
+                  element={
+                    <UserHistory
+                      token={token}
+                      initialUser={{ id: 0, name, client_id: 0 }}
+                    />
+                  }
+                />
+              )}
+              {isStaff && <Route path="/add-user" element={<AddUser token={token} />} />}
+              {isStaff && <Route path="/user-history" element={<UserHistory token={token} />} />}
+              {isStaff && <Route path="/pending" element={<Pending token={token} />} />}
+              {isStaff && (
+                <>
                   <Route
-                    path="/"
-                    element={
-                      role === 'volunteer' ? (
-                        <VolunteerDashboard token={token} />
-                      ) : isStaff ? (
-                        <Dashboard role="staff" token={token} />
-                      ) : (
-                        <UserDashboard token={token} />
-                      )
-                    }
+                    path="/volunteer-management"
+                    element={<VolunteerManagement token={token} />}
                   />
-                  <Route path="/profile" element={<Profile token={token} role={role} />} />
-                  {isStaff && (
-                    <Route path="/manage-availability" element={<ManageAvailability token={token} />} />
-                  )}
-                {isStaff && (
-                  <Route path="/pantry-schedule" element={<PantrySchedule token={token} />} />
-                )}
-                {role === 'shopper' && (
-                  <Route path="/slots" element={<SlotBooking token={token} role="shopper" />} />
-                )}
-                {role === 'shopper' && (
                   <Route
-                    path="/booking-history"
-                    element={
-                      <UserHistory
-                        token={token}
-                        initialUser={{ id: 0, name, client_id: 0 }}
-                      />
-                    }
+                    path="/volunteer-management/:tab"
+                    element={<VolunteerManagement token={token} />}
                   />
-                )}
-                {role === 'volunteer' && userRole === 'shopper' && (
-                  <Route path="/slots" element={<SlotBooking token={token} role="shopper" />} />
-                )}
-                {role === 'volunteer' && userRole === 'shopper' && (
+                </>
+              )}
+              {role === 'volunteer' && (
+                <>
                   <Route
-                    path="/booking-history"
-                    element={
-                      <UserHistory
-                        token={token}
-                        initialUser={{ id: 0, name, client_id: 0 }}
-                      />
-                    }
+                    path="/volunteer/schedule"
+                    element={<VolunteerSchedule token={token} />}
                   />
-                )}
-                {isStaff && <Route path="/add-user" element={<AddUser token={token} />} />}
-                {isStaff && <Route path="/user-history" element={<UserHistory token={token} />} />}
-                {isStaff && <Route path="/pending" element={<Pending token={token} />} />}
-                {isStaff && (
-                  <>
-                    <Route
-                      path="/volunteer-management"
-                      element={<VolunteerManagement token={token} />}
-                    />
-                    <Route
-                      path="/volunteer-management/:tab"
-                      element={<VolunteerManagement token={token} />}
-                    />
-                  </>
-                )}
-                {role === 'volunteer' && (
-                  <>
-                    <Route
-                      path="/volunteer/schedule"
-                      element={<VolunteerSchedule token={token} />}
-                    />
-                    <Route
-                      path="/volunteer/history"
-                      element={<VolunteerBookingHistory token={token} />}
-                    />
-                  </>
-                )}
-                  <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
-            </main>
-          </>
+                  <Route
+                    path="/volunteer/history"
+                    element={<VolunteerBookingHistory token={token} />}
+                  />
+                </>
+              )}
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </main>
+        ) : (
+          <main>
+            <Routes>
+              <Route path="/login/user" element={<Login onLogin={handleLogin} />} />
+              <Route path="/login/staff" element={<StaffLogin onLogin={handleLogin} />} />
+              <Route path="/login/volunteer" element={<VolunteerLogin onLogin={handleLogin} />} />
+              <Route path="/login" element={<Navigate to="/login/user" replace />} />
+              <Route path="*" element={<Navigate to="/login/user" replace />} />
+            </Routes>
+          </main>
         )}
       </div>
     </BrowserRouter>

--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import { loginUser } from '../api/api';
 import type { LoginResponse } from '../api/api';
 import { Link, TextField, Stack } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormContainer from './FormContainer';
 import PasswordResetDialog from './PasswordResetDialog';
 
-export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (user: LoginResponse) => void; onStaff: () => void; onVolunteer: () => void }) {
+export default function Login({ onLogin }: { onLogin: (user: LoginResponse) => void }) {
   const [clientId, setClientId] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -30,10 +31,10 @@ export default function Login({ onLogin, onStaff, onVolunteer }: { onLogin: (use
         title="User Login"
         header={
           <Stack direction="row" spacing={2} justifyContent="center">
-            <Link component="button" onClick={onStaff} underline="hover">
+            <Link component={RouterLink} to="/login/staff" underline="hover">
               Staff Login
             </Link>
-            <Link component="button" onClick={onVolunteer} underline="hover">
+            <Link component={RouterLink} to="/login/volunteer" underline="hover">
               Volunteer Login
             </Link>
           </Stack>

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -20,7 +20,7 @@ export type NavGroup = { label: string; links: NavLink[] };
 
 interface NavbarProps {
   groups: NavGroup[];
-  onLogout: () => void;
+  onLogout?: () => void;
   name?: string;
   loading?: boolean;
 }
@@ -152,22 +152,35 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
                   ))}
                 </Box>
               ))}
-              {name ? (
-                <>
-                  <MenuItem disabled sx={menuItemStyles}>
-                    Hello, {name}
-                  </MenuItem>
-                  <MenuItem
-                    component={RouterLink}
-                    to="/profile"
-                    onClick={() => {
-                      setMobileAnchorEl(null);
-                    }}
-                    disabled={loading}
-                    sx={menuItemStyles}
-                  >
-                    Profile
-                  </MenuItem>
+              {onLogout &&
+                (name ? (
+                  <>
+                    <MenuItem disabled sx={menuItemStyles}>
+                      Hello, {name}
+                    </MenuItem>
+                    <MenuItem
+                      component={RouterLink}
+                      to="/profile"
+                      onClick={() => {
+                        setMobileAnchorEl(null);
+                      }}
+                      disabled={loading}
+                      sx={menuItemStyles}
+                    >
+                      Profile
+                    </MenuItem>
+                    <MenuItem
+                      onClick={() => {
+                        setMobileAnchorEl(null);
+                        onLogout();
+                      }}
+                      disabled={loading}
+                      sx={menuItemStyles}
+                    >
+                      Logout
+                    </MenuItem>
+                  </>
+                ) : (
                   <MenuItem
                     onClick={() => {
                       setMobileAnchorEl(null);
@@ -178,19 +191,7 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
                   >
                     Logout
                   </MenuItem>
-                </>
-              ) : (
-                <MenuItem
-                  onClick={() => {
-                    setMobileAnchorEl(null);
-                    onLogout();
-                  }}
-                  disabled={loading}
-                  sx={menuItemStyles}
-                >
-                  Logout
-                </MenuItem>
-              )}
+                ))}
             </Menu>
           </>
         ) : (
@@ -240,48 +241,49 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
             )
           )
         )}
-        {name && !isSmall ? (
-          <>
-            <Button
-              color="inherit"
-              onClick={handleProfileClick}
-              endIcon={profileMenuOpen ? <ExpandLess /> : <ExpandMore />}
-              sx={navItemStyles}
-            >
-              Hello, {name}
+        {onLogout &&
+          (name && !isSmall ? (
+            <>
+              <Button
+                color="inherit"
+                onClick={handleProfileClick}
+                endIcon={profileMenuOpen ? <ExpandLess /> : <ExpandMore />}
+                sx={navItemStyles}
+              >
+                Hello, {name}
+              </Button>
+              <Menu
+                anchorEl={profileAnchorEl}
+                open={profileMenuOpen}
+                onClose={closeProfileMenu}
+                PaperProps={menuPaperProps}
+              >
+                <MenuItem
+                  component={RouterLink}
+                  to="/profile"
+                  onClick={closeProfileMenu}
+                  disabled={loading}
+                  sx={menuItemStyles}
+                >
+                  Profile
+                </MenuItem>
+                <MenuItem
+                  onClick={() => {
+                    closeProfileMenu();
+                    onLogout();
+                  }}
+                  disabled={loading}
+                  sx={menuItemStyles}
+                >
+                  Logout
+                </MenuItem>
+              </Menu>
+            </>
+          ) : !name && !isSmall ? (
+            <Button color="inherit" onClick={onLogout} disabled={loading} sx={navItemStyles}>
+              Logout
             </Button>
-            <Menu
-              anchorEl={profileAnchorEl}
-              open={profileMenuOpen}
-              onClose={closeProfileMenu}
-              PaperProps={menuPaperProps}
-            >
-              <MenuItem
-                component={RouterLink}
-                to="/profile"
-                onClick={closeProfileMenu}
-                disabled={loading}
-                sx={menuItemStyles}
-              >
-                Profile
-              </MenuItem>
-              <MenuItem
-                onClick={() => {
-                  closeProfileMenu();
-                  onLogout();
-                }}
-                disabled={loading}
-                sx={menuItemStyles}
-              >
-                Logout
-              </MenuItem>
-            </Menu>
-          </>
-        ) : !name && !isSmall ? (
-          <Button color="inherit" onClick={onLogout} disabled={loading} sx={navItemStyles}>
-            Logout
-          </Button>
-        ) : null}
+          ) : null)}
       </Toolbar>
     </AppBar>
   </Box>

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 import { loginStaff, staffExists, createStaff } from '../api/api';
 import type { LoginResponse } from '../api/api';
 import { Typography, TextField, Link } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FeedbackModal from './FeedbackModal';
 import FormContainer from './FormContainer';
 import PasswordResetDialog from './PasswordResetDialog';
 
-export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
+export default function StaffLogin({ onLogin }: { onLogin: (u: LoginResponse) => void }) {
   const [checking, setChecking] = useState(true);
   const [hasStaff, setHasStaff] = useState(false);
   const [error, setError] = useState('');
@@ -27,13 +28,13 @@ export default function StaffLogin({ onLogin, onBack }: { onLogin: (u: LoginResp
   if (checking) return <Typography>Loading...</Typography>;
 
   return hasStaff ? (
-    <StaffLoginForm onLogin={onLogin} error={error} onBack={onBack} />
+    <StaffLoginForm onLogin={onLogin} error={error} />
   ) : (
     <CreateStaffForm onCreated={() => setHasStaff(true)} error={error} />
   );
 }
 
-function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: LoginResponse) => void; error: string; onBack: () => void }) {
+function StaffLoginForm({ onLogin, error: initError }: { onLogin: (u: LoginResponse) => void; error: string }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(initError);
@@ -59,7 +60,7 @@ function StaffLoginForm({ onLogin, error: initError, onBack }: { onLogin: (u: Lo
         onSubmit={submit}
         submitLabel="Login"
         title="Staff Login"
-        header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
+        header={<Link component={RouterLink} to="/login/user" underline="hover">User Login</Link>}
       >
         <TextField
           type="email"

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import { loginVolunteer } from '../api/api';
 import type { LoginResponse } from '../api/api';
 import { TextField, Link } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormContainer from './FormContainer';
 import PasswordResetDialog from './PasswordResetDialog';
 
-export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: LoginResponse) => void; onBack: () => void }) {
+export default function VolunteerLogin({ onLogin }: { onLogin: (u: LoginResponse) => void }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -28,7 +29,7 @@ export default function VolunteerLogin({ onLogin, onBack }: { onLogin: (u: Login
         onSubmit={submit}
         submitLabel="Login"
         title="Volunteer Login"
-        header={<Link component="button" onClick={onBack} underline="hover">User Login</Link>}
+        header={<Link component={RouterLink} to="/login/user" underline="hover">User Login</Link>}
       >
         <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" fullWidth />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />


### PR DESCRIPTION
## Summary
- show navbar on login pages with links to user, volunteer, and staff login routes
- add dedicated /login/user, /login/volunteer, and /login/staff routes and default redirect
- make navbar logout optional and hide profile actions when not logged in

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b4f91e50832da9268e027492c234