### PR TITLE
feat: centralize auth with context and hook

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -17,43 +17,16 @@ import UserDashboard from './pages/UserDashboard';
 import VolunteerBookingHistory from './components/VolunteerBookingHistory';
 import VolunteerSchedule from './components/VolunteerSchedule';
 import type { Role, UserRole } from './types';
-import type { LoginResponse } from './api/api';
 import Navbar, { type NavGroup } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
+import { useAuth } from './hooks/useAuth';
 
 export default function App() {
-  const [token, setToken] = useState(() => localStorage.getItem('token') || '');
-  const [role, setRole] = useState<Role>(
-    () => (localStorage.getItem('role') as Role) || ('' as Role)
-  );
-  const [name, setName] = useState(() => localStorage.getItem('name') || '');
-  const [userRole, setUserRole] = useState<UserRole | ''>(
-    () => (localStorage.getItem('userRole') as UserRole) || ''
-  );
+  const { token, role, name, userRole, login, logout } = useAuth();
   const [loading] = useState(false);
   const [error, setError] = useState('');
   const isStaff = role === 'staff';
-
-  function handleLogin(u: LoginResponse) {
-    setToken('loggedin');
-    setRole(u.role);
-    setName(u.name);
-    setUserRole(u.userRole || '');
-    if (u.userRole) localStorage.setItem('userRole', u.userRole);
-    else localStorage.removeItem('userRole');
-  }
-
-  function logout() {
-    setToken('');
-    setRole('' as Role);
-    setName('');
-    setUserRole('');
-    localStorage.removeItem('token');
-    localStorage.removeItem('role');
-    localStorage.removeItem('name');
-    localStorage.removeItem('userRole');
-  }
 
   const navGroups: NavGroup[] = [];
   if (!token) {
@@ -126,7 +99,7 @@ export default function App() {
           severity="error"
         />
 
-        {token ? (
+          {token ? (
           <main>
             <Breadcrumbs />
             <Routes>
@@ -210,9 +183,9 @@ export default function App() {
         ) : (
           <main>
             <Routes>
-              <Route path="/login/user" element={<Login onLogin={handleLogin} />} />
-              <Route path="/login/staff" element={<StaffLogin onLogin={handleLogin} />} />
-              <Route path="/login/volunteer" element={<VolunteerLogin onLogin={handleLogin} />} />
+                <Route path="/login/user" element={<Login onLogin={login} />} />
+                <Route path="/login/staff" element={<StaffLogin onLogin={login} />} />
+                <Route path="/login/volunteer" element={<VolunteerLogin onLogin={login} />} />
               <Route path="/login" element={<Navigate to="/login/user" replace />} />
               <Route path="*" element={<Navigate to="/login/user" replace />} />
             </Routes>

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import App from '../App';
+import { AuthProvider } from '../hooks/useAuth';
 
 jest.mock('../api/api', () => ({
   getBookingHistory: jest.fn().mockResolvedValue([]),
@@ -13,15 +14,23 @@ describe('App authentication persistence', () => {
   });
 
   it('shows login when not authenticated', () => {
-    render(<App />);
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>,
+    );
     expect(screen.getByText(/user login/i)).toBeInTheDocument();
   });
 
   it('keeps user logged in when token exists', () => {
-    localStorage.setItem('token', 'loggedin');
+    localStorage.setItem('token', 'testtoken');
     localStorage.setItem('role', 'shopper');
     localStorage.setItem('name', 'Test User');
-    render(<App />);
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>,
+    );
     expect(screen.queryByText(/user login/i)).not.toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/api/api.ts
+++ b/MJ_FB_Frontend/src/api/api.ts
@@ -109,6 +109,13 @@ export async function loginVolunteer(
   return data;
 }
 
+export async function logout(): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/auth/logout`, {
+    method: 'POST',
+  });
+  await handleResponse(res);
+}
+
 export async function requestPasswordReset(data: {
   email?: string;
   username?: string;

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -1,0 +1,81 @@
+import { createContext, useContext, useState } from 'react';
+import type { Role, UserRole } from '../types';
+import type { LoginResponse } from '../api/api';
+import { logout as apiLogout } from '../api/api';
+
+interface AuthContextValue {
+  token: string;
+  role: Role;
+  name: string;
+  userRole: UserRole | '';
+  login: (u: LoginResponse) => void;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState(() => localStorage.getItem('token') || '');
+  const [role, setRole] = useState<Role>(
+    () => (localStorage.getItem('role') as Role) || ('' as Role)
+  );
+  const [name, setName] = useState(() => localStorage.getItem('name') || '');
+  const [userRole, setUserRole] = useState<UserRole | ''>(
+    () => (localStorage.getItem('userRole') as UserRole) || ''
+  );
+  const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
+
+  function login(u: LoginResponse) {
+    setRole(u.role);
+    setName(u.name);
+    setUserRole(u.userRole || '');
+    localStorage.setItem('role', u.role);
+    localStorage.setItem('name', u.name);
+    if (u.userRole) localStorage.setItem('userRole', u.userRole);
+    else localStorage.removeItem('userRole');
+    fetch(`${API_BASE}/auth/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+      .then(r => r.json().catch(() => ({})))
+      .then(data => {
+        if (data?.token) {
+          setToken(data.token);
+          localStorage.setItem('token', data.token);
+        }
+      })
+      .catch(() => {});
+  }
+
+  async function logout() {
+    try {
+      await apiLogout();
+    } catch {}
+    setToken('');
+    setRole('' as Role);
+    setName('');
+    setUserRole('');
+    localStorage.removeItem('token');
+    localStorage.removeItem('role');
+    localStorage.removeItem('name');
+    localStorage.removeItem('userRole');
+  }
+
+  const value: AuthContextValue = {
+    token,
+    role,
+    name,
+    userRole,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider');
+  return ctx;
+}
+

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -6,16 +6,19 @@ import { ThemeProvider, CssBaseline } from '@mui/material';
 import { theme } from './theme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { registerServiceWorker } from './registerServiceWorker';
+import { AuthProvider } from './hooks/useAuth';
 
 function Main() {
   const queryClient = new QueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <App />
-      </ThemeProvider>
+      <AuthProvider>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <App />
+        </ThemeProvider>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add AuthProvider and useAuth hook to share auth state
- replace hardcoded login token and wire logout API
- refactor App and setup to consume auth context

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a65464ac64832d8a8a93c5ee44bd01