### PR TITLE
feat: move staff events link to profile menu

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -62,7 +62,6 @@ export default function App() {
       { label: 'Add Client', to: '/add-user' },
       { label: 'Client History', to: '/user-history' },
       { label: 'Pending', to: '/pending' },
-      { label: 'Events', to: '/events' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
@@ -235,7 +234,7 @@ export default function App() {
               {showStaff && <Route path="/add-user" element={<AddUser token={token} />} />}
               {showStaff && <Route path="/user-history" element={<UserHistory token={token} />} />}
               {showStaff && <Route path="/pending" element={<Pending />} />}
-              {showStaff && <Route path="/events" element={<Events />} />}
+              {isStaff && <Route path="/events" element={<Events />} />}
               {showAdmin && <Route path="/admin/staff" element={<AdminStaffList />} />}
               {showAdmin && <Route path="/admin/staff/create" element={<AdminStaffForm />} />}
               {showAdmin && <Route path="/admin/staff/:id" element={<AdminStaffForm />} />}


### PR DESCRIPTION
## Summary
- remove Events from Harvest Pantry navigation
- allow all staff to access Events via profile menu

## Testing
- `npm test` *(fails: TextEncoder is not defined, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68abda78a550832d95d277975c9529ae