### PR TITLE
feat: show volunteer coverage on warehouse dashboard

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -40,7 +40,9 @@ import {
   Bar,
 } from 'recharts';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import VolunteerCoverageCard from '../../components/dashboard/VolunteerCoverageCard';
 import {
   getWarehouseOverall,
   rebuildWarehouseOverall,
@@ -82,6 +84,7 @@ function kpiDelta(curr: number, prev?: number) {
 export default function WarehouseDashboard() {
   const theme = useTheme();
   const navigate = useNavigate();
+  const { token } = useAuth();
   const searchRef = useRef<HTMLInputElement>(null);
   const years = [2024, 2025, 2026];
   const [year, setYear] = useState(() => {
@@ -451,7 +454,7 @@ export default function WarehouseDashboard() {
 
       <Box
         display="grid"
-        gridTemplateColumns={{ xs: '1fr', lg: '1fr 1fr 1fr' }}
+        gridTemplateColumns={{ xs: '1fr', lg: '1fr 1fr 1fr 1fr' }}
         gap={2}
         mb={2}
       >
@@ -530,6 +533,7 @@ export default function WarehouseDashboard() {
             </Stack>
           </CardContent>
         </Card>
+        <VolunteerCoverageCard token={token} masterRoleFilter={['Warehouse']} />
       </Box>
 
       <Tabs value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- surface daily volunteer coverage on the Warehouse dashboard
- fetch token via auth hook and filter for Warehouse roles

## Testing
- `npm test` *(fails: Cannot find module '../pages/volunteer/VolunteerDashboard' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abe512ff0c832d9290e04ae3a39f7e