### PR TITLE
feat: add reusable Excel table export

### DIFF
--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Tabs,
   Tab,
@@ -11,9 +11,12 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Stack,
+  Button,
 } from '@mui/material';
 import Page from '../components/Page';
 import { getDonorAggregations, type DonorAggregation } from '../api/donations';
+import { exportTableToExcel } from '../utils/exportTableToExcel';
 
 export default function Aggregations() {
   const [tab, setTab] = useState(0);
@@ -21,6 +24,13 @@ export default function Aggregations() {
   const currentYear = new Date().getFullYear();
   const [year, setYear] = useState(currentYear);
   const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
+  const tableRef = useRef<HTMLTableElement>(null);
+
+  const handleExport = () => {
+    if (tableRef.current) {
+      exportTableToExcel(tableRef.current, `donor_aggregations_${year}`);
+    }
+  };
 
   useEffect(() => {
     if (tab !== 0) return;
@@ -41,22 +51,27 @@ export default function Aggregations() {
       </Tabs>
       {tab === 0 && (
         <>
-          <FormControl size="small" sx={{ mb: 2, minWidth: 120 }}>
-            <InputLabel id="year-label">Year</InputLabel>
-            <Select
-              labelId="year-label"
-              label="Year"
-              value={year}
-              onChange={e => setYear(Number(e.target.value))}
-            >
-              {years.map(y => (
-                <MenuItem key={y} value={y}>
-                  {y}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <Table size="small">
+          <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+            <FormControl size="small" sx={{ minWidth: 120 }}>
+              <InputLabel id="year-label">Year</InputLabel>
+              <Select
+                labelId="year-label"
+                label="Year"
+                value={year}
+                onChange={e => setYear(Number(e.target.value))}
+              >
+                {years.map(y => (
+                  <MenuItem key={y} value={y}>
+                    {y}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Button size="small" variant="contained" onClick={handleExport}>
+              Export
+            </Button>
+          </Stack>
+          <Table size="small" ref={tableRef}>
             <TableHead>
               <TableRow>
                 <TableCell>Month</TableCell>

--- a/MJ_FB_Frontend/src/utils/exportTableToExcel.ts
+++ b/MJ_FB_Frontend/src/utils/exportTableToExcel.ts
@@ -1,0 +1,12 @@
+export function exportTableToExcel(table: HTMLTableElement, filename: string) {
+  const html = table.outerHTML;
+  const blob = new Blob(['\ufeff', html], { type: 'application/vnd.ms-excel' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${filename}.xls`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add utility to export HTML tables to Excel
- enable donor aggregation export via new button

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68a8df6a2018832dad5df9e2e31de056