### PR TITLE
refactor: replace tables with MUI components

### DIFF
--- a/MJ_FB_Frontend/src/components/ScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/ScheduleTable.tsx
@@ -1,6 +1,14 @@
 import type { Shift } from '../types';
 import { formatHHMM } from '../utils/time';
-import { useMediaQuery, useTheme } from '@mui/material';
+import {
+  useMediaQuery,
+  useTheme,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
 
 interface Props {
   shifts: Shift[];
@@ -13,54 +21,56 @@ export default function ScheduleTable({ shifts }: Props) {
 
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
-  const cellStyle: React.CSSProperties = {
-    padding: isSmall ? 4 : 8,
+  const cellSx = {
+    p: isSmall ? 0.5 : 1,
     fontSize: isSmall ? '0.75rem' : undefined,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-  };
+  } as const;
 
   const maxSlots = Math.max(...shifts.map((s) => s.maxVolunteers), 0);
 
   return (
-    <table
-      style={{
+    <Table
+      sx={{
         width: '100%',
         tableLayout: 'fixed',
         borderCollapse: 'collapse',
       }}
     >
-      <thead>
-        <tr>
-          <th style={cellStyle}>Shift</th>
+      <TableHead>
+        <TableRow>
+          <TableCell sx={cellSx}>Shift</TableCell>
           {Array.from({ length: maxSlots }).map((_, i) => (
-            <th key={i} style={cellStyle}>
+            <TableCell key={i} sx={cellSx}>
               Slot {i + 1}
-            </th>
+            </TableCell>
           ))}
-        </tr>
-      </thead>
-      <tbody>
+        </TableRow>
+      </TableHead>
+      <TableBody>
         {shifts.map((shift) => (
-          <tr key={shift.shiftId}>
-            <td style={cellStyle}>
+          <TableRow key={shift.shiftId}>
+            <TableCell sx={cellSx}>
               {formatHHMM(shift.startTime)}–{formatHHMM(shift.endTime)}
-            </td>
+            </TableCell>
             {Array.from({ length: maxSlots }).map((_, i) => (
-              <td
+              <TableCell
                 key={i}
-                style={{
-                  ...cellStyle,
+                sx={{
+                  ...cellSx,
                   backgroundColor:
-                    i >= shift.maxVolunteers ? '#eee' : undefined,
+                    i >= shift.maxVolunteers
+                      ? theme.palette.grey[200]
+                      : 'transparent',
                 }}
               />
             ))}
-          </tr>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   );
 }
 

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -2,7 +2,21 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { getBookingHistory } from '../../api/api';
 import { formatInTimeZone } from 'date-fns-tz';
-import { Box, Button, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import {
+  Box,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import RescheduleDialog from '../RescheduleDialog';
 import EntitySearch from '../EntitySearch';
 
@@ -77,6 +91,16 @@ export default function UserHistory({
   const totalPages = Math.max(1, Math.ceil(bookings.length / pageSize));
   const paginated = bookings.slice((page - 1) * pageSize, page * pageSize);
 
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const cellSx = {
+    border: 1,
+    borderColor: 'divider',
+    p: isSmall ? 0.5 : 1,
+    fontSize: isSmall ? '0.85rem' : undefined,
+    textAlign: 'left',
+  } as const;
+
   return (
     <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
       <Box width="100%" maxWidth={800} mt={4}>
@@ -107,75 +131,87 @@ export default function UserHistory({
                 <MenuItem value="past">Past</MenuItem>
               </Select>
             </FormControl>
-            <div className="history-table-container">
-              <table className="history-table">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Time</th>
-                  <th>Status</th>
-                  <th>Reason</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {paginated.length === 0 && (
-                  <tr>
-                    <td colSpan={5}>No bookings.</td>
-                  </tr>
-                )}
-                {paginated.map(b => {
-                  const hasStart = b.date && b.start_time;
-                  const hasEnd = b.date && b.end_time;
-                  const startTime =
-                    hasStart && !isNaN(new Date(`${b.date}T${b.start_time}`).getTime())
-                      ? formatInTimeZone(
-                          `${b.date}T${b.start_time}`,
-                          TIMEZONE,
-                          'h:mm a'
-                        )
-                      : 'N/A';
-                  const endTime =
-                    hasEnd && !isNaN(new Date(`${b.date}T${b.end_time}`).getTime())
-                      ? formatInTimeZone(
-                          `${b.date}T${b.end_time}`,
-                          TIMEZONE,
-                          'h:mm a'
-                        )
-                      : 'N/A';
-                  const formattedDate =
-                    b.date && !isNaN(new Date(b.date).getTime())
-                      ? formatInTimeZone(`${b.date}`, TIMEZONE, 'MMM d, yyyy')
-                      : 'N/A';
-                  return (
-                    <tr key={b.id}>
-                      <td>{formattedDate}</td>
-                      <td>
-                        {startTime !== 'N/A' && endTime !== 'N/A'
-                          ? `${startTime} - ${endTime}`
-                          : 'N/A'}
-                      </td>
-                      <td>{b.status}</td>
-                      <td>{b.reason || ''}</td>
-                      <td>
-                        {['approved', 'submitted'].includes(b.status.toLowerCase()) && (
-                          <Button
-                            onClick={() => setRescheduleBooking(b)}
-                            variant="outlined"
-                            color="primary"
-                          >
-                            Reschedule
-                          </Button>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+            <Box sx={{ overflowX: 'auto' }}>
+              <Table sx={{ width: '100%', borderCollapse: 'collapse' }}>
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={cellSx}>Date</TableCell>
+                    <TableCell sx={cellSx}>Time</TableCell>
+                    <TableCell sx={cellSx}>Status</TableCell>
+                    <TableCell sx={cellSx}>Reason</TableCell>
+                    <TableCell sx={cellSx}>Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {paginated.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={5} sx={{ textAlign: 'center' }}>
+                        No bookings.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {paginated.map(b => {
+                    const hasStart = b.date && b.start_time;
+                    const hasEnd = b.date && b.end_time;
+                    const startTime =
+                      hasStart && !isNaN(new Date(`${b.date}T${b.start_time}`).getTime())
+                        ? formatInTimeZone(
+                            `${b.date}T${b.start_time}`,
+                            TIMEZONE,
+                            'h:mm a'
+                          )
+                        : 'N/A';
+                    const endTime =
+                      hasEnd && !isNaN(new Date(`${b.date}T${b.end_time}`).getTime())
+                        ? formatInTimeZone(
+                            `${b.date}T${b.end_time}`,
+                            TIMEZONE,
+                            'h:mm a'
+                          )
+                        : 'N/A';
+                    const formattedDate =
+                      b.date && !isNaN(new Date(b.date).getTime())
+                        ? formatInTimeZone(`${b.date}`, TIMEZONE, 'MMM d, yyyy')
+                        : 'N/A';
+                    return (
+                      <TableRow key={b.id}>
+                        <TableCell sx={cellSx}>{formattedDate}</TableCell>
+                        <TableCell sx={cellSx}>
+                          {startTime !== 'N/A' && endTime !== 'N/A'
+                            ? `${startTime} - ${endTime}`
+                            : 'N/A'}
+                        </TableCell>
+                        <TableCell sx={cellSx}>{b.status}</TableCell>
+                        <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
+                        <TableCell sx={cellSx}>
+                          {['approved', 'submitted'].includes(
+                            b.status.toLowerCase()
+                          ) && (
+                            <Button
+                              onClick={() => setRescheduleBooking(b)}
+                              variant="outlined"
+                              color="primary"
+                            >
+                              Reschedule
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </Box>
             {totalPages > 1 && (
-              <div className="pagination">
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  gap: 1,
+                  mt: 1,
+                }}
+              >
                 <Button
                   disabled={page === 1}
                   onClick={() => setPage(p => Math.max(1, p - 1))}
@@ -195,7 +231,7 @@ export default function UserHistory({
                 >
                   Next
                 </Button>
-              </div>
+              </Box>
             )}
           </div>
         )}

--- a/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
@@ -33,6 +33,12 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
 } from '@mui/material';
 import Dashboard from '../pages/Dashboard';
 import EntitySearch from './EntitySearch';
@@ -90,6 +96,8 @@ export default function VolunteerManagement({ token }: { token: string }) {
   const [editMsg, setEditMsg] = useState('');
   const [editSeverity, setEditSeverity] = useState<'success' | 'error'>('success');
   const [history, setHistory] = useState<VolunteerBookingDetail[]>([]);
+
+  const cellSx = { border: 1, borderColor: 'divider', p: 0.5 } as const;
 
   const [shopperOpen, setShopperOpen] = useState(false);
   const [shopperClientId, setShopperClientId] = useState('');
@@ -656,45 +664,72 @@ export default function VolunteerManagement({ token }: { token: string }) {
                     </div>
                   )}
                 </div>
-                <Button onClick={saveTrainedAreas} variant="outlined" color="primary">Save Roles</Button>
-                <h3 style={{ marginTop: 16 }}>History for {selectedVolunteer.name}</h3>
-                <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                  <thead>
-                    <tr>
-                      <th style={{ border: '1px solid #ccc', padding: 4 }}>Role</th>
-                      <th style={{ border: '1px solid #ccc', padding: 4 }}>Date</th>
-                      <th style={{ border: '1px solid #ccc', padding: 4 }}>Time</th>
-                      <th style={{ border: '1px solid #ccc', padding: 4 }}>Status</th>
-                      <th style={{ border: '1px solid #ccc', padding: 4 }}></th>
-                    </tr>
-                  </thead>
-                  <tbody>
+                <Button onClick={saveTrainedAreas} variant="outlined" color="primary">
+                  Save Roles
+                </Button>
+                <Typography variant="h6" sx={{ mt: 2 }}>
+                  History for {selectedVolunteer.name}
+                </Typography>
+                <Table sx={{ width: '100%', borderCollapse: 'collapse' }}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={cellSx}>Role</TableCell>
+                      <TableCell sx={cellSx}>Date</TableCell>
+                      <TableCell sx={cellSx}>Time</TableCell>
+                      <TableCell sx={cellSx}>Status</TableCell>
+                      <TableCell sx={cellSx} />
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
                     {history.map(h => (
-                      <tr key={h.id}>
-                        <td style={{ border: '1px solid #ccc', padding: 4 }}>{h.role_name}</td>
-                        <td style={{ border: '1px solid #ccc', padding: 4 }}>{h.date}</td>
-                        <td style={{ border: '1px solid #ccc', padding: 4 }}>{formatTime(h.start_time || h.startTime || '')} - {formatTime(h.end_time || h.endTime || '')}</td>
-                        <td style={{ border: '1px solid #ccc', padding: 4 }}>{h.status}</td>
-                        <td style={{ border: '1px solid #ccc', padding: 4 }}>
+                      <TableRow key={h.id}>
+                        <TableCell sx={cellSx}>{h.role_name}</TableCell>
+                        <TableCell sx={cellSx}>{h.date}</TableCell>
+                        <TableCell sx={cellSx}>
+                          {formatTime(h.start_time || h.startTime || '')} -
+                          {formatTime(h.end_time || h.endTime || '')}
+                        </TableCell>
+                        <TableCell sx={cellSx}>{h.status}</TableCell>
+                        <TableCell sx={cellSx}>
                           {h.status === 'pending' && (
                             <>
-                              <Button onClick={() => decide(h.id, 'approved')} variant="outlined" color="primary">Approve</Button>{' '}
-                              <Button onClick={() => decide(h.id, 'rejected')} variant="outlined" color="primary">Reject</Button>
+                              <Button
+                                onClick={() => decide(h.id, 'approved')}
+                                variant="outlined"
+                                color="primary"
+                              >
+                                Approve
+                              </Button>{' '}
+                              <Button
+                                onClick={() => decide(h.id, 'rejected')}
+                                variant="outlined"
+                                color="primary"
+                              >
+                                Reject
+                              </Button>
                             </>
                           )}
-                            {h.status === 'approved' && (
-                              <Button onClick={() => decide(h.id, 'cancelled')} variant="outlined" color="primary">Cancel</Button>
-                            )}
-                        </td>
-                      </tr>
+                          {h.status === 'approved' && (
+                            <Button
+                              onClick={() => decide(h.id, 'cancelled')}
+                              variant="outlined"
+                              color="primary"
+                            >
+                              Cancel
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
                     ))}
                     {history.length === 0 && (
-                      <tr>
-                        <td colSpan={5} style={{ textAlign: 'center', padding: 8 }}>No bookings.</td>
-                      </tr>
+                      <TableRow>
+                        <TableCell colSpan={5} sx={{ textAlign: 'center', p: 1 }}>
+                          No bookings.
+                        </TableCell>
+                      </TableRow>
                     )}
-                  </tbody>
-                </table>
+                  </TableBody>
+                </Table>
               </div>
             )}
           </Box>

--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -241,35 +241,3 @@ select {
   }
 }
 
-/* User history table */
-.history-table-container {
-  overflow-x: auto;
-}
-
-.history-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.history-table th,
-.history-table td {
-  border: 1px solid #ccc;
-  padding: 0.5rem;
-  text-align: left;
-}
-
-.pagination {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 1rem;
-  margin-top: 0.5rem;
-}
-
-@media (max-width: 600px) {
-  .history-table th,
-  .history-table td {
-    font-size: 0.85rem;
-    padding: 0.3rem;
-  }
-}


### PR DESCRIPTION
## Summary
- refactor schedule table to use MUI Table components and theme-based colors
- convert volunteer management history to MUI table with theme spacing
- update user history view to MUI Table and remove global table CSS

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6545f12f8832d843c2bc4de5c8c3b