### PR TITLE
Fix top outgoing receivers ordering

### DIFF
--- a/MJ_FB_Backend/src/controllers/outgoingReceiverController.ts
+++ b/MJ_FB_Backend/src/controllers/outgoingReceiverController.ts
@@ -39,7 +39,7 @@ export async function topOutgoingReceivers(
        FROM outgoing_donation_log l JOIN outgoing_receivers r ON l.receiver_id = r.id
        WHERE EXTRACT(YEAR FROM l.date) = $1
        GROUP BY r.id, r.name
-       ORDER BY "totalKg" DESC, MAX(l.date) DESC
+       ORDER BY "totalLbs" DESC, MAX(l.date) DESC
        LIMIT $2`,
       [year, limit],
     );

--- a/MJ_FB_Backend/tests/topLists.test.ts
+++ b/MJ_FB_Backend/tests/topLists.test.ts
@@ -39,5 +39,6 @@ describe('GET /outgoing-receivers/top', () => {
     expect(res.body).toEqual([
       { name: 'Org', totalLbs: 50, lastPickupISO: '2024-02-15' },
     ]);
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/ORDER BY "totalLbs" DESC/);
   });
 });


### PR DESCRIPTION
## Summary
- fix SQL query for top outgoing receivers to order by `totalLbs`
- test ensures controller sorts by `totalLbs`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab92c33208832d8c0ef524afb2a415