### PR TITLE
feat(frontend): refine outgoing receiver addition

### DIFF
--- a/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
@@ -108,14 +108,16 @@ export default function TrackOutgoingDonations() {
   }
 
   function handleAddReceiver() {
-    if (!receiverName) return;
-    if (receivers.some(r => r.name === receiverName)) {
+    const name = receiverName.trim();
+    if (!name) return;
+    if (receivers.some(r => r.name.toLowerCase() === name.toLowerCase())) {
       setSnackbar({ open: true, message: 'Receiver already exists' });
       return;
     }
-    createOutgoingReceiver(receiverName)
+    createOutgoingReceiver(name)
       .then(newReceiver => {
         setReceivers([...receivers, newReceiver].sort((a, b) => a.name.localeCompare(b.name)));
+        setForm(prev => ({ ...prev, receiverId: newReceiver.id }));
         setSnackbar({ open: true, message: 'Receiver added' });
         setNewReceiverOpen(false);
         setReceiverName('');


### PR DESCRIPTION
## Summary
- improve outgoing receiver creation by trimming names and checking duplicates case-insensitively
- preselect newly added receiver in Track Outgoing Donations form

## Testing
- `npm test` *(fails: ESM syntax not allowed in CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7080ad74832d8db82aa2ad0c3cac