### PR TITLE
feat(pwa): add service worker for offline support

### DIFF
--- a/MJ_FB_Frontend/public/offline.html
+++ b/MJ_FB_Frontend/public/offline.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Offline</title>
+    <style>
+      body {
+        margin: 2rem;
+        font-family: system-ui, sans-serif;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>You're offline</h1>
+    <p>Check your internet connection and try again.</p>
+  </body>
+</html>

--- a/MJ_FB_Frontend/public/sw.js
+++ b/MJ_FB_Frontend/public/sw.js
@@ -1,0 +1,39 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+workbox.core.setCacheNameDetails({ prefix: 'mj-foodbank' });
+
+workbox.precaching.precacheAndRoute([{ url: '/offline.html', revision: null }]);
+
+workbox.routing.registerRoute(
+  ({ request }) => ['style', 'script', 'worker', 'image', 'font'].includes(request.destination),
+  new workbox.strategies.CacheFirst({
+    cacheName: 'static-assets',
+    plugins: [
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 100,
+        maxAgeSeconds: 60 * 60 * 24 * 30,
+      }),
+    ],
+  }),
+);
+
+workbox.routing.registerRoute(
+  ({ url }) => url.pathname.startsWith('/api'),
+  new workbox.strategies.NetworkFirst({
+    cacheName: 'api-cache',
+    networkTimeoutSeconds: 10,
+    plugins: [
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 60 * 60 * 24,
+      }),
+    ],
+  }),
+);
+
+workbox.routing.setCatchHandler(async ({ event }) => {
+  if (event.request.mode === 'navigate') {
+    return caches.match('/offline.html', { ignoreSearch: true });
+  }
+  return Response.error();
+});

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -25,5 +25,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   </React.StrictMode>,
 );
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}
+
 export default Main;
 


### PR DESCRIPTION
## Summary
- register service worker in the React app
- add Workbox-based service worker caching static assets and API calls
- provide offline fallback page

## Testing
- `npm test` *(fails: jest-environment-jsdom not installed; npm install blocked: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a622fc2af4832dab02b03a5ba3e797