### PR TITLE
Rename staff navigation to Harvest Pantry and adopt client terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,19 +93,19 @@
 
 ## Base Requirements
 
-Users with internet access submit appointment requests online. Staff then refer to the client database called Link2Feed (an external platform that our app is not connected to). Even though we track usage in our own table, we do not record visits for walk-in clients in our system. When a client uses the food bank without booking through our app, there is currently no way to capture that visit in our platform. This is why it’s important for staff to check Link2Feed to see if the client has already used the food bank twice this calendar month and is eligible (users can only use the food bank two times in a month). In the future, we plan to implement a feature that allows uploading an Excel sheet to update visit counts for visits not processed through our booking platform.
+Clients with internet access submit appointment requests online. Staff then refer to the client database called Link2Feed (an external platform that our app is not connected to). Even though we track usage in our own table, we do not record visits for walk-in clients in our system. When a client uses the food bank without booking through our app, there is currently no way to capture that visit in our platform. This is why it’s important for staff to check Link2Feed to see if the client has already used the food bank twice this calendar month and is eligible (clients can only use the food bank two times in a month). In the future, we plan to implement a feature that allows uploading an Excel sheet to update visit counts for visits not processed through our booking platform.
 
-Staff must also book appointments for clients who do not have internet access. In these cases, the client visits in person to request an appointment, and the staff member clicks on an empty cell in the pantry schedule to assign the client to that slot. Both users and staff should have the ability to cancel or reschedule appointments.
+Staff must also book appointments for clients who do not have internet access. In these cases, the client visits in person to request an appointment, and the staff member clicks on an empty cell in the pantry schedule to assign the client to that slot. Both clients and staff should have the ability to cancel or reschedule appointments.
 
-Similarly, volunteers should be able to log into the app to see which roles require volunteers for a given day. They will only see roles they are trained in, so they do not sign up for areas they are unfamiliar with. Just like user bookings, staff must approve volunteer requests. Staff can also view which volunteers are available on a given day for each role.
+Similarly, volunteers should be able to log into the app to see which roles require volunteers for a given day. They will only see roles they are trained in, so they do not sign up for areas they are unfamiliar with. Just like client bookings, staff must approve volunteer requests. Staff can also view which volunteers are available on a given day for each role.
 
 ## Functional Overview
 
 ### Backend
-- Express server configures CORS, initializes default slots, and mounts routes for users, slots, bookings, holidays, blocked slots, breaks, staff, volunteer roles, volunteer bookings, and authentication.
+- Express server configures CORS, initializes default slots, and mounts routes for clients, slots, bookings, holidays, blocked slots, breaks, staff, volunteer roles, volunteer bookings, and authentication.
 - Booking logic checks slot capacity, enforces monthly visit limits, and sends confirmation emails when a booking is created.
-- JWT-based middleware extracts tokens from headers or cookies, verifies them, and loads the matching staff, user, or volunteer record from PostgreSQL.
-- A setup script provisions PostgreSQL tables for slots, users, staff, volunteer roles, bookings, breaks, and related data when the server starts.
+- JWT-based middleware extracts tokens from headers or cookies, verifies them, and loads the matching staff, client, or volunteer record from PostgreSQL.
+- A setup script provisions PostgreSQL tables for slots, users (clients), staff, volunteer roles, bookings, breaks, and related data when the server starts.
 
 ### Frontend
 - The React app manages authentication for shoppers, staff, and volunteers, switching between login components and role-specific navigation/routes such as slot booking, schedule management, and volunteer coordination.
@@ -116,17 +116,17 @@ Similarly, volunteers should be able to log into the app to see which roles requ
 
 ## Booking Workflow
 
-### Users and Staff
-- **Users** book pantry appointments through a calendar, creating a `submitted` (pending) booking.
-- **Staff** manage pending bookings, approving, rejecting, canceling, or rescheduling them. Assigning a user directly to a slot approves the booking immediately. Rejections and cancellations require a reason.
-- Users can view a booking history table listing all pending and approved appointments, each with Cancel and Reschedule options.
+### Clients and Staff
+- **Clients** book pantry appointments through a calendar, creating a `submitted` (pending) booking.
+- **Staff** manage pending bookings, approving, rejecting, canceling, or rescheduling them. Assigning a client directly to a slot approves the booking immediately. Rejections and cancellations require a reason.
+- Clients can view a booking history table listing all pending and approved appointments, each with Cancel and Reschedule options.
 
 ### Key Components
 - **SlotBooking** – renders the calendar shoppers use to view and reserve open time slots.
 - **BookingHistory** – lists a shopper's pending and approved appointments with actions to cancel or reschedule.
 - **PendingBookings** and the schedule view in the staff dashboard show each slot's status and provide Approve/Reject/Reschedule controls.
 - **ManageAvailability** – lets staff maintain holidays, blocked slots, and recurring breaks.
