### PR TITLE
Implement role hierarchy and add authorization tests

### DIFF
--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -155,9 +155,11 @@ export async function optionalAuthMiddleware(
   return next();
 }
 
-export function authorizeRoles(...allowedRoles: string[]) {
-  const hierarchy: Record<string, string[]> = {};
+const roleHierarchy: Record<string, string[]> = {
+  staff: ['volunteer'],
+};
 
+export function authorizeRoles(...allowedRoles: string[]) {
   return (req: Request, res: Response, next: NextFunction) => {
     if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
     const { role, type, userRole, access = [] } = req.user as any;
@@ -169,7 +171,7 @@ export function authorizeRoles(...allowedRoles: string[]) {
 
     const effectiveRoles = new Set([role, type]);
     if (userRole) effectiveRoles.add(userRole);
-    (hierarchy[role] || []).forEach(r => effectiveRoles.add(r));
+    (roleHierarchy[role] || []).forEach(r => effectiveRoles.add(r));
 
     if (!allowedRoles.some(r => effectiveRoles.has(r))) {
       return res.status(403).json({ message: 'Forbidden' });


### PR DESCRIPTION
## Summary
- Allow staff to inherit volunteer permissions via a role hierarchy
- Extend authorization tests for staff access to volunteer routes and volunteer restrictions

## Testing
- `npm test` *(fails: GET /warehouse-overall/export returns undefined rows)*

------
https://chatgpt.com/codex/tasks/task_e_68abd9d7800c832d99978a18182a319f