### PR TITLE
feat: add granular staff access controls

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -103,6 +103,7 @@ export async function refreshToken(req: Request, res: Response, next: NextFuncti
       jti: string;
       userId?: number | string;
       userRole?: string;
+      access?: string[];
     };
     const subject = `${payload.type}:${payload.id}`;
     const stored = await pool.query(
@@ -124,6 +125,7 @@ export async function refreshToken(req: Request, res: Response, next: NextFuncti
     };
     if (payload.userId) basePayload.userId = payload.userId;
     if (payload.userRole) basePayload.userRole = payload.userRole;
+    if (payload.access) basePayload.access = payload.access;
 
     const accessToken = jwt.sign(basePayload, config.jwtSecret, {
       expiresIn: '1h',

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -43,7 +43,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
     }
 
     const staffQuery = await pool.query(
-      `SELECT id, first_name, last_name, email, password, role FROM staff WHERE email = $1`,
+      `SELECT id, first_name, last_name, email, password, role, access FROM staff WHERE email = $1`,
       [email]
     );
     if (staffQuery.rowCount === 0) {
@@ -54,11 +54,17 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
     if (!match) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
-    const payload: AuthPayload = { id: staff.id, role: staff.role, type: 'staff' };
+    const payload: AuthPayload = {
+      id: staff.id,
+      role: staff.role,
+      type: 'staff',
+      access: staff.access || [],
+    };
     await issueAuthTokens(res, payload, `staff:${staff.id}`);
     res.json({
       role: staff.role,
       name: `${staff.first_name} ${staff.last_name}`,
+      access: staff.access || [],
     });
   } catch (error) {
     logger.error('Error logging in:', error);

--- a/MJ_FB_Backend/src/routes/donations.ts
+++ b/MJ_FB_Backend/src/routes/donations.ts
@@ -1,15 +1,15 @@
 import { Router } from 'express';
 import { listDonations, addDonation, updateDonation, deleteDonation, donorAggregations } from '../controllers/donationController';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addDonationSchema, updateDonationSchema } from '../schemas/donationSchemas';
 
 const router = Router();
 
-router.get('/', authMiddleware, authorizeRoles('staff'), listDonations);
-router.get('/aggregations', authMiddleware, authorizeRoles('staff'), donorAggregations);
-router.post('/', authMiddleware, authorizeRoles('staff'), validate(addDonationSchema), addDonation);
-router.put('/:id', authMiddleware, authorizeRoles('staff'), validate(updateDonationSchema), updateDonation);
-router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteDonation);
+router.get('/', authMiddleware, authorizeAccess('warehouse'), listDonations);
+router.get('/aggregations', authMiddleware, authorizeAccess('warehouse'), donorAggregations);
+router.post('/', authMiddleware, authorizeAccess('warehouse'), validate(addDonationSchema), addDonation);
+router.put('/:id', authMiddleware, authorizeAccess('warehouse'), validate(updateDonationSchema), updateDonation);
+router.delete('/:id', authMiddleware, authorizeAccess('warehouse'), deleteDonation);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/donors.ts
+++ b/MJ_FB_Backend/src/routes/donors.ts
@@ -6,7 +6,7 @@ import {
   getDonor,
   donorDonations,
 } from '../controllers/donorController';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addDonorSchema } from '../schemas/donorSchemas';
 
@@ -14,9 +14,9 @@ const router = Router();
 
 // Public endpoint to list top donors
 router.get('/top', topDonors);
-router.get('/', authMiddleware, authorizeRoles('staff'), listDonors);
-router.post('/', authMiddleware, authorizeRoles('staff'), validate(addDonorSchema), addDonor);
-router.get('/:id', authMiddleware, authorizeRoles('staff'), getDonor);
-router.get('/:id/donations', authMiddleware, authorizeRoles('staff'), donorDonations);
+router.get('/', authMiddleware, authorizeAccess('warehouse'), listDonors);
+router.post('/', authMiddleware, authorizeAccess('warehouse'), validate(addDonorSchema), addDonor);
+router.get('/:id', authMiddleware, authorizeAccess('warehouse'), getDonor);
+router.get('/:id/donations', authMiddleware, authorizeAccess('warehouse'), donorDonations);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/outgoingDonations.ts
+++ b/MJ_FB_Backend/src/routes/outgoingDonations.ts
@@ -1,14 +1,14 @@
 import { Router } from 'express';
 import { listOutgoingDonations, addOutgoingDonation, updateOutgoingDonation, deleteOutgoingDonation } from '../controllers/outgoingDonationController';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addOutgoingDonationSchema, updateOutgoingDonationSchema } from '../schemas/outgoingDonationSchemas';
 
 const router = Router();
 