-- **PantrySchedule** – primary staff tool to view bookings per time block, book walk-in appointments, and approve user requests, while marking holidays, blocked slots, and breaks as non bookable entries in the schedule.
+- **PantrySchedule** – primary staff tool to view bookings per time block, book walk-in appointments, and approve client requests, while marking holidays, blocked slots, and breaks as non bookable entries in the schedule.
 - **VolunteerSchedule** and `VolunteerScheduleTable` – list volunteer shifts by role. The number of slot columns matches each role's `max_volunteers` (e.g., pantry shelf stocker shows one slot, while pantry greeter shows multiple). Holidays disable pantry, warehouse, and administrative roles, while gardening and special events remain bookable; breaks and blocked-slot restrictions are ignored.
 - Backend controllers such as `bookingController`, `slotController`, `holidayController`, `blockedSlotController`, `breakController`, `volunteerBookingController`, and `volunteerRoleController` enforce business rules and interact with the database.
 
@@ -182,9 +182,9 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `POST /auth/request-password-reset` → 204 No Content.
 - `POST /auth/change-password` → 204 No Content (auth required).
 
-### Users
+### Clients
 - `POST /users/login` → `{ token, role, name, bookingsThisMonth? }`
-- `POST /users` → `{ message: 'User created' }`
+- `POST /users` → `{ message: 'Client created' }`
 - `GET /users/search?search=query` → `[ { id, name, email, phone, client_id } ]`
 - `GET /users/me` → `{ id, firstName, lastName, email, phone, clientId, role, bookingsThisMonth }`
 
@@ -204,7 +204,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `POST /bookings/:id/cancel` → `{ message: 'Booking cancelled' }`
 - `POST /bookings/reschedule/:token` → `{ message: 'Booking rescheduled', rescheduleToken }`
 - `POST /bookings/preapproved` → `{ message: 'Preapproved booking created', rescheduleToken }`
