### PR TITLE
Add aggregation tabs for warehouse management

### DIFF
--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -1,5 +1,20 @@
+import { useState } from 'react';
+import { Tabs, Tab } from '@mui/material';
 import Page from '../components/Page';
 
 export default function Aggregations() {
-  return <Page title="Aggregations">{null}</Page>;
+  const [tab, setTab] = useState(0);
+
+  return (
+    <Page title="Aggregations">
+      <Tabs value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label="Donor Aggregations" />
+        <Tab label="Retail Program" />
+        <Tab label="Overall" />
+      </Tabs>
+      {tab === 0 && null}
+      {tab === 1 && null}
+      {tab === 2 && null}
+    </Page>
+  );
 }


### PR DESCRIPTION
## Summary
- Add tabbed layout for warehouse management aggregations with sections for Donor Aggregations, Retail Program, and Overall

## Testing
- `npm test` *(fails: ESM syntax not allowed in CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cc4dd80c832db588a633b02ef9a1