### PR TITLE
fix: handle undefined weights in warehouse dashboard

### DIFF
--- a/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/WarehouseDashboard.tsx
@@ -63,8 +63,9 @@ function monthName(m: number) {
   return new Date(2000, m - 1).toLocaleString(undefined, { month: 'short' });
 }
 
-function fmtLbs(n: number) {
-  return `${n.toLocaleString(undefined, { maximumFractionDigits: 0 })} lbs`;
+function fmtLbs(n?: number) {
+  const safe = typeof n === 'number' && !Number.isNaN(n) ? n : 0;
+  return `${safe.toLocaleString(undefined, { maximumFractionDigits: 0 })} lbs`;
 }
 
 function kpiDelta(curr: number, prev?: number) {


### PR DESCRIPTION
## Summary
- avoid runtime error when formatting undefined weight values on WarehouseDashboard

## Testing
- `CI=true npm test` *(fails: ESM syntax is not allowed in a CommonJS module...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab77a07e38832da47d80528e483fea