### PR TITLE
Use lbs for warehouse weights

### DIFF
--- a/MJ_FB_Backend/src/controllers/donorController.ts
+++ b/MJ_FB_Backend/src/controllers/donorController.ts
@@ -35,11 +35,11 @@ export async function topDonors(req: Request, res: Response, next: NextFunction)
     const year = parseInt((req.query.year as string) ?? '', 10) || new Date().getFullYear();
     const limit = parseInt((req.query.limit as string) ?? '', 10) || 7;
     const result = await pool.query(
-      `SELECT o.name, SUM(d.weight)::int AS "totalKg", MAX(d.date) AS "lastDonationISO"
+      `SELECT o.name, SUM(d.weight)::int AS "totalLbs", MAX(d.date) AS "lastDonationISO"
        FROM donations d JOIN donors o ON d.donor_id = o.id
        WHERE EXTRACT(YEAR FROM d.date) = $1
        GROUP BY o.id, o.name
-       ORDER BY "totalKg" DESC
+       ORDER BY "totalLbs" DESC
        LIMIT $2`,
       [year, limit],
     );

--- a/MJ_FB_Backend/src/controllers/outgoingReceiverController.ts
+++ b/MJ_FB_Backend/src/controllers/outgoingReceiverController.ts
@@ -35,11 +35,11 @@ export async function topOutgoingReceivers(
     const year = parseInt((req.query.year as string) ?? '', 10) || new Date().getFullYear();
     const limit = parseInt((req.query.limit as string) ?? '', 10) || 7;
     const result = await pool.query(
-      `SELECT r.name, SUM(l.weight)::int AS "totalKg", MAX(l.date) AS "lastPickupISO"
+      `SELECT r.name, SUM(l.weight)::int AS "totalLbs", MAX(l.date) AS "lastPickupISO"
        FROM outgoing_donation_log l JOIN outgoing_receivers r ON l.receiver_id = r.id
        WHERE EXTRACT(YEAR FROM l.date) = $1
        GROUP BY r.id, r.name
-       ORDER BY "totalKg" DESC
+       ORDER BY "totalLbs" DESC
        LIMIT $2`,
       [year, limit],
     );

