### PR TITLE
feat: wire warehouse dashboard to real data

### DIFF
--- a/MJ_FB_Backend/src/controllers/outgoingReceiverController.ts
+++ b/MJ_FB_Backend/src/controllers/outgoingReceiverController.ts
@@ -25,3 +25,27 @@ export async function addOutgoingReceiver(req: Request, res: Response, next: Nex
     next(error);
   }
 }
+
+export async function topOutgoingReceivers(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const year = parseInt((req.query.year as string) ?? '', 10) || new Date().getFullYear();
+    const limit = parseInt((req.query.limit as string) ?? '', 10) || 7;
+    const result = await pool.query(
+      `SELECT r.name, SUM(l.weight)::int AS "totalKg", MAX(l.date) AS "lastPickupISO"
+       FROM outgoing_donation_log l JOIN outgoing_receivers r ON l.receiver_id = r.id
+       WHERE EXTRACT(YEAR FROM l.date) = $1
+       GROUP BY r.id, r.name
+       ORDER BY "totalKg" DESC
+       LIMIT $2`,
+      [year, limit],
+    );
+    res.json(result.rows);
+  } catch (error) {
+    logger.error('Error listing top receivers:', error);
+    next(error);
+  }
+}

--- a/MJ_FB_Backend/src/routes/donors.ts
+++ b/MJ_FB_Backend/src/routes/donors.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
-import { listDonors, addDonor } from '../controllers/donorController';
+import { listDonors, addDonor, topDonors } from '../controllers/donorController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addDonorSchema } from '../schemas/donorSchemas';
 
 const router = Router();
 
+router.get('/top', authMiddleware, authorizeRoles('staff'), topDonors);
 router.get('/', authMiddleware, authorizeRoles('staff'), listDonors);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(addDonorSchema), addDonor);
 

--- a/MJ_FB_Backend/src/routes/outgoingReceivers.ts
+++ b/MJ_FB_Backend/src/routes/outgoingReceivers.ts
@@ -1,11 +1,16 @@
 import { Router } from 'express';
-import { listOutgoingReceivers, addOutgoingReceiver } from '../controllers/outgoingReceiverController';
+import {
+  listOutgoingReceivers,
+  addOutgoingReceiver,
+  topOutgoingReceivers,
+} from '../controllers/outgoingReceiverController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addOutgoingReceiverSchema } from '../schemas/outgoingReceiverSchemas';
 
 const router = Router();
 
+router.get('/top', authMiddleware, authorizeRoles('staff'), topOutgoingReceivers);
 router.get('/', authMiddleware, authorizeRoles('staff'), listOutgoingReceivers);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(addOutgoingReceiverSchema), addOutgoingReceiver);
 

--- a/MJ_FB_Backend/tests/topLists.test.ts
+++ b/MJ_FB_Backend/tests/topLists.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import donorsRoutes from '../src/routes/donors';
+import outgoingReceiversRoutes from '../src/routes/outgoingReceivers';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+
+const app = express();
+app.use('/donors', donorsRoutes);
+app.use('/outgoing-receivers', outgoingReceiversRoutes);
+
+beforeEach(() => {
+  (pool.query as jest.Mock).mockReset();
+});
+
+describe('GET /donors/top', () => {
+  it('returns top donors for the year', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ name: 'Alice', totalKg: 100, lastDonationISO: '2024-01-10' }],
+    });
+
+    const res = await request(app).get('/donors/top?year=2024&limit=5');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { name: 'Alice', totalKg: 100, lastDonationISO: '2024-01-10' },
+    ]);
+  });
+});
+
+describe('GET /outgoing-receivers/top', () => {
+  it('returns top receivers for the year', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ name: 'Org', totalKg: 50, lastPickupISO: '2024-02-15' }],
+    });
+
+    const res = await request(app).get('/outgoing-receivers/top?year=2024&limit=5');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { name: 'Org', totalKg: 50, lastPickupISO: '2024-02-15' },
+    ]);
+  });
+});

--- a/MJ_FB_Frontend/src/api/donors.ts
+++ b/MJ_FB_Frontend/src/api/donors.ts
@@ -5,6 +5,12 @@ export interface Donor {
   name: string;
 }
 
+export interface TopDonor {
+  name: string;
+  totalKg: number;
+  lastDonationISO: string;
+}
+
 export async function getDonors(search?: string): Promise<Donor[]> {
   const query = search ? `?search=${encodeURIComponent(search)}` : '';
   const res = await apiFetch(`${API_BASE}/donors${query}`);
@@ -17,5 +23,10 @@ export async function createDonor(name: string): Promise<Donor> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name }),
   });
+  return handleResponse(res);
+}
+
+export async function getTopDonors(year: number, limit: number): Promise<TopDonor[]> {
+  const res = await apiFetch(`${API_BASE}/donors/top?year=${year}&limit=${limit}`);
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/api/outgoingReceivers.ts
+++ b/MJ_FB_Frontend/src/api/outgoingReceivers.ts
@@ -5,6 +5,12 @@ export interface OutgoingReceiver {
   name: string;
 }
 
+export interface TopReceiver {
+  name: string;
+  totalKg: number;
+  lastPickupISO: string;
+}
+
 export async function getOutgoingReceivers(): Promise<OutgoingReceiver[]> {
   const res = await apiFetch(`${API_BASE}/outgoing-receivers`);
   return handleResponse(res);
@@ -16,5 +22,15 @@ export async function createOutgoingReceiver(name: string): Promise<OutgoingRece
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name }),
   });
+  return handleResponse(res);
+}
+
+export async function getTopReceivers(
+  year: number,
+  limit: number,
+): Promise<TopReceiver[]> {
+  const res = await apiFetch(
+    `${API_BASE}/outgoing-receivers/top?year=${year}&limit=${limit}`,
+  );
   return handleResponse(res);
 }


### PR DESCRIPTION
## Summary
- add top donors and receivers endpoints
- fetch real warehouse data on dashboard
- cover new endpoints with backend tests

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm test` (frontend) *(fails: ESM syntax is not allowed in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab68a5b4c0832da8956f04fe3b1dec