### PR TITLE
Fix SlotBooking layout gap

### DIFF
--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -268,7 +268,7 @@ export default function SlotBooking({ token, role }: Props) {
         {role === 'staff' && selectedUser ? `Booking for: ${selectedUser.name}` : `Booking for: ${loggedInName}`}
       </h3>
       <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
+        <Grid item xs={12} md="auto">
           <Calendar
             onChange={value => {
               if (value instanceof Date) {
@@ -297,7 +297,7 @@ export default function SlotBooking({ token, role }: Props) {
           />
         </Grid>
         {selectedDate && (
-          <Grid item xs={12} md={6}>
+          <Grid item xs={12} md>
             <div className="slot-day-container">
               {dayMessage ? (
                 <div className="day-message">{dayMessage}</div>


### PR DESCRIPTION
## Summary
- shrink calendar grid item to its content and let slot list fill remaining width

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; attempted install but registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b5ede8d8832dbceef0772806e1db