### PR TITLE
feat(frontend): improve add receiver flow

### DIFF
--- a/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
@@ -108,18 +108,21 @@ export default function TrackOutgoingDonations() {
   }
 
   function handleAddReceiver() {
-    if (receiverName && !receivers.some(r => r.name === receiverName)) {
-      createOutgoingReceiver(receiverName)
-        .then(newReceiver => {
-          setReceivers([...receivers, newReceiver].sort((a, b) => a.name.localeCompare(b.name)));
-          setSnackbar({ open: true, message: 'Receiver added' });
-        })
-        .catch(err => {
-          setSnackbar({ open: true, message: err.message || 'Failed to add receiver' });
-        });
+    if (!receiverName) return;
+    if (receivers.some(r => r.name === receiverName)) {
+      setSnackbar({ open: true, message: 'Receiver already exists' });
+      return;
     }
-    setReceiverName('');
-    setNewReceiverOpen(false);
+    createOutgoingReceiver(receiverName)
+      .then(newReceiver => {
+        setReceivers([...receivers, newReceiver].sort((a, b) => a.name.localeCompare(b.name)));
+        setSnackbar({ open: true, message: 'Receiver added' });
+        setNewReceiverOpen(false);
+        setReceiverName('');
+      })
+      .catch(err => {
+        setSnackbar({ open: true, message: err.message || 'Failed to add receiver' });
+      });
   }
 
   return (


### PR DESCRIPTION
## Summary
- prevent duplicate outgoing donation receivers and show message
- keep add receiver dialog open if creation fails
- record outgoing donation and add receiver actions available on tracking page

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm test` (frontend) *(ts-jest warnings, process requires manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5de63d8c832d8c6155317eb409e8