### PR TITLE
Add database migration support

### DIFF
--- a/MJ_FB_Backend/migrations/001-create-example-table.js
+++ b/MJ_FB_Backend/migrations/001-create-example-table.js
@@ -1,0 +1,10 @@
+exports.up = pgm => {
+  pgm.createTable('migration_example', {
+    id: 'id',
+    name: { type: 'text', notNull: true }
+  });
+};
+
+exports.down = pgm => {
+  pgm.dropTable('migration_example');
+};

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -26,7 +26,8 @@
     "ts-jest": "^29.4.1",
     "read-excel-file": "^5.8.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "node-pg-migrate": "^7.0.0"
   },
   "overrides": {
     "test-exclude": "^7.0.1"
@@ -35,7 +36,8 @@
     "dev": "ts-node src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "test": "jest"
+    "test": "jest",
+    "migrate": "node-pg-migrate -m migrations -d \"postgres://$PG_USER:$PG_PASSWORD@$PG_HOST:$PG_PORT/$PG_DATABASE\""
   },
   "keywords": [],
   "author": "",

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Install and run:
 ```bash
 cd MJ_FB_Backend
 npm install
+npm run migrate up   # Run pending database migrations
 npm start   # or npm run dev
 ```
 


### PR DESCRIPTION
## Summary
- integrate `node-pg-migrate` for running database migrations
- add example migration and `npm run migrate` script
- document migration step in backend setup

## Testing
- `npm install node-pg-migrate --save-dev` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-pg-migrate)*
- `npm test` *(fails: Cannot find module 'write-excel-file/node'; Cannot find module 'read-excel-file/node')*


------
https://chatgpt.com/codex/tasks/task_e_68abd5e1004c832d8fcc1a1c5510955c