### PR TITLE
Add Zod validation for blocked slot routes

### DIFF
--- a/MJ_FB_Backend/src/middleware/validate.ts
+++ b/MJ_FB_Backend/src/middleware/validate.ts
@@ -18,3 +18,21 @@ export function validate(schema: ZodTypeAny) {
   };
 }
 
+
+// Middleware factory that validates the request params against a Zod schema.
+// If validation passes, the parsed data replaces `req.params`.
+// If validation fails, a 400 response with error details is returned.
+export function validateParams(schema: ZodTypeAny) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      req.params = schema.parse(req.params) as any;
+      next();
+    } catch (err) {
+      if (err instanceof ZodError) {
+        return res.status(400).json({ errors: err.issues });
+      }
+      next(err);
+    }
+  };
+}
+

--- a/MJ_FB_Backend/src/schemas/blockedSlotSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/blockedSlotSchemas.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const addBlockedSlotSchema = z.object({
+  date: z.string().min(1),
+  slotId: z.coerce.number().int().positive(),
+  reason: z.string().optional(),
+});
+
+export const deleteBlockedSlotParamsSchema = z.object({
+  date: z.string().min(1),
+  slotId: z.coerce.number().int().positive(),
+});
+
+export type AddBlockedSlotInput = z.infer<typeof addBlockedSlotSchema>;
+export type DeleteBlockedSlotParams = z.infer<typeof deleteBlockedSlotParamsSchema>;

--- a/MJ_FB_Backend/tests/blockedSlots.test.ts
+++ b/MJ_FB_Backend/tests/blockedSlots.test.ts
@@ -1,0 +1,34 @@
+import request from 'supertest';
+import express from 'express';
+import blockedSlotsRouter from '../src/routes/blockedSlots';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/blocked-slots', blockedSlotsRouter);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('blocked slots validation', () => {
+  it('returns 400 for invalid POST body', async () => {
+    const res = await request(app).post('/blocked-slots').send({ date: '', slotId: 'abc' });
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toBeDefined();
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid DELETE params', async () => {
+    const res = await request(app).delete('/blocked-slots/not-a-date/abc');
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toBeDefined();
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add Zod schemas for creating and removing blocked slots
- validate request params using new `validateParams` middleware
- test error handling for invalid blocked slot requests

## Testing
- `npm test` *(fails: GET /warehouse-overall/export returns undefined rows)*

------
https://chatgpt.com/codex/tasks/task_e_68abd9ddd558832d9a40f922d40e19ff