### PR TITLE
Wrap tables in scrollable containers

### DIFF
--- a/MJ_FB_Frontend/src/components/ScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/ScheduleTable.tsx
@@ -8,6 +8,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TableContainer,
 } from '@mui/material';
 
 interface Props {
@@ -32,45 +33,47 @@ export default function ScheduleTable({ shifts }: Props) {
   const maxSlots = Math.max(...shifts.map((s) => s.maxVolunteers), 0);
 
   return (
-    <Table
-      sx={{
-        width: '100%',
-        tableLayout: 'fixed',
-        borderCollapse: 'collapse',
-      }}
-    >
-      <TableHead>
-        <TableRow>
-          <TableCell sx={cellSx}>Shift</TableCell>
-          {Array.from({ length: maxSlots }).map((_, i) => (
-            <TableCell key={i} sx={cellSx}>
-              Slot {i + 1}
-            </TableCell>
-          ))}
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {shifts.map((shift) => (
-          <TableRow key={shift.shiftId}>
-            <TableCell sx={cellSx}>
-              {formatHHMM(shift.startTime)}–{formatHHMM(shift.endTime)}
-            </TableCell>
+    <TableContainer sx={{ overflowX: 'auto' }}>
+      <Table
+        sx={{
+          width: '100%',
+          tableLayout: 'fixed',
+          borderCollapse: 'collapse',
+        }}
+      >
+        <TableHead>
+          <TableRow>
+            <TableCell sx={cellSx}>Shift</TableCell>
             {Array.from({ length: maxSlots }).map((_, i) => (
-              <TableCell
-                key={i}
-                sx={{
-                  ...cellSx,
-                  backgroundColor:
-                    i >= shift.maxVolunteers
-                      ? theme.palette.grey[200]
-                      : 'transparent',
-                }}
-              />
+              <TableCell key={i} sx={cellSx}>
+                Slot {i + 1}
+              </TableCell>
             ))}
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHead>
+        <TableBody>
+          {shifts.map((shift) => (
+            <TableRow key={shift.shiftId}>
+              <TableCell sx={cellSx}>
+                {formatHHMM(shift.startTime)}–{formatHHMM(shift.endTime)}
+              </TableCell>
+              {Array.from({ length: maxSlots }).map((_, i) => (
+                <TableCell
+                  key={i}
+                  sx={{
+                    ...cellSx,
+                    backgroundColor:
+                      i >= shift.maxVolunteers
+                        ? theme.palette.grey[200]
+                        : 'transparent',
+                  }}
+                />
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
   );
 }
 

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -9,6 +9,7 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  TableContainer,
   Table,
   TableBody,
   TableCell,
@@ -131,7 +132,7 @@ export default function UserHistory({
                 <MenuItem value="past">Past</MenuItem>
               </Select>
             </FormControl>
-            <Box sx={{ overflowX: 'auto' }}>
+            <TableContainer sx={{ overflowX: 'auto' }}>
               <Table sx={{ width: '100%', borderCollapse: 'collapse' }}>
                 <TableHead>
                   <TableRow>
@@ -201,7 +202,7 @@ export default function UserHistory({
                   })}
                 </TableBody>
               </Table>
-            </Box>
+            </TableContainer>
             {totalPages > 1 && (
               <Box
                 sx={{

--- a/MJ_FB_Frontend/src/components/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerBookingHistory.tsx
@@ -24,7 +24,7 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
 
   return (
     <Page title="Booking History">
-      <TableContainer component={Paper}>
+      <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
         <Table>
           <TableHead>
             <TableRow>

--- a/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
@@ -38,6 +38,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TableContainer,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -675,66 +676,68 @@ export default function VolunteerManagement({ token }: { token: string }) {
                 <Typography variant="h6" sx={{ mt: 2 }}>
                   History for {selectedVolunteer.name}
                 </Typography>
-                <Table sx={{ width: '100%', borderCollapse: 'collapse' }}>
-                  <TableHead>
-                    <TableRow>
-                      <TableCell sx={cellSx}>Role</TableCell>
-                      <TableCell sx={cellSx}>Date</TableCell>
-                      <TableCell sx={cellSx}>Time</TableCell>
-                      <TableCell sx={cellSx}>Status</TableCell>
-                      <TableCell sx={cellSx} />
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {history.map(h => (
-                      <TableRow key={h.id}>
-                        <TableCell sx={cellSx}>{h.role_name}</TableCell>
-                        <TableCell sx={cellSx}>{h.date}</TableCell>
-                        <TableCell sx={cellSx}>
-                          {formatTime(h.start_time || '')} -
-                          {formatTime(h.end_time || '')}
-                        </TableCell>
-                        <TableCell sx={cellSx}>{h.status}</TableCell>
-                        <TableCell sx={cellSx}>
-                          {h.status === 'pending' && (
-                            <>
-                              <Button
-                                onClick={() => decide(h.id, 'approved')}
-                                variant="outlined"
-                                color="primary"
-                              >
-                                Approve
-                              </Button>{' '}
-                              <Button
-                                onClick={() => decide(h.id, 'rejected')}
-                                variant="outlined"
-                                color="primary"
-                              >
-                                Reject
-                              </Button>
-                            </>
-                          )}
-                          {h.status === 'approved' && (
-                            <Button
-                              onClick={() => decide(h.id, 'cancelled')}
-                              variant="outlined"
-                              color="primary"
-                            >
-                              Cancel
-                            </Button>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                    {history.length === 0 && (
+                <TableContainer sx={{ overflowX: 'auto' }}>
+                  <Table sx={{ width: '100%', borderCollapse: 'collapse' }}>
+                    <TableHead>
                       <TableRow>
-                        <TableCell colSpan={5} sx={{ textAlign: 'center', p: 1 }}>
-                          No bookings.
-                        </TableCell>
+                        <TableCell sx={cellSx}>Role</TableCell>
+                        <TableCell sx={cellSx}>Date</TableCell>
+                        <TableCell sx={cellSx}>Time</TableCell>
+                        <TableCell sx={cellSx}>Status</TableCell>
+                        <TableCell sx={cellSx} />
                       </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
+                    </TableHead>
+                    <TableBody>
+                      {history.map(h => (
+                        <TableRow key={h.id}>
+                          <TableCell sx={cellSx}>{h.role_name}</TableCell>
+                          <TableCell sx={cellSx}>{h.date}</TableCell>
+                          <TableCell sx={cellSx}>
+                            {formatTime(h.start_time || '')} -
+                            {formatTime(h.end_time || '')}
+                          </TableCell>
+                          <TableCell sx={cellSx}>{h.status}</TableCell>
+                          <TableCell sx={cellSx}>
+                            {h.status === 'pending' && (
+                              <>
+                                <Button
+                                  onClick={() => decide(h.id, 'approved')}
+                                  variant="outlined"
+                                  color="primary"
+                                >
+                                  Approve
+                                </Button>{' '}
+                                <Button
+                                  onClick={() => decide(h.id, 'rejected')}
+                                  variant="outlined"
+                                  color="primary"
+                                >
+                                  Reject
+                                </Button>
+                              </>
+                            )}
+                            {h.status === 'approved' && (
+                              <Button
+                                onClick={() => decide(h.id, 'cancelled')}
+                                variant="outlined"
+                                color="primary"
+                              >
+                                Cancel
+                              </Button>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                      {history.length === 0 && (
+                        <TableRow>
+                          <TableCell colSpan={5} sx={{ textAlign: 'center', p: 1 }}>
+                            No bookings.
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
               </div>
             )}
           </Box>

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -32,7 +32,7 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   return (
-    <TableContainer component={Paper}>
+    <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
       <Table
         size="small"
         sx={{

--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -5,6 +5,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableContainer,
   FormControl,
   InputLabel,
   Select,
@@ -117,45 +118,47 @@ export default function Aggregations() {
           {rebuilding ? <CircularProgress size={20} /> : 'Calculate Overall'}
         </Button>
       </Stack>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Month</TableCell>
-            <TableCell align="right">Donations</TableCell>
-            <TableCell align="right">Surplus</TableCell>
-            <TableCell align="right">Pig Pound</TableCell>
-            <TableCell align="right">Outgoing Donations</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {overallLoading ? (
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
             <TableRow>
-              <TableCell colSpan={5} align="center">
-                <CircularProgress size={24} />
-              </TableCell>
+              <TableCell>Month</TableCell>
+              <TableCell align="right">Donations</TableCell>
+              <TableCell align="right">Surplus</TableCell>
+              <TableCell align="right">Pig Pound</TableCell>
+              <TableCell align="right">Outgoing Donations</TableCell>
             </TableRow>
-          ) : (
-            <>
-              {overallData.map((r, idx) => (
-                <TableRow key={idx}>
-                  <TableCell>{monthNames[r.month - 1]}</TableCell>
-                  <TableCell align="right">{r.donations}</TableCell>
-                  <TableCell align="right">{r.surplus}</TableCell>
-                  <TableCell align="right">{r.pigPound}</TableCell>
-                  <TableCell align="right">{r.outgoingDonations}</TableCell>
-                </TableRow>
-              ))}
+          </TableHead>
+          <TableBody>
+            {overallLoading ? (
               <TableRow>
-                <TableCell>Total</TableCell>
-                <TableCell align="right">{totals.donations}</TableCell>
-                <TableCell align="right">{totals.surplus}</TableCell>
-                <TableCell align="right">{totals.pigPound}</TableCell>
-                <TableCell align="right">{totals.outgoingDonations}</TableCell>
+                <TableCell colSpan={5} align="center">
+                  <CircularProgress size={24} />
+                </TableCell>
               </TableRow>
-            </>
-          )}
-        </TableBody>
-      </Table>
+            ) : (
+              <>
+                {overallData.map((r, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell>{monthNames[r.month - 1]}</TableCell>
+                    <TableCell align="right">{r.donations}</TableCell>
+                    <TableCell align="right">{r.surplus}</TableCell>
+                    <TableCell align="right">{r.pigPound}</TableCell>
+                    <TableCell align="right">{r.outgoingDonations}</TableCell>
+                  </TableRow>
+                ))}
+                <TableRow>
+                  <TableCell>Total</TableCell>
+                  <TableCell align="right">{totals.donations}</TableCell>
+                  <TableCell align="right">{totals.surplus}</TableCell>
+                  <TableCell align="right">{totals.pigPound}</TableCell>
+                  <TableCell align="right">{totals.outgoingDonations}</TableCell>
+                </TableRow>
+              </>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
       <FeedbackSnackbar
         open={snackbar.open}
         onClose={() => setSnackbar({ ...snackbar, open: false })}

--- a/MJ_FB_Frontend/src/pages/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/DonationLog.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableContainer,
   Stack,
   Autocomplete,
   IconButton,
@@ -147,35 +148,37 @@ export default function DonationLog() {
           <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
         ))}
       </Tabs>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Donor</TableCell>
-            <TableCell>Weight</TableCell>
-            <TableCell align="right"></TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {donations.map(d => (
-            <TableRow key={d.id}>
-              <TableCell>{d.donor}</TableCell>
-              <TableCell>{d.weight}</TableCell>
-              <TableCell align="right">
-                <IconButton size="small" onClick={() => {
-                  setEditing(d);
-                  setForm({ date: d.date, donorId: d.donorId, weight: String(d.weight) });
-                  setRecordOpen(true);
-                }} aria-label="Edit donation">
-                  <Edit fontSize="small" />
-                </IconButton>
-                <IconButton size="small" onClick={() => { setToDelete(d); setDeleteOpen(true); }} aria-label="Delete donation">
-                  <Delete fontSize="small" />
-                </IconButton>
-              </TableCell>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Donor</TableCell>
+              <TableCell>Weight</TableCell>
+              <TableCell align="right"></TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {donations.map(d => (
+              <TableRow key={d.id}>
+                <TableCell>{d.donor}</TableCell>
+                <TableCell>{d.weight}</TableCell>
+                <TableCell align="right">
+                  <IconButton size="small" onClick={() => {
+                    setEditing(d);
+                    setForm({ date: d.date, donorId: d.donorId, weight: String(d.weight) });
+                    setRecordOpen(true);
+                  }} aria-label="Edit donation">
+                    <Edit fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => { setToDelete(d); setDeleteOpen(true); }} aria-label="Delete donation">
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Donation' : 'Record Donation'}</DialogTitle>

--- a/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableContainer,
   Stack,
   Autocomplete,
   IconButton,
@@ -140,43 +141,45 @@ export default function TrackOutgoingDonations() {
           <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
         ))}
       </Tabs>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell>Receiver</TableCell>
-            <TableCell>Weight</TableCell>
-            <TableCell>Note</TableCell>
-            <TableCell align="right"></TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {donations.map(d => (
-            <TableRow key={d.id}>
-              <TableCell>{d.date}</TableCell>
-              <TableCell>{d.receiver}</TableCell>
-              <TableCell>{d.weight}</TableCell>
-              <TableCell>{d.note}</TableCell>
-              <TableCell align="right">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setEditing(d);
-                    setForm({ date: d.date, receiverId: d.receiverId, weight: String(d.weight), note: d.note || '' });
-                    setRecordOpen(true);
-                  }}
-                  aria-label="Edit outgoing donation"
-                >
-                  <Edit fontSize="small" />
-                </IconButton>
-                <IconButton size="small" onClick={() => { setToDelete(d); setDeleteOpen(true); }} aria-label="Delete outgoing donation">
-                  <Delete fontSize="small" />
-                </IconButton>
-              </TableCell>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Date</TableCell>
+              <TableCell>Receiver</TableCell>
+              <TableCell>Weight</TableCell>
+              <TableCell>Note</TableCell>
+              <TableCell align="right"></TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {donations.map(d => (
+              <TableRow key={d.id}>
+                <TableCell>{d.date}</TableCell>
+                <TableCell>{d.receiver}</TableCell>
+                <TableCell>{d.weight}</TableCell>
+                <TableCell>{d.note}</TableCell>
+                <TableCell align="right">
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setEditing(d);
+                      setForm({ date: d.date, receiverId: d.receiverId, weight: String(d.weight), note: d.note || '' });
+                      setRecordOpen(true);
+                    }}
+                    aria-label="Edit outgoing donation"
+                  >
+                    <Edit fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => { setToDelete(d); setDeleteOpen(true); }} aria-label="Delete outgoing donation">
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Outgoing Donation' : 'Record Outgoing Donation'}</DialogTitle>

--- a/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableContainer,
   Stack,
   TextField,
   IconButton,
@@ -90,48 +91,50 @@ export default function TrackPigpound() {
         </Button>
       }
     >
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell>Weight</TableCell>
-            <TableCell align="right"></TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {entries.map(e => (
-            <TableRow key={e.id}>
-              <TableCell>
-                {new Date(e.date).toLocaleDateString('en-CA')}
-              </TableCell>
-              <TableCell>{e.weight}</TableCell>
-              <TableCell align="right">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setEditing(e);
-                    setForm({ date: e.date, weight: String(e.weight) });
-                    setRecordOpen(true);
-                  }}
-                  aria-label="Edit entry"
-                >
-                  <Edit fontSize="small" />
-                </IconButton>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setToDelete(e);
-                    setDeleteOpen(true);
-                  }}
-                  aria-label="Delete entry"
-                >
-                  <Delete fontSize="small" />
-                </IconButton>
-              </TableCell>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Date</TableCell>
+              <TableCell>Weight</TableCell>
+              <TableCell align="right"></TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {entries.map(e => (
+              <TableRow key={e.id}>
+                <TableCell>
+                  {new Date(e.date).toLocaleDateString('en-CA')}
+                </TableCell>
+                <TableCell>{e.weight}</TableCell>
+                <TableCell align="right">
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setEditing(e);
+                      setForm({ date: e.date, weight: String(e.weight) });
+                      setRecordOpen(true);
+                    }}
+                    aria-label="Edit entry"
+                  >
+                    <Edit fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setToDelete(e);
+                      setDeleteOpen(true);
+                    }}
+                    aria-label="Delete entry"
+                  >
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
 
       <Dialog
         open={recordOpen}

--- a/MJ_FB_Frontend/src/pages/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackSurplus.tsx
@@ -11,6 +11,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TableContainer,
   TextField,
   MenuItem,
   IconButton,
@@ -134,57 +135,59 @@ export default function TrackSurplus() {
           <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
         ))}
       </Tabs>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell>Type</TableCell>
-            <TableCell>Count</TableCell>
-            <TableCell>Weight</TableCell>
-            <TableCell align="right"></TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {filteredRecords.map(r => (
-            <TableRow key={r.id}>
-              <TableCell>
-                {new Date(r.date).toLocaleDateString(undefined, {
-                  weekday: 'short',
-                  year: 'numeric',
-                  month: 'short',
-                  day: 'numeric',
-                })}
-              </TableCell>
-              <TableCell>{r.type}</TableCell>
-              <TableCell>{r.count}</TableCell>
-              <TableCell>{r.weight}</TableCell>
-              <TableCell align="right">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setEditing(r);
-                    setForm({ date: normalize(r.date), type: r.type, count: String(r.count) });
-                    setRecordOpen(true);
-                  }}
-                  aria-label="Edit surplus"
-                >
-                  <Edit fontSize="small" />
-                </IconButton>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setToDelete(r);
-                    setDeleteOpen(true);
-                  }}
-                  aria-label="Delete surplus"
-                >
-                  <Delete fontSize="small" />
-                </IconButton>
-              </TableCell>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Date</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell>Count</TableCell>
+              <TableCell>Weight</TableCell>
+              <TableCell align="right"></TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {filteredRecords.map(r => (
+              <TableRow key={r.id}>
+                <TableCell>
+                  {new Date(r.date).toLocaleDateString(undefined, {
+                    weekday: 'short',
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </TableCell>
+                <TableCell>{r.type}</TableCell>
+                <TableCell>{r.count}</TableCell>
+                <TableCell>{r.weight}</TableCell>
+                <TableCell align="right">
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setEditing(r);
+                      setForm({ date: normalize(r.date), type: r.type, count: String(r.count) });
+                      setRecordOpen(true);
+                    }}
+                    aria-label="Edit surplus"
+                  >
+                    <Edit fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setToDelete(r);
+                      setDeleteOpen(true);
+                    }}
+                    aria-label="Delete surplus"
+                  >
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Surplus' : 'Record Surplus'}</DialogTitle>


### PR DESCRIPTION
## Summary
- wrap all tables in `TableContainer` with `overflowX: 'auto'` so wide content scrolls on small screens

## Testing
- `npm test` (fails: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled)


------
https://chatgpt.com/codex/tasks/task_e_68ab60362b7c832db38805fe7df0635b