### PR TITLE
Fix pig pound log date display

### DIFF
--- a/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
@@ -102,7 +102,7 @@ export default function TrackPigpound() {
           {entries.map(e => (
             <TableRow key={e.id}>
               <TableCell>
-                {new Date(`${e.date}T00:00:00`).toLocaleDateString()}
+                {new Date(e.date).toLocaleDateString('en-CA')}
               </TableCell>
               <TableCell>{e.weight}</TableCell>
               <TableCell align="right">


### PR DESCRIPTION
## Summary
- parse pig pound log dates without appending time to avoid Invalid Date display

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5e6220e4832d84bb585acb842366