### PR TITLE
Treat admin accounts as staff with admin access

### DIFF
--- a/MJ_FB_Backend/src/controllers/adminStaffController.ts
+++ b/MJ_FB_Backend/src/controllers/adminStaffController.ts
@@ -60,7 +60,7 @@ export async function createStaff(req: Request, res: Response, next: NextFunctio
       return res.status(400).json({ message: 'Email already exists' });
     }
     const hashed = await bcrypt.hash(password, 10);
-    const role = access.includes('admin') ? 'admin' : 'staff';
+    const role = 'staff';
     await pool.query(
       `INSERT INTO staff (first_name, last_name, role, email, password, access) VALUES ($1, $2, $3, $4, $5, $6)`,
       [firstName, lastName, role, email, hashed, access],
@@ -80,7 +80,7 @@ export async function updateStaff(req: Request, res: Response, next: NextFunctio
     return res.status(400).json({ errors: parsed.error.errors });
   }
   const { firstName, lastName, email, password, access } = parsed.data;
-  const role = access.includes('admin') ? 'admin' : 'staff';
+  const role = 'staff';
   try {
     let query =
       'UPDATE staff SET first_name=$1, last_name=$2, email=$3, access=$4, role=$5';

--- a/MJ_FB_Backend/src/controllers/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/staffController.ts
@@ -40,25 +40,25 @@ export async function createStaff(
     finalAccess = access && access.length > 0 ? access : ['pantry'];
   }
 
-    const role = finalAccess.includes('admin') ? 'admin' : 'staff';
+  const role = 'staff';
 
-    try {
-      const emailCheck = await pool.query('SELECT id FROM staff WHERE email = $1', [email]);
-      if (emailCheck.rowCount && emailCheck.rowCount > 0) {
-        return res.status(400).json({ message: 'Email already exists' });
-      }
-
-      const hashed = await bcrypt.hash(password, 10);
-
-      await pool.query(
-        `INSERT INTO staff (first_name, last_name, role, email, password, access) VALUES ($1, $2, $3, $4, $5, $6)`,
-        [firstName, lastName, role, email, hashed, finalAccess]
-      );
-
-      res.status(201).json({ message: 'Staff created' });
-    } catch (error) {
-      logger.error('Error creating staff:', error);
-      next(error);
+  try {
+    const emailCheck = await pool.query('SELECT id FROM staff WHERE email = $1', [email]);
+    if (emailCheck.rowCount && emailCheck.rowCount > 0) {
+      return res.status(400).json({ message: 'Email already exists' });
     }
+
+    const hashed = await bcrypt.hash(password, 10);
+
+    await pool.query(
+      `INSERT INTO staff (first_name, last_name, role, email, password, access) VALUES ($1, $2, $3, $4, $5, $6)`,
+      [firstName, lastName, role, email, hashed, finalAccess]
+    );
+
+    res.status(201).json({ message: 'Staff created' });
+  } catch (error) {
+    logger.error('Error creating staff:', error);
+    next(error);
+  }
 }
 

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -54,15 +54,16 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
     if (!match) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
+    const role = 'staff';
     const payload: AuthPayload = {
       id: staff.id,
-      role: staff.role,
+      role,
       type: 'staff',
       access: staff.access || [],
     };
     await issueAuthTokens(res, payload, `staff:${staff.id}`);
     res.json({
-      role: staff.role,
+      role,
       name: `${staff.first_name} ${staff.last_name}`,
       access: staff.access || [],
     });

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -177,8 +177,7 @@ export function authorizeRoles(...allowedRoles: string[]) {
 export function authorizeAccess(...allowed: string[]) {
   return (req: Request, res: Response, next: NextFunction) => {
     if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
-    const { access = [], role } = req.user as any;
-    if (role === 'admin') return next();
+    const { access = [] } = req.user as any;
     if (!allowed.some(a => (access as string[]).includes(a))) {
       return res.status(403).json({ message: 'Forbidden' });
     }


### PR DESCRIPTION
## Summary
- Ensure staff creation and updates always store `staff` as the role even when granting admin privileges
- Issue staff login tokens with role `staff` so admins are distinguished via `access` only
- Remove automatic access bypass for `admin` role; access checks rely solely on the access list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab9a3c383c832db18cf5ecceddfc2b