### PR TITLE
feat: display event details and allow deletion

### DIFF
--- a/MJ_FB_Backend/src/routes/events.ts
+++ b/MJ_FB_Backend/src/routes/events.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { listEvents, createEvent } from '../controllers/eventController';
+import { listEvents, createEvent, deleteEvent } from '../controllers/eventController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import { createEventSchema } from '../schemas/eventSchemas';
@@ -8,5 +8,6 @@ const router = Router();
 
 router.get('/', listEvents);
 router.post('/', authMiddleware, authorizeRoles('staff'), validate(createEventSchema), createEvent);
+router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteEvent);
 
 export default router;

--- a/MJ_FB_Frontend/src/__tests__/Events.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Events.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import Events from '../pages/events/Events';
-import { getEvents } from '../api/events';
+import { getEvents, deleteEvent } from '../api/events';
 
 jest.mock('../api/events', () => ({
   getEvents: jest.fn(),
+  deleteEvent: jest.fn(),
 }));
 
 describe('Events page', () => {
@@ -26,6 +27,8 @@ describe('Events page', () => {
           title: 'Today Event',
           date: new Date().toISOString(),
           createdBy: 1,
+          createdByName: 'Alice Smith',
+          details: 'Details today',
         },
       ],
       upcoming: [
@@ -34,6 +37,8 @@ describe('Events page', () => {
           title: 'Future Event',
           date: new Date(Date.now() + 86400000).toISOString(),
           createdBy: 1,
+          createdByName: 'Alice Smith',
+          details: 'Future details',
         },
       ],
       past: [
@@ -42,6 +47,8 @@ describe('Events page', () => {
           title: 'Past Event',
           date: new Date(Date.now() - 86400000).toISOString(),
           createdBy: 1,
+          createdByName: 'Alice Smith',
+          details: 'Past details',
         },
       ],
     });
@@ -53,5 +60,35 @@ describe('Events page', () => {
     expect(screen.getByText(/Today Event/)).toBeInTheDocument();
     expect(screen.getByText(/Future Event/)).toBeInTheDocument();
     expect(screen.getByText(/Past Event/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Created by Alice Smith/)).toHaveLength(3);
+    expect(screen.getByText(/Details today/)).toBeInTheDocument();
+  });
+
+  it('deletes an event', async () => {
+    const getEventsMock = getEvents as jest.Mock;
+    const deleteEventMock = deleteEvent as jest.Mock;
+    getEventsMock.mockResolvedValue({
+      today: [
+        {
+          id: 1,
+          title: 'Delete Me',
+          date: new Date().toISOString(),
+          createdBy: 1,
+          createdByName: 'Alice Smith',
+        },
+      ],
+      upcoming: [],
+      past: [],
+    });
+    deleteEventMock.mockResolvedValue({ message: 'Deleted' });
+
+    render(<Events />);
+
+    await waitFor(() => expect(getEventsMock).toHaveBeenCalled());
+
+    const delButton = screen.getByLabelText(/delete/i);
+    fireEvent.click(delButton);
+
+    await waitFor(() => expect(deleteEventMock).toHaveBeenCalledWith(1));
   });
 });

