### PR TITLE
Add donor search with profile view

### DIFF
--- a/MJ_FB_Backend/src/routes/donors.ts
+++ b/MJ_FB_Backend/src/routes/donors.ts
@@ -1,5 +1,11 @@
 import { Router } from 'express';
-import { listDonors, addDonor, topDonors } from '../controllers/donorController';
+import {
+  listDonors,
+  addDonor,
+  topDonors,
+  getDonor,
+  donorDonations,
+} from '../controllers/donorController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addDonorSchema } from '../schemas/donorSchemas';
@@ -10,5 +16,7 @@ const router = Router();
 router.get('/top', topDonors);
 router.get('/', authMiddleware, authorizeRoles('staff'), listDonors);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(addDonorSchema), addDonor);
+router.get('/:id', authMiddleware, authorizeRoles('staff'), getDonor);
+router.get('/:id/donations', authMiddleware, authorizeRoles('staff'), donorDonations);
 
 export default router;

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -22,6 +22,7 @@ import TrackPigpound from './pages/TrackPigpound';
 import TrackOutgoingDonations from './pages/TrackOutgoingDonations';
 import TrackSurplus from './pages/TrackSurplus';
 import Aggregations from './pages/Aggregations';
+import DonorProfile from './pages/DonorProfile';
 import Navbar, { type NavGroup } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
@@ -146,6 +147,9 @@ export default function App() {
               )}
               {isStaff && (
                 <Route path="/warehouse-management/donation-log" element={<DonationLog />} />
+              )}
+              {isStaff && (
+                <Route path="/warehouse-management/donors/:id" element={<DonorProfile />} />
               )}
               {isStaff && (
                 <Route

--- a/MJ_FB_Frontend/src/api/donors.ts
+++ b/MJ_FB_Frontend/src/api/donors.ts
@@ -11,6 +11,17 @@ export interface TopDonor {
   lastDonationISO: string;
 }
 
+export interface DonorDetail extends Donor {
+  totalLbs: number;
+  lastDonationISO: string | null;
+}
+
+export interface DonorDonation {
+  id: number;
+  date: string;
+  weight: number;
+}
+
 export async function getDonors(search?: string): Promise<Donor[]> {
   const query = search ? `?search=${encodeURIComponent(search)}` : '';
   const res = await apiFetch(`${API_BASE}/donors${query}`);
@@ -23,6 +34,18 @@ export async function createDonor(name: string): Promise<Donor> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name }),
   });
+  return handleResponse(res);
+}
+
+export async function getDonor(id: number): Promise<DonorDetail> {
+  const res = await apiFetch(`${API_BASE}/donors/${id}`);
+  return handleResponse(res);
+}
+
+export async function getDonorDonations(
+  id: number,
+): Promise<DonorDonation[]> {
+  const res = await apiFetch(`${API_BASE}/donors/${id}/donations`);
   return handleResponse(res);
 }
 

--- a/MJ_FB_Frontend/src/pages/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/DonorProfile.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@mui/material';
+import FeedbackSnackbar from '../components/FeedbackSnackbar';
+import {
+  getDonor,
+  getDonorDonations,
+  type DonorDetail,
+  type DonorDonation,
+} from '../api/donors';
+
+export default function DonorProfile() {
+  const { id } = useParams<{ id: string }>();
+  const [donor, setDonor] = useState<DonorDetail | null>(null);
+  const [donations, setDonations] = useState<DonorDonation[]>([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!id) return;
+    const donorId = Number(id);
+    getDonor(donorId)
+      .then(setDonor)
+      .catch(err => setError(err.message || 'Failed to load donor'));
+    getDonorDonations(donorId)
+      .then(setDonations)
+      .catch(err => setError(err.message || 'Failed to load donations'));
+  }, [id]);
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Donor Profile
+      </Typography>
+      {donor && (
+        <Card variant="outlined" sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography variant="h6">{donor.name}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Total: {donor.totalLbs.toLocaleString()} lbs
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Last Donation: {donor.lastDonationISO ? new Date(donor.lastDonationISO).toLocaleDateString() : 'N/A'}
+            </Typography>
+          </CardContent>
+        </Card>
+      )}
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="subtitle1" gutterBottom>
+            Donations
+          </Typography>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Date</TableCell>
+                <TableCell>Weight (lbs)</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {donations.map(d => (
+                <TableRow key={d.id}>
+                  <TableCell>{new Date(d.date).toLocaleDateString()}</TableCell>
+                  <TableCell>{d.weight}</TableCell>
+                </TableRow>
+              ))}
+              {donations.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      No donations found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <FeedbackSnackbar
+        open={!!error}
+        onClose={() => setError('')}
+        message={error}
+        severity="error"
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add backend endpoints to fetch donor details and donation history
- enable donor search on warehouse dashboard with profile navigation
- add donor profile page and API helpers

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: TS1286 ESM syntax not allowed)


------
https://chatgpt.com/codex/tasks/task_e_68ab8d0f6604832d820304d54cc0720a