### PR TITLE
Use lighter success color for approved schedule cells

### DIFF
--- a/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
@@ -7,6 +7,7 @@ import { formatTime } from '../../utils/time';
 import VolunteerScheduleTable from '../VolunteerScheduleTable';
 import FeedbackSnackbar from '../FeedbackSnackbar';
 import { Button, type AlertColor, useTheme } from '@mui/material';
+import { lighten } from '@mui/material/styles';
 import RescheduleDialog from '../RescheduleDialog';
 
 interface Booking {
@@ -52,6 +53,7 @@ export default function PantrySchedule({ token }: { token: string }) {
   const [rescheduleBooking, setRescheduleBooking] = useState<Booking | null>(null);
 
   const theme = useTheme();
+  const approvedColor = lighten(theme.palette.success.light, 0.4);
 
   const formatDate = (date: Date) => formatInTimeZone(date, reginaTimeZone, 'yyyy-MM-dd');
 
@@ -230,7 +232,7 @@ export default function PantrySchedule({ token }: { token: string }) {
           backgroundColor: booking
             ? booking.status === 'submitted'
               ? theme.palette.warning.light
-              : theme.palette.success.light
+              : approvedColor
             : undefined,
           onClick: () => {
             if (booking) {

--- a/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
@@ -41,6 +41,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import { lighten } from '@mui/material/styles';
 import Dashboard from '../pages/Dashboard';
 import EntitySearch from './EntitySearch';
 import ConfirmDialog from './ConfirmDialog';
@@ -101,6 +102,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
   const cellSx = { border: 1, borderColor: 'divider', p: 0.5 } as const;
 
   const theme = useTheme();
+  const approvedColor = lighten(theme.palette.success.light, 0.4);
 
   const [shopperOpen, setShopperOpen] = useState(false);
   const [shopperClientId, setShopperClientId] = useState('');
@@ -529,7 +531,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
                 : 'Available',
               backgroundColor: booking
                 ? booking.status.toLowerCase() === 'approved'
-                  ? theme.palette.success.light
+                  ? approvedColor
                   : theme.palette.warning.light
                 : undefined,
               onClick: () => {

--- a/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerSchedule.tsx
@@ -33,6 +33,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import { lighten } from '@mui/material/styles';
 
 const reginaTimeZone = 'America/Regina';
 
@@ -51,6 +52,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
   const [decisionReason, setDecisionReason] = useState('');
   const [message, setMessage] = useState('');
   const theme = useTheme();
+  const approvedColor = lighten(theme.palette.success.light, 0.4);
 
   const formatDate = (date: Date) =>
     formatInTimeZone(date, reginaTimeZone, 'yyyy-MM-dd');
@@ -214,7 +216,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
         backgroundColor:
           myBooking.status === 'pending'
             ? theme.palette.warning.light
-            : theme.palette.success.light,
+            : approvedColor,
         onClick: () => {
           setDecisionBooking(myBooking);
           setDecisionReason('');

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -74,9 +74,9 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
                     onClick={cell.onClick}
                     sx={{
                       textAlign: 'center',
-                      backgroundColor: cell.backgroundColor,
                       cursor: cell.onClick ? 'pointer' : 'default',
                     }}
+                    style={cell.backgroundColor ? { backgroundColor: cell.backgroundColor } : undefined}
                   >
                     {cell.content}
                   </TableCell>


### PR DESCRIPTION
## Summary
- Override reset.css zebra striping by applying inline background colors on schedule table cells
- Lighten the success palette color for approved bookings across schedule views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7004e2c832d90ae7f19eb1a2a81