### PR TITLE
feat(navbar): add support for extra profile links

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -25,7 +25,7 @@ import Aggregations from './pages/Aggregations';
 import DonorProfile from './pages/DonorProfile';
 import AdminStaffList from './pages/AdminStaffList';
 import AdminStaffForm from './pages/AdminStaffForm';
-import Navbar, { type NavGroup } from './components/Navbar';
+import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
 import { useAuth } from './hooks/useAuth';
@@ -43,6 +43,9 @@ export default function App() {
   const showAdmin = isStaff && access.includes('admin');
 
   const navGroups: NavGroup[] = [];
+  const profileLinks: NavLink[] | undefined = isStaff
+    ? [{ label: 'Events', to: '/events' }]
+    : undefined;
   if (!token) {
     navGroups.push(
       { label: 'User Login', links: [{ label: 'User Login', to: '/login/user' }] },
@@ -127,6 +130,8 @@ export default function App() {
           onLogout={token ? logout : undefined}
           name={token ? name || undefined : undefined}
           loading={loading}
+          role={role}
+          profileLinks={profileLinks}
         />
 
         <FeedbackSnackbar

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -23,9 +23,18 @@ interface NavbarProps {
   onLogout?: () => void;
   name?: string;
   loading?: boolean;
+  profileLinks?: NavLink[];
+  role?: string;
 }
 
-export default function Navbar({ groups, onLogout, name, loading }: NavbarProps) {
+export default function Navbar({
+  groups,
+  onLogout,
+  name,
+  loading,
+  profileLinks,
+  role,
+}: NavbarProps) {
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -158,6 +167,21 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
                     <MenuItem disabled sx={menuItemStyles}>
                       Hello, {name}
                     </MenuItem>
+                    {role === 'staff' &&
+                      profileLinks?.map(({ label, to }) => (
+                        <MenuItem
+                          key={to}
+                          component={RouterLink}
+                          to={to}
+                          onClick={() => {
+                            setMobileAnchorEl(null);
+                          }}
+                          disabled={loading}
+                          sx={menuItemStyles}
+                        >
+                          {label}
+                        </MenuItem>
+                      ))}
                     <MenuItem
                       component={RouterLink}
                       to="/profile"
@@ -258,6 +282,19 @@ export default function Navbar({ groups, onLogout, name, loading }: NavbarProps)
                 onClose={closeProfileMenu}
                 PaperProps={menuPaperProps}
               >
+                {role === 'staff' &&
+                  profileLinks?.map(({ label, to }) => (
+                    <MenuItem
+                      key={to}
+                      component={RouterLink}
+                      to={to}
+                      onClick={closeProfileMenu}
+                      disabled={loading}
+                      sx={menuItemStyles}
+                    >
+                      {label}
+                    </MenuItem>
+                  ))}
                 <MenuItem
                   component={RouterLink}
                   to="/profile"


### PR DESCRIPTION
## Summary
- allow Navbar to accept extra profile links for staff
- pass Events link into Navbar when logged in as staff

## Testing
- `npm test` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', or 'nodenext'.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9ea1d8fc832d8482a0db56f3ac40