### PR TITLE
refactor: remove unused booking token params

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -111,13 +111,13 @@ export default function App() {
                   ) : isStaff ? (
                     <Dashboard role="staff" token={token} />
                   ) : (
-                    <UserDashboard token={token} />
+                    <UserDashboard />
                   )
                 }
               />
               <Route path="/profile" element={<Profile token={token} role={role} />} />
               {isStaff && (
-                <Route path="/manage-availability" element={<ManageAvailability token={token} />} />
+                <Route path="/manage-availability" element={<ManageAvailability />} />
               )}
               {isStaff && (
                 <Route path="/pantry-schedule" element={<PantrySchedule token={token} />} />
@@ -152,7 +152,7 @@ export default function App() {
               )}
               {isStaff && <Route path="/add-user" element={<AddUser token={token} />} />}
               {isStaff && <Route path="/user-history" element={<UserHistory token={token} />} />}
-              {isStaff && <Route path="/pending" element={<Pending token={token} />} />}
+              {isStaff && <Route path="/pending" element={<Pending />} />}
               {isStaff && (
                 <>
                   <Route

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -1,7 +1,7 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
 import type { Slot, SlotsByDate } from '../types';
 
-export async function getSlots(token: string, date?: string) {
+export async function getSlots(date?: string) {
   let url = `${API_BASE}/slots`;
   if (date) url += `?date=${encodeURIComponent(date)}`;
   const res = await apiFetch(url);
@@ -15,7 +15,6 @@ export async function getSlots(token: string, date?: string) {
 }
 
 export async function getSlotsRange(
-  token: string,
   start: string,
   days: number,
 ): Promise<SlotsByDate[]> {
@@ -35,7 +34,7 @@ export async function getSlotsRange(
   }));
 }
 
-export async function createBooking(token: string, slotId: string, date: string) {
+export async function createBooking(slotId: string, date: string) {
   const res = await apiFetch(`${API_BASE}/bookings`, {
     method: 'POST',
     headers: {
@@ -46,7 +45,7 @@ export async function createBooking(token: string, slotId: string, date: string)
   return handleResponse(res);
 }
 
-export async function getBookings(token: string, opts: { status?: string } = {}) {
+export async function getBookings(opts: { status?: string } = {}) {
   const params = new URLSearchParams();
   if (opts.status) params.append('status', opts.status);
   const query = params.toString();
@@ -55,8 +54,7 @@ export async function getBookings(token: string, opts: { status?: string } = {})
 }
 
 export async function getBookingHistory(
-  token: string,
-  opts: { status?: string; past?: boolean; userId?: number } = {}
+  opts: { status?: string; past?: boolean; userId?: number } = {},
 ) {
   const params = new URLSearchParams();
   if (opts.status) params.append('status', opts.status);
@@ -68,12 +66,12 @@ export async function getBookingHistory(
   return handleResponse(res);
 }
 
-export async function getHolidays(token: string) {
+export async function getHolidays() {
   const res = await apiFetch(`${API_BASE}/holidays`);
   return handleResponse(res);
 }
 
-export async function addHoliday(token: string, date: string, reason: string): Promise<void> {
+export async function addHoliday(date: string, reason: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/holidays`, {
     method: 'POST',
     headers: {
@@ -84,14 +82,14 @@ export async function addHoliday(token: string, date: string, reason: string): P
   await handleResponse(res);
 }
 
-export async function removeHoliday(token: string, date: string): Promise<void> {
+export async function removeHoliday(date: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/holidays/${encodeURIComponent(date)}`, {
     method: 'DELETE',
   });
   await handleResponse(res);
 }
 
-export async function getAllSlots(token: string) {
+export async function getAllSlots() {
   const res = await apiFetch(`${API_BASE}/slots/all`);
   const data = await handleResponse(res);
   return data.map((s: any) => ({
@@ -102,13 +100,12 @@ export async function getAllSlots(token: string) {
   })) as Slot[];
 }
 
-export async function getBlockedSlots(token: string, date: string) {
+export async function getBlockedSlots(date: string) {
   const res = await apiFetch(`${API_BASE}/blocked-slots?date=${encodeURIComponent(date)}`);
   return handleResponse(res);
 }
 
 export async function addBlockedSlot(
-  token: string,
   date: string,
   slotId: number,
   reason: string
@@ -123,20 +120,19 @@ export async function addBlockedSlot(
   await handleResponse(res);
 }
 
-export async function removeBlockedSlot(token: string, date: string, slotId: number): Promise<void> {
+export async function removeBlockedSlot(date: string, slotId: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/blocked-slots/${encodeURIComponent(date)}/${slotId}`, {
     method: 'DELETE',
   });
   await handleResponse(res);
 }
 
-export async function getBreaks(token: string) {
+export async function getBreaks() {
   const res = await apiFetch(`${API_BASE}/breaks`);
   return handleResponse(res);
 }
 
 export async function addBreak(
-  token: string,
   dayOfWeek: number,
   slotId: number,
   reason: string
@@ -151,7 +147,7 @@ export async function addBreak(
   await handleResponse(res);
 }
 
-export async function removeBreak(token: string, dayOfWeek: number, slotId: number): Promise<void> {
+export async function removeBreak(dayOfWeek: number, slotId: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/breaks/${dayOfWeek}/${slotId}`, {
     method: 'DELETE',
   });
@@ -159,7 +155,6 @@ export async function removeBreak(token: string, dayOfWeek: number, slotId: numb
 }
 
 export async function decideBooking(
-  token: string,
   bookingId: string,
   decision: 'approve' | 'reject',
   reason: string
@@ -175,7 +170,6 @@ export async function decideBooking(
 }
 
 export async function cancelBooking(
-  token: string,
   bookingId: string,
   reason?: string
 ): Promise<void> {
@@ -190,7 +184,6 @@ export async function cancelBooking(
 }
 
 export async function createBookingForUser(
-  token: string,
   userId: number,
   slotId: number,
   date: string,
@@ -207,16 +200,16 @@ export async function createBookingForUser(
 }
 
 export async function rescheduleBookingByToken(
-  token: string,
+  rescheduleToken: string,
   slotId: string,
   date: string,
-  authToken?: string,
 ): Promise<void> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  const res = await apiFetch(`${API_BASE}/bookings/reschedule/${token}`, {
+  const res = await apiFetch(`${API_BASE}/bookings/reschedule/${rescheduleToken}`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ slotId, date }),
   });
   await handleResponse(res);
 }
+

--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -15,7 +15,6 @@ import type { Slot } from '../types';
 
 interface RescheduleDialogProps {
   open: boolean;
-  token: string;
   rescheduleToken: string;
   onClose: () => void;
   onRescheduled: () => void;
@@ -23,7 +22,6 @@ interface RescheduleDialogProps {
 
 export default function RescheduleDialog({
   open,
-  token,
   rescheduleToken,
   onClose,
   onRescheduled,
@@ -35,14 +33,14 @@ export default function RescheduleDialog({
 
   useEffect(() => {
     if (open && date) {
-      getSlots(token, date)
+      getSlots(date)
         .then(setSlots)
         .catch(() => setSlots([]));
     } else {
       setSlots([]);
       setSlotId('');
     }
-  }, [open, date, token]);
+  }, [open, date]);
 
   async function submit() {
     if (!date || !slotId) {
@@ -50,7 +48,7 @@ export default function RescheduleDialog({
       return;
     }
     try {
-      await rescheduleBookingByToken(rescheduleToken, slotId, date, token);
+      await rescheduleBookingByToken(rescheduleToken, slotId, date);
       onRescheduled();
       onClose();
       setDate('');

--- a/MJ_FB_Frontend/src/components/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/components/SlotBooking.tsx
@@ -65,8 +65,8 @@ export default function SlotBooking({ token, role }: Props) {
   }, []);
 
   const { data: holidays = [] } = useQuery<Holiday[]>({
-    queryKey: ['holidays', token],
-    queryFn: () => getHolidays(token),
+    queryKey: ['holidays'],
+    queryFn: () => getHolidays(),
   });
 
   const isHoliday = useCallback(
@@ -143,7 +143,7 @@ export default function SlotBooking({ token, role }: Props) {
   const slotsEnabled = !!selectedDate && !isWeekend(selectedDate) && !isHoliday(selectedDate);
   const { data: slots = [] } = useQuery<Slot[]>({
     queryKey: ['slots', token, selectedDate ? formatDate(selectedDate) : null],
-    queryFn: () => getSlots(token, formatDate(selectedDate as Date)),
+    queryFn: () => getSlots(formatDate(selectedDate as Date)),
     enabled: slotsEnabled,
     onError: (err: unknown) => setMessage(err instanceof Error ? err.message : 'Failed to load slots'),
   });
@@ -151,11 +151,11 @@ export default function SlotBooking({ token, role }: Props) {
   const queryClient = useQueryClient();
   const bookingMutation = useMutation({
     mutationFn: (vars: { slotId: string; date: string }) =>
-      createBooking(token, vars.slotId, vars.date),
+      createBooking(vars.slotId, vars.date),
   });
   const staffBookingMutation = useMutation({
     mutationFn: (vars: { userId: number; slotId: number; date: string }) =>
-      createBookingForUser(token, vars.userId, vars.slotId, vars.date, true),
+      createBookingForUser(vars.userId, vars.slotId, vars.date, true),
   });
 
   async function submitBooking() {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/ManageAvailability.tsx
@@ -18,7 +18,7 @@ import { Box, Button } from '@mui/material';
 
 const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-export default function ManageAvailability({ token }: { token: string }) {
+export default function ManageAvailability() {
   const [view, setView] = useState<'holiday' | 'blocked' | 'break'>('holiday');
 
   const [holidays, setHolidays] = useState<Holiday[]>([]);
@@ -41,21 +41,21 @@ export default function ManageAvailability({ token }: { token: string }) {
 
   const fetchHolidays = useCallback(async () => {
     try {
-      const data = await getHolidays(token);
+      const data = await getHolidays();
       setHolidays(data);
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
     }
-  }, [token]);
+  }, []);
 
   const fetchBreaks = useCallback(async () => {
     try {
-      const data = await getBreaks(token);
+      const data = await getBreaks();
       setBreaks(data);
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
     }
-  }, [token]);
+  }, []);
 
   const fetchBlocked = useCallback(async () => {
     if (!blockedDate) {
@@ -63,20 +63,20 @@ export default function ManageAvailability({ token }: { token: string }) {
       return;
     }
     try {
-      const data = await getBlockedSlots(token, blockedDate);
+      const data = await getBlockedSlots(blockedDate);
       setBlockedList(data);
     } catch (err: unknown) {
       setMessage(err instanceof Error ? err.message : String(err));
     }
-  }, [token, blockedDate]);
+  }, [blockedDate]);
 
   useEffect(() => {
     fetchHolidays();
     fetchBreaks();
-    getAllSlots(token)
+    getAllSlots()
       .then(setAllSlots)
       .catch(err => setMessage(err instanceof Error ? err.message : String(err)));
-  }, [fetchHolidays, fetchBreaks, token]);
+  }, [fetchHolidays, fetchBreaks]);
 
   useEffect(() => {
     fetchBlocked();
@@ -85,7 +85,7 @@ export default function ManageAvailability({ token }: { token: string }) {
   async function addHoliday() {
     if (!newHoliday) return setMessage('Select a date to add');
     try {
-      await apiAddHoliday(token, newHoliday, newHolidayReason);
+      await apiAddHoliday(newHoliday, newHolidayReason);
       setMessage('Holiday added');
       setNewHoliday('');
       setNewHolidayReason('');
@@ -97,7 +97,7 @@ export default function ManageAvailability({ token }: { token: string }) {
 
   async function removeHoliday(date: string) {
     try {
-      await apiRemoveHoliday(token, date);
+      await apiRemoveHoliday(date);
       setMessage('Holiday removed');
       fetchHolidays();
     } catch (err: unknown) {
@@ -108,7 +108,7 @@ export default function ManageAvailability({ token }: { token: string }) {
   async function addBlocked() {
     if (!blockedDate || !blockedSlot) return setMessage('Select date and slot');
     try {
-      await apiAddBlockedSlot(token, blockedDate, Number(blockedSlot), blockedReason);
+      await apiAddBlockedSlot(blockedDate, Number(blockedSlot), blockedReason);
       setMessage('Slot blocked');
       setBlockedSlot('');
       setBlockedReason('');
@@ -120,7 +120,7 @@ export default function ManageAvailability({ token }: { token: string }) {
 
   async function removeBlocked(slotId: number) {
     try {
-      await apiRemoveBlockedSlot(token, blockedDate, slotId);
+      await apiRemoveBlockedSlot(blockedDate, slotId);
       setMessage('Blocked slot removed');
       fetchBlocked();
     } catch (err: unknown) {
@@ -131,7 +131,7 @@ export default function ManageAvailability({ token }: { token: string }) {
   async function addBreak() {
     if (breakDay === '' || breakSlot === '') return setMessage('Select day and slot');
     try {
-      await apiAddBreak(token, Number(breakDay), Number(breakSlot), breakReason);
+      await apiAddBreak(Number(breakDay), Number(breakSlot), breakReason);
       setMessage('Break added');
       setBreakDay('');
       setBreakSlot('');
@@ -144,7 +144,7 @@ export default function ManageAvailability({ token }: { token: string }) {
 
   async function removeBreak(day: number, slotId: number) {
     try {
-      await apiRemoveBreak(token, day, slotId);
+      await apiRemoveBreak(day, slotId);
       setMessage('Break removed');
       fetchBreaks();
     } catch (err: unknown) {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
@@ -64,9 +64,9 @@ export default function PantrySchedule({ token }: { token: string }) {
     }
     try {
       const [slotsData, bookingsData, blockedData] = await Promise.all([
-        getSlots(token, dateStr),
-        getBookings(token),
-        getBlockedSlots(token, dateStr),
+        getSlots(dateStr),
+        getBookings(),
+        getBlockedSlots(dateStr),
       ]);
       setSlots(slotsData);
       setBlockedSlots(blockedData);
@@ -77,13 +77,13 @@ export default function PantrySchedule({ token }: { token: string }) {
     } catch (err) {
       console.error(err);
     }
-  }, [currentDate, token, holidays]);
+  }, [currentDate, holidays]);
 
   useEffect(() => {
-    getHolidays(token).then(setHolidays).catch(() => {});
-    getBreaks(token).then(setBreaks).catch(() => {});
-    getAllSlots(token).then(setAllSlots).catch(() => {});
-  }, [token]);
+    getHolidays().then(setHolidays).catch(() => {});
+    getBreaks().then(setBreaks).catch(() => {});
+    getAllSlots().then(setAllSlots).catch(() => {});
+  }, []);
 
   useEffect(() => {
     loadData();
@@ -113,7 +113,7 @@ export default function PantrySchedule({ token }: { token: string }) {
       return;
     }
     try {
-      await decideBooking(token, decisionBooking.id.toString(), decision, decisionReason);
+      await decideBooking(decisionBooking.id.toString(), decision, decisionReason);
       await loadData();
       setSnackbar({ message: `Booking ${decision}d`, severity: 'success' });
     } catch {
@@ -127,7 +127,7 @@ export default function PantrySchedule({ token }: { token: string }) {
   async function cancelSelected() {
     if (!decisionBooking) return;
     try {
-      await cancelBooking(token, decisionBooking.id.toString(), decisionReason);
+      await cancelBooking(decisionBooking.id.toString(), decisionReason);
       await loadData();
       setSnackbar({ message: 'Booking cancelled', severity: 'success' });
     } catch {
@@ -150,7 +150,6 @@ export default function PantrySchedule({ token }: { token: string }) {
     try {
       setAssignMessage('');
       await createBookingForUser(
-        token,
         user.id,
         parseInt(assignSlot.id),
         formatDate(currentDate),
@@ -400,7 +399,6 @@ export default function PantrySchedule({ token }: { token: string }) {
       {rescheduleBooking && (
         <RescheduleDialog
           open={!!rescheduleBooking}
-          token={token}
           rescheduleToken={rescheduleBooking.reschedule_token}
           onClose={() => setRescheduleBooking(null)}
           onRescheduled={() => {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/Pending.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/Pending.tsx
@@ -17,25 +17,25 @@ interface Booking {
   endTime?: string;
 }
 
-export default function Pending({ token }: { token: string }) {
+export default function Pending() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [reasons, setReasons] = useState<Record<number, string>>({});
   const [message, setMessage] = useState('');
   const [severity, setSeverity] = useState<'success' | 'error'>('success');
 
   function loadBookings() {
-    getBookings(token, { status: 'pending' })
+    getBookings({ status: 'pending' })
       .then(b => setBookings(b.filter(x => x.status === 'submitted')))
       .catch(() => {});
   }
 
   useEffect(() => {
     loadBookings();
-  }, [token]);
+  }, []);
 
   async function handleDecision(id: number, decision: 'approve' | 'reject') {
     try {
-      await decideBooking(token, String(id), decision, reasons[id] || '');
+      await decideBooking(String(id), decision, reasons[id] || '');
       setSeverity('success');
       setMessage(`Booking ${decision === 'approve' ? 'approved' : 'rejected'}`);
       setReasons(r => {

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -63,7 +63,7 @@ export default function UserHistory({
     if (!initialUser) opts.userId = selected.id;
     if (filter === 'past') opts.past = true;
     else if (filter !== 'all') opts.status = filter;
-    return getBookingHistory(token, opts)
+    return getBookingHistory(opts)
       .then(data => {
         const sorted = [...data].sort(
           (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
@@ -72,7 +72,7 @@ export default function UserHistory({
         setPage(1);
       })
       .catch(err => console.error('Error loading history:', err));
-  }, [selected, filter, token, initialUser]);
+  }, [selected, filter, initialUser]);
 
   useEffect(() => {
     loadBookings();
@@ -238,7 +238,6 @@ export default function UserHistory({
         {rescheduleBooking && (
           <RescheduleDialog
             open={!!rescheduleBooking}
-            token={token}
             rescheduleToken={rescheduleBooking.reschedule_token}
             onClose={() => setRescheduleBooking(null)}
             onRescheduled={() => {

--- a/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
@@ -106,8 +106,8 @@ export default function VolunteerSchedule({ token }: { token: string }) {
   }, [currentDate, token, holidays]);
 
   useEffect(() => {
-    getHolidays(token).then(setHolidays).catch(() => {});
-  }, [token]);
+    getHolidays().then(setHolidays).catch(() => {});
+  }, []);
 
   useEffect(() => {
     loadData();

--- a/MJ_FB_Frontend/src/pages/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/Dashboard.tsx
@@ -91,7 +91,7 @@ function StaffDashboard({ token }: { token: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    getBookings(token).then(setBookings).catch(() => {});
+    getBookings().then(setBookings).catch(() => {});
 
     const todayStr = formatLocalDate(new Date());
     getVolunteerRoles(token)
@@ -113,7 +113,7 @@ function StaffDashboard({ token }: { token: string }) {
 
     const today = new Date();
     const todayStr = formatLocalDate(today);
-    getSlotsRange(token, todayStr, 7)
+    getSlotsRange(todayStr, 7)
       .then(days =>
         days.map(d => ({
           day: new Date(d.date).toLocaleDateString(undefined, {
@@ -124,7 +124,7 @@ function StaffDashboard({ token }: { token: string }) {
       )
       .then(setSchedule)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   const todayStr = formatLocalDate(new Date());
   const pending = bookings.filter(b => b.status === 'submitted');
@@ -301,15 +301,15 @@ function StaffDashboard({ token }: { token: string }) {
   );
 }
 
-function UserDashboard({ token }: { token: string }) {
+function UserDashboard() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [slotOptions, setSlotOptions] = useState<string[]>([]);
 
   useEffect(() => {
-    getBookings(token).then(setBookings).catch(() => {});
+    getBookings().then(setBookings).catch(() => {});
 
     const todayStr = formatLocalDate(new Date());
-    getSlotsRange(token, todayStr, 5)
+    getSlotsRange(todayStr, 5)
       .then(days => {
         const merged = days.flatMap(d =>
           d.slots
@@ -415,6 +415,6 @@ function UserDashboard({ token }: { token: string }) {
 
 export default function Dashboard({ role, token }: DashboardProps) {
   if (role === 'staff') return <StaffDashboard token={token} />;
-  return <UserDashboard token={token} />;
+  return <UserDashboard />;
 }
 

--- a/MJ_FB_Frontend/src/pages/UserDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/UserDashboard.tsx
@@ -79,7 +79,7 @@ function statusColor(status: string):
   }
 }
 
-export default function UserDashboard({ token }: { token: string }) {
+export default function UserDashboard() {
   const navigate = useNavigate();
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [nextSlots, setNextSlots] = useState<NextSlot[]>([]);
@@ -88,10 +88,10 @@ export default function UserDashboard({ token }: { token: string }) {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    getBookingHistory(token)
+    getBookingHistory()
       .then(setBookings)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     const today = new Date();
@@ -100,18 +100,18 @@ export default function UserDashboard({ token }: { token: string }) {
         const d = new Date(today);
         d.setDate(today.getDate() + i);
         const dateStr = d.toISOString().split('T')[0];
-        const slots = (await getSlots(token, dateStr)) as Slot[];
+        const slots = (await getSlots(dateStr)) as Slot[];
         const first = slots.find(s => (s.available ?? 0) > 0);
         return first ? { date: dateStr, slot: first } : null;
       }),
     )
       .then(res => setNextSlots(res.filter(Boolean).slice(0, 3) as NextSlot[]))
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   useEffect(() => {
-    getHolidays(token).then(setHolidays).catch(() => {});
-  }, [token]);
+    getHolidays().then(setHolidays).catch(() => {});
+  }, []);
 
   const today = new Date();
   const approved = bookings
@@ -128,7 +128,7 @@ export default function UserDashboard({ token }: { token: string }) {
   async function confirmCancel() {
     if (!cancelId) return;
     try {
-      await cancelBooking(token, String(cancelId));
+      await cancelBooking(String(cancelId));
       setMessage('Booking cancelled');
       setBookings(prev => prev.filter(b => b.id !== cancelId));
     } catch (err) {


### PR DESCRIPTION
## Summary
- remove `token` arguments from booking API wrappers
- drop token props from UI components that no longer require them
- update reschedule dialog to call booking APIs without token

## Testing
- `npm test` *(fails: jest-environment-jsdom missing; install attempt blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a6843fcb60832d97e0df538015794c