### PR TITLE
Handle zero slots in VolunteerScheduleTable

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerScheduleTable.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerScheduleTable.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import VolunteerScheduleTable from '../components/VolunteerScheduleTable';
+
+describe('VolunteerScheduleTable', () => {
+  it('handles maxSlots=0 gracefully', () => {
+    render(<VolunteerScheduleTable maxSlots={0} rows={[]} />);
+    expect(screen.getByText('Slot 1')).toBeInTheDocument();
+    expect(screen.getByText(/No bookings\./i)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -28,7 +28,8 @@ interface Props {
 }
 
 export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
-  const slotWidth = `calc((100% - 160px) / ${maxSlots})`;
+  const safeMaxSlots = Math.max(1, maxSlots);
+  const slotWidth = `calc((100% - 160px) / ${safeMaxSlots})`;
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   return (
@@ -49,14 +50,14 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
       >
         <colgroup>
           <col style={{ width: 160 }} />
-          {Array.from({ length: maxSlots }).map((_, i) => (
+          {Array.from({ length: safeMaxSlots }).map((_, i) => (
             <col key={i} style={{ width: slotWidth }} />
           ))}
         </colgroup>
         <TableHead>
           <TableRow>
             <TableCell>Time</TableCell>
-            {Array.from({ length: maxSlots }).map((_, i) => (
+            {Array.from({ length: safeMaxSlots }).map((_, i) => (
               <TableCell key={i}>Slot {i + 1}</TableCell>
             ))}
           </TableRow>
@@ -81,7 +82,7 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
                     {cell.content}
                   </TableCell>
                 ))}
-                {Array.from({ length: maxSlots - used }).map((_, i) => (
+                {Array.from({ length: safeMaxSlots - used }).map((_, i) => (
                   <TableCell key={`empty-${i}`} />
                 ))}
               </TableRow>
@@ -89,7 +90,7 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
           })}
           {rows.length === 0 && (
             <TableRow>
-              <TableCell colSpan={maxSlots + 1} align="center">
+              <TableCell colSpan={safeMaxSlots + 1} align="center">
                 No bookings.
               </TableCell>
             </TableRow>


### PR DESCRIPTION
## Summary
- avoid divide-by-zero by defaulting VolunteerScheduleTable maxSlots to at least one
- compute slot widths and empty cells using the safe slot count
- add a regression test ensuring the table renders when maxSlots is 0

## Testing
- `npm test` *(fails: TextEncoder not defined and missing modules; VolunteerScheduleTable test passes)*

------
https://chatgpt.com/codex/tasks/task_e_68abda069890832d9177335535127000