### PR TITLE
feat: add warehouse tracking routes

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -18,6 +18,10 @@ import VolunteerBookingHistory from './components/VolunteerBookingHistory';
 import VolunteerSchedule from './components/VolunteerSchedule';
 import WarehouseDashboard from './pages/WarehouseDashboard';
 import DonationLog from './pages/DonationLog';
+import TrackPigpound from './pages/TrackPigpound';
+import TrackOutgoingDonations from './pages/TrackOutgoingDonations';
+import TrackSurplus from './pages/TrackSurplus';
+import Aggregations from './pages/Aggregations';
 import Navbar, { type NavGroup } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
@@ -60,6 +64,13 @@ export default function App() {
       links: [
         { label: 'Dashboard', to: '/warehouse-management' },
         { label: 'Donation Log', to: '/warehouse-management/donation-log' },
+        { label: 'Track Pigpound', to: '/warehouse-management/track-pigpound' },
+        {
+          label: 'Track Outgoing Donations',
+          to: '/warehouse-management/track-outgoing-donations',
+        },
+        { label: 'Track Surplus', to: '/warehouse-management/track-surplus' },
+        { label: 'Aggregations', to: '/warehouse-management/aggregations' },
       ],
     });
   } else if (role === 'shopper') {
@@ -135,6 +146,30 @@ export default function App() {
               )}
               {isStaff && (
                 <Route path="/warehouse-management/donation-log" element={<DonationLog />} />
+              )}
+              {isStaff && (
+                <Route
+                  path="/warehouse-management/track-pigpound"
+                  element={<TrackPigpound />}
+                />
+              )}
+              {isStaff && (
+                <Route
+                  path="/warehouse-management/track-outgoing-donations"
+                  element={<TrackOutgoingDonations />}
+                />
+              )}
+              {isStaff && (
+                <Route
+                  path="/warehouse-management/track-surplus"
+                  element={<TrackSurplus />}
+                />
+              )}
+              {isStaff && (
+                <Route
+                  path="/warehouse-management/aggregations"
+                  element={<Aggregations />}
+                />
               )}
               {role === 'shopper' && (
                 <Route path="/slots" element={<SlotBooking token={token} role="shopper" />} />

--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -1,0 +1,5 @@
+import Page from '../components/Page';
+
+export default function Aggregations() {
+  return <Page title="Aggregations">{null}</Page>;
+}

--- a/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
@@ -1,0 +1,5 @@
+import Page from '../components/Page';
+
+export default function TrackOutgoingDonations() {
+  return <Page title="Track Outgoing Donations">{null}</Page>;
+}

--- a/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
@@ -1,0 +1,5 @@
+import Page from '../components/Page';
+
+export default function TrackPigpound() {
+  return <Page title="Track Pigpound">{null}</Page>;
+}

--- a/MJ_FB_Frontend/src/pages/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackSurplus.tsx
@@ -1,0 +1,5 @@
+import Page from '../components/Page';
+
+export default function TrackSurplus() {
+  return <Page title="Track Surplus">{null}</Page>;
+}


### PR DESCRIPTION
## Summary
- add placeholder pages for warehouse tracking features
- wire new pages into warehouse management navigation and routing

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bd1ea790832d870f817a2148724b