### PR TITLE
Refactor volunteer coverage into reusable card

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/SectionCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/SectionCard.tsx
@@ -1,0 +1,17 @@
+import { Card, CardHeader, CardContent } from '@mui/material';
+import type { ReactNode } from 'react';
+
+interface SectionCardProps {
+  title: string;
+  icon?: ReactNode;
+  children: ReactNode;
+}
+
+export default function SectionCard({ title, icon, children }: SectionCardProps) {
+  return (
+    <Card variant="outlined" sx={{ borderRadius: 1, boxShadow: 1 }}>
+      <CardHeader title={title} avatar={icon} />
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import { List, ListItem, ListItemText, Chip } from '@mui/material';
+import SectionCard from './SectionCard';
+import { getVolunteerRoles, getVolunteerBookingsByRole } from '../../api/volunteers';
+
+interface CoverageItem {
+  roleName: string;
+  masterRole: string;
+  filled: number;
+  total: number;
+}
+
+interface VolunteerCoverageCardProps {
+  token: string;
+  masterRoleFilter?: string[];
+  onCoverageLoaded?: (data: CoverageItem[]) => void;
+}
+
+function formatLocalDate(date: Date) {
+  return date.toLocaleDateString('en-CA');
+}
+
+export default function VolunteerCoverageCard({
+  token,
+  masterRoleFilter,
+  onCoverageLoaded,
+}: VolunteerCoverageCardProps) {
+  const [coverage, setCoverage] = useState<CoverageItem[]>([]);
+
+  useEffect(() => {
+    const todayStr = formatLocalDate(new Date());
+
+    getVolunteerRoles(token)
+      .then(roles =>
+        masterRoleFilter
+          ? roles.filter(r => masterRoleFilter.includes(r.category_name))
+          : roles,
+      )
+      .then(roles =>
+        Promise.all(
+          roles.map(async r => {
+            const bookings = await getVolunteerBookingsByRole(token, r.id);
+            const filled = bookings.filter(
+              (b: any) =>
+                b.status === 'approved' &&
+                formatLocalDate(new Date(b.date)) === todayStr,
+            ).length;
+            return {
+              roleName: r.name,
+              masterRole: r.category_name,
+              filled,
+              total: r.max_volunteers,
+            };
+          }),
+        ),
+      )
+      .then(data => {
+        setCoverage(data);
+        onCoverageLoaded?.(data);
+      })
+      .catch(() => {});
+  }, [token, masterRoleFilter, onCoverageLoaded]);
+
+  return (
+    <SectionCard title="Volunteer Coverage">
+      <List>
+        {coverage.map((c, i) => {
+          const ratio = c.filled / c.total;
+          let color: 'success' | 'warning' | 'error' | 'default' = 'default';
+          if (ratio >= 1) color = 'success';
+          else if (ratio >= 0.5) color = 'warning';
+          else color = 'error';
+          return (
+            <ListItem
+              key={i}
+              secondaryAction={<Chip color={color} label={`${c.filled}/${c.total}`} />}
+            >
+              <ListItemText primary={`${c.roleName} (${c.masterRole})`} />
+            </ListItem>
+          );
+        })}
+      </List>
+    </SectionCard>
+  );
+}


### PR DESCRIPTION
## Summary
- add SectionCard helper
- add reusable VolunteerCoverageCard with optional master role filter
- refactor Dashboard to consume VolunteerCoverageCard and allow filtering

## Testing
- `npm test` *(fails: Cannot find module '../pages/volunteer/VolunteerDashboard' etc., The 'import.meta' meta-property is only allowed...)*

------
https://chatgpt.com/codex/tasks/task_e_68abe138a920832d8280b29a3008bae5