### PR TITLE
Add snackbar severity handling to messages

### DIFF
--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField } from '@mui/material';
 import { requestPasswordReset } from '../api/users';
 import FeedbackSnackbar from './FeedbackSnackbar';
+import type { AlertColor } from '@mui/material';
 
 export default function PasswordResetDialog({
   open,
@@ -15,6 +16,7 @@ export default function PasswordResetDialog({
   const [identifier, setIdentifier] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
 
   const label =
     type === 'staff' ? 'Email' : type === 'volunteer' ? 'Username' : 'Client ID';
@@ -29,6 +31,7 @@ export default function PasswordResetDialog({
           ? { username: identifier }
           : { clientId: identifier };
       await requestPasswordReset(body);
+      setSnackbarSeverity('success');
       setMessage('If the account exists, a reset link has been sent.');
       setIdentifier('');
     } catch (err: unknown) {
@@ -56,7 +59,7 @@ export default function PasswordResetDialog({
           <Button type="submit" variant="contained">Submit</Button>
         </DialogActions>
       </Dialog>
-      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity="success" />
+      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity={snackbarSeverity} />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </>
   );

--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -12,6 +12,7 @@ import { getSlots, rescheduleBookingByToken } from '../api/bookings';
 import { formatTime } from '../utils/time';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import type { Slot } from '../types';
+import type { AlertColor } from '@mui/material';
 
 interface RescheduleDialogProps {
   open: boolean;
@@ -30,6 +31,7 @@ export default function RescheduleDialog({
   const [slots, setSlots] = useState<Slot[]>([]);
   const [slotId, setSlotId] = useState('');
   const [message, setMessage] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
 
   useEffect(() => {
     if (open && date) {
@@ -44,6 +46,7 @@ export default function RescheduleDialog({
 
   async function submit() {
     if (!date || !slotId) {
+      setSnackbarSeverity('error');
       setMessage('Please select date and time');
       return;
     }
@@ -54,6 +57,7 @@ export default function RescheduleDialog({
       setDate('');
       setSlotId('');
     } catch {
+      setSnackbarSeverity('error');
       setMessage('Failed to reschedule booking');
     }
   }
@@ -90,7 +94,7 @@ export default function RescheduleDialog({
           open={!!message}
           message={message}
           onClose={() => setMessage('')}
-          severity="error"
+          severity={snackbarSeverity}
         />
       </DialogContent>
       <DialogActions>

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -22,6 +22,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../../api/bookings';
 import type { Slot, Holiday } from '../../types';
 import { formatTime } from '../../utils/time';
+import type { AlertColor } from '@mui/material';
 
 interface Booking {
   id: number;
@@ -86,6 +87,7 @@ export default function ClientDashboard() {
   const [holidays, setHolidays] = useState<Holiday[]>([]);
   const [cancelId, setCancelId] = useState<number | null>(null);
   const [message, setMessage] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
 
   useEffect(() => {
     getBookingHistory()
@@ -129,9 +131,11 @@ export default function ClientDashboard() {
     if (!cancelId) return;
     try {
       await cancelBooking(String(cancelId));
+      setSnackbarSeverity('success');
       setMessage('Booking cancelled');
       setBookings(prev => prev.filter(b => b.id !== cancelId));
     } catch (err) {
+      setSnackbarSeverity('error');
       setMessage(err instanceof Error ? err.message : 'Cancel failed');
     } finally {
       setCancelId(null);
@@ -352,7 +356,7 @@ export default function ClientDashboard() {
         open={!!message}
         onClose={() => setMessage('')}
         message={message}
-        severity={message.includes('failed') ? 'error' : 'success'}
+        severity={snackbarSeverity}
       />
     </>
   );

--- a/MJ_FB_Frontend/src/pages/staff/Pending.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/Pending.tsx
@@ -3,6 +3,7 @@ import { Grid, Card, CardContent, CardActions, Typography, TextField, Button } f
 import { getBookings, decideBooking } from '../../api/bookings';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { formatTime } from '../../utils/time';
+import type { AlertColor } from '@mui/material';
 
 interface Booking {
   id: number;
@@ -21,7 +22,7 @@ export default function Pending() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [reasons, setReasons] = useState<Record<number, string>>({});
   const [message, setMessage] = useState('');
-  const [severity, setSeverity] = useState<'success' | 'error'>('success');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
 
   function loadBookings() {
     getBookings({ status: 'pending' })
@@ -36,7 +37,7 @@ export default function Pending() {
   async function handleDecision(id: number, decision: 'approve' | 'reject') {
     try {
       await decideBooking(String(id), decision, reasons[id] || '');
-      setSeverity('success');
+      setSnackbarSeverity('success');
       setMessage(`Booking ${decision === 'approve' ? 'approved' : 'rejected'}`);
       setReasons(r => {
         const copy = { ...r };
@@ -48,7 +49,7 @@ export default function Pending() {
       // Fetch latest pending bookings in case new ones were added
       loadBookings();
     } catch (e) {
-      setSeverity('error');
+      setSnackbarSeverity('error');
       setMessage(e instanceof Error ? e.message : String(e));
     }
   }
@@ -106,7 +107,7 @@ export default function Pending() {
           </Grid>
         )}
       </Grid>
-      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity={severity} />
+      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity={snackbarSeverity} />
     </>
   );
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -29,6 +29,7 @@ import type { VolunteerBooking, VolunteerRole } from '../../types';
 import { formatTime } from '../../utils/time';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import Page from '../../components/Page';
+import type { AlertColor } from '@mui/material';
 
 function formatDateLabel(dateStr: string) {
   const d = new Date(dateStr);
@@ -45,6 +46,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   const [dateMode, setDateMode] = useState<'today' | 'week'>('today');
   const [roleFilter, setRoleFilter] = useState<string>('');
   const [message, setMessage] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -111,10 +113,12 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   async function request(role: VolunteerRole) {
     try {
       await requestVolunteerBooking(token, role.id, role.date);
+      setSnackbarSeverity('success');
       setMessage('Request submitted');
       const data = await getMyVolunteerBookings(token);
       setBookings(data);
     } catch {
+      setSnackbarSeverity('error');
       setMessage('Failed to request shift');
     }
   }
@@ -123,10 +127,12 @@ export default function VolunteerDashboard({ token }: { token: string }) {
     if (!nextShift) return;
     try {
       await updateVolunteerBookingStatus(token, nextShift.id, 'cancelled');
+      setSnackbarSeverity('success');
       setMessage('Booking cancelled');
       const data = await getMyVolunteerBookings(token);
       setBookings(data);
     } catch {
+      setSnackbarSeverity('error');
       setMessage('Failed to cancel booking');
     }
   }
@@ -316,7 +322,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
         open={!!message}
         onClose={() => setMessage('')}
         message={message}
-        severity="info"
+        severity={snackbarSeverity}
       />
     </Page>
   );

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -92,6 +92,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
   const [selectedRole, setSelectedRole] = useState<string>('');
   const [bookings, setBookings] = useState<VolunteerBookingDetail[]>([]);
   const [message, setMessage] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'error' | 'info' | 'warning'>('success');
   const [pending, setPending] = useState<VolunteerBookingDetail[]>([]);
 
   const [selectedVolunteer, setSelectedVolunteer] = useState<VolunteerResult | null>(null);
@@ -296,6 +297,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
       }
       if (tab === 'pending') loadPending();
     } catch (e) {
+      setSnackbarSeverity('error');
       setMessage(e instanceof Error ? e.message : String(e));
     }
   }
@@ -929,7 +931,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
         />
       )}
 
-      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity="error" />
+      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity={snackbarSeverity} />
       <FeedbackSnackbar
         open={!!editMsg}
         onClose={() => setEditMsg('')}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -34,6 +34,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { lighten } from '@mui/material/styles';
+import type { AlertColor } from '@mui/material';
 
 const reginaTimeZone = 'America/Regina';
 
@@ -51,6 +52,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     useState<VolunteerBooking | null>(null);
   const [decisionReason, setDecisionReason] = useState('');
   const [message, setMessage] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
   const theme = useTheme();
   const approvedColor = lighten(theme.palette.success.light, 0.4);
 
@@ -133,10 +135,12 @@ export default function VolunteerSchedule({ token }: { token: string }) {
       const timeLabel = `${formatTime(requestRole.start_time)}–${formatTime(
         requestRole.end_time,
       )}`;
+      setSnackbarSeverity('success');
       setMessage(`Booking request for ${dateLabel} · ${timeLabel} submitted`);
       setRequestRole(null);
       await loadData();
     } catch (err) {
+      setSnackbarSeverity('error');
       setMessage(err instanceof Error ? err.message : String(err));
     }
   }
@@ -151,6 +155,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
       );
       await loadData();
     } catch {
+      setSnackbarSeverity('error');
       setMessage('Failed to cancel booking');
     } finally {
       setDecisionBooking(null);
@@ -171,6 +176,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
       );
       await loadData();
     } catch {
+      setSnackbarSeverity('error');
       setMessage('Failed to reschedule booking');
     } finally {
       setDecisionBooking(null);
@@ -237,6 +243,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
               setRequestRole(role);
               setMessage('');
             } else {
+              setSnackbarSeverity('error');
               setMessage('Booking not allowed on weekends or holidays');
             }
           },
@@ -300,7 +307,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
             open={!!message}
             onClose={() => setMessage('')}
             message={message}
-            severity={message.startsWith('Booking') ? 'success' : 'error'}
+            severity={snackbarSeverity}
           />
           {isClosed ? (
             <Typography align="center">


### PR DESCRIPTION
## Summary
- Track snackbar severity alongside messages across booking, management, and dashboard pages
- Provide severity information when setting messages for success and error cases
- Pass snackbar message and severity into `FeedbackSnackbar` for consistent alerts

## Testing
- `npm test` *(failed: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68abd9fee8dc832d84ec51c143b58c0d