### PR TITLE
feat: add week view to pig pound log

### DIFF
--- a/MJ_FB_Backend/src/controllers/pigPoundController.ts
+++ b/MJ_FB_Backend/src/controllers/pigPoundController.ts
@@ -2,10 +2,13 @@ import { Request, Response, NextFunction } from 'express';
 import pool from '../db';
 import logger from '../utils/logger';
 
-export async function listPigPounds(_req: Request, res: Response, next: NextFunction) {
+export async function listPigPounds(req: Request, res: Response, next: NextFunction) {
   try {
+    const date = req.query.date as string;
+    if (!date) return res.status(400).json({ message: 'Date required' });
     const result = await pool.query(
-      'SELECT id, date, weight FROM pig_pound_log ORDER BY date DESC, id DESC',
+      'SELECT id, date, weight FROM pig_pound_log WHERE date = $1 ORDER BY id',
+      [date],
     );
     res.json(result.rows);
   } catch (error) {

--- a/MJ_FB_Frontend/src/api/pigPounds.ts
+++ b/MJ_FB_Frontend/src/api/pigPounds.ts
@@ -6,8 +6,8 @@ export interface PigPound {
   weight: number;
 }
 
-export async function getPigPounds(): Promise<PigPound[]> {
-  const res = await apiFetch(`${API_BASE}/pig-pounds`);
+export async function getPigPounds(date: string): Promise<PigPound[]> {
+  const res = await apiFetch(`${API_BASE}/pig-pounds?date=${date}`);
   return handleResponse(res);
 }
 


### PR DESCRIPTION
## Summary
- filter pig pound API by date
- add date parameter to pig pound API client
- show pig pound donations in a 7-day tabbed view

## Testing
- `npm test` *(backend - jest: not found)*
- `npm test` *(frontend - ESM syntax is not allowed in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab615e4358832db95e77ae4ba03d7a