### PR TITLE
fix: expose dev server and add jsdom env

### DIFF
--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -42,6 +42,7 @@
     "@testing-library/jest-dom": "^6.4.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/MJ_FB_Frontend/vite.config.ts
+++ b/MJ_FB_Frontend/vite.config.ts
@@ -4,4 +4,14 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    port: 5173,
+    strictPort: true,
+    hmr: {
+      protocol: 'ws',
+      host: 'localhost',
+      port: 5173,
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to explicitly expose port 5173 and HMR websocket
- add `jest-environment-jsdom` dev dependency for Jest tests

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88f48a188832da92948edcb4707e9