### PR TITLE
Separate incoming and outgoing donation trends on warehouse dashboard

### DIFF
--- a/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
@@ -173,7 +173,6 @@ export default function WarehouseDashboard() {
           month: monthName(m),
           incoming,
           outgoing,
-          net: incoming - outgoing,
           donations: incoming,
           surplus: t?.surplusKg ?? 0,
           pigPound: t?.pigPoundKg ?? 0,
@@ -346,40 +345,45 @@ export default function WarehouseDashboard() {
       >
         <Card variant="outlined">
           <CardHeader title="Monthly Trend" />
-          <CardContent sx={{ height: 300 }}>
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={chartData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="month" />
-                <YAxis />
-                <RTooltip formatter={(val: number) => fmtKg(val)} />
-                <Legend />
-                <Line
-                  type="monotone"
-                  dataKey="incoming"
-                  name="Incoming"
-                  stroke={theme.palette.success.main}
-                  strokeWidth={2}
-                  dot={false}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="outgoing"
-                  name="Outgoing"
-                  stroke={theme.palette.error.main}
-                  strokeWidth={2}
-                  dot={false}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="net"
-                  name="Net"
-                  stroke={theme.palette.warning.main}
-                  strokeWidth={2}
-                  dot={false}
-                />
-              </LineChart>
-            </ResponsiveContainer>
+          <CardContent sx={{ height: 300, display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={{ flex: 1 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="month" />
+                  <YAxis />
+                  <RTooltip formatter={(val: number) => fmtKg(val)} />
+                  <Legend />
+                  <Line
+                    type="monotone"
+                    dataKey="incoming"
+                    name="Incoming"
+                    stroke={theme.palette.success.main}
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </Box>
+            <Box sx={{ flex: 1 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="month" />
+                  <YAxis />
+                  <RTooltip formatter={(val: number) => fmtKg(val)} />
+                  <Legend />
+                  <Line
+                    type="monotone"
+                    dataKey="outgoing"
+                    name="Outgoing"
+                    stroke={theme.palette.error.main}
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </Box>
           </CardContent>
         </Card>
         <Card variant="outlined">


### PR DESCRIPTION
## Summary
- display incoming donations and outgoing shipments in separate line charts
- drop net line from warehouse monthly trend visualization

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68ab72f5cc38832d8ac5901bf2c5e7d2