### PR TITLE
refactor: validate env vars via schema

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -1,3 +1,6 @@
+## Example backend environment variables
+# All variables are required unless marked optional.
+
 # PostgreSQL username
 PG_USER=your_pg_username
 # PostgreSQL password
@@ -17,9 +20,9 @@ JWT_REFRESH_SECRET=
 # Allowed frontend origins for CORS (comma separated)
 # Include both localhost and 127.0.0.1 for local development
 FRONTEND_ORIGIN=http://localhost:5173,http://127.0.0.1:5173
-# Server port
+# Server port (defaults to 4000)
 PORT=4000
-# Power Automate HTTP trigger URL
+# Power Automate HTTP trigger URL (optional)
 POWER_AUTOMATE_URL=https://your_flow_url
 # Optional key or code for the flow
 POWER_AUTOMATE_KEY=your_flow_key

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -1,47 +1,32 @@
 import dotenv from 'dotenv';
 import { z } from 'zod';
+import logger from './utils/logger';
 
 dotenv.config();
 
-if (!process.env.JWT_SECRET) {
-  throw new Error('JWT_SECRET environment variable is required');
-}
-if (!process.env.JWT_REFRESH_SECRET) {
-  throw new Error('JWT_REFRESH_SECRET environment variable is required');
-}
-
 const envSchema = z.object({
-  PG_USER: z.string().default('postgres'),
-  PG_PASSWORD: z.string().default('password'),
-  PG_HOST: z.string().default('localhost'),
-  PG_PORT: z.coerce.number().default(5432),
-  PG_DATABASE: z.string().default('mj_fb_db'),
+  PG_USER: z.string(),
+  PG_PASSWORD: z.string(),
+  PG_HOST: z.string(),
+  PG_PORT: z.coerce.number(),
+  PG_DATABASE: z.string(),
   JWT_SECRET: z.string(),
   JWT_REFRESH_SECRET: z.string(),
-  FRONTEND_ORIGIN: z.string().default('http://localhost:5173,http://127.0.0.1:5173'),
+  FRONTEND_ORIGIN: z.string(),
   PORT: z.coerce.number().default(4000),
   POWER_AUTOMATE_URL: z.string().optional(),
   POWER_AUTOMATE_KEY: z.string().optional(),
 });
 
-const env = envSchema.parse(process.env);
+let env: z.infer<typeof envSchema>;
+try {
+  env = envSchema.parse(process.env);
+} catch (err) {
+  logger.error('❌ Invalid or missing environment variables:', err);
+  process.exit(1);
+}
 
 const frontendOrigins = env.FRONTEND_ORIGIN.split(',').map(o => o.trim());
-
-const requiredVars: Array<keyof typeof env> = [
-  'PG_USER',
-  'PG_PASSWORD',
-  'PG_HOST',
-  'PG_PORT',
-  'PG_DATABASE',
-  'FRONTEND_ORIGIN',
-];
-
-const missing = requiredVars.filter(key => !process.env[key]);
-if (missing.length > 0) {
-  // eslint-disable-next-line no-console
-  console.warn(`Missing environment variables: ${missing.join(', ')}`);
-}
 
 export default {
   pgUser: env.PG_USER,

--- a/MJ_FB_Backend/tests/config.test.ts
+++ b/MJ_FB_Backend/tests/config.test.ts
@@ -36,19 +36,29 @@ describe('config', () => {
     ]);
   });
 
-  it('throws if JWT_SECRET is missing', () => {
+  it('exits if JWT_SECRET is missing', () => {
     delete process.env.JWT_SECRET;
     process.env.JWT_REFRESH_SECRET = 'testrefresh';
     jest.resetModules();
-    expect(() => require('../src/config')).toThrow('JWT_SECRET environment variable is required');
+    const exitMock = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+    expect(() => require('../src/config')).toThrow('process.exit: 1');
+    exitMock.mockRestore();
   });
 
-  it('throws if JWT_REFRESH_SECRET is missing', () => {
+  it('exits if JWT_REFRESH_SECRET is missing', () => {
     process.env.JWT_SECRET = 'testsecret';
     delete process.env.JWT_REFRESH_SECRET;
     jest.resetModules();
-    expect(() => require('../src/config')).toThrow(
-      'JWT_REFRESH_SECRET environment variable is required',
-    );
+    const exitMock = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit: ${code}`);
+      }) as never);
+    expect(() => require('../src/config')).toThrow('process.exit: 1');
+    exitMock.mockRestore();
   });
 });

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ npm install
 npm start   # or npm run dev
 ```
 
-### Required environment variables
+### Environment variables
 
-Create a `.env` file in `MJ_FB_Backend` with the following variables:
+Create a `.env` file in `MJ_FB_Backend` with the following variables. The server fails to start if any required variable is missing.
 
 | Variable | Description |
 | --- | --- |
@@ -36,8 +36,8 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables:
 | `JWT_SECRET` | Secret used to sign JWT tokens. Generate a strong random value, e.g., `openssl rand -hex 32` |
 | `JWT_REFRESH_SECRET` | Secret used to sign refresh JWT tokens. Use a different strong value from `JWT_SECRET`. |
 | `FRONTEND_ORIGIN` | Allowed origins for CORS (comma separated) |
-| `PORT` | Port for the backend server |
-| `POWER_AUTOMATE_URL` | HTTP endpoint for the Power Automate email flow |
+| `PORT` | Port for the backend server (defaults to 4000) |
+| `POWER_AUTOMATE_URL` | HTTP endpoint for the Power Automate email flow (optional) |
 | `POWER_AUTOMATE_KEY` | Optional key or code for the Power Automate flow |
 
 You can generate a secure `JWT_SECRET` with:


### PR DESCRIPTION
## Summary
- remove manual required env var warnings in backend config
- enforce env requirements via zod schema and log parse failures on startup
- document backend environment variables in `.env.example` and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6544f5018832d8412af2c1f492e12