### PR TITLE
Add event creation dialog for staff events

### DIFF
--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -15,6 +15,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^6.2.0",
     "@mui/material": "^6.2.0",
+    "@mui/x-date-pickers": "^6.2.0",
     "@tanstack/react-query": "^5.62.0",
     "date-fns-tz": "^3.2.0",
     "prettier": "^3.6.2",

--- a/MJ_FB_Frontend/src/api/events.ts
+++ b/MJ_FB_Frontend/src/api/events.ts
@@ -4,10 +4,27 @@ export interface Event {
   id: number;
   title: string;
   date: string; // ISO string
-  description?: string;
+  details?: string;
+  category?: string;
+  staffIds?: number[];
 }
 
 export async function getEvents(): Promise<Event[]> {
   const res = await apiFetch(`${API_BASE}/events`);
+  return handleResponse(res);
+}
+
+export async function createEvent(data: {
+  title: string;
+  details?: string;
+  category: string;
+  date: string;
+  staffIds: number[];
+}) {
+  const res = await apiFetch(`${API_BASE}/events`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/api/staff.ts
+++ b/MJ_FB_Frontend/src/api/staff.ts
@@ -1,0 +1,13 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+
+export interface StaffOption {
+  id: number;
+  name: string;
+}
+
+export async function searchStaff(query: string): Promise<StaffOption[]> {
+  const res = await apiFetch(
+    `${API_BASE}/staff/search?query=${encodeURIComponent(query)}`,
+  );
+  return handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/components/EventForm.tsx
+++ b/MJ_FB_Frontend/src/components/EventForm.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  MenuItem,
+  Button,
+  Autocomplete,
+} from '@mui/material';
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import FeedbackSnackbar from './FeedbackSnackbar';
+import { createEvent } from '../api/events';
+import { searchStaff, type StaffOption } from '../api/staff';
+
+interface EventFormProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+const categories = [
+  'harvest pantry',
+  'volunteers',
+  'warehouse',
+  'fundraiser',
+  'staff leave',
+];
+
+const tagAllOption: StaffOption = { id: -1, name: 'Tag All' };
+
+export default function EventForm({ open, onClose, onCreated }: EventFormProps) {
+  const [title, setTitle] = useState('');
+  const [details, setDetails] = useState('');
+  const [category, setCategory] = useState('');
+  const [date, setDate] = useState<Date | null>(null);
+  const [staffInput, setStaffInput] = useState('');
+  const [staffOptions, setStaffOptions] = useState<StaffOption[]>([tagAllOption]);
+  const [selectedStaff, setSelectedStaff] = useState<StaffOption[]>([]);
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    if (!staffInput) {
+      setStaffOptions([tagAllOption]);
+      return undefined;
+    }
+    searchStaff(staffInput)
+      .then(data => {
+        if (active) setStaffOptions([tagAllOption, ...data]);
+      })
+      .catch(() => {
+        if (active) setStaffOptions([tagAllOption]);
+      });
+    return () => {
+      active = false;
+    };
+  }, [staffInput]);
+
+  async function handleStaffChange(_: any, value: StaffOption[]) {
+    if (value.some(v => v.id === tagAllOption.id)) {
+      try {
+        const all = await searchStaff('%');
+        setSelectedStaff(all);
+      } catch {
+        setSelectedStaff([]);
+      }
+    } else {
+      setSelectedStaff(value);
+    }
+  }
+
+  async function submit() {
+    if (!title || !category || !date) {
+      setError('Please fill in title, category, and date');
+      return;
+    }
+    try {
+      await createEvent({
+        title,
+        details,
+        category,
+        date: date.toISOString().split('T')[0],
+        staffIds: selectedStaff.map(s => s.id),
+      });
+      setSuccess('Event created');
+      setTitle('');
+      setDetails('');
+      setCategory('');
+      setDate(null);
+      setSelectedStaff([]);
+      onCreated();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogTitle>Create Event</DialogTitle>
+        <DialogContent>
+          <TextField
+            label="Title"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+          <TextField
+            label="Details"
+            value={details}
+            onChange={e => setDetails(e.target.value)}
+            fullWidth
+            margin="normal"
+            multiline
+            rows={3}
+          />
+          <TextField
+            select
+            label="Category"
+            value={category}
+            onChange={e => setCategory(e.target.value)}
+            fullWidth
+            margin="normal"
+          >
+            {categories.map(c => (
+              <MenuItem key={c} value={c}>
+                {c}
+              </MenuItem>
+            ))}
+          </TextField>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <DatePicker
+              label="Date"
+              value={date}
+              onChange={newDate => setDate(newDate)}
+              slotProps={{ textField: { fullWidth: true, margin: 'normal' } }}
+            />
+          </LocalizationProvider>
+          <Autocomplete
+            multiple
+            options={staffOptions}
+            value={selectedStaff}
+            onChange={handleStaffChange}
+            onInputChange={(_, val) => setStaffInput(val)}
+            getOptionLabel={option => option.name}
+            renderInput={params => (
+              <TextField {...params} label="Staff Involved" margin="normal" />
+            )}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} variant="outlined" color="primary">
+            Cancel
+          </Button>
+          <Button onClick={submit} variant="contained" color="primary">
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <FeedbackSnackbar
+        open={!!success}
+        message={success}
+        onClose={() => setSuccess('')}
+        severity="success"
+      />
+      <FeedbackSnackbar
+        open={!!error}
+        message={error}
+        onClose={() => setError('')}
+        severity="error"
+      />
+    </>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/Events.tsx
+++ b/MJ_FB_Frontend/src/pages/Events.tsx
@@ -1,18 +1,7 @@
 import { useEffect, useState } from 'react';
-import {
-  Button,
-  Card,
-  CardContent,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Grid,
-  List,
-  ListItem,
-  Typography,
-} from '@mui/material';
+import { Button, Card, CardContent, Grid, List, ListItem, Typography } from '@mui/material';
 import Page from '../components/Page';
+import EventForm from '../components/EventForm';
 import { getEvents, type Event } from '../api/events';
 
 function groupEvents(events: Event[] = []) {
@@ -47,28 +36,18 @@ function EventList({ events }: { events: Event[] }) {
   );
 }
 
-function EventFormDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
-  return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogTitle>Create Event</DialogTitle>
-      <DialogContent>
-        <Typography variant="body2">Event form coming soon.</Typography>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Close</Button>
-      </DialogActions>
-    </Dialog>
-  );
-}
-
 export default function Events() {
   const [events, setEvents] = useState<Event[]>([]);
   const [open, setOpen] = useState(false);
 
-  useEffect(() => {
+  function fetchEvents() {
     getEvents()
       .then(data => setEvents(Array.isArray(data) ? data : []))
       .catch(() => setEvents([]));
+  }
+
+  useEffect(() => {
+    fetchEvents();
   }, []);
 
   const { today, upcoming, past } = groupEvents(events);
@@ -108,7 +87,11 @@ export default function Events() {
           </Card>
         </Grid>
       </Grid>
-      <EventFormDialog open={open} onClose={() => setOpen(false)} />
+      <EventForm
+        open={open}
+        onClose={() => setOpen(false)}
+        onCreated={fetchEvents}
+      />
     </Page>
   );
 }


### PR DESCRIPTION
## Summary
- add EventForm component with title, details, category, date picker, and staff tagging
- create staff search API and event creation API wrapper
- wire Create Event button on Events page to open dialog

## Testing
- `npm install` *(fails: 403 Forbidden for @mui/x-date-pickers)*
- `npm test` *(fails: Cannot find module '@mui/x-date-pickers'; TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aba1ed7410832daab9ac54518015b2