### PR TITLE
Allow donor aggregation endpoint without auth

### DIFF
--- a/MJ_FB_Backend/src/routes/donations.ts
+++ b/MJ_FB_Backend/src/routes/donations.ts
@@ -7,7 +7,7 @@ import { addDonationSchema, updateDonationSchema } from '../schemas/donationSche
 const router = Router();
 
 router.get('/', authMiddleware, authorizeRoles('staff'), listDonations);
-router.get('/aggregations/donors', authMiddleware, authorizeRoles('staff'), donorAggregations);
+router.get('/aggregations/donors', donorAggregations);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(addDonationSchema), addDonation);
 router.put('/:id', authMiddleware, authorizeRoles('staff'), validate(updateDonationSchema), updateDonation);
 router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteDonation);


### PR DESCRIPTION
## Summary
- Expose donors aggregation endpoint without requiring a token

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8de47e0ec832d89ebd373d7c024b7