### PR TITLE
Pass pantry role filter to dashboard coverage card

### DIFF
--- a/MJ_FB_Frontend/src/pages/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import Dashboard, { type DashboardProps } from '../components/dashboard/Dashboard';
 
 export default function DashboardPage(props: DashboardProps) {
-  return <Dashboard {...props} />;
+  return <Dashboard {...props} masterRoleFilter={['Pantry']} />;
 }
 
 export { type DashboardProps };


### PR DESCRIPTION
## Summary
- Filter staff dashboard volunteer coverage by 'Pantry' master role

## Testing
- `npm test` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.)*

------
https://chatgpt.com/codex/tasks/task_e_68abe30a9694832db653573b691e2f5a