--- a/MJ_FB_Backend/tests/topLists.test.ts
+++ b/MJ_FB_Backend/tests/topLists.test.ts
@@ -17,13 +17,13 @@ beforeEach(() => {
 describe('GET /donors/top', () => {
   it('returns top donors for the year', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({
-      rows: [{ name: 'Alice', totalKg: 100, lastDonationISO: '2024-01-10' }],
+      rows: [{ name: 'Alice', totalLbs: 100, lastDonationISO: '2024-01-10' }],
     });
 
     const res = await request(app).get('/donors/top?year=2024&limit=5');
     expect(res.status).toBe(200);
     expect(res.body).toEqual([
-      { name: 'Alice', totalKg: 100, lastDonationISO: '2024-01-10' },
+      { name: 'Alice', totalLbs: 100, lastDonationISO: '2024-01-10' },
     ]);
   });
 });
@@ -31,13 +31,13 @@ describe('GET /donors/top', () => {
 describe('GET /outgoing-receivers/top', () => {
   it('returns top receivers for the year', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({
-      rows: [{ name: 'Org', totalKg: 50, lastPickupISO: '2024-02-15' }],
+      rows: [{ name: 'Org', totalLbs: 50, lastPickupISO: '2024-02-15' }],
     });
 
     const res = await request(app).get('/outgoing-receivers/top?year=2024&limit=5');
     expect(res.status).toBe(200);
     expect(res.body).toEqual([
-      { name: 'Org', totalKg: 50, lastPickupISO: '2024-02-15' },
+      { name: 'Org', totalLbs: 50, lastPickupISO: '2024-02-15' },
     ]);
   });
 });

--- a/MJ_FB_Frontend/src/api/donors.ts
+++ b/MJ_FB_Frontend/src/api/donors.ts
@@ -7,7 +7,7 @@ export interface Donor {
 
 export interface TopDonor {
   name: string;
-  totalKg: number;
+  totalLbs: number;
   lastDonationISO: string;
 }
 

--- a/MJ_FB_Frontend/src/api/outgoingReceivers.ts
+++ b/MJ_FB_Frontend/src/api/outgoingReceivers.ts
@@ -7,7 +7,7 @@ export interface OutgoingReceiver {
 
 export interface TopReceiver {
   name: string;
-  totalKg: number;
+  totalLbs: number;
   lastPickupISO: string;
 }
 

--- a/MJ_FB_Frontend/src/pages/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/DonationLog.tsx
@@ -153,7 +153,7 @@ export default function DonationLog() {
           <TableHead>
           <TableRow>
             <TableCell>Donor</TableCell>
-            <TableCell>Weight</TableCell>
+            <TableCell>Weight (lbs)</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
           </TableHead>
@@ -161,7 +161,7 @@ export default function DonationLog() {
           {donations.map(d => (
             <TableRow key={d.id}>
               <TableCell>{d.donor}</TableCell>
-              <TableCell>{d.weight}</TableCell>
+              <TableCell>{d.weight} lbs</TableCell>
               <TableCell align="right">
                 <IconButton size="small" onClick={() => {
                   setEditing(d);
@@ -192,7 +192,7 @@ export default function DonationLog() {
               InputLabelProps={{ shrink: true }}
             />
             <TextField
-              label="Weight"
+              label="Weight (lbs)"
               type="number"
               value={form.weight}
               onChange={e => setForm({ ...form, weight: e.target.value })}

--- a/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackOutgoingDonations.tsx
@@ -167,7 +167,7 @@ export default function TrackOutgoingDonations() {
           <TableRow>
             <TableCell>Date</TableCell>
             <TableCell>Receiver</TableCell>
-            <TableCell>Weight</TableCell>
+            <TableCell>Weight (lbs)</TableCell>
             <TableCell>Note</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
@@ -177,7 +177,7 @@ export default function TrackOutgoingDonations() {
             <TableRow key={d.id}>
               <TableCell>{d.date}</TableCell>
               <TableCell>{d.receiver}</TableCell>
-              <TableCell>{d.weight}</TableCell>
+              <TableCell>{d.weight} lbs</TableCell>
               <TableCell>{d.note}</TableCell>
               <TableCell align="right">
                 <IconButton
@@ -213,7 +213,7 @@ export default function TrackOutgoingDonations() {
               InputLabelProps={{ shrink: true }}
             />
             <TextField
-              label="Weight"
+              label="Weight (lbs)"
               type="number"
               value={form.weight}
               onChange={e => setForm({ ...form, weight: e.target.value })}

--- a/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackPigpound.tsx
@@ -135,7 +135,7 @@ export default function TrackPigpound() {
           <TableHead>
           <TableRow>
             <TableCell>Date</TableCell>
-            <TableCell>Weight</TableCell>
+            <TableCell>Weight (lbs)</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
           </TableHead>
@@ -152,7 +152,7 @@ export default function TrackPigpound() {
                 <TableCell>
                   {new Date(e.date).toLocaleDateString('en-CA')}
                 </TableCell>
-                <TableCell>{e.weight}</TableCell>
+                <TableCell>{e.weight} lbs</TableCell>
                 <TableCell align="right">
                   <IconButton
                     size="small"
@@ -201,7 +201,7 @@ export default function TrackPigpound() {
               InputLabelProps={{ shrink: true }}
             />
             <TextField
-              label="Weight"
+              label="Weight (lbs)"
               type="number"
               value={form.weight}
               onChange={e => setForm({ ...form, weight: e.target.value })}

--- a/MJ_FB_Frontend/src/pages/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/TrackSurplus.tsx
@@ -142,7 +142,7 @@ export default function TrackSurplus() {
             <TableCell>Date</TableCell>
             <TableCell>Type</TableCell>
             <TableCell>Count</TableCell>
-            <TableCell>Weight</TableCell>
+            <TableCell>Weight (lbs)</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
           </TableHead>
@@ -159,7 +159,7 @@ export default function TrackSurplus() {
               </TableCell>
               <TableCell>{r.type}</TableCell>
               <TableCell>{r.count}</TableCell>
-              <TableCell>{r.weight}</TableCell>
+              <TableCell>{r.weight} lbs</TableCell>
               <TableCell align="right">
                 <IconButton
                   size="small"
@@ -215,7 +215,7 @@ export default function TrackSurplus() {
               value={form.count}
               onChange={e => setForm({ ...form, count: e.target.value })}
             />
-            <TextField label="Weight" type="number" value={weight} InputProps={{ readOnly: true }} />
+            <TextField label="Weight (lbs)" type="number" value={weight} InputProps={{ readOnly: true }} />
           </Stack>
         </DialogContent>
         <DialogActions>

--- a/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
@@ -52,10 +52,10 @@ import type { AlertColor } from '@mui/material';
 interface MonthlyTotal {
   year: number;
   month: number;
-  donationsKg: number;
-  surplusKg: number;
-  pigPoundKg: number;
-  outgoingKg: number;
+  donationsLbs: number;
+  surplusLbs: number;
+  pigPoundLbs: number;
+  outgoingLbs: number;
 }
 
 
@@ -63,8 +63,8 @@ function monthName(m: number) {
   return new Date(2000, m - 1).toLocaleString(undefined, { month: 'short' });
 }
 
-function fmtKg(n: number) {
-  return `${n.toLocaleString(undefined, { maximumFractionDigits: 0 })} kg`;
+function fmtLbs(n: number) {
+  return `${n.toLocaleString(undefined, { maximumFractionDigits: 0 })} lbs`;
 }
 
 function kpiDelta(curr: number, prev?: number) {
@@ -118,10 +118,10 @@ export default function WarehouseDashboard() {
         tRes.value.map(t => ({
           year: selectedYear,
           month: t.month,
-          donationsKg: t.donations,
-          surplusKg: t.surplus,
-          pigPoundKg: t.pigPound,
-          outgoingKg: t.outgoingDonations,
+          donationsLbs: t.donations,
+          surplusLbs: t.surplus,
+          pigPoundLbs: t.pigPound,
+          outgoingLbs: t.outgoingDonations,
         })),
       );
     else
@@ -142,7 +142,7 @@ export default function WarehouseDashboard() {
   const currentMonth = useMemo(() => {
     const thisMonth = new Date().getMonth() + 1;
     const monthsWithData = totals
-      .filter(t => t.donationsKg || t.surplusKg || t.pigPoundKg || t.outgoingKg)
+      .filter(t => t.donationsLbs || t.surplusLbs || t.pigPoundLbs || t.outgoingLbs)
       .map(t => t.month);
     if (monthsWithData.includes(thisMonth)) return thisMonth;
     return monthsWithData.length ? Math.max(...monthsWithData) : thisMonth;
@@ -151,14 +151,14 @@ export default function WarehouseDashboard() {
   const currentTotals = totals.find(t => t.month === currentMonth);
   const prevTotals = totals.find(t => t.month === currentMonth - 1);
 
-  const incoming = currentTotals?.donationsKg ?? 0;
-  const prevIncoming = prevTotals?.donationsKg ?? 0;
+  const incoming = currentTotals?.donationsLbs ?? 0;
+  const prevIncoming = prevTotals?.donationsLbs ?? 0;
   const totalIncoming =
-    (currentTotals?.donationsKg ?? 0) +
-    (currentTotals?.surplusKg ?? 0) +
-    (currentTotals?.pigPoundKg ?? 0);
-  const outgoing = currentTotals?.outgoingKg ?? 0;
-  const prevOutgoing = prevTotals?.outgoingKg ?? 0;
+    (currentTotals?.donationsLbs ?? 0) +
+    (currentTotals?.surplusLbs ?? 0) +
+    (currentTotals?.pigPoundLbs ?? 0);
+  const outgoing = currentTotals?.outgoingLbs ?? 0;
+  const prevOutgoing = prevTotals?.outgoingLbs ?? 0;
   const anomalyRatio = totalIncoming ? outgoing / totalIncoming : 0;
   const showAnomaly = totalIncoming > 0 && anomalyRatio > 1.25;
 
@@ -167,15 +167,15 @@ export default function WarehouseDashboard() {
       Array.from({ length: 12 }, (_, i) => {
         const m = i + 1;
         const t = totals.find(tt => tt.month === m);
-        const incoming = t?.donationsKg ?? 0;
-        const outgoing = t?.outgoingKg ?? 0;
+        const incoming = t?.donationsLbs ?? 0;
+        const outgoing = t?.outgoingLbs ?? 0;
         return {
           month: monthName(m),
           incoming,
           outgoing,
           donations: incoming,
-          surplus: t?.surplusKg ?? 0,
-          pigPound: t?.pigPoundKg ?? 0,
+          surplus: t?.surplusLbs ?? 0,
+          pigPound: t?.pigPoundLbs ?? 0,
         };
       }),
     [totals],
@@ -225,9 +225,9 @@ export default function WarehouseDashboard() {
   }
 
   const kpis = [
-    { title: 'Incoming (Donations)', value: currentTotals?.donationsKg ?? 0, prev: prevTotals?.donationsKg ?? 0 },
-    { title: 'Surplus Logged', value: currentTotals?.surplusKg ?? 0, prev: prevTotals?.surplusKg ?? 0 },
-    { title: 'Pig Pound', value: currentTotals?.pigPoundKg ?? 0, prev: prevTotals?.pigPoundKg ?? 0 },
+    { title: 'Incoming (Donations)', value: currentTotals?.donationsLbs ?? 0, prev: prevTotals?.donationsLbs ?? 0 },
+    { title: 'Surplus Logged', value: currentTotals?.surplusLbs ?? 0, prev: prevTotals?.surplusLbs ?? 0 },
+    { title: 'Pig Pound', value: currentTotals?.pigPoundLbs ?? 0, prev: prevTotals?.pigPoundLbs ?? 0 },
     { title: 'Outgoing Shipments', value: outgoing, prev: prevOutgoing },
   ];
 
@@ -320,7 +320,7 @@ export default function WarehouseDashboard() {
               />
               <CardContent>
                 <Typography variant="h5" gutterBottom>
-                  {fmtKg(k.value)}
+                  {fmtLbs(k.value)}
                 </Typography>
                 <Stack direction="row" spacing={0.5} alignItems="center">
                   <TrendingUp
@@ -352,7 +352,7 @@ export default function WarehouseDashboard() {
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="month" />
                   <YAxis />
-                  <RTooltip formatter={(val: number) => fmtKg(val)} />
+                  <RTooltip formatter={(val: number) => fmtLbs(val)} />
                   <Legend />
                   <Line
                     type="monotone"
@@ -371,7 +371,7 @@ export default function WarehouseDashboard() {
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="month" />
                   <YAxis />
-                  <RTooltip formatter={(val: number) => fmtKg(val)} />
+                  <RTooltip formatter={(val: number) => fmtLbs(val)} />
                   <Legend />
                   <Line
                     type="monotone"
@@ -394,7 +394,7 @@ export default function WarehouseDashboard() {
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="month" />
                 <YAxis />
-                <RTooltip formatter={(val: number) => fmtKg(val)} />
+                <RTooltip formatter={(val: number) => fmtLbs(val)} />
                 <Legend />
                 <Bar
                   dataKey="donations"
@@ -434,7 +434,7 @@ export default function WarehouseDashboard() {
         <Card variant="outlined">
           <CardHeader
             title="Top Donors"
-            subheader="This year by total kg"
+            subheader="This year by total lbs"
             action={<Chip label={filteredDonors.length} size="small" />}
           />
           <CardContent>
@@ -448,7 +448,7 @@ export default function WarehouseDashboard() {
                         Last: {new Date(d.lastDonationISO).toLocaleDateString()}
                       </Typography>
                     </Box>
-                    <Typography variant="body2">{fmtKg(d.totalKg)}</Typography>
+                    <Typography variant="body2">{fmtLbs(d.totalLbs)}</Typography>
                   </Stack>
                 ))}
               </Stack>
@@ -462,7 +462,7 @@ export default function WarehouseDashboard() {
         <Card variant="outlined">
           <CardHeader
             title="Top Receivers"
-            subheader="This year by total kg"
+            subheader="This year by total lbs"
             action={<Chip label={filteredReceivers.length} size="small" />}
           />
           <CardContent>
@@ -476,7 +476,7 @@ export default function WarehouseDashboard() {
                         Last: {new Date(r.lastPickupISO).toLocaleDateString()}
                       </Typography>
                     </Box>
-                    <Typography variant="body2">{fmtKg(r.totalKg)}</Typography>
+                    <Typography variant="body2">{fmtLbs(r.totalLbs)}</Typography>
                   </Stack>
                 ))}
               </Stack>
@@ -524,7 +524,7 @@ export default function WarehouseDashboard() {
                 </Button>
               </li>
               <li>Outgoing weight &gt; incoming by 25% this month — verify logs.</li>
-              <li>Surplus records missing count-to-kg conversion factor — check categories.</li>
+              <li>Surplus records missing count-to-lb conversion factor — check categories.</li>
             </ul>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- replace kg references with lbs across warehouse dashboard and management pages
- update backend queries and types to return totalLbs
- adjust donation log, surplus, pig pound and outgoing donations screens to label weight in lbs

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ab73d50948832d9fd0ba0653eda5d9