### PR TITLE
Fix dashboard KPIs to show latest warehouse data

### DIFF
--- a/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
@@ -140,7 +140,12 @@ export default function WarehouseDashboard() {
   }, [year]);
 
   const currentMonth = useMemo(() => {
-    return totals.length ? Math.max(...totals.map(t => t.month)) : 1;
+    const thisMonth = new Date().getMonth() + 1;
+    const monthsWithData = totals
+      .filter(t => t.donationsKg || t.surplusKg || t.pigPoundKg || t.outgoingKg)
+      .map(t => t.month);
+    if (monthsWithData.includes(thisMonth)) return thisMonth;
+    return monthsWithData.length ? Math.max(...monthsWithData) : thisMonth;
   }, [totals]);
 
   const currentTotals = totals.find(t => t.month === currentMonth);


### PR DESCRIPTION
## Summary
- ensure WarehouseDashboard KPIs use the current or latest month with data instead of always selecting December

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b3104a8832d9b1bcab42d72f560