### PR TITLE
Record creator for events and expose shared events page

### DIFF
--- a/MJ_FB_Backend/migrations/003-add-created-by-to-events.js
+++ b/MJ_FB_Backend/migrations/003-add-created-by-to-events.js
@@ -1,0 +1,14 @@
+exports.up = pgm => {
+  pgm.addColumn('events', {
+    created_by: {
+      type: 'integer',
+      notNull: true,
+      references: 'staff',
+      onDelete: 'cascade',
+    },
+  });
+};
+
+exports.down = pgm => {
+  pgm.dropColumn('events', 'created_by');
+};

--- a/MJ_FB_Backend/src/models/event.ts
+++ b/MJ_FB_Backend/src/models/event.ts
@@ -4,6 +4,7 @@ export interface Event {
   details: string | null;
   category: string | null;
   date: string;
+  created_by: number;
   created_at: string;
   updated_at: string;
 }

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -99,6 +99,7 @@ export async function setupDatabase() {
         details text,
         category text,
         date date NOT NULL,
+        created_by integer NOT NULL REFERENCES public.staff(id),
         created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
         updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
       );
@@ -154,6 +155,7 @@ CREATE TABLE IF NOT EXISTS events (
     details text,
     category text,
     date date NOT NULL,
+    created_by integer NOT NULL REFERENCES public.staff(id),
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -46,7 +46,7 @@ export default function App() {
 
   const navGroups: NavGroup[] = [];
   const profileLinks: NavLink[] | undefined = isStaff
-    ? [{ label: 'Events', to: '/pantry/events' }]
+    ? [{ label: 'Events', to: '/events' }]
     : undefined;
   if (!token) {
     navGroups.push(
@@ -234,7 +234,7 @@ export default function App() {
               {showStaff && <Route path="/pantry/add-user" element={<AddUser token={token} />} />}
               {showStaff && <Route path="/pantry/user-history" element={<UserHistory token={token} />} />}
               {showStaff && <Route path="/pantry/pending" element={<Pending />} />}
-              {showStaff && <Route path="/pantry/events" element={<Events />} />}
+              {isStaff && <Route path="/events" element={<Events />} />}
               {showAdmin && <Route path="/admin/staff" element={<AdminStaffList />} />}
               {showAdmin && <Route path="/admin/staff/create" element={<AdminStaffForm />} />}
               {showAdmin && <Route path="/admin/staff/:id" element={<AdminStaffForm />} />}

--- a/MJ_FB_Frontend/src/__tests__/Events.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Events.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import Events from '../pages/Events';
+import Events from '../pages/events/Events';
 import { getEvents } from '../api/events';
 
 jest.mock('../api/events', () => ({

--- a/MJ_FB_Frontend/src/api/events.ts
+++ b/MJ_FB_Frontend/src/api/events.ts
@@ -7,6 +7,7 @@ export interface Event {
   details?: string;
   category?: string;
   staffIds?: number[];
+  createdBy: number;
 }
 
 export async function getEvents(): Promise<Event[]> {


### PR DESCRIPTION
## Summary
- show Events page for all staff at `/events`
- add `created_by` to events table and capture creator in API

## Testing
- `npm test` (frontend) *(fails: TextEncoder not defined and other existing issues)*
- `npm test` (backend) *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abdc54e51c832d943653fd36a21f77