### PR TITLE
Ensure database setup checks for clients table

### DIFF
--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -26,9 +26,9 @@ export async function setupDatabase() {
 
   // Check if the database has already been initialized
   const tableCheck = await client.query(
-    "SELECT to_regclass('public.slots') as table_exists;"
+    "SELECT to_regclass('public.slots') as slots_exists, to_regclass('public.clients') as clients_exists;"
   );
-  if (tableCheck.rows[0].table_exists) {
+  if (tableCheck.rows[0].slots_exists && tableCheck.rows[0].clients_exists) {
     const userIdRes = await client.query(`
       SELECT column_name FROM information_schema.columns
       WHERE table_name = 'volunteers' AND column_name = 'user_id';


### PR DESCRIPTION
## Summary
- Prevent missing clients table by verifying both slots and clients exist before assuming the DB is initialized

## Testing
- `npm test` *(fails: GET /warehouse-overall/export returns excel buffer)*

------
https://chatgpt.com/codex/tasks/task_e_68abcba807e4832db06f62002c6baa5b