### PR TITLE
feat: add basic pwa support

### DIFF
--- a/MJ_FB_Frontend/index.html
+++ b/MJ_FB_Frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#941818" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="stylesheet" href="/src/reset.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Golos+Text:wght@400;500;700&display=swap"

--- a/MJ_FB_Frontend/public/manifest.webmanifest
+++ b/MJ_FB_Frontend/public/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "MJ Food Bank Booking",
+  "short_name": "FoodBank",
+  "description": "Booking platform for MJ Food Bank",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#941818",
+  "icons": [
+    {
+      "src": "/images/mjfoodbank_logo.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/images/mjfoodbank_logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/MJ_FB_Frontend/public/sw.js
+++ b/MJ_FB_Frontend/public/sw.js
@@ -1,0 +1,39 @@
+const CACHE_NAME = 'mj-foodbank-cache-v1';
+const URLS_TO_CACHE = ['/', '/index.html'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)),
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)),
+      ),
+    ),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match('/index.html'));
+    }),
+  );
+});

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -25,5 +25,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   </React.StrictMode>,
 );
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}
+
 export default Main;
 


### PR DESCRIPTION
## Summary
- add web app manifest and theme color to HTML
- register a basic service worker for offline caching
- include manifest and service worker files for PWA installability

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run build` *(fails: TypeScript compile errors)*
- `npx vite build`
- `npx vite preview --host 0.0.0.0`
- `npx lighthouse http://localhost:4173 --only-categories=pwa --quiet --chrome-flags="--headless --no-sandbox"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lighthouse)*

------
https://chatgpt.com/codex/tasks/task_e_68a6233950a0832d8812d507ead41e50