### PR TITLE
Refine warehouse monthly trend chart

### DIFF
--- a/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
@@ -163,15 +163,22 @@ export default function WarehouseDashboard() {
 
   const chartData = useMemo(
     () =>
-      totals.map(t => ({
-        month: monthName(t.month),
-        incoming: t.donationsKg + t.surplusKg + t.pigPoundKg,
-        outgoing: t.outgoingKg,
-        net: t.donationsKg + t.surplusKg + t.pigPoundKg - t.outgoingKg,
-        donations: t.donationsKg,
-        surplus: t.surplusKg,
-        pigPound: t.pigPoundKg,
-      })),
+      Array.from({ length: 12 }, (_, i) => {
+        const m = i + 1;
+        const t = totals.find(tt => tt.month === m);
+        const incoming =
+          (t?.donationsKg ?? 0) + (t?.surplusKg ?? 0) + (t?.pigPoundKg ?? 0);
+        const outgoing = t?.outgoingKg ?? 0;
+        return {
+          month: monthName(m),
+          incoming,
+          outgoing,
+          net: incoming - outgoing,
+          donations: t?.donationsKg ?? 0,
+          surplus: t?.surplusKg ?? 0,
+          pigPound: t?.pigPoundKg ?? 0,
+        };
+      }),
     [totals],
   );
 
@@ -357,7 +364,7 @@ export default function WarehouseDashboard() {
                   type="monotone"
                   dataKey="incoming"
                   name="Incoming"
-                  stroke={theme.palette.primary.main}
+                  stroke={theme.palette.success.main}
                   strokeWidth={2}
                   dot={false}
                 />
@@ -365,7 +372,7 @@ export default function WarehouseDashboard() {
                   type="monotone"
                   dataKey="outgoing"
                   name="Outgoing"
-                  stroke={theme.palette.success.main}
+                  stroke={theme.palette.error.main}
                   strokeWidth={2}
                   dot={false}
                 />


### PR DESCRIPTION
## Summary
- Show full 12 months using real warehouse totals
- Adjust monthly trend colors: incoming green, outgoing red

## Testing
- `npm test` *(fails: TS1286 ESM syntax not allowed when 'verbatimModuleSyntax' enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b82f020832d920b5bbc11d46554