### PR TITLE
fix: use centralized API client for role schedule

### DIFF
--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -1,5 +1,10 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
-import type { VolunteerRole, VolunteerRoleWithShifts } from '../types';
+import type {
+  VolunteerRole,
+  VolunteerRoleWithShifts,
+  RoleOption,
+  Shift,
+} from '../types';
 import type { LoginResponse } from './users';
 
 export async function loginVolunteer(
@@ -19,6 +24,16 @@ export async function searchVolunteers(_token: string, search: string) {
   const res = await apiFetch(
     `${API_BASE}/volunteers/search?search=${encodeURIComponent(search)}`,
   );
+  return handleResponse(res);
+}
+
+export async function getRoles(): Promise<RoleOption[]> {
+  const res = await apiFetch(`${API_BASE}/api/roles`);
+  return handleResponse(res);
+}
+
+export async function getRoleShifts(roleId: number): Promise<Shift[]> {
+  const res = await apiFetch(`${API_BASE}/api/roles/${roleId}/shifts`);
   return handleResponse(res);
 }
 

--- a/MJ_FB_Frontend/src/components/RoleSelect.tsx
+++ b/MJ_FB_Frontend/src/components/RoleSelect.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react';
 import type { RoleOption } from '../types';
+import { getRoles } from '../api/volunteers';
 
 interface Props {
   onChange: (roleId: number) => void;
 }
-
-const API_BASE = import.meta.env.VITE_API_BASE || '';
 
 export default function RoleSelect({ onChange }: Props) {
   const [roles, setRoles] = useState<RoleOption[]>([]);
@@ -17,10 +16,9 @@ export default function RoleSelect({ onChange }: Props) {
     const fetchRoles = async () => {
       setLoading(true);
       try {
-        const res = await fetch(`${API_BASE}/api/roles`);
-        if (!res.ok) throw new Error('Failed to load roles');
-        const data: RoleOption[] = await res.json();
+        const data = await getRoles();
         setRoles(data);
+        setError(null);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Error fetching roles');
       } finally {

--- a/MJ_FB_Frontend/src/pages/CoordinatorSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/CoordinatorSchedule.tsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react';
 import RoleSelect from '../components/RoleSelect';
 import ScheduleTable from '../components/ScheduleTable';
 import type { Shift } from '../types';
-
-const API_BASE = import.meta.env.VITE_API_BASE || '';
+import { getRoleShifts } from '../api/volunteers';
 
 export default function CoordinatorSchedule() {
   const [roleId, setRoleId] = useState<number | null>(null);
@@ -16,9 +15,7 @@ export default function CoordinatorSchedule() {
     const fetchShifts = async () => {
       setLoading(true);
       try {
-        const res = await fetch(`${API_BASE}/api/roles/${roleId}/shifts`);
-        if (!res.ok) throw new Error('Failed to load shifts');
-        const data: Shift[] = await res.json();
+        const data = await getRoleShifts(roleId);
         setShifts(data);
         setError(null);
       } catch (err) {


### PR DESCRIPTION
## Summary
- add role and shift helpers to volunteers API client
- switch RoleSelect and CoordinatorSchedule to the new helpers

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a896e23298832d9362263daea6ed3c