### PR TITLE
Prevent repeated slot initialization

### DIFF
--- a/MJ_FB_Backend/src/data.ts
+++ b/MJ_FB_Backend/src/data.ts
@@ -17,8 +17,15 @@ export const slots: Slot[] = [];
 
 export const bookings: Booking[] = [];
 
+let slotsInitialized = false;
+
 // Initialize slots: 9:30 to 14:30 every 30 minutes (10 slots)
 export function initializeSlots() {
+  if (slotsInitialized) {
+    return;
+  }
+
+  slots.length = 0;
   let hour = 9;
   let minute = 30;
 
@@ -38,4 +45,6 @@ export function initializeSlots() {
       maxCapacity: 4,
     });
   }
+
+  slotsInitialized = true;
 }

--- a/MJ_FB_Backend/tests/initializeSlots.test.ts
+++ b/MJ_FB_Backend/tests/initializeSlots.test.ts
@@ -1,0 +1,11 @@
+import { initializeSlots, slots } from '../src/data';
+
+describe('initializeSlots', () => {
+  it('populates slots only once', () => {
+    initializeSlots();
+    const firstRun = slots.slice();
+    initializeSlots();
+    expect(slots).toHaveLength(10);
+    expect(slots).toEqual(firstRun);
+  });
+});


### PR DESCRIPTION
## Summary
- Reset global slots array and guard repeated `initializeSlots` calls
- Add unit test verifying `initializeSlots` is idempotent

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden for node-pg-migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68abd9e5e2d0832d9deefa777123b50b