### PR TITLE
Add pantry visits page navigation and route

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -26,6 +26,7 @@ import DonorProfile from './pages/DonorProfile';
 import AdminStaffList from './pages/AdminStaffList';
 import AdminStaffForm from './pages/AdminStaffForm';
 import Events from './pages/Events';
+import PantryVisits from './components/StaffDashboard/PantryVisits';
 import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
@@ -57,6 +58,7 @@ export default function App() {
     const staffLinks = [
       { label: 'Manage Availability', to: '/manage-availability' },
       { label: 'Pantry Schedule', to: '/pantry-schedule' },
+      { label: 'Pantry Visits', to: '/pantry-visits' },
       { label: 'Add Client', to: '/add-user' },
       { label: 'Client History', to: '/user-history' },
       { label: 'Pending', to: '/pending' },
@@ -165,6 +167,9 @@ export default function App() {
               )}
               {showStaff && (
                 <Route path="/pantry-schedule" element={<PantrySchedule token={token} />} />
+              )}
+              {showStaff && (
+                <Route path="/pantry-visits" element={<PantryVisits token={token} />} />
               )}
               {showWarehouse && (
                 <Route path="/warehouse-management" element={<WarehouseDashboard />} />


### PR DESCRIPTION
## Summary
- add Pantry Visits link to staff navigation
- route Pantry Visits page for staff users

## Testing
- `CI=true npm test` *(fails: process hung with ts-jest warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68abb285ab6c832d9e0421d28578bfcb