### PR TITLE
chore: upgrade date pickers for MUI 6 compatibility

### DIFF
--- a/MJ_FB_Frontend/package-lock.json
+++ b/MJ_FB_Frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^6.2.0",
         "@mui/material": "^6.2.0",
+        "@mui/x-date-pickers": "^7.0.0",
         "@tanstack/react-query": "^5.62.0",
         "date-fns-tz": "^3.2.0",
         "prettier": "^3.6.2",

--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^6.2.0",
     "@mui/material": "^6.2.0",
-    "@mui/x-date-pickers": "^6.2.0",
+    "@mui/x-date-pickers": "^7.0.0",
     "@tanstack/react-query": "^5.62.0",
     "date-fns-tz": "^3.2.0",
     "prettier": "^3.6.2",


### PR DESCRIPTION
## Summary
- align x-date-pickers with Material UI 6 to prevent dependency conflicts

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@mui%2fx-date-pickers)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba49fc204832d96a63f25ebf8f391