### PR TITLE
fix: ensure body spans viewport height

### DIFF
--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -31,7 +31,7 @@ a:hover {
 body, html, #root {
   margin: 0;
   padding: 0;
-  min-height: 100%;
+  min-height: 100vh;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- ensure `body`, `html`, and `#root` elements span full viewport height to avoid overflow

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b5c53f64832db8d3be06ffc34805