### PR TITLE
Remove unused token parameters from frontend API calls

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -107,20 +107,20 @@ export default function App() {
                 path="/"
                 element={
                   role === 'volunteer' ? (
-                    <VolunteerDashboard token={token} />
+                    <VolunteerDashboard />
                   ) : isStaff ? (
-                    <Dashboard role="staff" token={token} />
+                    <Dashboard role="staff" />
                   ) : (
-                    <UserDashboard token={token} />
+                    <UserDashboard />
                   )
                 }
               />
-              <Route path="/profile" element={<Profile token={token} role={role} />} />
+              <Route path="/profile" element={<Profile role={role} />} />
               {isStaff && (
-                <Route path="/manage-availability" element={<ManageAvailability token={token} />} />
+                <Route path="/manage-availability" element={<ManageAvailability />} />
               )}
               {isStaff && (
-                <Route path="/pantry-schedule" element={<PantrySchedule token={token} />} />
+                <Route path="/pantry-schedule" element={<PantrySchedule />} />
               )}
               {role === 'shopper' && (
                 <Route path="/slots" element={<SlotBooking token={token} role="shopper" />} />
@@ -130,7 +130,6 @@ export default function App() {
                   path="/booking-history"
                   element={
                     <UserHistory
-                      token={token}
                       initialUser={{ id: 0, name, client_id: 0 }}
                     />
                   }
@@ -144,24 +143,23 @@ export default function App() {
                   path="/booking-history"
                   element={
                     <UserHistory
-                      token={token}
                       initialUser={{ id: 0, name, client_id: 0 }}
                     />
                   }
                 />
               )}
-              {isStaff && <Route path="/add-user" element={<AddUser token={token} />} />}
-              {isStaff && <Route path="/user-history" element={<UserHistory token={token} />} />}
-              {isStaff && <Route path="/pending" element={<Pending token={token} />} />}
+              {isStaff && <Route path="/add-user" element={<AddUser />} />}
+              {isStaff && <Route path="/user-history" element={<UserHistory />} />}
+              {isStaff && <Route path="/pending" element={<Pending />} />}
               {isStaff && (
                 <>
                   <Route
                     path="/volunteer-management"
-                    element={<VolunteerManagement token={token} />}
+                    element={<VolunteerManagement />}
                   />
                   <Route
                     path="/volunteer-management/:tab"
-                    element={<VolunteerManagement token={token} />}
+                    element={<VolunteerManagement />}
                   />
                 </>
               )}
@@ -169,11 +167,11 @@ export default function App() {
                 <>
                   <Route
                     path="/volunteer/schedule"
-                    element={<VolunteerSchedule token={token} />}
+                    element={<VolunteerSchedule />}
                   />
                   <Route
                     path="/volunteer/history"
-                    element={<VolunteerBookingHistory token={token} />}
+                    element={<VolunteerBookingHistory />}
                   />
                 </>
               )}

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -51,7 +51,7 @@ describe('VolunteerManagement shopper profile', () => {
     render(
       <MemoryRouter initialEntries={['/volunteers/search']}>
         <Routes>
-          <Route path="/volunteers/:tab" element={<VolunteerManagement token="t" />} />
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
         </Routes>
       </MemoryRouter>
     );
@@ -67,7 +67,6 @@ describe('VolunteerManagement shopper profile', () => {
 
     await waitFor(() =>
       expect(createVolunteerShopperProfile).toHaveBeenCalledWith(
-        't',
         1,
         '123',
         'pass',
@@ -87,7 +86,7 @@ describe('VolunteerManagement shopper profile', () => {
     render(
       <MemoryRouter initialEntries={['/volunteers/search']}>
         <Routes>
-          <Route path="/volunteers/:tab" element={<VolunteerManagement token="t" />} />
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
         </Routes>
       </MemoryRouter>
     );
@@ -99,7 +98,7 @@ describe('VolunteerManagement shopper profile', () => {
     fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
 
     await waitFor(() =>
-      expect(removeVolunteerShopperProfile).toHaveBeenCalledWith('t', 1)
+      expect(removeVolunteerShopperProfile).toHaveBeenCalledWith(1)
     );
     await waitFor(() =>
       expect(screen.getByLabelText(/shopper profile/i)).not.toBeChecked()

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -1,7 +1,7 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
 import type { Slot } from '../types';
 
-export async function getSlots(token: string, date?: string) {
+export async function getSlots(date?: string) {
   let url = `${API_BASE}/slots`;
   if (date) url += `?date=${encodeURIComponent(date)}`;
   const res = await apiFetch(url);
@@ -14,18 +14,16 @@ export async function getSlots(token: string, date?: string) {
   })) as Slot[];
 }
 
-export async function createBooking(token: string, slotId: string, date: string) {
+export async function createBooking(slotId: string, date: string) {
   const res = await apiFetch(`${API_BASE}/bookings`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ slotId: Number(slotId), date, requestData: '' }),
   });
   return handleResponse(res);
 }
 
-export async function getBookings(token: string, opts: { status?: string } = {}) {
+export async function getBookings(opts: { status?: string } = {}) {
   const params = new URLSearchParams();
   if (opts.status) params.append('status', opts.status);
   const query = params.toString();
@@ -34,8 +32,7 @@ export async function getBookings(token: string, opts: { status?: string } = {})
 }
 
 export async function getBookingHistory(
-  token: string,
-  opts: { status?: string; past?: boolean; userId?: number } = {}
+  opts: { status?: string; past?: boolean; userId?: number } = {},
 ) {
   const params = new URLSearchParams();
   if (opts.status) params.append('status', opts.status);
@@ -47,30 +44,28 @@ export async function getBookingHistory(
   return handleResponse(res);
 }
 
-export async function getHolidays(token: string) {
+export async function getHolidays() {
   const res = await apiFetch(`${API_BASE}/holidays`);
   return handleResponse(res);
 }
 
-export async function addHoliday(token: string, date: string, reason: string): Promise<void> {
+export async function addHoliday(date: string, reason: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/holidays`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ date, reason }),
   });
   await handleResponse(res);
 }
 
-export async function removeHoliday(token: string, date: string): Promise<void> {
+export async function removeHoliday(date: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/holidays/${encodeURIComponent(date)}`, {
     method: 'DELETE',
   });
   await handleResponse(res);
 }
 
-export async function getAllSlots(token: string) {
+export async function getAllSlots() {
   const res = await apiFetch(`${API_BASE}/slots/all`);
   const data = await handleResponse(res);
   return data.map((s: any) => ({
@@ -81,56 +76,50 @@ export async function getAllSlots(token: string) {
   })) as Slot[];
 }
 
-export async function getBlockedSlots(token: string, date: string) {
+export async function getBlockedSlots(date: string) {
   const res = await apiFetch(`${API_BASE}/blocked-slots?date=${encodeURIComponent(date)}`);
   return handleResponse(res);
 }
 
 export async function addBlockedSlot(
-  token: string,
   date: string,
   slotId: number,
-  reason: string
+  reason: string,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/blocked-slots`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ date, slotId, reason }),
   });
   await handleResponse(res);
 }
 
-export async function removeBlockedSlot(token: string, date: string, slotId: number): Promise<void> {
+export async function removeBlockedSlot(date: string, slotId: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/blocked-slots/${encodeURIComponent(date)}/${slotId}`, {
     method: 'DELETE',
   });
   await handleResponse(res);
 }
 
-export async function getBreaks(token: string) {
+export async function getBreaks() {
   const res = await apiFetch(`${API_BASE}/breaks`);
   return handleResponse(res);
 }
 
 export async function addBreak(
-  token: string,
   dayOfWeek: number,
   slotId: number,
-  reason: string
+  reason: string,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/breaks`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ dayOfWeek, slotId, reason }),
   });
   await handleResponse(res);
 }
 
-export async function removeBreak(token: string, dayOfWeek: number, slotId: number): Promise<void> {
+export async function removeBreak(dayOfWeek: number, slotId: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/breaks/${dayOfWeek}/${slotId}`, {
     method: 'DELETE',
   });
@@ -138,48 +127,39 @@ export async function removeBreak(token: string, dayOfWeek: number, slotId: numb
 }
 
 export async function decideBooking(
-  token: string,
   bookingId: string,
   decision: 'approve' | 'reject',
-  reason: string
+  reason: string,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/bookings/${bookingId}/decision`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ decision, reason }),
   });
   await handleResponse(res);
 }
 
 export async function cancelBooking(
-  token: string,
   bookingId: string,
-  reason?: string
+  reason?: string,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/bookings/${bookingId}/cancel`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(reason ? { reason } : {}),
   });
   await handleResponse(res);
 }
 
 export async function createBookingForUser(
-  token: string,
   userId: number,
   slotId: number,
   date: string,
-  isStaffBooking: boolean
+  isStaffBooking: boolean,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/bookings/staff`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ userId, slotId, date, isStaffBooking }),
   });
   await handleResponse(res);
@@ -189,7 +169,6 @@ export async function rescheduleBookingByToken(
   token: string,
   slotId: string,
   date: string,
-  authToken?: string,
 ): Promise<void> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   const res = await apiFetch(`${API_BASE}/bookings/reschedule/${token}`, {

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -53,7 +53,6 @@ export async function requestPasswordReset(data: {
 }
 
 export async function changePassword(
-  token: string,
   currentPassword: string,
   newPassword: string,
 ): Promise<void> {
@@ -65,7 +64,7 @@ export async function changePassword(
   await handleResponse(res);
 }
 
-export async function getUserProfile(token: string): Promise<UserProfile> {
+export async function getUserProfile(): Promise<UserProfile> {
   const res = await apiFetch(`${API_BASE}/users/me`);
   return handleResponse(res);
 }
@@ -82,7 +81,6 @@ export async function createStaff(
   role: StaffRole,
   email: string,
   password: string,
-  token?: string
 ): Promise<void> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -96,7 +94,6 @@ export async function createStaff(
 }
 
 export async function addUser(
-  token: string,
   firstName: string,
   lastName: string,
   clientId: string,
@@ -123,7 +120,7 @@ export async function addUser(
   await handleResponse(res);
 }
 
-export async function searchUsers(token: string, search: string) {
+export async function searchUsers(search: string) {
   const res = await apiFetch(`${API_BASE}/users/search?search=${encodeURIComponent(search)}`);
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -15,7 +15,7 @@ export async function loginVolunteer(
   return data;
 }
 
-export async function searchVolunteers(token: string, search: string) {
+export async function searchVolunteers(search: string) {
   const res = await apiFetch(
     `${API_BASE}/volunteers/search?search=${encodeURIComponent(search)}`,
   );
@@ -23,7 +23,6 @@ export async function searchVolunteers(token: string, search: string) {
 }
 
 export async function getVolunteerRolesForVolunteer(
-  token: string,
   date: string,
 ): Promise<VolunteerRole[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-roles/mine?date=${date}`);
@@ -31,7 +30,6 @@ export async function getVolunteerRolesForVolunteer(
 }
 
 export async function requestVolunteerBooking(
-  token: string,
   roleId: number,
   date: string
 ): Promise<void> {
@@ -45,28 +43,26 @@ export async function requestVolunteerBooking(
   await handleResponse(res);
 }
 
-export async function getMyVolunteerBookings(token: string) {
+export async function getMyVolunteerBookings() {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/mine`);
   return handleResponse(res);
 }
 
 export async function getVolunteerRoles(
-  token: string,
 ): Promise<VolunteerRoleWithShifts[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-roles`);
   return handleResponse(res);
 }
 
-export async function getVolunteerMasterRoles(token: string) {
+export async function getVolunteerMasterRoles() {
   const res = await apiFetch(`${API_BASE}/volunteer-master-roles`);
   return handleResponse(res);
 }
 
 export async function updateVolunteerRoleStatus(
-  token: string,
   id: number,
   isActive: boolean,
-) {
+ ) {
   const res = await apiFetch(`${API_BASE}/volunteer-roles/${id}`, {
     method: 'PATCH',
     headers: {
@@ -77,13 +73,12 @@ export async function updateVolunteerRoleStatus(
   return handleResponse(res);
 }
 
-export async function getVolunteerBookingsByRole(token: string, roleId: number) {
+export async function getVolunteerBookingsByRole(roleId: number) {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/${roleId}`);
   return handleResponse(res);
 }
 
 export async function updateVolunteerBookingStatus(
-  token: string,
   bookingId: number,
   status: 'approved' | 'rejected' | 'cancelled'
 ): Promise<void> {
@@ -98,7 +93,6 @@ export async function updateVolunteerBookingStatus(
 }
 
 export async function createVolunteerBookingForVolunteer(
-  token: string,
   volunteerId: number,
   roleId: number,
   date: string
@@ -113,13 +107,12 @@ export async function createVolunteerBookingForVolunteer(
   await handleResponse(res);
 }
 
-export async function getVolunteerBookingHistory(token: string, volunteerId: number) {
+export async function getVolunteerBookingHistory(volunteerId: number) {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/volunteer/${volunteerId}`);
   return handleResponse(res);
 }
 
 export async function createVolunteer(
-  token: string,
   firstName: string,
   lastName: string,
   username: string,
@@ -147,7 +140,6 @@ export async function createVolunteer(
 }
 
 export async function updateVolunteerTrainedAreas(
-  token: string,
   id: number,
   roleIds: number[]
 ): Promise<void> {
@@ -175,7 +167,6 @@ export async function rescheduleVolunteerBookingByToken(
 }
 
 export async function createVolunteerShopperProfile(
-  token: string,
   volunteerId: number,
   clientId: string,
   password: string,
@@ -196,7 +187,6 @@ export async function createVolunteerShopperProfile(
 }
 
 export async function removeVolunteerShopperProfile(
-  token: string,
   volunteerId: number,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/volunteers/${volunteerId}/shopper`, {

--- a/MJ_FB_Frontend/src/components/ChangePasswordForm.tsx
+++ b/MJ_FB_Frontend/src/components/ChangePasswordForm.tsx
@@ -4,7 +4,7 @@ import { changePassword } from '../api/users';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormContainer from './FormContainer';
 
-export default function ChangePasswordForm({ token }: { token: string }) {
+export default function ChangePasswordForm() {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [success, setSuccess] = useState('');
@@ -13,7 +13,7 @@ export default function ChangePasswordForm({ token }: { token: string }) {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      await changePassword(token, currentPassword, newPassword);
+      await changePassword(currentPassword, newPassword);
       setSuccess('Password updated');
       setCurrentPassword('');
       setNewPassword('');

--- a/MJ_FB_Frontend/src/components/EntitySearch.tsx
+++ b/MJ_FB_Frontend/src/components/EntitySearch.tsx
@@ -4,7 +4,6 @@ import { searchUsers } from '../api/users';
 import { searchVolunteers } from '../api/volunteers';
 
 interface EntitySearchProps {
-  token: string;
   type: 'user' | 'volunteer';
   placeholder?: string;
   onSelect: (result: any) => void;
@@ -12,7 +11,6 @@ interface EntitySearchProps {
 }
 
 export default function EntitySearch({
-  token,
   type,
   placeholder,
   onSelect,
@@ -28,7 +26,7 @@ export default function EntitySearch({
     }
     let active = true;
     const fn = type === 'user' ? searchUsers : searchVolunteers;
-    fn(token, query)
+    fn(query)
       .then(data => {
         if (active) setResults(data);
       })
@@ -36,7 +34,7 @@ export default function EntitySearch({
     return () => {
       active = false;
     };
-  }, [query, token, type]);
+  }, [query, type]);
 
   const getLabel = (r: any) =>
     type === 'user' ? `${r.name} (${r.client_id})` : r.name;

--- a/MJ_FB_Frontend/src/components/Profile.tsx
+++ b/MJ_FB_Frontend/src/components/Profile.tsx
@@ -5,17 +5,17 @@ import { getUserProfile } from '../api/users';
 import Page from './Page';
 import ChangePasswordForm from './ChangePasswordForm';
 
-export default function Profile({ token, role }: { token: string; role: Role }) {
+export default function Profile({ role }: { role: Role }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [error, setError] = useState('');
 
   useEffect(() => {
     if (role === 'shopper') {
-      getUserProfile(token)
+      getUserProfile()
         .then(setProfile)
         .catch(e => setError(e instanceof Error ? e.message : String(e)));
     }
-  }, [role, token]);
+  }, [role]);
 
   return (
     <Page title="User Profile">
@@ -31,7 +31,7 @@ export default function Profile({ token, role }: { token: string; role: Role }) 
         </List>
       )}
       {role !== 'shopper' && <Typography>No profile information available.</Typography>}
-      <ChangePasswordForm token={token} />
+      <ChangePasswordForm />
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -15,7 +15,6 @@ import type { Slot } from '../types';
 
 interface RescheduleDialogProps {
   open: boolean;
-  token: string;
   rescheduleToken: string;
   onClose: () => void;
   onRescheduled: () => void;
@@ -23,7 +22,6 @@ interface RescheduleDialogProps {
 
 export default function RescheduleDialog({
   open,
-  token,
   rescheduleToken,
   onClose,
   onRescheduled,
@@ -35,14 +33,14 @@ export default function RescheduleDialog({
 
   useEffect(() => {
     if (open && date) {
-      getSlots(token, date)
+      getSlots(date)
         .then(setSlots)
         .catch(() => setSlots([]));
     } else {
       setSlots([]);
       setSlotId('');
     }
-  }, [open, date, token]);
+  }, [open, date]);
 
   async function submit() {
     if (!date || !slotId) {
@@ -50,7 +48,7 @@ export default function RescheduleDialog({
       return;
     }
     try {
-      await rescheduleBookingByToken(rescheduleToken, slotId, date, token);
+      await rescheduleBookingByToken(rescheduleToken, slotId, date);
       onRescheduled();
       onClose();
       setDate('');

--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -66,7 +66,7 @@ export default function SlotBooking({ token, role }: Props) {
 
   const { data: holidays = [] } = useQuery<Holiday[]>({
     queryKey: ['holidays', token],
-    queryFn: () => getHolidays(token),
+    queryFn: () => getHolidays(),
   });
 
   const isHoliday = useCallback(
@@ -112,7 +112,7 @@ export default function SlotBooking({ token, role }: Props) {
     isFetching: userFetching,
   } = useQuery({
     queryKey: ['userSearch', searchTerm],
-    queryFn: () => searchUsers(token, searchTerm),
+    queryFn: () => searchUsers(searchTerm),
     enabled: role === 'staff' && searchTerm.length >= 3,
     onError: (err: unknown) => setMessage(err instanceof Error ? err.message : 'Search failed'),
   });
@@ -143,7 +143,7 @@ export default function SlotBooking({ token, role }: Props) {
   const slotsEnabled = !!selectedDate && !isWeekend(selectedDate) && !isHoliday(selectedDate);
   const { data: slots = [] } = useQuery<Slot[]>({
     queryKey: ['slots', token, selectedDate ? formatDate(selectedDate) : null],
-    queryFn: () => getSlots(token, formatDate(selectedDate as Date)),
+    queryFn: () => getSlots(formatDate(selectedDate as Date)),
     enabled: slotsEnabled,
     onError: (err: unknown) => setMessage(err instanceof Error ? err.message : 'Failed to load slots'),
   });
@@ -151,11 +151,11 @@ export default function SlotBooking({ token, role }: Props) {
   const queryClient = useQueryClient();
   const bookingMutation = useMutation({
     mutationFn: (vars: { slotId: string; date: string }) =>
-      createBooking(token, vars.slotId, vars.date),
+      createBooking(vars.slotId, vars.date),
   });
   const staffBookingMutation = useMutation({
     mutationFn: (vars: { userId: number; slotId: number; date: string }) =>
-      createBookingForUser(token, vars.userId, vars.slotId, vars.date, true),
+      createBookingForUser(vars.userId, vars.slotId, vars.date, true),
   });
 
   async function submitBooking() {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -5,7 +5,7 @@ import FeedbackSnackbar from '../FeedbackSnackbar';
 import FeedbackModal from '../FeedbackModal';
 import { Box, Button, Stack, TextField, MenuItem, Typography } from '@mui/material';
 
-export default function AddUser({ token }: { token: string }) {
+export default function AddUser() {
   const [mode, setMode] = useState<'user' | 'staff'>('user');
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<UserRole>('shopper');
@@ -26,7 +26,6 @@ export default function AddUser({ token }: { token: string }) {
     }
     try {
       await addUser(
-        token,
         firstName,
         lastName,
         clientId,
@@ -54,7 +53,7 @@ export default function AddUser({ token }: { token: string }) {
       return;
     }
     try {
-      await createStaff(firstName, lastName, staffRole, email, password, token);
+      await createStaff(firstName, lastName, staffRole, email, password);
       setSuccess('Staff added successfully');
       setFirstName('');
       setLastName('');

--- a/MJ_FB_Frontend/src/components/StaffDashboard/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/ManageAvailability.tsx
@@ -18,7 +18,7 @@ import { Box, Button } from '@mui/material';
 
 const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-export default function ManageAvailability({ token }: { token: string }) {
+export default function ManageAvailability() {
   const [view, setView] = useState<'holiday' | 'blocked' | 'break'>('holiday');
 
   const [holidays, setHolidays] = useState<Holiday[]>([]);
@@ -41,21 +41,21 @@ export default function ManageAvailability({ token }: { token: string }) {
 
   const fetchHolidays = useCallback(async () => {
     try {
-      const data = await getHolidays(token);
+      const data = await getHolidays();
       setHolidays(data);
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
     }
-  }, [token]);
+  }, []);
 
   const fetchBreaks = useCallback(async () => {
     try {
-      const data = await getBreaks(token);
+      const data = await getBreaks();
       setBreaks(data);
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
     }
-  }, [token]);
+  }, []);
 
   const fetchBlocked = useCallback(async () => {
     if (!blockedDate) {
@@ -63,20 +63,20 @@ export default function ManageAvailability({ token }: { token: string }) {
       return;
     }
     try {
-      const data = await getBlockedSlots(token, blockedDate);
+      const data = await getBlockedSlots(blockedDate);
       setBlockedList(data);
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
     }
-  }, [token, blockedDate]);
+  }, [blockedDate]);
 
   useEffect(() => {
     fetchHolidays();
     fetchBreaks();
-    getAllSlots(token)
+    getAllSlots()
       .then(setAllSlots)
       .catch(err => setMessage(err instanceof Error ? err.message : String(err)));
-  }, [fetchHolidays, fetchBreaks, token]);
+  }, [fetchHolidays, fetchBreaks]);
 
   useEffect(() => {
     fetchBlocked();
@@ -85,7 +85,7 @@ export default function ManageAvailability({ token }: { token: string }) {
   async function addHoliday() {
     if (!newHoliday) return setMessage('Select a date to add');
     try {
-      await apiAddHoliday(token, newHoliday, newHolidayReason);
+      await apiAddHoliday(newHoliday, newHolidayReason);
       setMessage('Holiday added');
       setNewHoliday('');
       setNewHolidayReason('');
@@ -97,7 +97,7 @@ export default function ManageAvailability({ token }: { token: string }) {
 
   async function removeHoliday(date: string) {
     try {
-      await apiRemoveHoliday(token, date);
+      await apiRemoveHoliday(date);
       setMessage('Holiday removed');
       fetchHolidays();
     } catch (err: unknown) {
@@ -108,7 +108,7 @@ export default function ManageAvailability({ token }: { token: string }) {
   async function addBlocked() {
     if (!blockedDate || !blockedSlot) return setMessage('Select date and slot');
     try {
-      await apiAddBlockedSlot(token, blockedDate, Number(blockedSlot), blockedReason);
+      await apiAddBlockedSlot(blockedDate, Number(blockedSlot), blockedReason);
       setMessage('Slot blocked');
       setBlockedSlot('');
       setBlockedReason('');
@@ -120,7 +120,7 @@ export default function ManageAvailability({ token }: { token: string }) {
 
   async function removeBlocked(slotId: number) {
     try {
-      await apiRemoveBlockedSlot(token, blockedDate, slotId);
+      await apiRemoveBlockedSlot(blockedDate, slotId);
       setMessage('Blocked slot removed');
       fetchBlocked();
     } catch (err: unknown) {
@@ -131,7 +131,7 @@ export default function ManageAvailability({ token }: { token: string }) {
   async function addBreak() {
     if (breakDay === '' || breakSlot === '') return setMessage('Select day and slot');
     try {
-      await apiAddBreak(token, Number(breakDay), Number(breakSlot), breakReason);
+      await apiAddBreak(Number(breakDay), Number(breakSlot), breakReason);
       setMessage('Break added');
       setBreakDay('');
       setBreakSlot('');
@@ -144,7 +144,7 @@ export default function ManageAvailability({ token }: { token: string }) {
 
   async function removeBreak(day: number, slotId: number) {
     try {
-      await apiRemoveBreak(token, day, slotId);
+      await apiRemoveBreak(day, slotId);
       setMessage('Break removed');
       fetchBreaks();
     } catch (err: unknown) {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/Pending.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/Pending.tsx
@@ -17,25 +17,25 @@ interface Booking {
   endTime?: string;
 }
 
-export default function Pending({ token }: { token: string }) {
+export default function Pending() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [reasons, setReasons] = useState<Record<number, string>>({});
   const [message, setMessage] = useState('');
   const [severity, setSeverity] = useState<'success' | 'error'>('success');
 
   function loadBookings() {
-    getBookings(token, { status: 'pending' })
+    getBookings({ status: 'pending' })
       .then(b => setBookings(b.filter(x => x.status === 'submitted')))
       .catch(() => {});
   }
 
   useEffect(() => {
     loadBookings();
-  }, [token]);
+  }, []);
 
   async function handleDecision(id: number, decision: 'approve' | 'reject') {
     try {
-      await decideBooking(token, String(id), decision, reasons[id] || '');
+      await decideBooking(String(id), decision, reasons[id] || '');
       setSeverity('success');
       setMessage(`Booking ${decision === 'approve' ? 'approved' : 'rejected'}`);
       setReasons(r => {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -42,10 +42,8 @@ interface Booking {
 }
 
 export default function UserHistory({
-  token,
   initialUser,
 }: {
-  token: string;
   initialUser?: User;
 }) {
   const [searchParams] = useSearchParams();
@@ -63,7 +61,7 @@ export default function UserHistory({
     if (!initialUser) opts.userId = selected.id;
     if (filter === 'past') opts.past = true;
     else if (filter !== 'all') opts.status = filter;
-    return getBookingHistory(token, opts)
+    return getBookingHistory(opts)
       .then(data => {
         const sorted = [...data].sort(
           (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
@@ -72,7 +70,7 @@ export default function UserHistory({
         setPage(1);
       })
       .catch(err => console.error('Error loading history:', err));
-  }, [selected, filter, token, initialUser]);
+  }, [selected, filter, initialUser]);
 
   useEffect(() => {
     loadBookings();
@@ -106,8 +104,7 @@ export default function UserHistory({
       <Box width="100%" maxWidth={800} mt={4}>
         <h2>{initialUser ? 'Booking History' : 'User History'}</h2>
         {!initialUser && (
-          <EntitySearch
-            token={token}
+            <EntitySearch
             type="user"
             placeholder="Search by name or client ID"
             onSelect={u => setSelected(u as User)}
@@ -238,7 +235,6 @@ export default function UserHistory({
         {rescheduleBooking && (
           <RescheduleDialog
             open={!!rescheduleBooking}
-            token={token}
             rescheduleToken={rescheduleBooking.reschedule_token}
             onClose={() => setRescheduleBooking(null)}
             onRescheduled={() => {

--- a/MJ_FB_Frontend/src/components/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerBookingHistory.tsx
@@ -13,14 +13,14 @@ import {
   TableBody,
 } from '@mui/material';
 
-export default function VolunteerBookingHistory({ token }: { token: string }) {
+export default function VolunteerBookingHistory() {
   const [history, setHistory] = useState<VolunteerBooking[]>([]);
 
   useEffect(() => {
-    getMyVolunteerBookings(token)
+    getMyVolunteerBookings()
       .then(setHistory)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   return (
     <Page title="Booking History">

--- a/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerDashboard.tsx
@@ -39,7 +39,7 @@ function formatDateLabel(dateStr: string) {
   });
 }
 
-export default function VolunteerDashboard({ token }: { token: string }) {
+export default function VolunteerDashboard() {
   const [bookings, setBookings] = useState<VolunteerBooking[]>([]);
   const [availability, setAvailability] = useState<VolunteerRole[]>([]);
   const [dateMode, setDateMode] = useState<'today' | 'week'>('today');
@@ -48,10 +48,10 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    getMyVolunteerBookings(token)
+    getMyVolunteerBookings()
       .then(setBookings)
       .catch(() => setBookings([]));
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     async function loadAvailability() {
@@ -68,7 +68,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
       for (const day of days) {
         const ds = day.toISOString().split('T')[0];
         try {
-          const roles = await getVolunteerRolesForVolunteer(token, ds);
+          const roles = await getVolunteerRolesForVolunteer(ds);
           all.push(...roles);
         } catch {
           // ignore
@@ -77,7 +77,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
       setAvailability(all);
     }
     loadAvailability();
-  }, [token, dateMode]);
+  }, [dateMode]);
 
   const nextShift = useMemo(() => {
     const now = new Date();
@@ -110,9 +110,9 @@ export default function VolunteerDashboard({ token }: { token: string }) {
 
   async function request(role: VolunteerRole) {
     try {
-      await requestVolunteerBooking(token, role.id, role.date);
+      await requestVolunteerBooking(role.id, role.date);
       setMessage('Request submitted');
-      const data = await getMyVolunteerBookings(token);
+      const data = await getMyVolunteerBookings();
       setBookings(data);
     } catch {
       setMessage('Failed to request shift');
@@ -122,9 +122,9 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   async function cancelNext() {
     if (!nextShift) return;
     try {
-      await updateVolunteerBookingStatus(token, nextShift.id, 'cancelled');
+      await updateVolunteerBookingStatus(nextShift.id, 'cancelled');
       setMessage('Booking cancelled');
-      const data = await getMyVolunteerBookings(token);
+      const data = await getMyVolunteerBookings();
       setBookings(data);
     } catch {
       setMessage('Failed to cancel booking');

--- a/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
@@ -35,7 +35,7 @@ import {
 
 const reginaTimeZone = 'America/Regina';
 
-export default function VolunteerSchedule({ token }: { token: string }) {
+export default function VolunteerSchedule() {
   const [currentDate, setCurrentDate] = useState(() => {
     const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
     return fromZonedTime(`${todayStr}T00:00:00`, reginaTimeZone);
@@ -60,8 +60,8 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     const holiday = holidays.some(h => h.date === dateStr);
     try {
       const [roleData, bookingData] = await Promise.all([
-        getVolunteerRolesForVolunteer(token, dateStr),
-        getMyVolunteerBookings(token),
+        getVolunteerRolesForVolunteer(dateStr),
+        getMyVolunteerBookings(),
       ]);
       const disallowed = weekend || holiday
         ? ['Pantry', 'Warehouse', 'Administrative']
@@ -103,11 +103,11 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     } catch (err) {
       console.error(err);
     }
-  }, [currentDate, token, holidays]);
+  }, [currentDate, holidays]);
 
   useEffect(() => {
-    getHolidays(token).then(setHolidays).catch(() => {});
-  }, [token]);
+    getHolidays().then(setHolidays).catch(() => {});
+  }, []);
 
   useEffect(() => {
     loadData();
@@ -121,7 +121,6 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     if (!requestRole) return;
     try {
       await requestVolunteerBooking(
-        token,
         requestRole.id,
         formatDate(currentDate),
       );
@@ -141,7 +140,6 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     if (!decisionBooking) return;
     try {
       await updateVolunteerBookingStatus(
-        token,
         decisionBooking.id,
         'cancelled'
       );

--- a/MJ_FB_Frontend/src/pages/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/Dashboard.tsx
@@ -29,7 +29,6 @@ import EntitySearch from '../components/EntitySearch';
 
 export interface DashboardProps {
   role: Role;
-  token: string;
 }
 
 interface SectionCardProps {
@@ -81,7 +80,7 @@ function formatLocalDate(date: Date) {
   return date.toLocaleDateString('en-CA');
 }
 
-function StaffDashboard({ token }: { token: string }) {
+function StaffDashboard() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [coverage, setCoverage] = useState<
     { role: string; filled: number; total: number }[]
@@ -91,14 +90,14 @@ function StaffDashboard({ token }: { token: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    getBookings(token).then(setBookings).catch(() => {});
+    getBookings().then(setBookings).catch(() => {});
 
     const todayStr = formatLocalDate(new Date());
-    getVolunteerRoles(token)
+    getVolunteerRoles()
       .then(roles =>
         Promise.all(
           roles.map(async r => {
-            const bookings = await getVolunteerBookingsByRole(token, r.id);
+            const bookings = await getVolunteerBookingsByRole(r.id);
             const filled = bookings.filter(
               (b: any) =>
                 b.status === 'approved' &&
@@ -117,7 +116,7 @@ function StaffDashboard({ token }: { token: string }) {
         const d = new Date(today);
         d.setDate(today.getDate() + i);
         const dateStr = formatLocalDate(d);
-        const slots = await getSlots(token, dateStr);
+        const slots = await getSlots(dateStr);
         const open = (slots as Slot[]).reduce(
           (sum, s) => sum + (s.available || 0),
           0,
@@ -130,7 +129,7 @@ function StaffDashboard({ token }: { token: string }) {
     )
       .then(setSchedule)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   const todayStr = formatLocalDate(new Date());
   const pending = bookings.filter(b => b.status === 'submitted');
@@ -238,8 +237,7 @@ function StaffDashboard({ token }: { token: string }) {
           <Grid item xs={12}>
             <SectionCard title="Quick Search">
               <Stack spacing={2}>
-                <EntitySearch
-                  token={token}
+            <EntitySearch
                   type={searchType}
                   placeholder="Search"
                   onSelect={res => {
@@ -307,12 +305,12 @@ function StaffDashboard({ token }: { token: string }) {
   );
 }
 
-function UserDashboard({ token }: { token: string }) {
+function UserDashboard() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [slotOptions, setSlotOptions] = useState<string[]>([]);
 
   useEffect(() => {
-    getBookings(token).then(setBookings).catch(() => {});
+    getBookings().then(setBookings).catch(() => {});
 
     const today = new Date();
     Promise.all(
@@ -320,7 +318,7 @@ function UserDashboard({ token }: { token: string }) {
         const d = new Date(today);
         d.setDate(today.getDate() + i);
         const dateStr = formatLocalDate(d);
-        const slots = await getSlots(token, dateStr);
+        const slots = await getSlots(dateStr);
         return (slots as Slot[])
           .filter(s => s.available > 0)
           .map(s => `${formatDate(dateStr)} ${formatTime(s.startTime)}-${formatTime(s.endTime)}`);
@@ -331,7 +329,7 @@ function UserDashboard({ token }: { token: string }) {
         setSlotOptions(merged.slice(0, 3));
       })
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   const appointments = bookings.filter(b => b.status === 'approved');
   const pending = bookings.filter(b => b.status === 'submitted');
@@ -423,8 +421,8 @@ function UserDashboard({ token }: { token: string }) {
   );
 }
 
-export default function Dashboard({ role, token }: DashboardProps) {
-  if (role === 'staff') return <StaffDashboard token={token} />;
-  return <UserDashboard token={token} />;
+export default function Dashboard({ role }: DashboardProps) {
+  if (role === 'staff') return <StaffDashboard />;
+  return <UserDashboard />;
 }
 

--- a/MJ_FB_Frontend/src/pages/UserDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/UserDashboard.tsx
@@ -79,7 +79,7 @@ function statusColor(status: string):
   }
 }
 
-export default function UserDashboard({ token }: { token: string }) {
+export default function UserDashboard() {
   const navigate = useNavigate();
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [nextSlots, setNextSlots] = useState<NextSlot[]>([]);
@@ -88,10 +88,10 @@ export default function UserDashboard({ token }: { token: string }) {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    getBookingHistory(token)
+    getBookingHistory()
       .then(setBookings)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     const today = new Date();
@@ -100,18 +100,18 @@ export default function UserDashboard({ token }: { token: string }) {
         const d = new Date(today);
         d.setDate(today.getDate() + i);
         const dateStr = d.toISOString().split('T')[0];
-        const slots = (await getSlots(token, dateStr)) as Slot[];
+        const slots = (await getSlots(dateStr)) as Slot[];
         const first = slots.find(s => (s.available ?? 0) > 0);
         return first ? { date: dateStr, slot: first } : null;
       }),
     )
       .then(res => setNextSlots(res.filter(Boolean).slice(0, 3) as NextSlot[]))
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   useEffect(() => {
-    getHolidays(token).then(setHolidays).catch(() => {});
-  }, [token]);
+    getHolidays().then(setHolidays).catch(() => {});
+  }, []);
 
   const today = new Date();
   const approved = bookings
@@ -128,7 +128,7 @@ export default function UserDashboard({ token }: { token: string }) {
   async function confirmCancel() {
     if (!cancelId) return;
     try {
-      await cancelBooking(token, String(cancelId));
+      await cancelBooking(String(cancelId));
       setMessage('Booking cancelled');
       setBookings(prev => prev.filter(b => b.id !== cancelId));
     } catch (err) {


### PR DESCRIPTION
## Summary
- drop unused token parameters from booking, user, and volunteer API helpers
- simplify components and pages to no longer pass redundant tokens

## Testing
- `npm test` *(fails: jest-environment-jsdom not installed, attempted install but 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a68189bd20832d82267869563cd45f