### PR TITLE
Add access-based staff controls

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -27,12 +27,17 @@ import Navbar, { type NavGroup } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
 import { useAuth } from './hooks/useAuth';
+import type { StaffAccess } from './types';
 
 export default function App() {
-  const { token, role, name, userRole, login, logout } = useAuth();
+  const { token, role, name, userRole, access, login, logout } = useAuth();
   const [loading] = useState(false);
   const [error, setError] = useState('');
   const isStaff = role === 'staff';
+  const hasAccess = (a: StaffAccess) => access.includes('admin') || access.includes(a);
+  const showStaff = isStaff && hasAccess('staff');
+  const showVolunteerManagement = isStaff && hasAccess('volunteer_management');
+  const showWarehouse = isStaff && hasAccess('warehouse');
 
   const navGroups: NavGroup[] = [];
   if (!token) {
@@ -49,17 +54,18 @@ export default function App() {
       { label: 'User History', to: '/user-history' },
       { label: 'Pending', to: '/pending' },
     ];
-    navGroups.push({ label: 'Staff', links: staffLinks });
-    navGroups.push({
-      label: 'Volunteer Management',
-      links: [
-        { label: 'Dashboard', to: '/volunteer-management' },
-        { label: 'Schedule', to: '/volunteer-management/schedule' },
-        { label: 'Search', to: '/volunteer-management/search' },
-        { label: 'Create', to: '/volunteer-management/create' },
-        { label: 'Pending', to: '/volunteer-management/pending' },
-      ],
-    });
+    if (showStaff) navGroups.push({ label: 'Staff', links: staffLinks });
+    if (showVolunteerManagement)
+      navGroups.push({
+        label: 'Volunteer Management',
+        links: [
+          { label: 'Dashboard', to: '/volunteer-management' },
+          { label: 'Schedule', to: '/volunteer-management/schedule' },
+          { label: 'Search', to: '/volunteer-management/search' },
+          { label: 'Create', to: '/volunteer-management/create' },
+          { label: 'Pending', to: '/volunteer-management/pending' },
+        ],
+      });
 
     const warehouseLinks = [
       { label: 'Dashboard', to: '/warehouse-management' },
@@ -72,7 +78,7 @@ export default function App() {
       { label: 'Track Surplus', to: '/warehouse-management/track-surplus' },
       { label: 'Aggregations', to: '/warehouse-management/aggregations' },
     ];
-    navGroups.push({ label: 'Warehouse Management', links: warehouseLinks });
+    if (showWarehouse) navGroups.push({ label: 'Warehouse Management', links: warehouseLinks });
 
   } else if (role === 'shopper') {
     navGroups.push({
@@ -136,40 +142,40 @@ export default function App() {
                 }
               />
               <Route path="/profile" element={<Profile token={token} role={role} />} />
-              {isStaff && (
+              {showStaff && (
                 <Route path="/manage-availability" element={<ManageAvailability />} />
               )}
-              {isStaff && (
+              {showStaff && (
                 <Route path="/pantry-schedule" element={<PantrySchedule token={token} />} />
               )}
-              {isStaff && (
+              {showWarehouse && (
                 <Route path="/warehouse-management" element={<WarehouseDashboard />} />
               )}
-              {isStaff && (
+              {showWarehouse && (
                 <Route path="/warehouse-management/donation-log" element={<DonationLog />} />
               )}
-              {isStaff && (
+              {showWarehouse && (
                 <Route path="/warehouse-management/donors/:id" element={<DonorProfile />} />
               )}
-              {isStaff && (
+              {showWarehouse && (
                 <Route
                   path="/warehouse-management/track-pigpound"
                   element={<TrackPigpound />}
                 />
               )}
-              {isStaff && (
+              {showWarehouse && (
                 <Route
                   path="/warehouse-management/track-outgoing-donations"
                   element={<TrackOutgoingDonations />}
                 />
               )}
-              {isStaff && (
+              {showWarehouse && (
                 <Route
                   path="/warehouse-management/track-surplus"
                   element={<TrackSurplus />}
                 />
               )}
-              {isStaff && (
+              {showWarehouse && (
                 <Route
                   path="/warehouse-management/aggregations"
                   element={<Aggregations />}
@@ -203,10 +209,10 @@ export default function App() {
                   }
                 />
               )}
-              {isStaff && <Route path="/add-user" element={<AddUser token={token} />} />}
-              {isStaff && <Route path="/user-history" element={<UserHistory token={token} />} />}
-              {isStaff && <Route path="/pending" element={<Pending />} />}
-              {isStaff && (
+              {showStaff && <Route path="/add-user" element={<AddUser token={token} />} />}
+              {showStaff && <Route path="/user-history" element={<UserHistory token={token} />} />}
+              {showStaff && <Route path="/pending" element={<Pending />} />}
+              {showVolunteerManagement && (
                 <>
                   <Route
                     path="/volunteer-management"

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -1,12 +1,12 @@
-import type { Role, UserRole, StaffRole, UserProfile } from '../types';
+import type {
+  UserRole,
+  StaffRole,
+  UserProfile,
+  StaffAccess,
+  LoginResponse,
+} from '../types';
 import { API_BASE, apiFetch, handleResponse } from './client';
-
-export interface LoginResponse {
-  role: Role;
-  name: string;
-  bookingsThisMonth?: number;
-  userRole?: UserRole;
-}
+export type { LoginResponse } from '../types';
 
 export async function loginUser(
   clientId: string,
@@ -79,10 +79,10 @@ export async function staffExists(): Promise<boolean> {
 export async function createStaff(
   firstName: string,
   lastName: string,
-  role: StaffRole,
+  access: StaffAccess[],
   email: string,
   password: string,
-  _token?: string
+  _token?: string,
 ): Promise<void> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -90,7 +90,14 @@ export async function createStaff(
   const res = await apiFetch(`${API_BASE}/staff`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ firstName, lastName, role, email, password }),
+    body: JSON.stringify({
+      firstName,
+      lastName,
+      role: 'staff' as StaffRole,
+      email,
+      password,
+      access,
+    }),
   });
   await handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -1,9 +1,18 @@
 import { useState } from 'react';
 import { addUser, createStaff } from '../../api/users';
-import type { UserRole, StaffRole } from '../../types';
+import type { UserRole, StaffAccess } from '../../types';
 import FeedbackSnackbar from '../FeedbackSnackbar';
 import FeedbackModal from '../FeedbackModal';
-import { Box, Button, Stack, TextField, MenuItem, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Stack,
+  TextField,
+  MenuItem,
+  Typography,
+  Checkbox,
+  FormControlLabel,
+} from '@mui/material';
 
 export default function AddUser({ token }: { token: string }) {
   const [mode, setMode] = useState<'user' | 'staff'>('user');
@@ -16,8 +25,8 @@ export default function AddUser({ token }: { token: string }) {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [clientId, setClientId] = useState('');
-  const [staffRole, setStaffRole] = useState<StaffRole>('staff');
   const [password, setPassword] = useState('');
+  const [access, setAccess] = useState<StaffAccess[]>([]);
 
   async function submitUser() {
     if (!firstName || !lastName || !clientId || !password) {
@@ -54,13 +63,13 @@ export default function AddUser({ token }: { token: string }) {
       return;
     }
     try {
-      await createStaff(firstName, lastName, staffRole, email, password, token);
+      await createStaff(firstName, lastName, access, email, password, token);
       setSuccess('Staff added successfully');
       setFirstName('');
       setLastName('');
       setEmail('');
       setPassword('');
-      setStaffRole('staff');
+      setAccess([]);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     }
@@ -84,44 +93,96 @@ export default function AddUser({ token }: { token: string }) {
         <FeedbackModal open={!!success} onClose={() => setSuccess('')} message={success} />
         {mode === 'user' ? (
           <Stack spacing={2}>
-          <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
-          <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
-          <TextField label="Client ID" value={clientId} onChange={e => setClientId(e.target.value)} />
-          <TextField label="Email (optional)" type="email" value={email} onChange={e => setEmail(e.target.value)} />
-          <TextField
-            label="Phone (optional)"
-            type="tel"
-            value={phone}
-            onChange={e => setPhone(e.target.value)}
-          />
-          <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
-          <TextField select label="Role" value={role} onChange={e => setRole(e.target.value as UserRole)}>
-            <MenuItem value="shopper">Shopper</MenuItem>
-            <MenuItem value="delivery">Delivery</MenuItem>
-          </TextField>
-          <Button variant="contained" color="primary" onClick={submitUser}>
-            Add User
-          </Button>
-        </Stack>
-      ) : (
-        <Stack spacing={2}>
-          <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
-          <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
-          <TextField
-            select
-            label="Staff Role"
-            value={staffRole}
-            onChange={e => setStaffRole(e.target.value as StaffRole)}
-          >
-            <MenuItem value="staff">Staff</MenuItem>
-          </TextField>
-          <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} />
-          <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
-          <Button variant="contained" color="primary" onClick={submitStaff}>
-            Add Staff
-          </Button>
-        </Stack>
-      )}
+            <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
+            <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
+            <TextField label="Client ID" value={clientId} onChange={e => setClientId(e.target.value)} />
+            <TextField label="Email (optional)" type="email" value={email} onChange={e => setEmail(e.target.value)} />
+            <TextField
+              label="Phone (optional)"
+              type="tel"
+              value={phone}
+              onChange={e => setPhone(e.target.value)}
+            />
+            <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+            <TextField select label="Role" value={role} onChange={e => setRole(e.target.value as UserRole)}>
+              <MenuItem value="shopper">Shopper</MenuItem>
+              <MenuItem value="delivery">Delivery</MenuItem>
+            </TextField>
+            <Button variant="contained" color="primary" onClick={submitUser}>
+              Add User
+            </Button>
+          </Stack>
+        ) : (
+          <Stack spacing={2}>
+            <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
+            <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
+            <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} />
+            <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={access.includes('staff')}
+                  onChange={e =>
+                    setAccess(prev =>
+                      e.target.checked
+                        ? [...prev, 'staff']
+                        : prev.filter(a => a !== 'staff'),
+                    )
+                  }
+                />
+              }
+              label="Staff"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={access.includes('volunteer_management')}
+                  onChange={e =>
+                    setAccess(prev =>
+                      e.target.checked
+                        ? [...prev, 'volunteer_management']
+                        : prev.filter(a => a !== 'volunteer_management'),
+                    )
+                  }
+                />
+              }
+              label="Volunteer Management"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={access.includes('warehouse')}
+                  onChange={e =>
+                    setAccess(prev =>
+                      e.target.checked
+                        ? [...prev, 'warehouse']
+                        : prev.filter(a => a !== 'warehouse'),
+                    )
+                  }
+                />
+              }
+              label="Warehouse"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={access.includes('admin')}
+                  onChange={e =>
+                    setAccess(prev =>
+                      e.target.checked
+                        ? [...prev, 'admin']
+                        : prev.filter(a => a !== 'admin'),
+                    )
+                  }
+                />
+              }
+              label="Admin"
+            />
+            <Button variant="contained" color="primary" onClick={submitStaff}>
+              Add Staff
+            </Button>
+          </Stack>
+        )}
       </Box>
     </Box>
   );

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -89,7 +89,7 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      await createStaff(firstName, lastName, 'staff', email, password);
+      await createStaff(firstName, lastName, ['admin'], email, password);
       setMessage('Staff account created. You can login now.');
       setTimeout(onCreated, 1000);
     } catch (err: unknown) {

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -1,6 +1,19 @@
 export type Role = 'staff' | 'shopper' | 'delivery' | 'volunteer';
 export type UserRole = 'shopper' | 'delivery';
 export type StaffRole = 'staff';
+export type StaffAccess =
+  | 'admin'
+  | 'staff'
+  | 'volunteer_management'
+  | 'warehouse';
+
+export interface LoginResponse {
+  role: Role;
+  name: string;
+  bookingsThisMonth?: number;
+  userRole?: UserRole;
+  access: StaffAccess[];
+}
 
 export interface Slot {
   id: string;


### PR DESCRIPTION
## Summary
- add StaffAccess type and include access list in login responses
- persist staff access in auth context and gate navigation/routes accordingly
- allow assigning staff access via checkboxes when creating staff

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module; missing jest-dom matchers)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9273f280832da92f7b8b26f0bac6