### PR TITLE
Serve frontend build with Express

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
+import path from 'path';
 import config from './config';
 import usersRoutes from './routes/users';
 import slotsRoutes from './routes/slots';
@@ -45,6 +46,21 @@ app.use('/volunteer-bookings', volunteerBookingsRoutes);
 app.use('/auth', authRoutes);
 app.use('/api/roles', rolesRoutes);
 app.use('/donors', donorsRoutes);
+
+// Serve the frontend in production
+if (process.env.NODE_ENV === 'production') {
+  const frontendPath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'MJ_FB_Frontend',
+    'dist'
+  );
+  app.use(express.static(frontendPath));
+  app.get('*', (_req, res) => {
+    res.sendFile(path.join(frontendPath, 'index.html'));
+  });
+}
 
 // Global error handler
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Summary
- serve React build from Express when running in production

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: jest not found, package install error)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a9e2c534832db7b8e681b82237b3