### PR TITLE
Add event creation dialog with staff tagging

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -25,6 +25,7 @@ import Aggregations from './pages/Aggregations';
 import DonorProfile from './pages/DonorProfile';
 import AdminStaffList from './pages/AdminStaffList';
 import AdminStaffForm from './pages/AdminStaffForm';
+import Events from './pages/Events';
 import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
@@ -158,6 +159,7 @@ export default function App() {
                 }
               />
               <Route path="/profile" element={<Profile token={token} role={role} />} />
+              {isStaff && <Route path="/events" element={<Events />} />}
               {showStaff && (
                 <Route path="/manage-availability" element={<ManageAvailability />} />
               )}

--- a/MJ_FB_Frontend/src/api/events.ts
+++ b/MJ_FB_Frontend/src/api/events.ts
@@ -1,0 +1,18 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+
+export interface CreateEventInput {
+  title: string;
+  details: string;
+  category: string;
+  date: string;
+  staffIds?: number[];
+}
+
+export async function createEvent(data: CreateEventInput): Promise<{ id: number }> {
+  const res = await apiFetch(`${API_BASE}/events`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/api/staff.ts
+++ b/MJ_FB_Frontend/src/api/staff.ts
@@ -1,0 +1,13 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+
+export interface StaffSearchResult {
+  id: number;
+  name: string;
+}
+
+export async function searchStaff(query: string): Promise<StaffSearchResult[]> {
+  const res = await apiFetch(
+    `${API_BASE}/staff/search?query=${encodeURIComponent(query)}`
+  );
+  return handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/components/EventForm.tsx
+++ b/MJ_FB_Frontend/src/components/EventForm.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  MenuItem,
+  Stack,
+  Autocomplete,
+} from '@mui/material';
+import FeedbackSnackbar from './FeedbackSnackbar';
+import { createEvent } from '../api/events';
+import { searchStaff } from '../api/staff';
+
+interface EventFormProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+const categories = [
+  'harvest pantry',
+  'volunteers',
+  'warehouse',
+  'fundraiser',
+  'staff leave',
+];
+
+interface StaffOption {
+  id: number | 'all';
+  name: string;
+}
+
+const TAG_ALL: StaffOption = { id: 'all', name: 'Tag All' };
+
+export default function EventForm({ open, onClose, onCreated }: EventFormProps) {
+  const [title, setTitle] = useState('');
+  const [details, setDetails] = useState('');
+  const [category, setCategory] = useState('');
+  const [date, setDate] = useState('');
+  const [staffInput, setStaffInput] = useState('');
+  const [staffOptions, setStaffOptions] = useState<StaffOption[]>([TAG_ALL]);
+  const [staff, setStaff] = useState<StaffOption[]>([]);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({ open: false, message: '', severity: 'success' });
+
+  useEffect(() => {
+    let active = true;
+    if (staffInput.length < 2) {
+      setStaffOptions([TAG_ALL]);
+      return;
+    }
+    searchStaff(staffInput)
+      .then(res => {
+        if (!active) return;
+        setStaffOptions([...res, TAG_ALL]);
+      })
+      .catch(() => setStaffOptions([TAG_ALL]));
+    return () => {
+      active = false;
+    };
+  }, [staffInput]);
+
+  function handleStaffChange(_e: any, value: StaffOption[]) {
+    if (value.some(v => v.id === 'all')) {
+      searchStaff(' ')
+        .then(all => {
+          setStaffOptions([...all, TAG_ALL]);
+          setStaff(all);
+        })
+        .catch(() => setStaff([]));
+    } else {
+      setStaff(value);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      await createEvent({
+        title,
+        details,
+        category,
+        date,
+        staffIds: staff.map(s => s.id as number),
+      });
+      setSnackbar({ open: true, message: 'Event created', severity: 'success' });
+      setTitle('');
+      setDetails('');
+      setCategory('');
+      setDate('');
+      setStaff([]);
+      setStaffInput('');
+      onCreated?.();
+      onClose();
+    } catch (err: any) {
+      setSnackbar({ open: true, message: err.message || 'Failed to create event', severity: 'error' });
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogTitle>Create Event</DialogTitle>
+        <form onSubmit={handleSubmit}>
+          <DialogContent sx={{ pt: 2 }}>
+            <Stack spacing={2} mt={1}>
+              <TextField label="Title" value={title} onChange={e => setTitle(e.target.value)} fullWidth required />
+              <TextField label="Details" value={details} onChange={e => setDetails(e.target.value)} multiline rows={3} fullWidth />
+              <TextField select label="Category" value={category} onChange={e => setCategory(e.target.value)} fullWidth required>
+                {categories.map(c => (
+                  <MenuItem key={c} value={c}>
+                    {c}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                label="Date"
+                type="date"
+                value={date}
+                onChange={e => setDate(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+                fullWidth
+                required
+              />
+              <Autocomplete
+                multiple
+                options={staffOptions}
+                value={staff}
+                onChange={handleStaffChange}
+                onInputChange={(_e, val) => setStaffInput(val)}
+                getOptionLabel={option => option.name}
+                isOptionEqualToValue={(o, v) => o.id === v.id}
+                renderInput={params => <TextField {...params} label="Staff Involved" />}
+              />
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={onClose} size="small">Cancel</Button>
+            <Button type="submit" variant="contained" size="small" disabled={!title || !category || !date}>
+              Save
+            </Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+      <FeedbackSnackbar
+        open={snackbar.open}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        message={snackbar.message}
+        severity={snackbar.severity}
+      />
+    </>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/Events.tsx
+++ b/MJ_FB_Frontend/src/pages/Events.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { Button, Box } from '@mui/material';
+import Page from '../components/Page';
+import EventForm from '../components/EventForm';
+
+export default function Events() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Page title="Events">
+      <Box mb={2}>
+        <Button variant="contained" size="small" onClick={() => setOpen(true)}>
+          Create Event
+        </Button>
+      </Box>
+      <EventForm open={open} onClose={() => setOpen(false)} />
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary
- add EventForm dialog to create events with category, date, details, and staff tagging including Tag All
- expose events page with Create Event button and staff search API wrappers

## Testing
- `npm test` *(fails: TS1343 import.meta not allowed, Navbar component errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aba0040c14832db5193bede9537e5a