### PR TITLE
Expose public endpoints for top donation lists

### DIFF
--- a/MJ_FB_Backend/src/routes/donors.ts
+++ b/MJ_FB_Backend/src/routes/donors.ts
@@ -6,7 +6,8 @@ import { addDonorSchema } from '../schemas/donorSchemas';
 
 const router = Router();
 
-router.get('/top', authMiddleware, authorizeRoles('staff'), topDonors);
+// Public endpoint to list top donors
+router.get('/top', topDonors);
 router.get('/', authMiddleware, authorizeRoles('staff'), listDonors);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(addDonorSchema), addDonor);
 

--- a/MJ_FB_Backend/src/routes/outgoingReceivers.ts
+++ b/MJ_FB_Backend/src/routes/outgoingReceivers.ts
@@ -10,7 +10,8 @@ import { addOutgoingReceiverSchema } from '../schemas/outgoingReceiverSchemas';
 
 const router = Router();
 
-router.get('/top', authMiddleware, authorizeRoles('staff'), topOutgoingReceivers);
+// Public endpoint to list top outgoing receivers
+router.get('/top', topOutgoingReceivers);
 router.get('/', authMiddleware, authorizeRoles('staff'), listOutgoingReceivers);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(addOutgoingReceiverSchema), addOutgoingReceiver);
 


### PR DESCRIPTION
## Summary
- Expose `/donors/top` and `/outgoing-receivers/top` without auth so the endpoints can be reached publicly

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6fce2d34832d9865d2a11aabd5ec