### PR TITLE
Register service worker

### DIFF
--- a/MJ_FB_Frontend/public/sw.js
+++ b/MJ_FB_Frontend/public/sw.js
@@ -1,0 +1,8 @@
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -25,5 +25,13 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   </React.StrictMode>,
 );
 
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/sw.js')
+      .catch((error) => console.error('Service worker registration failed:', error));
+  });
+}
+
 export default Main;
 


### PR DESCRIPTION
## Summary
- register service worker on app load in production
- provide basic service worker script to claim clients
- simplify registration by removing optional chaining

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6230f61f4832d99da96008ba041fc