-- `POST /bookings/staff` → `{ message: 'Booking created for user', rescheduleToken }`
+- `POST /bookings/staff` → `{ message: 'Booking created for client', rescheduleToken }`
 
 ### Holidays
 - `GET /holidays` → `[ { date, reason } ]`

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -49,7 +49,7 @@ export default function App() {
     : undefined;
   if (!token) {
     navGroups.push(
-      { label: 'User Login', links: [{ label: 'User Login', to: '/login/user' }] },
+      { label: 'Client Login', links: [{ label: 'Client Login', to: '/login/user' }] },
       { label: 'Volunteer Login', links: [{ label: 'Volunteer Login', to: '/login/volunteer' }] },
       { label: 'Staff Login', links: [{ label: 'Staff Login', to: '/login/staff' }] },
     );
@@ -57,12 +57,12 @@ export default function App() {
     const staffLinks = [
       { label: 'Manage Availability', to: '/manage-availability' },
       { label: 'Pantry Schedule', to: '/pantry-schedule' },
-      { label: 'Add User', to: '/add-user' },
-      { label: 'User History', to: '/user-history' },
+      { label: 'Add Client', to: '/add-user' },
+      { label: 'Client History', to: '/user-history' },
       { label: 'Pending', to: '/pending' },
       { label: 'Events', to: '/events' },
     ];
-    if (showStaff) navGroups.push({ label: 'Staff', links: staffLinks });
+    if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
       navGroups.push({
         label: 'Volunteer Management',

--- a/MJ_FB_Frontend/src/components/Login.tsx
+++ b/MJ_FB_Frontend/src/components/Login.tsx
@@ -28,7 +28,7 @@ export default function Login({ onLogin }: { onLogin: (user: LoginResponse) => v
       <FormContainer
         onSubmit={handleSubmit}
         submitLabel="Login"
-        title="User Login"
+        title="Client Login"
         header={
           <Stack direction="row" spacing={2} justifyContent="center">
             <Link component={RouterLink} to="/login/staff" underline="hover">

--- a/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/AddUser.tsx
@@ -7,7 +7,7 @@ import FeedbackModal from '../FeedbackModal';
 import { Box, Button, Stack, TextField, MenuItem, Typography } from '@mui/material';
 
 export default function AddUser({ token }: { token: string }) {
-  const [mode, setMode] = useState<'user' | 'staff'>('user');
+  const [mode, setMode] = useState<'client' | 'staff'>('client');
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<UserRole>('shopper');
   const [phone, setPhone] = useState('');
@@ -35,7 +35,7 @@ export default function AddUser({ token }: { token: string }) {
         email || undefined,
         phone || undefined
       );
-      setSuccess('User added successfully');
+      setSuccess('Client added successfully');
       setFirstName('');
       setLastName('');
       setClientId('');
@@ -62,23 +62,23 @@ export default function AddUser({ token }: { token: string }) {
     <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
       <Box maxWidth={400} width="100%" mt={4}>
         <Typography variant="h5" gutterBottom>
-          {mode === 'user' ? 'Create User' : 'Create Staff'}
+          {mode === 'client' ? 'Create Client' : 'Create Staff'}
         </Typography>
         <Stack direction="row" spacing={1} mb={2}>
-          <Button variant="outlined" color="primary" onClick={() => setMode('user')}>
-            Create User
+          <Button variant="outlined" color="primary" onClick={() => setMode('client')}>
+            Create Client
           </Button>
           <Button variant="outlined" color="primary" onClick={() => setMode('staff')}>
             Create Staff
           </Button>
         </Stack>
-        {mode === 'user' && (
+        {mode === 'client' && (
           <>
             <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
             <FeedbackModal open={!!success} onClose={() => setSuccess('')} message={success} />
           </>
         )}
-        {mode === 'user' ? (
+        {mode === 'client' ? (
           <Stack spacing={2}>
             <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
             <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
@@ -96,7 +96,7 @@ export default function AddUser({ token }: { token: string }) {
               <MenuItem value="delivery">Delivery</MenuItem>
             </TextField>
             <Button variant="contained" color="primary" onClick={submitUser}>
-              Add User
+              Add Client
             </Button>
           </Stack>
         ) : (

--- a/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/components/StaffDashboard/UserHistory.tsx
@@ -105,7 +105,7 @@ export default function UserHistory({
   return (
     <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
       <Box width="100%" maxWidth={800} mt={4}>
-        <h2>{initialUser ? 'Booking History' : 'User History'}</h2>
+        <h2>{initialUser ? 'Booking History' : 'Client History'}</h2>
         {!initialUser && (
           <EntitySearch
             token={token}

--- a/MJ_FB_Frontend/src/components/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/components/StaffLogin.tsx
@@ -60,7 +60,7 @@ function StaffLoginForm({ onLogin, error: initError }: { onLogin: (u: LoginRespo
         onSubmit={submit}
         submitLabel="Login"
         title="Staff Login"
-        header={<Link component={RouterLink} to="/login/user" underline="hover">User Login</Link>}
+        header={<Link component={RouterLink} to="/login/user" underline="hover">Client Login</Link>}
       >
         <TextField
           type="email"

--- a/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerLogin.tsx
@@ -29,7 +29,7 @@ export default function VolunteerLogin({ onLogin }: { onLogin: (u: LoginResponse
         onSubmit={submit}
         submitLabel="Login"
         title="Volunteer Login"
-        header={<Link component={RouterLink} to="/login/user" underline="hover">User Login</Link>}
+        header={<Link component={RouterLink} to="/login/user" underline="hover">Client Login</Link>}
       >
         <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" fullWidth />
         <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository uses Git submodules for the backend and frontend components. After cloning, make sure to pull in the submodules and install their dependencies.
 
+Individuals who use the food bank are referred to as clients throughout the application.
+
 ## Clone and initialize submodules
 
 ```bash


### PR DESCRIPTION
## Summary
- Rename Staff navigation section to Harvest Pantry with Add Client and Client History links
- Refer to food bank patrons as clients in UI, docs, and guidance
- Update login screens to show Client Login and clarify client terminology in README and AGENTS

## Testing
- `npm test` *(fails: TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', or 'nodenext')*

------
https://chatgpt.com/codex/tasks/task_e_68aba2866cec832db7061be8becffab9