### PR TITLE
Restrict zebra striping to tables with striped class

### DIFF
--- a/MJ_FB_Frontend/src/reset.css
+++ b/MJ_FB_Frontend/src/reset.css
@@ -340,7 +340,8 @@ table tfoot th,table thead th {
 table caption+thead tr:first-child td,table caption+thead tr:first-child th,table colgroup+thead tr:first-child td,table colgroup+thead tr:first-child th,table thead:first-child tr:first-child td,table thead:first-child tr:first-child th {
     border-block-start:1px solid hsla(0,0%,50%,.502)}
 
-table tbody>tr:nth-child(odd)>td,table tbody>tr:nth-child(odd)>th {
+table.striped tbody>tr:nth-child(odd)>td,
+table.striped tbody>tr:nth-child(odd)>th {
     background-color: hsla(0,0%,50%,.071)
 }
 


### PR DESCRIPTION
## Summary
- scope zebra striping to tables with `.striped` class to avoid overriding cell backgrounds

## Testing
- `npm test` *(fails: ESM syntax not allowed in CommonJS modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d13d8fd8832d87ae7699e6c3f89c