### PR TITLE
refactor: migrate MUI grids to v2

### DIFF
--- a/MJ_FB_Frontend/src/pages/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/Dashboard.tsx
@@ -143,32 +143,32 @@ function StaffDashboard({ token }: { token: string }) {
   };
 
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={12} md={6}>
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Today at a Glance">
-          <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid container spacing={2}>
+              <Grid size={6}>
               <Stat
                 icon={<CalendarToday color="primary" />}
                 label="Appointments Today"
                 value={stats.appointments}
               />
-            </Grid>
-            <Grid item xs={6}>
+              </Grid>
+              <Grid size={6}>
               <Stat
                 icon={<People color="primary" />}
                 label="Volunteers Scheduled"
                 value={stats.volunteers}
               />
-            </Grid>
-            <Grid item xs={6}>
+              </Grid>
+              <Grid size={6}>
               <Stat
                 icon={<WarningAmber color="warning" />}
                 label="Pending Approvals"
                 value={stats.approvals}
               />
-            </Grid>
-            <Grid item xs={6}>
+              </Grid>
+              <Grid size={6}>
               <Stat
                 icon={<CancelIcon color="error" />}
                 label="Cancellations"
@@ -177,8 +177,8 @@ function StaffDashboard({ token }: { token: string }) {
             </Grid>
           </Grid>
         </SectionCard>
-      </Grid>
-      <Grid item xs={12} md={6}>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Pending Approvals">
           <List>
             {pending.map(b => (
@@ -188,8 +188,8 @@ function StaffDashboard({ token }: { token: string }) {
             ))}
           </List>
         </SectionCard>
-      </Grid>
-      <Grid item xs={12} md={6}>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Volunteer Coverage">
           <List>
             {coverage.map((c, i) => {
@@ -209,14 +209,14 @@ function StaffDashboard({ token }: { token: string }) {
             })}
           </List>
         </SectionCard>
-      </Grid>
-      <Grid item xs={12} md={6}>
-        <Grid container spacing={2}>
-          <Grid item xs={12}>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Grid container spacing={2}>
+            <Grid size={12}>
             <SectionCard title="Pantry Schedule (This Week)">
-              <Grid container columns={7} spacing={2}>
-                {schedule.map((day, i) => (
-                  <Grid item xs={1} key={i}>
+                <Grid container columns={7} spacing={2}>
+                  {schedule.map((day, i) => (
+                    <Grid size={1} key={i}>
                     <Stack alignItems="center" spacing={1}>
                       <Typography variant="body2">{day.day}</Typography>
                       <Chip
@@ -228,8 +228,8 @@ function StaffDashboard({ token }: { token: string }) {
                 ))}
               </Grid>
             </SectionCard>
-          </Grid>
-          <Grid item xs={12}>
+            </Grid>
+            <Grid size={12}>
             <SectionCard title="Quick Search">
               <Stack spacing={2}>
                 <EntitySearch
@@ -272,8 +272,8 @@ function StaffDashboard({ token }: { token: string }) {
                 </Stack>
               </Stack>
             </SectionCard>
-          </Grid>
-          <Grid item xs={12}>
+            </Grid>
+            <Grid size={12}>
             <SectionCard title="Recent Cancellations">
               <List>
                 {cancellations.slice(0, 5).map(c => (
@@ -285,8 +285,8 @@ function StaffDashboard({ token }: { token: string }) {
                 ))}
               </List>
             </SectionCard>
-          </Grid>
-          <Grid item xs={12}>
+            </Grid>
+            <Grid size={12}>
             <SectionCard title="Notices & Events" icon={<Announcement color="primary" />}>
               <List>
                 <ListItem>
@@ -326,9 +326,9 @@ function UserDashboard() {
   const appointments = bookings.filter(b => b.status === 'approved');
   const pending = bookings.filter(b => b.status === 'submitted');
 
-  return (
-    <Grid container spacing={2}>
-      <Grid item xs={12} md={6}>
+    return (
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="My Upcoming Appointments" icon={<EventAvailable color="primary" />}>
           <List>
             {appointments.map(a => (
@@ -352,8 +352,8 @@ function UserDashboard() {
             ))}
           </List>
         </SectionCard>
-      </Grid>
-      <Grid item xs={12} md={6}>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Pending Requests">
           <List>
             {pending.map(p => (
@@ -368,8 +368,8 @@ function UserDashboard() {
             ))}
           </List>
         </SectionCard>
-      </Grid>
-      <Grid item xs={12} md={6}>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Next Available Slots" icon={<EventAvailable color="primary" />}>
           <Stack direction="row" spacing={1} flexWrap="wrap">
             {slotOptions.map((s, i) => (
@@ -384,8 +384,8 @@ function UserDashboard() {
             ))}
           </Stack>
         </SectionCard>
-      </Grid>
-      <Grid item xs={12} md={6}>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Notices" icon={<Announcement color="primary" />}>
           <List>
             <ListItem>
@@ -393,8 +393,8 @@ function UserDashboard() {
             </ListItem>
           </List>
         </SectionCard>
-      </Grid>
-      <Grid item xs={12}>
+        </Grid>
+        <Grid size={12}>
         <SectionCard title="Quick Actions">
           <Stack direction="row" spacing={1}>
             <Button size="small" variant="contained" sx={{ textTransform: 'none' }}>
@@ -408,8 +408,8 @@ function UserDashboard() {
             </Button>
           </Stack>
         </SectionCard>
+        </Grid>
       </Grid>
-    </Grid>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/Events.tsx
+++ b/MJ_FB_Frontend/src/pages/Events.tsx
@@ -61,8 +61,8 @@ export default function Events() {
         </Button>
       }
     >
-      <Grid container spacing={2}>
-        <Grid item xs={12}>
+        <Grid container spacing={2}>
+          <Grid size={12}>
           <Card>
             <CardContent>
               <Typography variant="h6">Today</Typography>
@@ -70,7 +70,7 @@ export default function Events() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12}>
+          <Grid size={12}>
           <Card>
             <CardContent>
               <Typography variant="h6">Upcoming</Typography>
@@ -78,7 +78,7 @@ export default function Events() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12}>
+          <Grid size={12}>
           <Card sx={{ maxHeight: 200, overflowY: 'auto' }}>
             <CardContent>
               <Typography variant="h6">Past</Typography>

--- a/MJ_FB_Frontend/src/pages/UserDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/UserDashboard.tsx
@@ -141,7 +141,7 @@ export default function UserDashboard() {
   return (
     <>
       <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard
             title="My Upcoming Appointment"
             icon={<EventAvailable color="primary" />}
@@ -192,7 +192,7 @@ export default function UserDashboard() {
             )}
           </SectionCard>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard title="Pending Requests">
             <List>
               {pending.length ? (
@@ -221,7 +221,7 @@ export default function UserDashboard() {
             </List>
           </SectionCard>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard
             title="Next Available Slots"
             icon={<EventAvailable color="primary" />}
@@ -257,7 +257,7 @@ export default function UserDashboard() {
             </List>
           </SectionCard>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard title="Notices" icon={<Announcement color="primary" />}>
             <List>
               {holidays.map(h => (
@@ -273,7 +273,7 @@ export default function UserDashboard() {
             </List>
           </SectionCard>
         </Grid>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <SectionCard title="Quick Actions">
             <Stack direction="row" spacing={1}>
               <Button
@@ -303,7 +303,7 @@ export default function UserDashboard() {
             </Stack>
           </SectionCard>
         </Grid>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <SectionCard title="Recent Bookings" icon={<History color="primary" />}>
             <List>
               {history.slice(0, 3).map(b => (

--- a/MJ_FB_Frontend/src/pages/booking/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/SlotBooking.tsx
@@ -288,8 +288,8 @@ export default function SlotBooking({ token, role }: Props) {
       <h3>
         {role === 'staff' && selectedUser ? `Booking for: ${selectedUser.name}` : `Booking for: ${loggedInName}`}
       </h3>
-      <Grid container spacing={2}>
-        <Grid item xs={12} md="auto">
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, md: 'auto' }}>
           <Calendar
             onChange={value => {
               if (value instanceof Date) {
@@ -317,8 +317,8 @@ export default function SlotBooking({ token, role }: Props) {
             tileClassName={({ date }) => (isHoliday(toReginaDate(date)) ? 'holiday-tile' : undefined)}
           />
         </Grid>
-        {selectedDate && (
-          <Grid item xs={12} md>
+          {selectedDate && (
+            <Grid size={{ xs: 12, md: true }}>
             <div className="slot-day-container">
               {dayMessage ? (
                 <div className="day-message">{dayMessage}</div>

--- a/MJ_FB_Frontend/src/pages/staff/Pending.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/Pending.tsx
@@ -58,9 +58,9 @@ export default function Pending() {
       <Typography variant="h5" gutterBottom>
         Pending Requests
       </Typography>
-      <Grid container spacing={2}>
-        {bookings.map(b => (
-          <Grid item xs={12} sm={6} md={4} key={b.id}>
+        <Grid container spacing={2}>
+          {bookings.map(b => (
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} key={b.id}>
             <Card variant="outlined" sx={{ borderRadius: 1 }}>
               <CardContent>
                 <Typography variant="subtitle1">{b.user_name || 'Unknown'}</Typography>
@@ -99,9 +99,9 @@ export default function Pending() {
               </CardActions>
             </Card>
           </Grid>
-        ))}
-        {bookings.length === 0 && (
-          <Grid item xs={12}>
+          ))}
+          {bookings.length === 0 && (
+            <Grid size={12}>
             <Typography>No pending bookings.</Typography>
           </Grid>
         )}

--- a/MJ_FB_Frontend/src/pages/volunteer/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer/VolunteerDashboard.tsx
@@ -133,8 +133,8 @@ export default function VolunteerDashboard({ token }: { token: string }) {
 
   return (
     <Page title="Volunteer Dashboard">
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="My Next Shift" />
             <CardContent>
@@ -167,9 +167,9 @@ export default function VolunteerDashboard({ token }: { token: string }) {
               )}
             </CardContent>
           </Card>
-        </Grid>
+          </Grid>
 
-        <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Pending Requests" />
             <CardContent>
@@ -188,9 +188,9 @@ export default function VolunteerDashboard({ token }: { token: string }) {
               </List>
             </CardContent>
           </Card>
-        </Grid>
+          </Grid>
 
-        <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Available in My Roles" />
             <CardContent>
@@ -244,9 +244,9 @@ export default function VolunteerDashboard({ token }: { token: string }) {
               </List>
             </CardContent>
           </Card>
-        </Grid>
+          </Grid>
 
-        <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Quick Actions" />
             <CardContent>
@@ -280,18 +280,18 @@ export default function VolunteerDashboard({ token }: { token: string }) {
               </Stack>
             </CardContent>
           </Card>
-        </Grid>
+          </Grid>
 
-        <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Announcements" />
             <CardContent>
               <Typography>No announcements</Typography>
             </CardContent>
           </Card>
-        </Grid>
+          </Grid>
 
-        <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Profile & Training" />
             <CardContent>


### PR DESCRIPTION
## Summary
- update pages to use MUI Grid v2 `size` prop
- remove deprecated `item` and breakpoint props

## Testing
- `npm test` *(fails: TextEncoder is not defined, ts-jest config warnings, import.meta env unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_68abcbd5f7a8832d81232bd2b382e66c