### PR TITLE
Ensure root elements hide horizontal overflow

### DIFF
--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -17,6 +17,10 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
 }
 
 a {
@@ -33,6 +37,8 @@ body, html, #root {
   padding: 0;
   min-height: 100vh;
   width: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
 }
 
 main {


### PR DESCRIPTION
## Summary
- Prevent horizontal scroll by hiding overflow on `:root`, `html`, `body`, and `#root`

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ebdb240832d91c4e834758cd19e