### PR TITLE
Use theme colors for schedule statuses

### DIFF
--- a/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
@@ -6,7 +6,7 @@ import { fromZonedTime, toZonedTime, formatInTimeZone } from 'date-fns-tz';
 import { formatTime } from '../../utils/time';
 import VolunteerScheduleTable from '../VolunteerScheduleTable';
 import FeedbackSnackbar from '../FeedbackSnackbar';
-import { Button, type AlertColor } from '@mui/material';
+import { Button, type AlertColor, useTheme } from '@mui/material';
 import RescheduleDialog from '../RescheduleDialog';
 
 interface Booking {
@@ -50,6 +50,8 @@ export default function PantrySchedule({ token }: { token: string }) {
   const [showRejectReason, setShowRejectReason] = useState(false);
   const [assignMessage, setAssignMessage] = useState('');
   const [rescheduleBooking, setRescheduleBooking] = useState<Booking | null>(null);
+
+  const theme = useTheme();
 
   const formatDate = (date: Date) => formatInTimeZone(date, reginaTimeZone, 'yyyy-MM-dd');
 
@@ -227,8 +229,8 @@ export default function PantrySchedule({ token }: { token: string }) {
           content: booking ? booking.user_name : '',
           backgroundColor: booking
             ? booking.status === 'submitted'
-              ? '#ffe5b4'
-              : '#e0f7e0'
+              ? theme.palette.warning.light
+              : theme.palette.success.light
             : undefined,
           onClick: () => {
             if (booking) {

--- a/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
@@ -39,6 +39,7 @@ import {
   TableHead,
   TableRow,
   Typography,
+  useTheme,
 } from '@mui/material';
 import Dashboard from '../pages/Dashboard';
 import EntitySearch from './EntitySearch';
@@ -98,6 +99,8 @@ export default function VolunteerManagement({ token }: { token: string }) {
   const [history, setHistory] = useState<VolunteerBookingDetail[]>([]);
 
   const cellSx = { border: 1, borderColor: 'divider', p: 0.5 } as const;
+
+  const theme = useTheme();
 
   const [shopperOpen, setShopperOpen] = useState(false);
   const [shopperClientId, setShopperClientId] = useState('');
@@ -526,8 +529,8 @@ export default function VolunteerManagement({ token }: { token: string }) {
                 : 'Available',
               backgroundColor: booking
                 ? booking.status.toLowerCase() === 'approved'
-                  ? '#c8e6c9'
-                  : '#ffd8b2'
+                  ? theme.palette.success.light
+                  : theme.palette.warning.light
                 : undefined,
               onClick: () => {
                 if (booking) {

--- a/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
@@ -31,6 +31,7 @@ import {
   DialogActions,
   TextField,
   Typography,
+  useTheme,
 } from '@mui/material';
 
 const reginaTimeZone = 'America/Regina';
@@ -49,6 +50,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     useState<VolunteerBooking | null>(null);
   const [decisionReason, setDecisionReason] = useState('');
   const [message, setMessage] = useState('');
+  const theme = useTheme();
 
   const formatDate = (date: Date) =>
     formatInTimeZone(date, reginaTimeZone, 'yyyy-MM-dd');
@@ -210,7 +212,9 @@ export default function VolunteerSchedule({ token }: { token: string }) {
       cells.push({
         content: 'My Booking',
         backgroundColor:
-          myBooking.status === 'pending' ? '#ffe5b4' : '#e0f7e0',
+          myBooking.status === 'pending'
+            ? theme.palette.warning.light
+            : theme.palette.success.light,
         onClick: () => {
           setDecisionBooking(myBooking);
           setDecisionReason('');
@@ -219,7 +223,10 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     }
     for (let i = cells.length; i < role.max_volunteers; i++) {
       if (i - (myBooking ? 1 : 0) < othersBooked) {
-        cells.push({ content: 'Booked', backgroundColor: '#f5f5f5' });
+        cells.push({
+          content: 'Booked',
+          backgroundColor: theme.palette.grey[200],
+        });
       } else {
         cells.push({
           content: 'Available',


### PR DESCRIPTION
## Summary
- use MUI theme palette for schedule status colors
- approved bookings now appear with a green background in schedules

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b2768218832da0a80d4f00519781