### PR TITLE
Expose formatted top donor/receiver data

### DIFF
--- a/MJ_FB_Backend/src/controllers/donorController.ts
+++ b/MJ_FB_Backend/src/controllers/donorController.ts
@@ -35,11 +35,13 @@ export async function topDonors(req: Request, res: Response, next: NextFunction)
     const year = parseInt((req.query.year as string) ?? '', 10) || new Date().getFullYear();
     const limit = parseInt((req.query.limit as string) ?? '', 10) || 7;
     const result = await pool.query(
-      `SELECT o.name, SUM(d.weight)::int AS "totalKg", MAX(d.date) AS "lastDonationISO"
+      `SELECT o.name,
+              SUM(d.weight)::int AS "totalKg",
+              TO_CHAR(MAX(d.date), 'YYYY-MM-DD') AS "lastDonationISO"
        FROM donations d JOIN donors o ON d.donor_id = o.id
        WHERE EXTRACT(YEAR FROM d.date) = $1
        GROUP BY o.id, o.name
-       ORDER BY "totalKg" DESC
+       ORDER BY "totalKg" DESC, MAX(d.date) DESC
        LIMIT $2`,
       [year, limit],
     );

--- a/MJ_FB_Backend/src/controllers/outgoingReceiverController.ts
+++ b/MJ_FB_Backend/src/controllers/outgoingReceiverController.ts
@@ -35,11 +35,13 @@ export async function topOutgoingReceivers(
     const year = parseInt((req.query.year as string) ?? '', 10) || new Date().getFullYear();
     const limit = parseInt((req.query.limit as string) ?? '', 10) || 7;
     const result = await pool.query(
-      `SELECT r.name, SUM(l.weight)::int AS "totalKg", MAX(l.date) AS "lastPickupISO"
+      `SELECT r.name,
+              SUM(l.weight)::int AS "totalKg",
+              TO_CHAR(MAX(l.date), 'YYYY-MM-DD') AS "lastPickupISO"
        FROM outgoing_donation_log l JOIN outgoing_receivers r ON l.receiver_id = r.id
        WHERE EXTRACT(YEAR FROM l.date) = $1
        GROUP BY r.id, r.name
-       ORDER BY "totalKg" DESC
+       ORDER BY "totalKg" DESC, MAX(l.date) DESC
        LIMIT $2`,
       [year, limit],
     );


### PR DESCRIPTION
## Summary
- format dates returned by top donor and receiver endpoints
- order results by total kilograms and most recent activity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab730d9fc0832dbe7ee8a962c55aeb