### PR TITLE
feat: filter donor aggregations by year

### DIFF
--- a/MJ_FB_Backend/src/controllers/donationController.ts
+++ b/MJ_FB_Backend/src/controllers/donationController.ts
@@ -61,16 +61,19 @@ export async function deleteDonation(req: Request, res: Response, next: NextFunc
   }
 }
 
-export async function donorAggregations(_req: Request, res: Response, next: NextFunction) {
+export async function donorAggregations(req: Request, res: Response, next: NextFunction) {
   try {
+    const year = parseInt((req.query.year as string) ?? '', 10) || new Date().getFullYear();
     const result = await pool.query(
       `SELECT to_char(date_trunc('month', d.date), 'YYYY-MM') as month,
               o.name as donor,
               SUM(d.weight)::int as total
        FROM donations d
        JOIN donors o ON d.donor_id = o.id
+       WHERE EXTRACT(YEAR FROM d.date) = $1
        GROUP BY month, donor
-       ORDER BY month, donor`
+       ORDER BY month, donor`,
+      [year]
     );
     res.json(result.rows);
   } catch (error) {

--- a/MJ_FB_Frontend/src/api/donations.ts
+++ b/MJ_FB_Frontend/src/api/donations.ts
@@ -42,7 +42,7 @@ export async function deleteDonation(id: number): Promise<void> {
   await handleResponse(res);
 }
 
-export async function getDonorAggregations(): Promise<DonorAggregation[]> {
-  const res = await apiFetch(`${API_BASE}/donations/aggregations/donors`);
+export async function getDonorAggregations(year: number): Promise<DonorAggregation[]> {
+  const res = await apiFetch(`${API_BASE}/donations/aggregations/donors?year=${year}`);
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -1,18 +1,33 @@
 import { useState, useEffect } from 'react';
-import { Tabs, Tab, Table, TableHead, TableRow, TableCell, TableBody } from '@mui/material';
+import {
+  Tabs,
+  Tab,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from '@mui/material';
 import Page from '../components/Page';
 import { getDonorAggregations, type DonorAggregation } from '../api/donations';
 
 export default function Aggregations() {
   const [tab, setTab] = useState(0);
   const [rows, setRows] = useState<DonorAggregation[]>([]);
+  const currentYear = new Date().getFullYear();
+  const [year, setYear] = useState(currentYear);
+  const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
 
   useEffect(() => {
     if (tab !== 0) return;
-    getDonorAggregations()
+    getDonorAggregations(year)
       .then(setRows)
       .catch(() => setRows([]));
-  }, [tab]);
+  }, [tab, year]);
 
   const donors = Array.from(new Set(rows.map(r => r.donor))).sort((a, b) => a.localeCompare(b));
   const months = Array.from(new Set(rows.map(r => r.month))).sort();
@@ -25,30 +40,47 @@ export default function Aggregations() {
         <Tab label="Overall" />
       </Tabs>
       {tab === 0 && (
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Month</TableCell>
-              {donors.map(d => (
-                <TableCell key={d} align="right">
-                  {d}
-                </TableCell>
+        <>
+          <FormControl size="small" sx={{ mb: 2, minWidth: 120 }}>
+            <InputLabel id="year-label">Year</InputLabel>
+            <Select
+              labelId="year-label"
+              label="Year"
+              value={year}
+              onChange={e => setYear(Number(e.target.value))}
+            >
+              {years.map(y => (
+                <MenuItem key={y} value={y}>
+                  {y}
+                </MenuItem>
               ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {months.map(m => (
-              <TableRow key={m}>
-                <TableCell>{m}</TableCell>
+            </Select>
+          </FormControl>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Month</TableCell>
                 {donors.map(d => (
                   <TableCell key={d} align="right">
-                    {rows.find(r => r.month === m && r.donor === d)?.total || 0}
+                    {d}
                   </TableCell>
                 ))}
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {months.map(m => (
+                <TableRow key={m}>
+                  <TableCell>{m}</TableCell>
+                  {donors.map(d => (
+                    <TableCell key={d} align="right">
+                      {rows.find(r => r.month === m && r.donor === d)?.total || 0}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </>
       )}
       {tab === 1 && null}
       {tab === 2 && null}


### PR DESCRIPTION
## Summary
- allow querying donor aggregation by selected year
- add year dropdown to donor aggregation page

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d86ab9a8832db7706c909983b3b9