### PR TITLE
Show all master roles on volunteer dashboard

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -559,7 +559,9 @@ export default function VolunteerManagement({ token }: { token: string }) {
   return (
     <div>
       <h2>{title}</h2>
-      {tab === 'dashboard' && <Dashboard role="staff" token={token} />}
+      {tab === 'dashboard' && (
+        <Dashboard role="staff" token={token} masterRoleFilter={undefined} />
+      )}
       {tab === 'schedule' && (
         <div>
           <FormControl size="small" sx={{ minWidth: 200 }}>


### PR DESCRIPTION
## Summary
- Ensure volunteer management dashboard shows coverage for every master role by passing `masterRoleFilter={undefined}`

## Testing
- `npm test -- --runInBand --watchAll=false --passWithNoTests` *(fails: Property 'toBeInTheDocument' does not exist on type 'JestMatchers<HTMLElement>')*


------
https://chatgpt.com/codex/tasks/task_e_68abe3dedb90832db935ac5715c8477a