### PR TITLE
Enforce strong password policy

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -35,6 +35,10 @@ Backend: https://github.com/Amrutha-A-J/MJ_FB_Backend
 
 `SMTP_FROM_NAME` – Optional display name for the sender.
 
+## Password Policy
+
+Passwords must be at least 8 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character. Requests with weak passwords are rejected before hashing.
+
 ## Authentication Tokens
 
 Login responses now return a JSON Web Token (JWT) instead of a simple `type:id` string. Clients must send this token in the `Authorization` header using the standard Bearer format:

--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken';
 import config from '../config';
 import logger from '../utils/logger';
 import { randomUUID } from 'crypto';
+import { validatePassword } from '../utils/passwordUtils';
 
 export async function requestPasswordReset(
   req: Request,
@@ -53,6 +54,11 @@ export async function changePassword(
   if (!user) return res.status(401).json({ message: 'Unauthorized' });
   if (!currentPassword || !newPassword) {
     return res.status(400).json({ message: 'Missing fields' });
+  }
+
+  const pwError = validatePassword(newPassword);
+  if (pwError) {
+    return res.status(400).json({ message: pwError });
   }
   try {
     let table = 'clients';

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -5,6 +5,7 @@ import bcrypt from 'bcrypt';
 import { updateBookingsThisMonth } from '../utils/bookingUtils';
 import logger from '../utils/logger';
 import issueAuthTokens, { AuthPayload } from '../utils/authUtils';
+import { validatePassword } from '../utils/passwordUtils';
 
 export async function loginUser(req: Request, res: Response, next: NextFunction) {
   const { email, password, clientId } = req.body;
@@ -99,6 +100,13 @@ export async function createUser(req: Request, res: Response, next: NextFunction
 
   if (onlineAccess && (!firstName || !lastName || !password)) {
     return res.status(400).json({ message: 'Missing fields for online account' });
+  }
+
+  if (password) {
+    const pwError = validatePassword(password);
+    if (pwError) {
+      return res.status(400).json({ message: pwError });
+    }
   }
 
   if (!['shopper', 'delivery'].includes(role)) {

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken';
 import { randomUUID } from 'crypto';
 import config from '../../config';
 import logger from '../../utils/logger';
+import { validatePassword } from '../../utils/passwordUtils';
 
 export async function updateTrainedArea(
   req: Request,
@@ -145,6 +146,11 @@ export async function createVolunteer(
     });
   }
 
+  const pwError = validatePassword(password);
+  if (pwError) {
+    return res.status(400).json({ message: pwError });
+  }
+
   try {
     const usernameCheck = await pool.query('SELECT id FROM volunteers WHERE username=$1', [
       username,
@@ -204,6 +210,11 @@ export async function createVolunteerShopperProfile(
   };
   if (!clientId || !password) {
     return res.status(400).json({ message: 'Client ID and password required' });
+  }
+
+  const pwError2 = validatePassword(password);
+  if (pwError2) {
+    return res.status(400).json({ message: pwError2 });
   }
   try {
     const volRes = await pool.query(

--- a/MJ_FB_Backend/src/schemas/admin/staffSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/admin/staffSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { passwordSchema } from '../../utils/passwordUtils';
 
 export const staffAccessEnum = z.enum(['pantry','volunteer_management','warehouse','admin']);
 
@@ -6,14 +7,14 @@ export const createStaffSchema = z.object({
   firstName: z.string().min(1),
   lastName: z.string().min(1),
   email: z.string().email(),
-  password: z.string().min(1),
+  password: passwordSchema,
   access: z.array(staffAccessEnum).optional(),
 });
 
 export type CreateStaffInput = z.infer<typeof createStaffSchema>;
 
 export const updateStaffSchema = createStaffSchema.extend({
-  password: z.string().min(1).optional(),
+  password: passwordSchema.optional(),
   access: z.array(staffAccessEnum),
 });
 

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { passwordSchema } from '../utils/passwordUtils';
 
 // Schema for the login endpoint. Requires a password and either
 // an email or a clientId (but not both).
@@ -27,7 +28,7 @@ export const createUserSchema = z
     phone: z.string().optional(),
     clientId: z.coerce.number().int().min(1).max(9_999_999),
     role: z.enum(['shopper', 'delivery']),
-    password: z.string().optional(),
+    password: passwordSchema.optional(),
     onlineAccess: z.boolean(),
   })
   .refine(

--- a/MJ_FB_Backend/src/utils/passwordUtils.ts
+++ b/MJ_FB_Backend/src/utils/passwordUtils.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+// Zod schema enforcing password complexity requirements
+export const passwordSchema = z
+  .string()
+  .min(8, 'Password must be at least 8 characters long')
+  .refine(
+    p =>
+      /[a-z]/.test(p) &&
+      /[A-Z]/.test(p) &&
+      /\d/.test(p) &&
+      /[^A-Za-z0-9]/.test(p),
+    {
+      message:
+        'Password must include uppercase, lowercase, number, and special character',
+    },
+  );
+
+// Returns null if valid, otherwise an error message
+export function validatePassword(password: string): string | null {
+  const result = passwordSchema.safeParse(password);
+  if (result.success) return null;
+  // combine issues into single message
+  return result.error.issues[0]?.message || 'Invalid password';
+}

--- a/MJ_FB_Backend/tests/staffCreation.test.ts
+++ b/MJ_FB_Backend/tests/staffCreation.test.ts
@@ -29,7 +29,7 @@ describe('POST /staff (first staff member)', () => {
         firstName: 'Admin',
         lastName: 'Admin',
         email: 'harvestpantry@mjfoodbank.org',
-        password: 'Abcd12345',
+        password: 'Abcd12345!',
         access: ['admin'],
       });
 

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -36,7 +36,7 @@ describe('Volunteer routes role ID validation', () => {
       firstName: 'John',
       lastName: 'Doe',
       username: 'johndoe',
-      password: 'secret',
+      password: 'Secret1!',
       email: 'john@example.com',
       phone: '123',
       roleIds: [1, 2],
@@ -70,7 +70,7 @@ describe('Volunteer routes role ID validation', () => {
       firstName: 'John',
       lastName: 'Doe',
       username: 'johndoe',
-      password: 'secret',
+      password: 'Secret1!',
       roleIds: [1, 2],
     });
     expect(res.status).toBe(400);
@@ -105,7 +105,7 @@ describe('Volunteer shopper profile', () => {
 
     const res = await request(app)
       .post('/volunteers/1/shopper')
-      .send({ clientId: 123, password: 'pass' });
+      .send({ clientId: 123, password: 'Passw0rd!' });
 
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ userId: 9 });
@@ -149,7 +149,7 @@ describe('Volunteer login with shopper profile', () => {
 
     const res = await request(app)
       .post('/volunteers/login')
-      .send({ username: 'john', password: 'secret' });
+      .send({ username: 'john', password: 'Secret1!' });
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `SMTP_FROM_EMAIL` | Email address used as the sender |
 | `SMTP_FROM_NAME` | Optional sender name displayed in emails |
 
+### Password Requirements
+
+All API endpoints that create or change passwords enforce the following rules:
+- Minimum length of 8 characters
+- Must include uppercase, lowercase, numeric, and special characters
+Requests with passwords that do not meet these requirements are rejected before hashing.
+
 You can generate a secure `JWT_SECRET` with:
 
 ```bash


### PR DESCRIPTION
## Summary
- add shared password validator with Zod schema
- validate passwords for user, staff, volunteer creation and updates
- document password complexity requirements in README files

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-pg-migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68abd9e1bc24832dbd54d7a230f0d3ac