### PR TITLE
Bootstrap first staff member as admin

### DIFF
--- a/MJ_FB_Backend/src/routes/staff.ts
+++ b/MJ_FB_Backend/src/routes/staff.ts
@@ -13,7 +13,7 @@ router.post('/', async (req, res, next: NextFunction) => {
   const result = await pool.query('SELECT COUNT(*) FROM staff');
   const count = parseInt(result.rows[0].count, 10);
   if (count === 0) {
-    return createStaff(req, res, next);
+    return createStaff(req, res, next, ['admin']);
   }
   authMiddleware(req, res, () => {
     authorizeRoles('staff')(req, res, () => createStaff(req, res, next));


### PR DESCRIPTION
## Summary
- force initial staff creation through route to provide admin access
- ensure controller defaults first staff account to admin and rejects custom access overrides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab924739b0832db1069b501fb1f739