-router.get('/', authMiddleware, authorizeRoles('staff'), listOutgoingDonations);
-router.post('/', authMiddleware, authorizeRoles('staff'), validate(addOutgoingDonationSchema), addOutgoingDonation);
-router.put('/:id', authMiddleware, authorizeRoles('staff'), validate(updateOutgoingDonationSchema), updateOutgoingDonation);
-router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteOutgoingDonation);
+router.get('/', authMiddleware, authorizeAccess('warehouse'), listOutgoingDonations);
+router.post('/', authMiddleware, authorizeAccess('warehouse'), validate(addOutgoingDonationSchema), addOutgoingDonation);
+router.put('/:id', authMiddleware, authorizeAccess('warehouse'), validate(updateOutgoingDonationSchema), updateOutgoingDonation);
+router.delete('/:id', authMiddleware, authorizeAccess('warehouse'), deleteOutgoingDonation);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/outgoingReceivers.ts
+++ b/MJ_FB_Backend/src/routes/outgoingReceivers.ts
@@ -4,7 +4,7 @@ import {
   addOutgoingReceiver,
   topOutgoingReceivers,
 } from '../controllers/outgoingReceiverController';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addOutgoingReceiverSchema } from '../schemas/outgoingReceiverSchemas';
 
@@ -12,7 +12,7 @@ const router = Router();
 
 // Public endpoint to list top outgoing receivers
 router.get('/top', topOutgoingReceivers);
-router.get('/', authMiddleware, authorizeRoles('staff'), listOutgoingReceivers);
-router.post('/', authMiddleware, authorizeRoles('staff'), validate(addOutgoingReceiverSchema), addOutgoingReceiver);
+router.get('/', authMiddleware, authorizeAccess('warehouse'), listOutgoingReceivers);
+router.post('/', authMiddleware, authorizeAccess('warehouse'), validate(addOutgoingReceiverSchema), addOutgoingReceiver);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/pigPounds.ts
+++ b/MJ_FB_Backend/src/routes/pigPounds.ts
@@ -1,14 +1,14 @@
 import { Router } from 'express';
 import { listPigPounds, addPigPound, updatePigPound, deletePigPound } from '../controllers/pigPoundController';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addPigPoundSchema, updatePigPoundSchema } from '../schemas/pigPoundSchemas';
 
 const router = Router();
 
-router.get('/', authMiddleware, authorizeRoles('staff'), listPigPounds);
-router.post('/', authMiddleware, authorizeRoles('staff'), validate(addPigPoundSchema), addPigPound);
-router.put('/:id', authMiddleware, authorizeRoles('staff'), validate(updatePigPoundSchema), updatePigPound);
-router.delete('/:id', authMiddleware, authorizeRoles('staff'), deletePigPound);
+router.get('/', authMiddleware, authorizeAccess('warehouse'), listPigPounds);
+router.post('/', authMiddleware, authorizeAccess('warehouse'), validate(addPigPoundSchema), addPigPound);
+router.put('/:id', authMiddleware, authorizeAccess('warehouse'), validate(updatePigPoundSchema), updatePigPound);
+router.delete('/:id', authMiddleware, authorizeAccess('warehouse'), deletePigPound);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/surplus.ts
+++ b/MJ_FB_Backend/src/routes/surplus.ts
@@ -1,14 +1,14 @@
 import { Router } from 'express';
 import { listSurplus, addSurplus, updateSurplus, deleteSurplus } from '../controllers/surplusController';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { addSurplusSchema, updateSurplusSchema } from '../schemas/surplusSchemas';
 
 const router = Router();
 
