### PR TITLE
docs: update project guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,16 +9,16 @@
 
 ### Backend (`MJ_FB_Backend`)
 - Node.js + Express API written in TypeScript.
-- `controllers/` – business logic for each resource.
-- `routes/` – REST endpoints wiring.
+- `controllers/` – business logic for each resource, grouped by domain (e.g., volunteer, warehouse, admin).
+- `routes/` – REST endpoints wiring, organized by matching domain directories.
 - `models/` and `db.ts` – PostgreSQL access.
 - `middleware/` – shared Express middleware (authentication, validation, etc.).
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
 
 ### Frontend (`MJ_FB_Frontend`)
 - React app built with Vite.
-- `pages/` define top-level views.
-- `components/` provide reusable UI elements; use `FeedbackSnackbar` for notifications.
+- `pages/` define top-level views and are organized into feature-based directories (booking, staff, volunteer-management, warehouse-management, etc.).
+- `components/` provide reusable UI elements; use `FeedbackSnackbar` for notifications. The dashboard UI lives in `components/dashboard`.
 - `api/` wraps server requests.
 - `utils/`, `types.ts`, and theming files manage helpers, typings, and Material UI themes.
 
@@ -29,6 +29,7 @@
 - In the frontend, favor composition of reusable components and keep pages focused on layout and data flow.
 - Use `FeedbackSnackbar` for user feedback instead of custom alert implementations.
 - Document new environment variables in the repository README and `.env.example` files.
+- Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.
 
 ## UI Rules & Design System (Global)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This repository uses Git submodules for the backend and frontend components. Aft
 
 Individuals who use the food bank are referred to as clients throughout the application.
 
+## Features
+
+- Appointment booking workflow for clients with staff approval and rescheduling.
+- Volunteer role management and scheduling restricted to trained areas.
+- Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
+
 ## Clone and initialize submodules
 
 ```bash
@@ -76,6 +82,8 @@ control weight calculations:
 
 ### Frontend features
 
+- Pages are organized into feature-based directories (e.g., booking, staff, volunteer-management, warehouse-management).
+- A shared dashboard component lives in `src/components/dashboard`.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 
 ## Deploying to Azure


### PR DESCRIPTION
## Summary
- document domain-based backend layout and feature-based frontend pages
- note usage of `write-excel-file` and shared dashboard component
- expand README with features overview

## Testing
- `CI=1 npm test` (backend) – 1 failing test
- `CI=1 npm test` (frontend) – 8 failing tests


------
https://chatgpt.com/codex/tasks/task_e_68abd615bae4832d87ca4d067c16f32e