### PR TITLE
Default aggregations view to donor tab and add test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
@@ -1,0 +1,32 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import Aggregations from '../pages/Aggregations';
+
+const mockGetWarehouseOverall = jest.fn().mockResolvedValue([]);
+jest.mock('../api/warehouseOverall', () => ({
+  getWarehouseOverall: (...args: unknown[]) => mockGetWarehouseOverall(...args),
+  rebuildWarehouseOverall: jest.fn(),
+  exportWarehouseOverall: jest.fn(),
+}));
+
+const mockGetDonorAggregations = jest.fn().mockResolvedValue([]);
+jest.mock('../api/donations', () => ({
+  getDonorAggregations: (...args: unknown[]) => mockGetDonorAggregations(...args),
+}));
+
+describe('Aggregations page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads donor data on mount and when returning to Donor tab', async () => {
+    render(<Aggregations />);
+
+    await waitFor(() => expect(mockGetDonorAggregations).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('tab', { name: /yearly overall aggregations/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /donor aggregations/i }));
+
+    await waitFor(() => expect(mockGetDonorAggregations).toHaveBeenCalledTimes(2));
+  });
+});
+

--- a/MJ_FB_Frontend/src/pages/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/Aggregations.tsx
@@ -36,7 +36,7 @@ export default function Aggregations() {
   const [overallYear, setOverallYear] = useState(currentYear);
   const [donorYear, setDonorYear] = useState(currentYear);
   const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
-  const [tab, setTab] = useState(1);
+  const [tab, setTab] = useState(0);
   const [donorRows, setDonorRows] = useState<DonorAggregation[]>([]);
   const [donorLoading, setDonorLoading] = useState(false);
 

--- a/MJ_FB_Frontend/tsconfig.test.json
+++ b/MJ_FB_Frontend/tsconfig.test.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "allowImportingTsExtensions": false
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": false
   },
   "include": ["src", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary
- default Aggregations page to show the Donor tab on load
- cover donor tab data loading with a unit test
- tweak test tsconfig to permit CommonJS execution

## Testing
- `npm test src/__tests__/Aggregations.test.tsx`
- `npm test` *(fails: TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', or 'nodenext'.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8f80db10832d804935c1570da225