### PR TITLE
fix: refresh auth on mount to persist login

### DIFF
--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import type { Role, UserRole } from '../types';
 import type { LoginResponse } from '../api/users';
 import { logout as apiLogout } from '../api/users';
@@ -24,6 +24,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     () => (localStorage.getItem('userRole') as UserRole) || ''
   );
   const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
+
+  useEffect(() => {
+    if (token) return;
+    fetch(`${API_BASE}/auth/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+      .then(r => r.json().catch(() => ({})))
+      .then(data => {
+        if (data?.token) {
+          setToken(data.token);
+          localStorage.setItem('token', data.token);
+        }
+      })
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function login(u: LoginResponse) {
     setRole(u.role);


### PR DESCRIPTION
## Summary
- refresh token on mount to persist auth across page reloads

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a666f02058832d8a452b51ef6d2700