--- a/MJ_FB_Frontend/src/api/events.ts
+++ b/MJ_FB_Frontend/src/api/events.ts
@@ -8,6 +8,7 @@ export interface Event {
   category?: string;
   staffIds?: number[];
   createdBy: number;
+  createdByName: string;
 }
 
 export interface EventGroups {
@@ -32,6 +33,13 @@ export async function createEvent(data: {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
+export async function deleteEvent(id: number) {
+  const res = await apiFetch(`${API_BASE}/events/${id}`, {
+    method: 'DELETE',
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/EventList.tsx
+++ b/MJ_FB_Frontend/src/components/EventList.tsx
@@ -1,22 +1,46 @@
-import { List, ListItem, Typography } from '@mui/material';
+import { List, ListItem, Typography, ListItemText, IconButton } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
 import type { Event } from '../api/events';
 
 interface EventListProps {
   events: Event[];
   limit?: number;
+  onDelete?: (id: number) => void;
 }
 
-export default function EventList({ events, limit }: EventListProps) {
+export default function EventList({ events, limit, onDelete }: EventListProps) {
   const items = limit ? events.slice(0, limit) : events;
   if (!items.length)
     return <Typography variant="body2">No events</Typography>;
   return (
     <List>
       {items.map(ev => (
-        <ListItem key={ev.id} disableGutters>
-          <Typography variant="body2">
-            {new Date(ev.date).toLocaleDateString()} - {ev.title}
-          </Typography>
+        <ListItem
+          key={ev.id}
+          disableGutters
+          secondaryAction={
+            onDelete && (
+              <IconButton edge="end" aria-label="delete" onClick={() => onDelete(ev.id)}>
+                <DeleteIcon />
+              </IconButton>
+            )
+          }
+        >
+          <ListItemText
+            primary={`${new Date(ev.date).toLocaleDateString()} - ${ev.title}`}
+            secondary={
+              <>
+                {ev.details && (
+                  <Typography variant="body2" component="span" display="block">
+                    {ev.details}
+                  </Typography>
+                )}
+                <Typography variant="caption" component="span" display="block">
+                  Created by {ev.createdByName}
+                </Typography>
+              </>
+            }
+          />
         </ListItem>
       ))}
     </List>

--- a/MJ_FB_Frontend/src/pages/events/Events.tsx
+++ b/MJ_FB_Frontend/src/pages/events/Events.tsx
@@ -3,7 +3,8 @@ import { Button, Card, CardContent, Grid, Typography } from '@mui/material';
 import Page from '../../components/Page';
 import EventForm from '../../components/EventForm';
 import EventList from '../../components/EventList';
-import { getEvents, type EventGroups } from '../../api/events';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { getEvents, deleteEvent, type EventGroups } from '../../api/events';
 
 export default function Events() {
   const [events, setEvents] = useState<EventGroups>({
@@ -12,6 +13,8 @@ export default function Events() {
     past: [],
   });
   const [open, setOpen] = useState(false);
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
 
   function fetchEvents() {
     getEvents()
@@ -21,6 +24,16 @@ export default function Events() {
         ),
       )
       .catch(() => setEvents({ today: [], upcoming: [], past: [] }));
+  }
+
+  async function handleDelete(id: number) {
+    try {
+      await deleteEvent(id);
+      setSuccess('Event deleted');
+      fetchEvents();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
   }
 
   useEffect(() => {
@@ -41,7 +54,7 @@ export default function Events() {
           <Card>
             <CardContent>
               <Typography variant="h6">Today</Typography>
-              <EventList events={events.today} />
+              <EventList events={events.today} onDelete={handleDelete} />
             </CardContent>
           </Card>
         </Grid>
@@ -49,7 +62,7 @@ export default function Events() {
           <Card>
             <CardContent>
               <Typography variant="h6">Upcoming</Typography>
-              <EventList events={events.upcoming} />
+              <EventList events={events.upcoming} onDelete={handleDelete} />
             </CardContent>
           </Card>
         </Grid>
@@ -57,7 +70,7 @@ export default function Events() {
           <Card sx={{ maxHeight: 200, overflowY: 'auto' }}>
             <CardContent>
               <Typography variant="h6">Past</Typography>
-              <EventList events={events.past} />
+              <EventList events={events.past} onDelete={handleDelete} />
             </CardContent>
           </Card>
         </Grid>
@@ -66,6 +79,18 @@ export default function Events() {
         open={open}
         onClose={() => setOpen(false)}
         onCreated={fetchEvents}
+      />
+      <FeedbackSnackbar
+        open={!!success}
+        message={success}
+        onClose={() => setSuccess('')}
+        severity="success"
+      />
+      <FeedbackSnackbar
+        open={!!error}
+        message={error}
+        onClose={() => setError('')}
+        severity="error"
       />
     </Page>
   );


### PR DESCRIPTION
## Summary
- show event details and creator information in event lists
- enable staff to delete events and refresh view with feedback
- expose event deletion API on frontend and backend

## Testing
- `npm test` (backend) *(failed: jest not found)*
- `npm install` (backend) *(failed: 403 Forbidden)*
- `npm test` (frontend) *(failed: TS1343 import.meta errors and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68abe755c1d8832db02f2b427a4cb743