### PR TITLE
Fix missing times in volunteer booking history

### DIFF
--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -4,8 +4,19 @@ import type {
   VolunteerRoleWithShifts,
   RoleOption,
   Shift,
+  VolunteerBooking,
 } from '../types';
 import type { LoginResponse } from './users';
+
+function normalizeVolunteerBooking(b: any): VolunteerBooking {
+  return {
+    ...b,
+    start_time: b.start_time ?? b.startTime,
+    end_time: b.end_time ?? b.endTime,
+    startTime: b.startTime ?? b.start_time,
+    endTime: b.endTime ?? b.end_time,
+  };
+}
 
 export async function loginVolunteer(
   username: string,
@@ -62,7 +73,8 @@ export async function requestVolunteerBooking(
 
 export async function getMyVolunteerBookings(_token: string) {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/mine`);
-  return handleResponse(res);
+  const data = await handleResponse(res);
+  return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
 }
 
 export async function getVolunteerRoles(
@@ -128,9 +140,15 @@ export async function createVolunteerBookingForVolunteer(
   await handleResponse(res);
 }
 
-export async function getVolunteerBookingHistory(_token: string, volunteerId: number) {
-  const res = await apiFetch(`${API_BASE}/volunteer-bookings/volunteer/${volunteerId}`);
-  return handleResponse(res);
+export async function getVolunteerBookingHistory(
+  _token: string,
+  volunteerId: number,
+) {
+  const res = await apiFetch(
+    `${API_BASE}/volunteer-bookings/volunteer/${volunteerId}`,
+  );
+  const data = await handleResponse(res);
+  return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
 }
 
 export async function createVolunteer(


### PR DESCRIPTION
## Summary
- normalize volunteer booking responses to ensure `start_time` and `end_time` fields are always present

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bc4a4e30832db5ee8182b3358193