### PR TITLE
Allow specifying access when creating first staff

### DIFF
--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -35,11 +35,6 @@ export async function createStaff(
 
   let finalAccess: StaffAccess[];
   if (defaultAccess) {
-    if (access !== undefined) {
-      return res
-        .status(400)
-        .json({ message: 'Cannot set access for first staff member' });
-    }
     finalAccess = defaultAccess;
   } else {
     finalAccess = access && access.length > 0 ? access : ['pantry'];

--- a/MJ_FB_Backend/tests/staffCreation.test.ts
+++ b/MJ_FB_Backend/tests/staffCreation.test.ts
@@ -1,0 +1,40 @@
+import request from 'supertest';
+import express from 'express';
+import staffRoutes from '../src/routes/staff';
+import pool from '../src/db';
+import bcrypt from 'bcrypt';
+
+jest.mock('../src/db');
+jest.mock('bcrypt');
+
+const app = express();
+app.use(express.json());
+app.use('/staff', staffRoutes);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /staff (first staff member)', () => {
+  it('creates staff even when access is provided', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // check staff count
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // email check
+      .mockResolvedValueOnce({}); // insert
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+
+    const res = await request(app)
+      .post('/staff')
+      .send({
+        firstName: 'Admin',
+        lastName: 'Admin',
+        email: 'harvestpantry@mjfoodbank.org',
+        password: 'Abcd12345',
+        access: ['admin'],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ message: 'Staff created' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Allow default admin access even if `access` field is supplied for the first staff account
- Add test covering creation of first staff when `access` is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab96ff6f38832dbd96ae73507a52f9