### PR TITLE
feat: combine monthly trend lines

### DIFF
--- a/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
@@ -345,45 +345,32 @@ export default function WarehouseDashboard() {
       >
         <Card variant="outlined">
           <CardHeader title="Monthly Trend" />
-          <CardContent sx={{ height: 300, display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Box sx={{ flex: 1 }}>
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="month" />
-                  <YAxis />
-                  <RTooltip formatter={(val: number) => fmtKg(val)} />
-                  <Legend />
-                  <Line
-                    type="monotone"
-                    dataKey="incoming"
-                    name="Incoming"
-                    stroke={theme.palette.success.main}
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </Box>
-            <Box sx={{ flex: 1 }}>
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="month" />
-                  <YAxis />
-                  <RTooltip formatter={(val: number) => fmtKg(val)} />
-                  <Legend />
-                  <Line
-                    type="monotone"
-                    dataKey="outgoing"
-                    name="Outgoing"
-                    stroke={theme.palette.error.main}
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </Box>
+          <CardContent sx={{ height: 300 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="month" />
+                <YAxis />
+                <RTooltip formatter={(val: number) => fmtKg(val)} />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="incoming"
+                  name="Incoming"
+                  stroke={theme.palette.success.main}
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="outgoing"
+                  name="Outgoing"
+                  stroke={theme.palette.error.main}
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
           </CardContent>
         </Card>
         <Card variant="outlined">


### PR DESCRIPTION
## Summary
- show incoming and outgoing data in one monthly trend line chart

## Testing
- `npm test` *(fails: ESM syntax is not allowed in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab746b1928832dbe0a323317d38ea5