### PR TITLE
Handle missing Power Automate URL gracefully

### DIFF
--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -1,8 +1,10 @@
 import config from '../config';
+import logger from './logger';
 
 export async function sendEmail(to: string, subject: string, body: string): Promise<void> {
-  if (!config.powerAutomateUrl) {
-    console.warn('POWER_AUTOMATE_URL is not configured');
+  // Skip sending if the URL is missing or still set to the placeholder value
+  if (!config.powerAutomateUrl || config.powerAutomateUrl === 'your_flow_url') {
+    logger.warn('POWER_AUTOMATE_URL is not configured');
     return;
   }
 
@@ -13,15 +15,18 @@ export async function sendEmail(to: string, subject: string, body: string): Prom
     headers['x-functions-key'] = config.powerAutomateKey;
   }
 
-  const response = await fetch(config.powerAutomateUrl, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ to, subject, body }),
-  });
+  try {
+    const response = await fetch(config.powerAutomateUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ to, subject, body }),
+    });
 
-  if (!response.ok) {
-    const text = await response.text();
-    console.error(`Failed to send email: ${response.status} ${text}`);
-    throw new Error('Failed to send email');
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      logger.error(`Failed to send email: ${response.status} ${text}`);
+    }
+  } catch (error) {
+    logger.error('Failed to send email:', error);
   }
 }


### PR DESCRIPTION
## Summary
- Avoid throwing errors when email flow URL isn't configured
- Log failures when sending notification emails instead of aborting requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8ab128218832d8f631a5c45216d08