### PR TITLE
Redirect staff to appropriate module after login

### DIFF
--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+// Polyfill TextEncoder/Decoder for testing environment
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder as any;

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -44,6 +44,18 @@ export default function App() {
   const showWarehouse = isStaff && hasAccess('warehouse');
   const showAdmin = isStaff && access.includes('admin');
 
+  const singleAccessOnly =
+    isStaff && access.length === 1 && access[0] !== 'admin';
+  const staffRootPath = singleAccessOnly
+    ? access[0] === 'pantry'
+      ? '/pantry'
+      : access[0] === 'volunteer_management'
+        ? '/volunteer-management'
+        : access[0] === 'warehouse'
+          ? '/warehouse-management'
+          : '/'
+    : '/';
+
   const navGroups: NavGroup[] = [];
   const profileLinks: NavLink[] | undefined = isStaff
     ? [{ label: 'Events', to: '/pantry/events' }]
@@ -155,7 +167,11 @@ export default function App() {
                   role === 'volunteer' ? (
                     <VolunteerDashboard token={token} />
                   ) : isStaff ? (
-                    <Dashboard role="staff" token={token} />
+                    singleAccessOnly && staffRootPath !== '/' ? (
+                      <Navigate to={staffRootPath} replace />
+                    ) : (
+                      <Dashboard role="staff" token={token} />
+                    )
                   ) : (
                     <ClientDashboard />
                   )

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -2,6 +2,13 @@ import { render, screen } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
 
+jest.mock('../pages/volunteer-management/VolunteerManagement', () => () => (
+  <div>VolunteerManagement</div>
+));
+jest.mock('../pages/warehouse-management/WarehouseDashboard', () => () => (
+  <div>WarehouseDashboard</div>
+));
+
 jest.mock('../api/bookings', () => ({
   getBookingHistory: jest.fn().mockResolvedValue([]),
   getSlots: jest.fn().mockResolvedValue([]),
@@ -11,6 +18,7 @@ jest.mock('../api/bookings', () => ({
 describe('App authentication persistence', () => {
   beforeEach(() => {
     localStorage.clear();
+    window.history.pushState({}, '', '/');
   });
 
   it('shows login when not authenticated', () => {
@@ -32,5 +40,44 @@ describe('App authentication persistence', () => {
       </AuthProvider>,
     );
     expect(screen.queryByText(/user login/i)).not.toBeInTheDocument();
+  });
+
+  it('redirects staff with only pantry access to pantry dashboard', () => {
+    localStorage.setItem('token', 'testtoken');
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test Staff');
+    localStorage.setItem('access', JSON.stringify(['pantry']));
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>,
+    );
+    expect(window.location.pathname).toBe('/pantry');
+  });
+
+  it('redirects staff with only volunteer management access', () => {
+    localStorage.setItem('token', 'testtoken');
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test Staff');
+    localStorage.setItem('access', JSON.stringify(['volunteer_management']));
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>,
+    );
+    expect(window.location.pathname).toBe('/volunteer-management');
+  });
+
+  it('redirects staff with only warehouse access', () => {
+    localStorage.setItem('token', 'testtoken');
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test Staff');
+    localStorage.setItem('access', JSON.stringify(['warehouse']));
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>,
+    );
+    expect(window.location.pathname).toBe('/warehouse-management');
   });
 });


### PR DESCRIPTION
## Summary
- Redirect staff to pantry, volunteer management, or warehouse sections when they have only that access level
- Add unit tests verifying redirection behaviour for single-access staff
- Polyfill TextEncoder/TextDecoder in Jest setup for broader test compatibility

## Testing
- `npm test` *(fails: TS1343 import.meta not allowed, module not found errors in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abddd102e8832d893c6343d0105bae