### PR TITLE
feat: add pantry dashboard submenu

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -56,6 +56,7 @@ export default function App() {
     );
   } else if (isStaff) {
     const staffLinks = [
+      { label: 'Dashboard', to: '/pantry' },
       { label: 'Manage Availability', to: '/pantry/manage-availability' },
       { label: 'Pantry Schedule', to: '/pantry/schedule' },
       { label: 'Pantry Visits', to: '/pantry/visits' },
@@ -161,6 +162,9 @@ export default function App() {
                 }
               />
               <Route path="/profile" element={<Profile token={token} role={role} />} />
+              {showStaff && (
+                <Route path="/pantry" element={<Dashboard role="staff" token={token} />} />
+              )}
               {showStaff && (
                 <Route path="/pantry/manage-availability" element={<ManageAvailability />} />
               )}


### PR DESCRIPTION
## Summary
- add pantry dashboard submenu linking to staff dashboard
- serve staff dashboard at /pantry route

## Testing
- `npm test` *(fails: TextEncoder is not defined, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68abdc9a0658832d9489ff9d282f8253