### PR TITLE
Display events across app

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Events.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Events.test.tsx
@@ -16,4 +16,42 @@ describe('Events page', () => {
     await waitFor(() => expect(getEventsMock).toHaveBeenCalled());
     expect(screen.getAllByText(/no events/i)).toHaveLength(3);
   });
+
+  it('renders events in correct sections', async () => {
+    const getEventsMock = getEvents as jest.Mock;
+    getEventsMock.mockResolvedValue({
+      today: [
+        {
+          id: 1,
+          title: 'Today Event',
+          date: new Date().toISOString(),
+          createdBy: 1,
+        },
+      ],
+      upcoming: [
+        {
+          id: 2,
+          title: 'Future Event',
+          date: new Date(Date.now() + 86400000).toISOString(),
+          createdBy: 1,
+        },
+      ],
+      past: [
+        {
+          id: 3,
+          title: 'Past Event',
+          date: new Date(Date.now() - 86400000).toISOString(),
+          createdBy: 1,
+        },
+      ],
+    });
+
+    render(<Events />);
+
+    await waitFor(() => expect(getEventsMock).toHaveBeenCalled());
+
+    expect(screen.getByText(/Today Event/)).toBeInTheDocument();
+    expect(screen.getByText(/Future Event/)).toBeInTheDocument();
+    expect(screen.getByText(/Past Event/)).toBeInTheDocument();
+  });
 });

--- a/MJ_FB_Frontend/src/api/events.ts
+++ b/MJ_FB_Frontend/src/api/events.ts
@@ -10,7 +10,13 @@ export interface Event {
   createdBy: number;
 }
 
