### PR TITLE
Fix events page crash on undefined API response

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Events.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Events.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import Events from '../pages/Events';
+import { getEvents } from '../api/events';
+
+jest.mock('../api/events', () => ({
+  getEvents: jest.fn(),
+}));
+
+describe('Events page', () => {
+  it('handles undefined API responses gracefully', async () => {
+    const getEventsMock = getEvents as jest.Mock;
+    getEventsMock.mockResolvedValue(undefined);
+
+    render(<Events />);
+
+    await waitFor(() => expect(getEventsMock).toHaveBeenCalled());
+    expect(screen.getAllByText(/no events/i)).toHaveLength(3);
+  });
+});

--- a/MJ_FB_Frontend/src/pages/Events.tsx
+++ b/MJ_FB_Frontend/src/pages/Events.tsx
@@ -15,7 +15,7 @@ import {
 import Page from '../components/Page';
 import { getEvents, type Event } from '../api/events';
 
-function groupEvents(events: Event[]) {
+function groupEvents(events: Event[] = []) {
   const todayStr = new Date().toISOString().split('T')[0];
   const today: Event[] = [];
   const upcoming: Event[] = [];
@@ -67,7 +67,7 @@ export default function Events() {
 
   useEffect(() => {
     getEvents()
-      .then(setEvents)
+      .then(data => setEvents(Array.isArray(data) ? data : []))
       .catch(() => setEvents([]));
   }, []);
 


### PR DESCRIPTION
## Summary
- avoid crashing Events page when events API returns undefined
- add regression test for empty events API responses

## Testing
- `npm test` (fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', or 'nodenext'.)


------
https://chatgpt.com/codex/tasks/task_e_68aba0bb707c832d9d6b87ad5aad9a9d