### PR TITLE
Highlight pending volunteer bookings

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -75,8 +75,8 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
                     sx={{
                       textAlign: 'center',
                       cursor: cell.onClick ? 'pointer' : 'default',
+                      backgroundColor: cell.backgroundColor,
                     }}
-                    style={cell.backgroundColor ? { backgroundColor: cell.backgroundColor } : undefined}
                   >
                     {cell.content}
                   </TableCell>


### PR DESCRIPTION
## Summary
- Ensure VolunteerScheduleTable applies background color via MUI `sx` prop so pending volunteer bookings use warning tones

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cd76ddc0832da69aa873fa81b2fb