### PR TITLE
Handle invalid IDs in event deletion API

### DIFF
--- a/MJ_FB_Backend/src/controllers/eventController.ts
+++ b/MJ_FB_Backend/src/controllers/eventController.ts
@@ -68,7 +68,10 @@ export async function createEvent(req: Request, res: Response, next: NextFunctio
 }
 
 export async function deleteEvent(req: Request, res: Response, next: NextFunction) {
-  const { id } = req.params;
+  const id = Number(req.params.id);
+  if (Number.isNaN(id)) {
+    return res.status(400).json({ message: 'Invalid id' });
+  }
   try {
     const result = await pool.query('DELETE FROM events WHERE id = $1', [id]);
     if (result.rowCount === 0) {

--- a/MJ_FB_Backend/tests/events.test.ts
+++ b/MJ_FB_Backend/tests/events.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import eventsRouter from '../src/routes/events';
+import pool from '../src/db';
+import jwt from 'jsonwebtoken';
+
+jest.mock('../src/db');
+jest.mock('jsonwebtoken');
+
+const app = express();
+app.use(express.json());
+app.use('/events', eventsRouter);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DELETE /events/:id', () => {
+  it('returns 400 for invalid id', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff' });
+    const res = await request(app)
+      .delete('/events/abc')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(400);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('deletes an existing event', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff' });
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1 });
+    const res = await request(app)
+      .delete('/events/1')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Deleted' });
+    expect(pool.query).toHaveBeenCalledWith('DELETE FROM events WHERE id = $1', [1]);
+  });
+});


### PR DESCRIPTION
## Summary
- validate event ID before performing DELETE to avoid database errors
- cover event deletion API with tests for invalid and valid IDs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe91c13c0832d8b143efd3d2d8587