### PR TITLE
Include donors with zero donations in aggregation

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -45,4 +45,12 @@ Authorization: Bearer <token>
 
 The token payload includes the user's `id`, `role`, and `type` and expires after one hour.
 
+## Donation Aggregations Endpoint
+
+`GET /donations/aggregations?year=YYYY`
+
+Returns a list of donors with their total donated weight for each month of the specified year.
+Every donor in the system is included even if they have no donations in that year; months
+without records report `0`.
+
 


### PR DESCRIPTION
## Summary
- ensure donor aggregation left-joins donors and generates 12 monthly buckets with zero totals
- fill missing months for each donor during transformation
- test donors with no yearly donations
- document donor aggregation endpoint behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8f6e5828832da44771576011176f