### PR TITLE
feat: use Regina time for displayed dates

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { List, ListItem, ListItemText, Chip } from '@mui/material';
 import SectionCard from './SectionCard';
 import { getVolunteerRoles, getVolunteerBookingsByRole } from '../../api/volunteers';
+import { formatReginaDate } from '../../utils/time';
 
 interface CoverageItem {
   roleName: string;
@@ -16,10 +17,6 @@ interface VolunteerCoverageCardProps {
   onCoverageLoaded?: (data: CoverageItem[]) => void;
 }
 
-function formatLocalDate(date: Date) {
-  return date.toLocaleDateString('en-CA');
-}
-
 export default function VolunteerCoverageCard({
   token,
   masterRoleFilter,
@@ -28,7 +25,7 @@ export default function VolunteerCoverageCard({
   const [coverage, setCoverage] = useState<CoverageItem[]>([]);
 
   useEffect(() => {
-    const todayStr = formatLocalDate(new Date());
+    const todayStr = formatReginaDate(new Date());
 
     getVolunteerRoles(token)
       .then(roles =>
@@ -43,7 +40,7 @@ export default function VolunteerCoverageCard({
             const filled = bookings.filter(
               (b: any) =>
                 b.status === 'approved' &&
-                formatLocalDate(new Date(b.date)) === todayStr,
+                formatReginaDate(new Date(b.date)) === todayStr,
             ).length;
             return {
               roleName: r.name,

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -21,7 +21,7 @@ import { EventAvailable, Announcement, History } from '@mui/icons-material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../../api/bookings';
 import type { Slot, Holiday } from '../../types';
-import { formatTime } from '../../utils/time';
+import { formatTime, formatReginaDate, formatRegina } from '../../utils/time';
 import type { AlertColor } from '@mui/material';
 
 interface Booking {
@@ -55,7 +55,7 @@ const SectionCard = ({
 
 function formatDate(dateStr: string) {
   const d = new Date(dateStr);
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return formatReginaDate(d, { month: 'short', day: 'numeric' });
 }
 
 function statusColor(status: string):
@@ -101,7 +101,7 @@ export default function ClientDashboard() {
       [...Array(7)].map(async (_, i) => {
         const d = new Date(today);
         d.setDate(today.getDate() + i);
-        const dateStr = d.toISOString().split('T')[0];
+        const dateStr = formatRegina(d, 'yyyy-MM-dd');
         const slots = (await getSlots(dateStr)) as Slot[];
         const first = slots.find(s => (s.available ?? 0) > 0);
         return first ? { date: dateStr, slot: first } : null;

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -26,14 +26,14 @@ import {
   updateVolunteerBookingStatus,
 } from '../../api/volunteers';
 import type { VolunteerBooking, VolunteerRole } from '../../types';
-import { formatTime } from '../../utils/time';
+import { formatTime, formatReginaDate, formatRegina } from '../../utils/time';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import Page from '../../components/Page';
 import type { AlertColor } from '@mui/material';
 
 function formatDateLabel(dateStr: string) {
   const d = new Date(dateStr);
-  return d.toLocaleDateString(undefined, {
+  return formatReginaDate(d, {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
@@ -68,7 +68,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
           : [today];
       const all: VolunteerRole[] = [];
       for (const day of days) {
-        const ds = day.toISOString().split('T')[0];
+        const ds = formatRegina(day, 'yyyy-MM-dd');
         try {
           const roles = await getVolunteerRolesForVolunteer(token, ds);
           all.push(...roles);

--- a/MJ_FB_Frontend/src/utils/time.ts
+++ b/MJ_FB_Frontend/src/utils/time.ts
@@ -1,3 +1,7 @@
+import { formatInTimeZone } from 'date-fns-tz';
+
+export const REGINA_TIMEZONE = 'America/Regina';
+
 export function formatTime(time: string): string {
   if (!time) return '';
   const [hStr, mStr] = time.split(':');
@@ -13,3 +17,16 @@ export function formatHHMM(time: string): string {
   const [h, m] = time.split(':');
   return `${h.padStart(2, '0')}:${m.padStart(2, '0')}`;
 }
+
+export function formatReginaDate(
+  date: Date,
+  options: Intl.DateTimeFormatOptions = {},
+  locale = 'en-CA',
+): string {
+  return date.toLocaleDateString(locale, { timeZone: REGINA_TIMEZONE, ...options });
+}
+
+export function formatRegina(date: Date, fmt: string): string {
+  return formatInTimeZone(date, REGINA_TIMEZONE, fmt);
+}
+


### PR DESCRIPTION
## Summary
- add Regina timezone utilities
- display dates using Regina timezone across dashboards

## Testing
- `npm test` *(fails: import.meta not allowed, component tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abe957234c832dad259853c1216380