### PR TITLE
refactor: update mui grid to v2 syntax

### DIFF
--- a/MJ_FB_Frontend/src/pages/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/Dashboard.tsx
@@ -144,31 +144,31 @@ function StaffDashboard({ token }: { token: string }) {
 
   return (
     <Grid container spacing={2}>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Today at a Glance">
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid size={6}>
               <Stat
                 icon={<CalendarToday color="primary" />}
                 label="Appointments Today"
                 value={stats.appointments}
               />
             </Grid>
-            <Grid item xs={6}>
+            <Grid size={6}>
               <Stat
                 icon={<People color="primary" />}
                 label="Volunteers Scheduled"
                 value={stats.volunteers}
               />
             </Grid>
-            <Grid item xs={6}>
+            <Grid size={6}>
               <Stat
                 icon={<WarningAmber color="warning" />}
                 label="Pending Approvals"
                 value={stats.approvals}
               />
             </Grid>
-            <Grid item xs={6}>
+            <Grid size={6}>
               <Stat
                 icon={<CancelIcon color="error" />}
                 label="Cancellations"
@@ -178,7 +178,7 @@ function StaffDashboard({ token }: { token: string }) {
           </Grid>
         </SectionCard>
       </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Pending Approvals">
           <List>
             {pending.map(b => (
@@ -189,7 +189,7 @@ function StaffDashboard({ token }: { token: string }) {
           </List>
         </SectionCard>
       </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Volunteer Coverage">
           <List>
             {coverage.map((c, i) => {
@@ -210,13 +210,13 @@ function StaffDashboard({ token }: { token: string }) {
           </List>
         </SectionCard>
       </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <Grid container spacing={2}>
-          <Grid item xs={12}>
+          <Grid size={12}>
             <SectionCard title="Pantry Schedule (This Week)">
               <Grid container columns={7} spacing={2}>
                 {schedule.map((day, i) => (
-                  <Grid item xs={1} key={i}>
+                  <Grid size={1} key={i}>
                     <Stack alignItems="center" spacing={1}>
                       <Typography variant="body2">{day.day}</Typography>
                       <Chip
@@ -229,7 +229,7 @@ function StaffDashboard({ token }: { token: string }) {
               </Grid>
             </SectionCard>
           </Grid>
-          <Grid item xs={12}>
+          <Grid size={12}>
             <SectionCard title="Quick Search">
               <Stack spacing={2}>
                 <EntitySearch
@@ -273,7 +273,7 @@ function StaffDashboard({ token }: { token: string }) {
               </Stack>
             </SectionCard>
           </Grid>
-          <Grid item xs={12}>
+          <Grid size={12}>
             <SectionCard title="Recent Cancellations">
               <List>
                 {cancellations.slice(0, 5).map(c => (
@@ -286,7 +286,7 @@ function StaffDashboard({ token }: { token: string }) {
               </List>
             </SectionCard>
           </Grid>
-          <Grid item xs={12}>
+          <Grid size={12}>
             <SectionCard title="Notices & Events" icon={<Announcement color="primary" />}>
               <List>
                 <ListItem>
@@ -328,7 +328,7 @@ function UserDashboard() {
 
   return (
     <Grid container spacing={2}>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="My Upcoming Appointments" icon={<EventAvailable color="primary" />}>
           <List>
             {appointments.map(a => (
@@ -353,7 +353,7 @@ function UserDashboard() {
           </List>
         </SectionCard>
       </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Pending Requests">
           <List>
             {pending.map(p => (
@@ -369,7 +369,7 @@ function UserDashboard() {
           </List>
         </SectionCard>
       </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Next Available Slots" icon={<EventAvailable color="primary" />}>
           <Stack direction="row" spacing={1} flexWrap="wrap">
             {slotOptions.map((s, i) => (
@@ -385,7 +385,7 @@ function UserDashboard() {
           </Stack>
         </SectionCard>
       </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Notices" icon={<Announcement color="primary" />}>
           <List>
             <ListItem>
@@ -394,7 +394,7 @@ function UserDashboard() {
           </List>
         </SectionCard>
       </Grid>
-      <Grid item xs={12}>
+      <Grid size={12}>
         <SectionCard title="Quick Actions">
           <Stack direction="row" spacing={1}>
             <Button size="small" variant="contained" sx={{ textTransform: 'none' }}>

--- a/MJ_FB_Frontend/src/pages/Events.tsx
+++ b/MJ_FB_Frontend/src/pages/Events.tsx
@@ -62,7 +62,7 @@ export default function Events() {
       }
     >
       <Grid container spacing={2}>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Card>
             <CardContent>
               <Typography variant="h6">Today</Typography>
@@ -70,7 +70,7 @@ export default function Events() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Card>
             <CardContent>
               <Typography variant="h6">Upcoming</Typography>
@@ -78,7 +78,7 @@ export default function Events() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Card sx={{ maxHeight: 200, overflowY: 'auto' }}>
             <CardContent>
               <Typography variant="h6">Past</Typography>

--- a/MJ_FB_Frontend/src/pages/booking/SlotBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/SlotBooking.tsx
@@ -289,7 +289,7 @@ export default function SlotBooking({ token, role }: Props) {
         {role === 'staff' && selectedUser ? `Booking for: ${selectedUser.name}` : `Booking for: ${loggedInName}`}
       </h3>
       <Grid container spacing={2}>
-        <Grid item xs={12} md="auto">
+        <Grid size={{ xs: 12, md: 'auto' }}>
           <Calendar
             onChange={value => {
               if (value instanceof Date) {
@@ -318,7 +318,7 @@ export default function SlotBooking({ token, role }: Props) {
           />
         </Grid>
         {selectedDate && (
-          <Grid item xs={12} md>
+          <Grid size={{ xs: 12, md: 'grow' }}>
             <div className="slot-day-container">
               {dayMessage ? (
                 <div className="day-message">{dayMessage}</div>

--- a/MJ_FB_Frontend/src/pages/staff/Pending.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/Pending.tsx
@@ -60,7 +60,7 @@ export default function Pending() {
       </Typography>
       <Grid container spacing={2}>
         {bookings.map(b => (
-          <Grid item xs={12} sm={6} md={4} key={b.id}>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={b.id}>
             <Card variant="outlined" sx={{ borderRadius: 1 }}>
               <CardContent>
                 <Typography variant="subtitle1">{b.user_name || 'Unknown'}</Typography>
@@ -101,7 +101,7 @@ export default function Pending() {
           </Grid>
         ))}
         {bookings.length === 0 && (
-          <Grid item xs={12}>
+          <Grid size={12}>
             <Typography>No pending bookings.</Typography>
           </Grid>
         )}

--- a/MJ_FB_Frontend/src/pages/user/UserDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/user/UserDashboard.tsx
@@ -141,7 +141,7 @@ export default function UserDashboard() {
   return (
     <>
       <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard
             title="My Upcoming Appointment"
             icon={<EventAvailable color="primary" />}
@@ -192,7 +192,7 @@ export default function UserDashboard() {
             )}
           </SectionCard>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard title="Pending Requests">
             <List>
               {pending.length ? (
@@ -221,7 +221,7 @@ export default function UserDashboard() {
             </List>
           </SectionCard>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard
             title="Next Available Slots"
             icon={<EventAvailable color="primary" />}
@@ -257,7 +257,7 @@ export default function UserDashboard() {
             </List>
           </SectionCard>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard title="Notices" icon={<Announcement color="primary" />}>
             <List>
               {holidays.map(h => (
@@ -273,7 +273,7 @@ export default function UserDashboard() {
             </List>
           </SectionCard>
         </Grid>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <SectionCard title="Quick Actions">
             <Stack direction="row" spacing={1}>
               <Button
@@ -303,7 +303,7 @@ export default function UserDashboard() {
             </Stack>
           </SectionCard>
         </Grid>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <SectionCard title="Recent Bookings" icon={<History color="primary" />}>
             <List>
               {history.slice(0, 3).map(b => (

--- a/MJ_FB_Frontend/src/pages/volunteer/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer/VolunteerDashboard.tsx
@@ -134,7 +134,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   return (
     <Page title="Volunteer Dashboard">
       <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="My Next Shift" />
             <CardContent>
@@ -169,7 +169,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
           </Card>
         </Grid>
 
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Pending Requests" />
             <CardContent>
@@ -190,7 +190,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
           </Card>
         </Grid>
 
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Available in My Roles" />
             <CardContent>
@@ -246,7 +246,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
           </Card>
         </Grid>
 
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Quick Actions" />
             <CardContent>
@@ -282,7 +282,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
           </Card>
         </Grid>
 
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Announcements" />
             <CardContent>
@@ -291,7 +291,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
           </Card>
         </Grid>
 
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
             <CardHeader title="Profile & Training" />
             <CardContent>


### PR DESCRIPTION
## Summary
- remove deprecated `item`/breakpoint props from MUI Grid components
- adopt new `size` API to satisfy Grid v2 in multiple pages

## Testing
- `npm test` *(fails: TextEncoder is not defined; ts errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abcd6b1eac832da465793b84ac22e6