### PR TITLE
Reduce space between breadcrumbs and forms

### DIFF
--- a/MJ_FB_Frontend/src/components/ChangePasswordForm.tsx
+++ b/MJ_FB_Frontend/src/components/ChangePasswordForm.tsx
@@ -24,7 +24,7 @@ export default function ChangePasswordForm({ token }: { token: string }) {
 
   return (
     <>
-      <FormContainer onSubmit={handleSubmit} submitLabel="Reset Password">
+      <FormContainer onSubmit={handleSubmit} submitLabel="Reset Password" centered={false}>
         <TextField
           type="password"
           label="Current Password"

--- a/MJ_FB_Frontend/src/components/FormContainer.tsx
+++ b/MJ_FB_Frontend/src/components/FormContainer.tsx
@@ -7,12 +7,20 @@ interface FormContainerProps extends Omit<BoxProps, 'component' | 'onSubmit'> {
   children: ReactNode;
   title?: string;
   header?: ReactNode;
+  centered?: boolean;
 }
 
-export default function FormContainer({ onSubmit, submitLabel, children, title, header, ...boxProps }: FormContainerProps) {
+export default function FormContainer({ onSubmit, submitLabel, children, title, header, centered = true, ...boxProps }: FormContainerProps) {
   return (
     <Box display="flex" flexDirection="column" minHeight="100vh">
-      <Box flexGrow={1} display="flex" justifyContent="center" alignItems="center" px={2}>
+      <Box
+        flexGrow={1}
+        display="flex"
+        justifyContent="center"
+        alignItems={centered ? 'center' : 'flex-start'}
+        px={2}
+        py={centered ? 0 : 4}
+      >
         <Box component="form" onSubmit={onSubmit} maxWidth={400} width="100%" mx="auto" {...boxProps}>
           <Stack spacing={2}>
             {header && <Box textAlign="center">{header}</Box>}

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -67,8 +67,8 @@ export default function AddUser({ token }: { token: string }) {
   }
 
   return (
-    <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
-      <Box maxWidth={400} width="100%">
+    <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
+      <Box maxWidth={400} width="100%" mt={4}>
         <Typography variant="h5" gutterBottom>
           {mode === 'user' ? 'Create User' : 'Create Staff'}
         </Typography>

--- a/MJ_FB_Frontend/src/components/StaffDashboard/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/ManageAvailability.tsx
@@ -157,8 +157,8 @@ export default function ManageAvailability({ token }: { token: string }) {
     return slot ? `${formatTime(slot.startTime)} - ${formatTime(slot.endTime)}` : `Slot ${id}`;
   }
   return (
-    <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
-      <Box maxWidth={600} width="100%">
+    <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
+      <Box maxWidth={600} width="100%" mt={4}>
         <h2>Manage Availability</h2>
       <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} />
 

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -78,8 +78,8 @@ export default function UserHistory({
   const paginated = bookings.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
-      <Box width="100%" maxWidth={800}>
+    <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
+      <Box width="100%" maxWidth={800} mt={4}>
         <h2>{initialUser ? 'Booking History' : 'User History'}</h2>
         {!initialUser && (
           <EntitySearch

--- a/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
@@ -574,8 +574,8 @@ export default function VolunteerManagement({ token }: { token: string }) {
       )}
 
       {tab === 'search' && (
-        <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
-          <Box width="100%" maxWidth={600}>
+        <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
+          <Box width="100%" maxWidth={600} mt={4}>
             <EntitySearch
               token={token}
               type="volunteer"
@@ -709,6 +709,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
               submitVolunteer();
             }}
             submitLabel="Add Volunteer"
+            centered={false}
           >
             <TextField
               label="First Name"


### PR DESCRIPTION
## Summary
- add a `centered` option to `FormContainer` to allow top-aligned forms
- align various staff and volunteer management forms near the top to remove excessive gap below breadcrumbs

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b7fd238c832da6693883d7ed9610