### PR TITLE
Fix rescheduled bookings not appearing in schedule table

### DIFF
--- a/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/PantrySchedule.tsx
@@ -75,9 +75,10 @@ export default function PantrySchedule({ token }: { token: string }) {
       ]);
       setSlots(slotsData);
       setBlockedSlots(blockedData);
-      const filtered = bookingsData.filter(
-        (b: Booking) => b.date.split('T')[0] === dateStr && ['approved', 'submitted'].includes(b.status)
-      );
+      const filtered = bookingsData.filter((b: Booking) => {
+        const bookingDate = formatInTimeZone(new Date(b.date), reginaTimeZone, 'yyyy-MM-dd');
+        return bookingDate === dateStr && ['approved', 'submitted'].includes(b.status);
+      });
       setBookings(filtered);
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- ensure schedule table compares booking dates using Regina timezone

## Testing
- `npm test` (frontend) *(fails: ESM syntax is not allowed in a CommonJS module)*
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68a8b97a8ea8832db3b029375a6086e6