### PR TITLE
refactor: add booking repository

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -10,30 +10,17 @@ import {
 } from '../utils/bookingUtils';
 import { sendEmail } from '../utils/emailUtils';
 import logger from '../utils/logger';
-
-// Custom error to preserve HTTP status codes for capacity issues
-class SlotCapacityError extends Error {
-  status: number;
-  constructor(message: string) {
-    super(message);
-    this.status = 400;
-  }
-}
-
-// --- Helper: validate slot and check capacity ---
-async function checkSlotCapacity(slotId: number, date: string) {
-  const slotRes = await pool.query('SELECT * FROM slots WHERE id = $1', [slotId]);
-  if (slotRes.rowCount === 0) throw new SlotCapacityError('Invalid slot');
-
-  const approvedCountRes = await pool.query(
-    `SELECT COUNT(*) FROM bookings WHERE slot_id=$1 AND date=$2 AND status='approved'`,
-    [slotId, date]
-  );
-  const approvedCount = Number(approvedCountRes.rows[0].count);
-  if (approvedCount >= slotRes.rows[0].max_capacity) {
-    throw new SlotCapacityError('Slot full on selected date');
-  }
-}
+import {
+  SlotCapacityError,
+  checkSlotCapacity,
+  insertBooking,
+  fetchBookings as repoFetchBookings,
+  fetchBookingById,
+  updateBooking,
+  fetchBookingByToken,
+  fetchBookingHistory as repoFetchBookingHistory,
+  insertWalkinUser,
+} from '../models/bookingRepository';
 
 // --- Create booking for logged-in shopper ---
 export async function createBooking(req: Request, res: Response, next: NextFunction) {
@@ -70,10 +57,14 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
     const status = isStaffBooking ? 'approved' : 'submitted';
     const token = randomUUID();
 
-    await pool.query(
-      `INSERT INTO bookings (user_id, slot_id, status, request_data, date, is_staff_booking, reschedule_token)
-       VALUES ($1, $2, $3, '', $4, $5, $6)`,
-      [userId, slotIdNum, status, date, isStaffBooking || false, token]
+    await insertBooking(
+      userId,
+      slotIdNum,
+      status,
+      '',
+      date,
+      isStaffBooking || false,
+      token,
     );
 
     await sendEmail(
@@ -96,36 +87,8 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
 export async function listBookings(req: Request, res: Response, next: NextFunction) {
   try {
     const status = (req.query.status as string)?.toLowerCase();
-    const params: any[] = [];
-    let where = '';
-    if (status) {
-      const mapped = status === 'pending' ? 'submitted' : status;
-      params.push(mapped);
-      where = 'WHERE b.status = $1';
-    }
-
-    const result = await pool.query(
-      `SELECT
-        b.id, b.status, b.date, b.user_id, b.slot_id, b.is_staff_booking,
-        b.reschedule_token,
-        u.first_name || ' ' || u.last_name as user_name,
-        u.email as user_email, u.phone as user_phone,
-        u.client_id,
-        (
-          SELECT COUNT(*) FROM bookings b2
-          WHERE b2.user_id = b.user_id
-            AND b2.status = 'approved'
-            AND DATE_TRUNC('month', b2.date) = DATE_TRUNC('month', b.date)
-        ) AS bookings_this_month,
-        s.start_time, s.end_time
-      FROM bookings b
-      INNER JOIN users u ON b.user_id = u.id
-      INNER JOIN slots s ON b.slot_id = s.id
-      ${where}
-      ORDER BY b.date ASC, s.start_time ASC`,
-      params,
-    );
-    res.json(result.rows);
+    const rows = await repoFetchBookings(status);
+    res.json(rows);
   } catch (error) {
     logger.error('Error listing bookings:', error);
     next(error);
@@ -146,10 +109,9 @@ export async function decideBooking(req: Request, res: Response, next: NextFunct
   }
 
   try {
-    const bookingRes = await pool.query('SELECT * FROM bookings WHERE id = $1', [bookingId]);
-    if (bookingRes.rowCount === 0) return res.status(404).json({ message: 'Booking not found' });
+    const booking = await fetchBookingById(Number(bookingId));
+    if (!booking) return res.status(404).json({ message: 'Booking not found' });
 
-    const booking = bookingRes.rows[0];
     if (booking.status !== 'submitted') {
       return res.status(400).json({ message: 'Booking already processed' });
     }
@@ -163,10 +125,16 @@ export async function decideBooking(req: Request, res: Response, next: NextFunct
         return res.status(400).json({ message: LIMIT_MESSAGE });
       }
       await checkSlotCapacity(booking.slot_id, booking.date);
-      await pool.query(`UPDATE bookings SET status='approved', request_data=$2 WHERE id=$1`, [bookingId, reason]);
+      await updateBooking(Number(bookingId), {
+        status: 'approved',
+        request_data: reason,
+      });
       await updateBookingsThisMonth(booking.user_id);
     } else {
-      await pool.query(`UPDATE bookings SET status='rejected', request_data=$2 WHERE id=$1`, [bookingId, reason]);
+      await updateBooking(Number(bookingId), {
+        status: 'rejected',
+        request_data: reason,
+      });
     }
 
     await sendEmail(
@@ -191,9 +159,8 @@ export async function cancelBooking(req: Request, res: Response, next: NextFunct
     requester.role === 'staff' ? (req.body.reason as string) || '' : 'user cancelled';
 
   try {
-    const bookingRes = await pool.query('SELECT * FROM bookings WHERE id=$1', [bookingId]);
-    if (bookingRes.rowCount === 0) return res.status(404).json({ message: 'Booking not found' });
-    const booking = bookingRes.rows[0];
+    const booking = await fetchBookingById(Number(bookingId));
+    if (!booking) return res.status(404).json({ message: 'Booking not found' });
 
     const requesterId = Number((requester as any).userId ?? requester.id);
     if (requester.role !== 'staff' && booking.user_id !== requesterId) {
@@ -209,7 +176,7 @@ export async function cancelBooking(req: Request, res: Response, next: NextFunct
       return res.status(400).json({ message: 'Cannot cancel past bookings' });
     }
 
-    await pool.query(`UPDATE bookings SET status='cancelled', request_data=$2 WHERE id=$1`, [bookingId, reason]);
+    await updateBooking(Number(bookingId), { status: 'cancelled', request_data: reason });
     if (booking.status === 'approved') {
       await updateBookingsThisMonth(booking.user_id);
     }
@@ -235,14 +202,10 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
     return res.status(400).json({ message: 'slotId and date are required' });
   }
   try {
-    const bookingRes = await pool.query(
-      'SELECT * FROM bookings WHERE reschedule_token = $1',
-      [token],
-    );
-    if (bookingRes.rowCount === 0) {
+    const booking = await fetchBookingByToken(token);
+    if (!booking) {
       return res.status(404).json({ message: 'Booking not found' });
     }
-    const booking = bookingRes.rows[0];
     if (!['submitted', 'approved', 'preapproved'].includes(booking.status)) {
       return res.status(400).json({ message: 'Booking cannot be rescheduled' });
     }
@@ -253,10 +216,12 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
     const newToken = randomUUID();
     const isStaffReschedule = req.user && req.user.role === 'staff';
     const newStatus = isStaffReschedule ? booking.status : 'submitted';
-    await pool.query(
-      'UPDATE bookings SET slot_id=$1, date=$2, reschedule_token=$3, status=$4 WHERE id=$5',
-      [slotId, date, newToken, newStatus, booking.id],
-    );
+    await updateBooking(booking.id, {
+      slot_id: slotId,
+      date,
+      reschedule_token: newToken,
+      status: newStatus,
+    });
     await updateBookingsThisMonth(booking.user_id);
 
     await sendEmail(
@@ -299,12 +264,13 @@ export async function createPreapprovedBooking(
     const [firstName, ...lastParts] = name.split(' ');
     const lastName = lastParts.join(' ');
     const clientId = Math.floor(Math.random() * 9999999) + 1;
-    const userRes = await client.query(
-      `INSERT INTO users (first_name, last_name, email, phone, client_id, role)
-       VALUES ($1, $2, $3, NULL, $4, 'shopper') RETURNING id`,
-      [firstName, lastName, fakeEmail, clientId]
+    const newUserId = await insertWalkinUser(
+      firstName,
+      lastName,
+      fakeEmail,
+      clientId,
+      client,
     );
-    const newUserId = userRes.rows[0].id;
 
     const approvedCount = await countApprovedBookingsForMonth(newUserId, date);
     if (approvedCount >= 2) {
@@ -312,13 +278,18 @@ export async function createPreapprovedBooking(
       return res.status(400).json({ message: LIMIT_MESSAGE });
     }
 
-    await checkSlotCapacity(slotId, date);
+    await checkSlotCapacity(slotId, date, client);
     const token = randomUUID();
 
-    await client.query(
-      `INSERT INTO bookings (user_id, slot_id, status, request_data, date, is_staff_booking, reschedule_token)
-       VALUES ($1, $2, 'approved', $3, $4, TRUE, $5)`,
-      [newUserId, slotId, requestData || '', date, token]
+    await insertBooking(
+      newUserId,
+      slotId,
+      'approved',
+      requestData || '',
+      date,
+      true,
+      token,
+      client,
     );
 
     await client.query('COMMIT');
@@ -370,10 +341,14 @@ export async function createBookingForUser(
     const status = isStaffBooking ? 'approved' : 'submitted';
     const token = randomUUID();
 
-    await pool.query(
-      `INSERT INTO bookings (user_id, slot_id, status, request_data, date, is_staff_booking, reschedule_token)
-       VALUES ($1, $2, $3, '', $4, $5, $6)`,
-      [userId, slotIdNum, status, date, isStaffBooking || false, token]
+    await insertBooking(
+      userId,
+      slotIdNum,
+      status,
+      '',
+      date,
+      isStaffBooking || false,
+      token,
     );
 
     await updateBookingsThisMonth(userId);
@@ -406,26 +381,8 @@ export async function getBookingHistory(req: Request, res: Response, next: NextF
     const status = (req.query.status as string)?.toLowerCase();
     const past = req.query.past === 'true';
 
-    const params: any[] = [userId];
-    let where = "b.user_id = $1 AND b.date >= CURRENT_DATE - INTERVAL '6 months'";
-    if (past) {
-      where += ' AND b.date < CURRENT_DATE';
-    }
-    if (status) {
-      const mapped = status === 'pending' ? 'submitted' : status;
-      params.push(mapped);
-      where += ` AND b.status = $${params.length}`;
-    }
-
-    const result = await pool.query(
-      `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason, s.start_time, s.end_time, b.created_at, b.is_staff_booking, b.reschedule_token
-       FROM bookings b
-       INNER JOIN slots s ON b.slot_id = s.id
-       WHERE ${where}
-       ORDER BY b.created_at DESC`,
-      params
-    );
-    res.json(result.rows);
+    const rows = await repoFetchBookingHistory(userId, past, status);
+    res.json(rows);
   } catch (error) {
     logger.error('Error fetching booking history:', error);
     next(error);

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -1,0 +1,64 @@
+import pool from '../src/db';
+import {
+  checkSlotCapacity,
+  insertBooking,
+  updateBooking,
+  SlotCapacityError,
+} from '../src/models/bookingRepository';
+
+jest.mock('../src/db');
+
+describe('bookingRepository', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('checkSlotCapacity', () => {
+    it('throws for invalid slot', async () => {
+      (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 0 });
+      await expect(checkSlotCapacity(1, '2024-01-01')).rejects.toBeInstanceOf(
+        SlotCapacityError,
+      );
+    });
+
+    it('throws when slot full', async () => {
+      (pool.query as jest.Mock)
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_capacity: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ count: '1' }] });
+      await expect(checkSlotCapacity(1, '2024-01-01')).rejects.toThrow(
+        'Slot full on selected date',
+      );
+    });
+
+    it('resolves when slot has capacity', async () => {
+      (pool.query as jest.Mock)
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ max_capacity: 2 }] })
+        .mockResolvedValueOnce({ rows: [{ count: '1' }] });
+      await expect(checkSlotCapacity(1, '2024-01-01')).resolves.toBeUndefined();
+    });
+  });
+
+  it('insertBooking calls query with correct params', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({});
+    await insertBooking(1, 2, 'submitted', '', '2024-01-01', false, 'token');
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/INSERT INTO bookings/);
+    expect((pool.query as jest.Mock).mock.calls[0][1]).toEqual([
+      1,
+      2,
+      'submitted',
+      '',
+      '2024-01-01',
+      false,
+      'token',
+    ]);
+  });
+
+  it('updateBooking builds dynamic query', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({});
+    await updateBooking(1, { status: 'cancelled', request_data: 'reason' });
+    expect(pool.query).toHaveBeenCalledWith(
+      'UPDATE bookings SET status=$2, request_data=$3 WHERE id=$1',
+      [1, 'cancelled', 'reason'],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add bookingRepository for capacity checks and booking mutations
- refactor booking controller to use repository
- cover repository and controller interactions with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6545738c4832db0e54929ceeaa05b