### PR TITLE
Wrap tables with responsive containers

### DIFF
--- a/MJ_FB_Frontend/src/components/ScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/ScheduleTable.tsx
@@ -8,6 +8,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TableContainer,
 } from '@mui/material';
 
 interface Props {
@@ -32,13 +33,15 @@ export default function ScheduleTable({ shifts }: Props) {
   const maxSlots = Math.max(...shifts.map((s) => s.maxVolunteers), 0);
 
   return (
-    <Table
-      sx={{
-        width: '100%',
-        tableLayout: 'fixed',
-        borderCollapse: 'collapse',
-      }}
-    >
+    <TableContainer sx={{ overflowX: 'auto' }}>
+      <Table
+        size="small"
+        sx={{
+          width: '100%',
+          tableLayout: 'fixed',
+          borderCollapse: 'collapse',
+        }}
+      >
       <TableHead>
         <TableRow>
           <TableCell sx={cellSx}>Shift</TableCell>
@@ -70,7 +73,8 @@ export default function ScheduleTable({ shifts }: Props) {
           </TableRow>
         ))}
       </TableBody>
-    </Table>
+      </Table>
+    </TableContainer>
   );
 }
 

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -14,6 +14,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TableContainer,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
@@ -131,8 +132,8 @@ export default function UserHistory({
                 <MenuItem value="past">Past</MenuItem>
               </Select>
             </FormControl>
-            <Box sx={{ overflowX: 'auto' }}>
-              <Table sx={{ width: '100%', borderCollapse: 'collapse' }}>
+            <TableContainer sx={{ overflowX: 'auto' }}>
+              <Table size="small" sx={{ width: '100%', borderCollapse: 'collapse' }}>
                 <TableHead>
                   <TableRow>
                     <TableCell sx={cellSx}>Date</TableCell>
@@ -201,7 +202,7 @@ export default function UserHistory({
                   })}
                 </TableBody>
               </Table>
-            </Box>
+            </TableContainer>
             {totalPages > 1 && (
               <Box
                 sx={{

--- a/MJ_FB_Frontend/src/components/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerBookingHistory.tsx
@@ -24,8 +24,8 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
 
   return (
     <Page title="Booking History">
-      <TableContainer component={Paper}>
-        <Table>
+      <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
+        <Table size="small">
           <TableHead>
             <TableRow>
               <TableCell>Role</TableCell>

--- a/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerManagement.tsx
@@ -38,6 +38,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TableContainer,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -675,8 +676,9 @@ export default function VolunteerManagement({ token }: { token: string }) {
                 <Typography variant="h6" sx={{ mt: 2 }}>
                   History for {selectedVolunteer.name}
                 </Typography>
-                <Table sx={{ width: '100%', borderCollapse: 'collapse' }}>
-                  <TableHead>
+                <TableContainer sx={{ overflowX: 'auto' }}>
+                  <Table size="small" sx={{ width: '100%', borderCollapse: 'collapse' }}>
+                    <TableHead>
                     <TableRow>
                       <TableCell sx={cellSx}>Role</TableCell>
                       <TableCell sx={cellSx}>Date</TableCell>
@@ -684,57 +686,58 @@ export default function VolunteerManagement({ token }: { token: string }) {
                       <TableCell sx={cellSx}>Status</TableCell>
                       <TableCell sx={cellSx} />
                     </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {history.map(h => (
-                      <TableRow key={h.id}>
-                        <TableCell sx={cellSx}>{h.role_name}</TableCell>
-                        <TableCell sx={cellSx}>{h.date}</TableCell>
-                        <TableCell sx={cellSx}>
-                          {formatTime(h.start_time || '')} -
-                          {formatTime(h.end_time || '')}
-                        </TableCell>
-                        <TableCell sx={cellSx}>{h.status}</TableCell>
-                        <TableCell sx={cellSx}>
-                          {h.status === 'pending' && (
-                            <>
+                    </TableHead>
+                    <TableBody>
+                      {history.map(h => (
+                        <TableRow key={h.id}>
+                          <TableCell sx={cellSx}>{h.role_name}</TableCell>
+                          <TableCell sx={cellSx}>{h.date}</TableCell>
+                          <TableCell sx={cellSx}>
+                            {formatTime(h.start_time || '')} -
+                            {formatTime(h.end_time || '')}
+                          </TableCell>
+                          <TableCell sx={cellSx}>{h.status}</TableCell>
+                          <TableCell sx={cellSx}>
+                            {h.status === 'pending' && (
+                              <>
+                                <Button
+                                  onClick={() => decide(h.id, 'approved')}
+                                  variant="outlined"
+                                  color="primary"
+                                >
+                                  Approve
+                                </Button>{' '}
+                                <Button
+                                  onClick={() => decide(h.id, 'rejected')}
+                                  variant="outlined"
+                                  color="primary"
+                                >
+                                  Reject
+                                </Button>
+                              </>
+                            )}
+                            {h.status === 'approved' && (
                               <Button
-                                onClick={() => decide(h.id, 'approved')}
+                                onClick={() => decide(h.id, 'cancelled')}
                                 variant="outlined"
                                 color="primary"
                               >
-                                Approve
-                              </Button>{' '}
-                              <Button
-                                onClick={() => decide(h.id, 'rejected')}
-                                variant="outlined"
-                                color="primary"
-                              >
-                                Reject
+                                Cancel
                               </Button>
-                            </>
-                          )}
-                          {h.status === 'approved' && (
-                            <Button
-                              onClick={() => decide(h.id, 'cancelled')}
-                              variant="outlined"
-                              color="primary"
-                            >
-                              Cancel
-                            </Button>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                    {history.length === 0 && (
-                      <TableRow>
-                        <TableCell colSpan={5} sx={{ textAlign: 'center', p: 1 }}>
-                          No bookings.
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                      {history.length === 0 && (
+                        <TableRow>
+                          <TableCell colSpan={5} sx={{ textAlign: 'center', p: 1 }}>
+                            No bookings.
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
               </div>
             )}
           </Box>

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -32,7 +32,7 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   return (
-    <TableContainer component={Paper}>
+    <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
       <Table
         size="small"
         sx={{

--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -5,6 +5,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableContainer,
   FormControl,
   InputLabel,
   Select,
@@ -147,8 +148,9 @@ export default function Aggregations() {
           {exporting ? <CircularProgress size={20} /> : 'Export'}
         </Button>
       </Stack>
-      <Table size="small">
-        <TableHead>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
           <TableRow>
             <TableCell>Month</TableCell>
             <TableCell align="right">Donations</TableCell>
@@ -156,8 +158,8 @@ export default function Aggregations() {
             <TableCell align="right">Pig Pound</TableCell>
             <TableCell align="right">Outgoing Donations</TableCell>
           </TableRow>
-        </TableHead>
-        <TableBody>
+          </TableHead>
+          <TableBody>
           {overallLoading ? (
             <TableRow>
               <TableCell colSpan={5} align="center">
@@ -184,8 +186,9 @@ export default function Aggregations() {
               </TableRow>
             </>
           )}
-        </TableBody>
-      </Table>
+          </TableBody>
+        </Table>
+      </TableContainer>
       <FeedbackSnackbar
         open={snackbar.open}
         onClose={() => setSnackbar({ ...snackbar, open: false })}

--- a/MJ_FB_Frontend/src/pages/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/DonationLog.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableContainer,
   Stack,
   Autocomplete,
   IconButton,
@@ -147,15 +148,16 @@ export default function DonationLog() {
           <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
         ))}
       </Tabs>
-      <Table size="small">
-        <TableHead>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
           <TableRow>
             <TableCell>Donor</TableCell>
             <TableCell>Weight</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
-        </TableHead>
-        <TableBody>
+          </TableHead>
+          <TableBody>
           {donations.map(d => (
             <TableRow key={d.id}>
               <TableCell>{d.donor}</TableCell>
@@ -174,8 +176,9 @@ export default function DonationLog() {
               </TableCell>
             </TableRow>
           ))}
-        </TableBody>
-      </Table>
+          </TableBody>
+        </Table>
+      </TableContainer>
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Donation' : 'Record Donation'}</DialogTitle>

--- a/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableContainer,
   Stack,
   Autocomplete,
   IconButton,
@@ -140,8 +141,9 @@ export default function TrackOutgoingDonations() {
           <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
         ))}
       </Tabs>
-      <Table size="small">
-        <TableHead>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
           <TableRow>
             <TableCell>Date</TableCell>
             <TableCell>Receiver</TableCell>
@@ -149,8 +151,8 @@ export default function TrackOutgoingDonations() {
             <TableCell>Note</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
-        </TableHead>
-        <TableBody>
+          </TableHead>
+          <TableBody>
           {donations.map(d => (
             <TableRow key={d.id}>
               <TableCell>{d.date}</TableCell>
@@ -175,8 +177,9 @@ export default function TrackOutgoingDonations() {
               </TableCell>
             </TableRow>
           ))}
-        </TableBody>
-      </Table>
+          </TableBody>
+        </Table>
+      </TableContainer>
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Outgoing Donation' : 'Record Outgoing Donation'}</DialogTitle>

--- a/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableContainer,
   Stack,
   TextField,
   IconButton,
@@ -121,15 +122,16 @@ export default function TrackPigpound() {
           <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
         ))}
       </Tabs>
-      <Table size="small">
-        <TableHead>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
           <TableRow>
             <TableCell>Date</TableCell>
             <TableCell>Weight</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
-        </TableHead>
-        <TableBody>
+          </TableHead>
+          <TableBody>
           {entries.map(e => (
             <TableRow key={e.id}>
               <TableCell>
@@ -161,8 +163,9 @@ export default function TrackPigpound() {
               </TableCell>
             </TableRow>
           ))}
-        </TableBody>
-      </Table>
+          </TableBody>
+        </Table>
+      </TableContainer>
 
       <Dialog
         open={recordOpen}

--- a/MJ_FB_Frontend/src/pages/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackSurplus.tsx
@@ -11,6 +11,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TableContainer,
   TextField,
   MenuItem,
   IconButton,
@@ -134,8 +135,9 @@ export default function TrackSurplus() {
           <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
         ))}
       </Tabs>
-      <Table size="small">
-        <TableHead>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
           <TableRow>
             <TableCell>Date</TableCell>
             <TableCell>Type</TableCell>
@@ -143,8 +145,8 @@ export default function TrackSurplus() {
             <TableCell>Weight</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
-        </TableHead>
-        <TableBody>
+          </TableHead>
+          <TableBody>
           {filteredRecords.map(r => (
             <TableRow key={r.id}>
               <TableCell>
@@ -183,8 +185,9 @@ export default function TrackSurplus() {
               </TableCell>
             </TableRow>
           ))}
-        </TableBody>
-      </Table>
+          </TableBody>
+        </Table>
+      </TableContainer>
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Surplus' : 'Record Surplus'}</DialogTitle>


### PR DESCRIPTION
## Summary
- Wrap all table displays in `TableContainer` with horizontal scrolling
- Use compact `size="small"` setting for consistent table spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab63bc27fc832dbe99284e9e4c64d5