### PR TITLE
Add donor aggregation table with yearly breakdown

### DIFF
--- a/MJ_FB_Backend/src/routes/donations.ts
+++ b/MJ_FB_Backend/src/routes/donations.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { listDonations, addDonation, updateDonation, deleteDonation } from '../controllers/donationController';
+import { listDonations, addDonation, updateDonation, deleteDonation, donorAggregations } from '../controllers/donationController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addDonationSchema, updateDonationSchema } from '../schemas/donationSchemas';
@@ -7,6 +7,7 @@ import { addDonationSchema, updateDonationSchema } from '../schemas/donationSche
 const router = Router();
 
 router.get('/', authMiddleware, authorizeRoles('staff'), listDonations);
+router.get('/aggregations', authMiddleware, authorizeRoles('staff'), donorAggregations);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(addDonationSchema), addDonation);
 router.put('/:id', authMiddleware, authorizeRoles('staff'), validate(updateDonationSchema), updateDonation);
 router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteDonation);

--- a/MJ_FB_Backend/tests/donationAggregations.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregations.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import express from 'express';
+import donationsRoutes from '../src/routes/donations';
+import pool from '../src/db';
+import jwt from 'jsonwebtoken';
+
+jest.mock('../src/db');
+jest.mock('jsonwebtoken');
+
+const app = express();
+app.use('/donations', donationsRoutes);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /donations/aggregations', () => {
+  it('returns donor aggregations for the year', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff' });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 1, first_name: 'Test', last_name: 'User', email: 't@example.com', role: 'staff' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { donor: 'Alice', month: 1, total: 100 },
+          { donor: 'Alice', month: 2, total: 50 },
+          { donor: 'Bob', month: 1, total: 25 },
+        ],
+      });
+
+    const res = await request(app)
+      .get('/donations/aggregations?year=2024')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { donor: 'Alice', monthlyTotals: [100, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], total: 150 },
+      { donor: 'Bob', monthlyTotals: [25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], total: 25 },
+    ]);
+  });
+});

--- a/MJ_FB_Frontend/src/api/donations.ts
+++ b/MJ_FB_Frontend/src/api/donations.ts
@@ -35,3 +35,14 @@ export async function deleteDonation(id: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/donations/${id}`, { method: 'DELETE' });
   await handleResponse(res);
 }
+
+export interface DonorAggregation {
+  donor: string;
+  monthlyTotals: number[];
+  total: number;
+}
+
+export async function getDonorAggregations(year: number): Promise<DonorAggregation[]> {
+  const res = await apiFetch(`${API_BASE}/donations/aggregations?year=${year}`);
+  return handleResponse(res);
+}


### PR DESCRIPTION
## Summary
- add backend endpoint to return monthly donation totals by donor
- display donor aggregation table with year selector and totals
- cover donor aggregation endpoint with tests

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: ESM syntax in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cd243f8832db22b61c3da850b35