-router.get('/', authMiddleware, authorizeRoles('staff'), listSurplus);
-router.post('/', authMiddleware, authorizeRoles('staff'), validate(addSurplusSchema), addSurplus);
-router.put('/:id', authMiddleware, authorizeRoles('staff'), validate(updateSurplusSchema), updateSurplus);
-router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteSurplus);
+router.get('/', authMiddleware, authorizeAccess('warehouse'), listSurplus);
+router.post('/', authMiddleware, authorizeAccess('warehouse'), validate(addSurplusSchema), addSurplus);
+router.put('/:id', authMiddleware, authorizeAccess('warehouse'), validate(updateSurplusSchema), updateSurplus);
+router.delete('/:id', authMiddleware, authorizeAccess('warehouse'), deleteSurplus);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/warehouseOverall.ts
+++ b/MJ_FB_Backend/src/routes/warehouseOverall.ts
@@ -1,11 +1,11 @@
 import { Router } from 'express';
 import { listWarehouseOverall, rebuildWarehouseOverall, exportWarehouseOverall } from '../controllers/warehouseOverallController';
-import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 
 const router = Router();
 
 router.get('/', listWarehouseOverall);
-router.post('/rebuild', authMiddleware, authorizeRoles('staff'), rebuildWarehouseOverall);
+router.post('/rebuild', authMiddleware, authorizeAccess('warehouse'), rebuildWarehouseOverall);
 router.get('/export', exportWarehouseOverall);
 
 export default router;

--- a/MJ_FB_Backend/src/types/express.d.ts
+++ b/MJ_FB_Backend/src/types/express.d.ts
@@ -6,6 +6,7 @@ declare namespace Express {
       email?: string;
       userId?: string;
       userRole?: 'shopper' | 'delivery';
+      access?: string[];
     };
   }
 }

--- a/MJ_FB_Backend/src/utils/authUtils.ts
+++ b/MJ_FB_Backend/src/utils/authUtils.ts
@@ -8,6 +8,7 @@ export type AuthPayload = {
   id: number;
   role: string;
   type: 'user' | 'staff';
+  access?: string[];
 };
 
 /**

--- a/MJ_FB_Backend/tests/donationAggregations.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregations.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 
 describe('GET /donations/aggregations', () => {
   it('includes donors with zero yearly donations', async () => {
-    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff' });
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff', access: ['warehouse'] });
     const months = Array.from({ length: 12 }, (_, i) => i + 1);
     const rows = [
       ...months.map(month => ({ donor: 'Alice', month, total: month === 1 ? 100 : month === 2 ? 50 : 0 })),

--- a/MJ_FB_Backend/tests/donorDonations.test.ts
+++ b/MJ_FB_Backend/tests/donorDonations.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 
 describe('GET /donors/:id/donations', () => {
   it('returns donations in reverse chronological order', async () => {
-    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff' });
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff', access: ['warehouse'] });
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({
         rowCount: 1,

--- a/MJ_FB_Backend/tests/slots.test.ts
+++ b/MJ_FB_Backend/tests/slots.test.ts
@@ -7,6 +7,7 @@ jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   optionalAuthMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
 }));
 

--- a/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
@@ -16,6 +16,11 @@ jest.mock('../src/middleware/authMiddleware', () => ({
     _res: express.Response,
     next: express.NextFunction,
   ) => next(),
+  authorizeAccess: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
   optionalAuthMiddleware: (
     _req: express.Request,
     _res: express.Response,

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -8,6 +8,7 @@ jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   optionalAuthMiddleware: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
     if (req.headers['x-staff']) {
       (req as any).user = { role: 'staff' };

--- a/MJ_FB_Backend/tests/volunteerRolesActive.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesActive.test.ts
@@ -7,6 +7,7 @@ jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
 }));
 
 const app = express();

--- a/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
@@ -36,6 +36,11 @@ jest.mock('../src/middleware/authMiddleware', () => ({
     _res: express.Response,
     next: express.NextFunction,
   ) => next(),
+  authorizeAccess: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
   optionalAuthMiddleware: (
     req: any,
     _res: express.Response,

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -11,6 +11,7 @@ jest.mock('jsonwebtoken');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
 }));
 
 const app = express();


### PR DESCRIPTION
## Summary
- include staff `access` in JWT payload and request user
- add `authorizeAccess` middleware for page-level access with admin wildcard
- protect warehouse routes with `authorizeAccess('warehouse')`

## Testing
- `cd MJ_FB_Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab92671b98832d88801c18d32d3a7f