-export async function getEvents(): Promise<Event[]> {
+export interface EventGroups {
+  today: Event[];
+  upcoming: Event[];
+  past: Event[];
+}
+
+export async function getEvents(): Promise<EventGroups> {
   const res = await apiFetch(`${API_BASE}/events`);
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/EventList.tsx
+++ b/MJ_FB_Frontend/src/components/EventList.tsx
@@ -1,0 +1,24 @@
+import { List, ListItem, Typography } from '@mui/material';
+import type { Event } from '../api/events';
+
+interface EventListProps {
+  events: Event[];
+  limit?: number;
+}
+
+export default function EventList({ events, limit }: EventListProps) {
+  const items = limit ? events.slice(0, limit) : events;
+  if (!items.length)
+    return <Typography variant="body2">No events</Typography>;
+  return (
+    <List>
+      {items.map(ev => (
+        <ListItem key={ev.id} disableGutters>
+          <Typography variant="body2">
+            {new Date(ev.date).toLocaleDateString()} - {ev.title}
+          </Typography>
+        </ListItem>
+      ))}
+    </List>
+  );
+}

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -26,6 +26,8 @@ import { getVolunteerRoles, getVolunteerBookingsByRole } from '../../api/volunte
 import type { Role } from '../../types';
 import { formatTime } from '../../utils/time';
 import EntitySearch from '../EntitySearch';
+import { getEvents, type EventGroups } from '../../api/events';
+import EventList from '../EventList';
 
 export interface DashboardProps {
   role: Role;
@@ -87,11 +89,17 @@ function StaffDashboard({ token }: { token: string }) {
     { role: string; filled: number; total: number }[]
   >([]);
   const [schedule, setSchedule] = useState<{ day: string; open: number }[]>([]);
+  const [events, setEvents] = useState<EventGroups>({
+    today: [],
+    upcoming: [],
+    past: [],
+  });
   const [searchType, setSearchType] = useState<'user' | 'volunteer'>('user');
   const navigate = useNavigate();
 
   useEffect(() => {
     getBookings().then(setBookings).catch(() => {});
+    getEvents().then(setEvents).catch(() => {});
 
     const today = new Date();
     const todayStr = formatLocalDate(today);
@@ -288,11 +296,10 @@ function StaffDashboard({ token }: { token: string }) {
           </Grid>
           <Grid size={12}>
             <SectionCard title="Notices & Events" icon={<Announcement color="primary" />}>
-              <List>
-                <ListItem>
-                  <ListItemText primary="" />
-                </ListItem>
-              </List>
+              <EventList
+                events={[...events.today, ...events.upcoming]}
+                limit={5}
+              />
             </SectionCard>
           </Grid>
         </Grid>
@@ -304,6 +311,11 @@ function StaffDashboard({ token }: { token: string }) {
 function UserDashboard() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [slotOptions, setSlotOptions] = useState<string[]>([]);
+  const [events, setEvents] = useState<EventGroups>({
+    today: [],
+    upcoming: [],
+    past: [],
+  });
 
   useEffect(() => {
     getBookings().then(setBookings).catch(() => {});
@@ -321,6 +333,8 @@ function UserDashboard() {
         setSlotOptions(merged.slice(0, 3));
       })
       .catch(() => {});
+
+    getEvents().then(setEvents).catch(() => {});
   }, []);
 
   const appointments = bookings.filter(b => b.status === 'approved');
@@ -387,11 +401,10 @@ function UserDashboard() {
       </Grid>
       <Grid size={{ xs: 12, md: 6 }}>
         <SectionCard title="Notices" icon={<Announcement color="primary" />}>
-          <List>
-            <ListItem>
-              <ListItemText primary="" />
-            </ListItem>
-          </List>
+          <EventList
+            events={[...events.today, ...events.upcoming]}
+            limit={5}
+          />
         </SectionCard>
       </Grid>
       <Grid size={12}>

--- a/MJ_FB_Frontend/src/pages/events/Events.tsx
+++ b/MJ_FB_Frontend/src/pages/events/Events.tsx
@@ -1,56 +1,31 @@
 import { useEffect, useState } from 'react';
-import { Button, Card, CardContent, Grid, List, ListItem, Typography } from '@mui/material';
+import { Button, Card, CardContent, Grid, Typography } from '@mui/material';
 import Page from '../../components/Page';
 import EventForm from '../../components/EventForm';
-import { getEvents, type Event } from '../../api/events';
-
-function groupEvents(events: Event[] = []) {
-  const todayStr = new Date().toISOString().split('T')[0];
-  const today: Event[] = [];
-  const upcoming: Event[] = [];
-  const past: Event[] = [];
-  events.forEach(ev => {
-    const dateStr = ev.date.split('T')[0];
-    if (dateStr === todayStr) today.push(ev);
-    else if (dateStr > todayStr) upcoming.push(ev);
-    else past.push(ev);
-  });
-  upcoming.sort((a, b) => a.date.localeCompare(b.date));
-  past.sort((a, b) => b.date.localeCompare(a.date));
-  return { today, upcoming, past };
-}
-
-function EventList({ events }: { events: Event[] }) {
-  if (!events.length)
-    return <Typography variant="body2">No events</Typography>;
-  return (
-    <List>
-      {events.map(ev => (
-        <ListItem key={ev.id} disableGutters>
-          <Typography variant="body2">
-            {new Date(ev.date).toLocaleDateString()} - {ev.title}
-          </Typography>
-        </ListItem>
-      ))}
-    </List>
-  );
-}
+import EventList from '../../components/EventList';
+import { getEvents, type EventGroups } from '../../api/events';
 
 export default function Events() {
-  const [events, setEvents] = useState<Event[]>([]);
+  const [events, setEvents] = useState<EventGroups>({
+    today: [],
+    upcoming: [],
+    past: [],
+  });
   const [open, setOpen] = useState(false);
 
   function fetchEvents() {
     getEvents()
-      .then(data => setEvents(Array.isArray(data) ? data : []))
-      .catch(() => setEvents([]));
+      .then(data =>
+        setEvents(
+          data ?? { today: [], upcoming: [], past: [] },
+        ),
+      )
+      .catch(() => setEvents({ today: [], upcoming: [], past: [] }));
   }
 
   useEffect(() => {
     fetchEvents();
   }, []);
-
-  const { today, upcoming, past } = groupEvents(events);
 
   return (
     <Page
@@ -66,7 +41,7 @@ export default function Events() {
           <Card>
             <CardContent>
               <Typography variant="h6">Today</Typography>
-              <EventList events={today} />
+              <EventList events={events.today} />
             </CardContent>
           </Card>
         </Grid>
@@ -74,7 +49,7 @@ export default function Events() {
           <Card>
             <CardContent>
               <Typography variant="h6">Upcoming</Typography>
-              <EventList events={upcoming} />
+              <EventList events={events.upcoming} />
             </CardContent>
           </Card>
         </Grid>
@@ -82,7 +57,7 @@ export default function Events() {
           <Card sx={{ maxHeight: 200, overflowY: 'auto' }}>
             <CardContent>
               <Typography variant="h6">Past</Typography>
-              <EventList events={past} />
+              <EventList events={events.past} />
             </CardContent>
           </Card>
         </Grid>


### PR DESCRIPTION
## Summary
- Fetch grouped events from API and share display via reusable EventList
- Show event categories on Events page
- Surface upcoming events in dashboard notices

## Testing
- `npm test` *(fails: Cannot find module '../pages/volunteer/VolunteerDashboard'; TextEncoder is not defined; import.meta meta-property only allowed in certain module modes)*

------
https://chatgpt.com/codex/tasks/task_e_68abdf62e940832d9cde146b6c9d7849