### PR TITLE
Add donor aggregation table

### DIFF
--- a/MJ_FB_Backend/src/controllers/donationController.ts
+++ b/MJ_FB_Backend/src/controllers/donationController.ts
@@ -60,3 +60,21 @@ export async function deleteDonation(req: Request, res: Response, next: NextFunc
     next(error);
   }
 }
+
+export async function donorAggregations(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const result = await pool.query(
+      `SELECT to_char(date_trunc('month', d.date), 'YYYY-MM') as month,
+              o.name as donor,
+              SUM(d.weight)::int as total
+       FROM donations d
+       JOIN donors o ON d.donor_id = o.id
+       GROUP BY month, donor
+       ORDER BY month, donor`
+    );
+    res.json(result.rows);
+  } catch (error) {
+    logger.error('Error fetching donor aggregations:', error);
+    next(error);
+  }
+}

--- a/MJ_FB_Backend/src/routes/donations.ts
+++ b/MJ_FB_Backend/src/routes/donations.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { listDonations, addDonation, updateDonation, deleteDonation } from '../controllers/donationController';
+import { listDonations, addDonation, updateDonation, deleteDonation, donorAggregations } from '../controllers/donationController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addDonationSchema, updateDonationSchema } from '../schemas/donationSchemas';
@@ -7,6 +7,7 @@ import { addDonationSchema, updateDonationSchema } from '../schemas/donationSche
 const router = Router();
 
 router.get('/', authMiddleware, authorizeRoles('staff'), listDonations);
+router.get('/aggregations/donors', authMiddleware, authorizeRoles('staff'), donorAggregations);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(addDonationSchema), addDonation);
 router.put('/:id', authMiddleware, authorizeRoles('staff'), validate(updateDonationSchema), updateDonation);
 router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteDonation);

--- a/MJ_FB_Frontend/src/api/donations.ts
+++ b/MJ_FB_Frontend/src/api/donations.ts
@@ -8,6 +8,12 @@ export interface Donation {
   weight: number;
 }
 
+export interface DonorAggregation {
+  month: string;
+  donor: string;
+  total: number;
+}
+
 export async function getDonations(date: string): Promise<Donation[]> {
   const res = await apiFetch(`${API_BASE}/donations?date=${date}`);
   return handleResponse(res);
@@ -34,4 +40,9 @@ export async function updateDonation(id: number, data: { date: string; donorId: 
 export async function deleteDonation(id: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/donations/${id}`, { method: 'DELETE' });
   await handleResponse(res);
+}
+
+export async function getDonorAggregations(): Promise<DonorAggregation[]> {
+  const res = await apiFetch(`${API_BASE}/donations/aggregations/donors`);
+  return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -1,9 +1,21 @@
-import { useState } from 'react';
-import { Tabs, Tab } from '@mui/material';
+import { useState, useEffect } from 'react';
+import { Tabs, Tab, Table, TableHead, TableRow, TableCell, TableBody } from '@mui/material';
 import Page from '../components/Page';
+import { getDonorAggregations, type DonorAggregation } from '../api/donations';
 
 export default function Aggregations() {
   const [tab, setTab] = useState(0);
+  const [rows, setRows] = useState<DonorAggregation[]>([]);
+
+  useEffect(() => {
+    if (tab !== 0) return;
+    getDonorAggregations()
+      .then(setRows)
+      .catch(() => setRows([]));
+  }, [tab]);
+
+  const donors = Array.from(new Set(rows.map(r => r.donor))).sort((a, b) => a.localeCompare(b));
+  const months = Array.from(new Set(rows.map(r => r.month))).sort();
 
   return (
     <Page title="Aggregations">
@@ -12,7 +24,32 @@ export default function Aggregations() {
         <Tab label="Retail Program" />
         <Tab label="Overall" />
       </Tabs>
-      {tab === 0 && null}
+      {tab === 0 && (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Month</TableCell>
+              {donors.map(d => (
+                <TableCell key={d} align="right">
+                  {d}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {months.map(m => (
+              <TableRow key={m}>
+                <TableCell>{m}</TableCell>
+                {donors.map(d => (
+                  <TableCell key={d} align="right">
+                    {rows.find(r => r.month === m && r.donor === d)?.total || 0}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
       {tab === 1 && null}
       {tab === 2 && null}
     </Page>


### PR DESCRIPTION
## Summary
- compute monthly donation totals per donor in backend
- expose donor aggregation data via new API and display in frontend table

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: ESM syntax not allowed in CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d33aa740832d9b1acacedf72042f