### PR TITLE
refactor: extract app initialization from server

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -1,0 +1,55 @@
+import express, { Request, Response, NextFunction } from 'express';
+import cors from 'cors';
+import config from './config';
+import usersRoutes from './routes/users';
+import slotsRoutes from './routes/slots';
+import bookingsRoutes from './routes/bookings';
+import holidaysRoutes from './routes/holidays';
+import blockedSlotsRoutes from './routes/blockedSlots';
+import breaksRoutes from './routes/breaks';
+import staffRoutes from './routes/staff';
+import volunteerRolesRoutes from './routes/volunteerRoles';
+import volunteersRoutes from './routes/volunteers';
+import volunteerBookingsRoutes from './routes/volunteerBookings';
+import volunteerMasterRolesRoutes from './routes/volunteerMasterRoles';
+import authRoutes from './routes/auth';
+import rolesRoutes from './routes/roles';
+import { initializeSlots } from './data';
+import logger from './utils/logger';
+
+const app = express();
+
+// ⭐ Add CORS middleware before routes
+// Origins are parsed from FRONTEND_ORIGIN env variable as a comma-separated list.
+app.use(cors({
+  origin: config.frontendOrigins,
+  credentials: true,
+}));
+
+app.use(express.json());
+
+initializeSlots();
+
+app.use('/users', usersRoutes);
+app.use('/slots', slotsRoutes);
+app.use('/bookings', bookingsRoutes);
+app.use('/holidays', holidaysRoutes);
+app.use('/blocked-slots', blockedSlotsRoutes);
+app.use('/breaks', breaksRoutes);
+app.use('/staff', staffRoutes);
+app.use('/volunteer-roles', volunteerRolesRoutes);
+app.use('/volunteer-master-roles', volunteerMasterRolesRoutes);
+app.use('/volunteers', volunteersRoutes);
+app.use('/volunteer-bookings', volunteerBookingsRoutes);
+app.use('/auth', authRoutes);
+app.use('/api/roles', rolesRoutes);
+
+// Global error handler
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  logger.error('Unhandled error:', err);
+  const status = err.status || 500;
+  res.status(status).json({ message: err.message || 'Internal Server Error' });
+});
+
+export default app;

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -1,50 +1,8 @@
-import express, { Request, Response, NextFunction } from 'express';
-import cors from 'cors';
 import config from './config';
-import usersRoutes from './routes/users';
-import slotsRoutes from './routes/slots';
-import bookingsRoutes from './routes/bookings';
-import holidaysRoutes from './routes/holidays';
-import blockedSlotsRoutes from './routes/blockedSlots';
-import breaksRoutes from './routes/breaks';
-import staffRoutes from './routes/staff';
-import volunteerRolesRoutes from './routes/volunteerRoles';
-import volunteersRoutes from './routes/volunteers';
-import volunteerBookingsRoutes from './routes/volunteerBookings';
-import volunteerMasterRolesRoutes from './routes/volunteerMasterRoles';
-import authRoutes from './routes/auth';
-import rolesRoutes from './routes/roles';
-import { initializeSlots } from './data';
 import pool from './db';
 import { setupDatabase } from './setupDatabase';
 import logger from './utils/logger';
-
-const app = express();
-
-// ⭐ Add CORS middleware before routes
-// Origins are parsed from FRONTEND_ORIGIN env variable as a comma-separated list.
-app.use(cors({
-  origin: config.frontendOrigins,
-  credentials: true,
-}));
-
-app.use(express.json());
-
-initializeSlots();
-
-app.use('/users', usersRoutes);
-app.use('/slots', slotsRoutes);
-app.use('/bookings', bookingsRoutes);
-app.use('/holidays', holidaysRoutes);
-app.use('/blocked-slots', blockedSlotsRoutes);
-app.use('/breaks', breaksRoutes);
-app.use('/staff', staffRoutes);
-app.use('/volunteer-roles', volunteerRolesRoutes);
-app.use('/volunteer-master-roles', volunteerMasterRolesRoutes);
-app.use('/volunteers', volunteersRoutes);
-app.use('/volunteer-bookings', volunteerBookingsRoutes);
-app.use('/auth', authRoutes);
-app.use('/api/roles', rolesRoutes);
+import app from './app';
 
 const PORT = config.port;
 
@@ -65,11 +23,3 @@ async function init() {
 }
 
 init();
-
-// Global error handler
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-  logger.error('Unhandled error:', err);
-  const status = err.status || 500;
-  res.status(status).json({ message: err.message || 'Internal Server Error' });
-});

--- a/MJ_FB_Backend/tests/slots.test.ts
+++ b/MJ_FB_Backend/tests/slots.test.ts
@@ -1,16 +1,14 @@
 import request from 'supertest';
 import express from 'express';
-import slotsRouter from '../src/routes/slots';
+import app from '../src/app';
 import pool from '../src/db';
 
 jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  optionalAuthMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
 }));
-
-const app = express();
-app.use('/slots', slotsRouter);
 
 describe('GET /slots with invalid dates', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- create dedicated `app.ts` exporting the configured Express app
- streamline `server.ts` to only manage database setup and listening
- update slots test to use the shared app instance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6544125e0832dbb7fdad774533b24