### PR TITLE
Clear donor aggregation results when year changes

### DIFF
--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -24,6 +24,7 @@ export default function Aggregations() {
 
   useEffect(() => {
     if (tab !== 0) return;
+    setRows([]);
     getDonorAggregations(year)
       .then(setRows)
       .catch(() => setRows([]));
@@ -47,7 +48,10 @@ export default function Aggregations() {
               labelId="year-label"
               label="Year"
               value={year}
-              onChange={e => setYear(Number(e.target.value))}
+              onChange={e => {
+                setYear(Number(e.target.value));
+                setRows([]);
+              }}
             >
               {years.map(y => (
                 <MenuItem key={y} value={y}>
@@ -68,16 +72,24 @@ export default function Aggregations() {
               </TableRow>
             </TableHead>
             <TableBody>
-              {months.map(m => (
-                <TableRow key={m}>
-                  <TableCell>{m}</TableCell>
-                  {donors.map(d => (
-                    <TableCell key={d} align="right">
-                      {rows.find(r => r.month === m && r.donor === d)?.total || 0}
-                    </TableCell>
-                  ))}
+              {rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={donors.length + 1} align="center">
+                    No data
+                  </TableCell>
                 </TableRow>
-              ))}
+              ) : (
+                months.map(m => (
+                  <TableRow key={m}>
+                    <TableCell>{m}</TableCell>
+                    {donors.map(d => (
+                      <TableCell key={d} align="right">
+                        {rows.find(r => r.month === m && r.donor === d)?.total || 0}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              )}
             </TableBody>
           </Table>
         </>


### PR DESCRIPTION
## Summary
- reset donor aggregation table when the selected year changes so stale data disappears
- show a "No data" message when no donor aggregation results exist

## Testing
- `npx jest --runInBand --passWithNoTests` *(fails: ESM syntax is not allowed in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dfceee44832d9cad33948f9c8558