### PR TITLE
feat: add booking UI component

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -1,0 +1,259 @@
+import { useState } from 'react';
+import {
+  Box,
+  Container,
+  Grid,
+  Paper,
+  Typography,
+  List,
+  ListItemButton,
+  ListItemText,
+  ListSubheader,
+  Chip,
+  Divider,
+  Stack,
+  Button,
+  Toolbar,
+  Snackbar,
+  Alert,
+  Skeleton,
+} from '@mui/material';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { AccessTime, CheckCircle } from '@mui/icons-material';
+import dayjs, { Dayjs } from 'dayjs';
+import { useQuery } from '@tanstack/react-query';
+import type { Slot } from '../types';
+import { getSlots, createBooking } from '../api/bookings';
+
+// Wrappers to match required signatures
+function useSlots(date: Dayjs) {
+  const dateStr = date.format('YYYY-MM-DD');
+  const { data, isFetching, refetch } = useQuery<Slot[]>({
+    queryKey: ['slots', dateStr],
+    queryFn: () => getSlots(dateStr),
+  });
+  return { slots: data ?? [], isLoading: isFetching, refetch };
+}
+
+function bookSlot(payload: { date: string; slotId: string }): Promise<void> {
+  return createBooking(payload.slotId, payload.date);
+}
+
+export type BookingUIProps = {
+  shopperName?: string;
+  initialDate?: Dayjs;
+};
+
+export default function BookingUI({
+  shopperName = 'John Shopper',
+  initialDate = dayjs(),
+}: BookingUIProps) {
+  const [date, setDate] = useState<Dayjs>(initialDate);
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
+  const { slots, isLoading, refetch } = useSlots(date);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error';
+  }>({ open: false, message: '', severity: 'success' });
+  const [booking, setBooking] = useState(false);
+
+  const morningSlots = slots.filter(s =>
+    dayjs(s.startTime, 'HH:mm:ss').hour() < 12,
+  );
+  const afternoonSlots = slots.filter(s =>
+    dayjs(s.startTime, 'HH:mm:ss').hour() >= 12,
+  );
+
+  async function handleBook() {
+    if (!selectedSlotId) return;
+    setBooking(true);
+    try {
+      await bookSlot({
+        date: date.format('YYYY-MM-DD'),
+        slotId: selectedSlotId,
+      });
+      setSnackbar({
+        open: true,
+        message: 'Slot booked successfully',
+        severity: 'success',
+      });
+      setSelectedSlotId(null);
+      refetch();
+    } catch (err) {
+      setSnackbar({
+        open: true,
+        message: err instanceof Error ? err.message : 'Booking failed',
+        severity: 'error',
+      });
+    } finally {
+      setBooking(false);
+    }
+  }
+
+  function renderSlot(slot: Slot) {
+    const start = dayjs(slot.startTime, 'HH:mm:ss');
+    const end = dayjs(slot.endTime, 'HH:mm:ss');
+    const label = `${start.format('HH:mm')} – ${end.format('HH:mm')}`;
+    const available = slot.available ?? 0;
+    const isFull = available <= 0;
+    const selected = selectedSlotId === slot.id;
+    return (
+      <ListItemButton
+        key={slot.id}
+        disabled={isFull}
+        selected={selected}
+        onClick={() => setSelectedSlotId(slot.id)}
+        aria-label={`Select ${start.format('H:mm')} to ${end.format('H:mm')} time slot`}
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+          pl: 2,
+          ...(selected && {
+            bgcolor: 'action.selected',
+            borderLeft: theme => `3px solid ${theme.palette.primary.main}`,
+          }),
+        }}
+      >
+        <ListItemText
+          primary={label}
+          secondary={isFull ? 'Fully booked' : 'Choose this time'}
+        />
+        <Chip
+          label={isFull ? 'Full' : `Available: ${available}`}
+          color={isFull ? 'default' : 'success'}
+          size="small"
+        />
+      </ListItemButton>
+    );
+  }
+
+  const selectedSlot = slots.find(s => s.id === selectedSlotId);
+  const selectedLabel = selectedSlot
+    ? `${dayjs(selectedSlot.startTime, 'HH:mm:ss').format('HH:mm')} – ${dayjs(
+        selectedSlot.endTime,
+        'HH:mm:ss',
+      ).format('HH:mm')}`
+    : '';
+
+  return (
+    <Container maxWidth="lg">
+      <Toolbar />
+      <Typography variant="h5" gutterBottom>
+        Booking for: {shopperName}
+      </Typography>
+      <Typography
+        variant="subtitle1"
+        sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}
+      >
+        <AccessTime fontSize="small" />
+        Available Slots for {date.format('ddd, MMM D')}
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <Paper sx={{ p: 2, borderRadius: 2 }}>
+            <DateCalendar
+              value={date}
+              onChange={newDate => {
+                if (newDate) {
+                  setDate(newDate);
+                  setSelectedSlotId(null);
+                }
+              }}
+            />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Paper
+            sx={{
+              p: 2,
+              borderRadius: 2,
+              maxHeight: { xs: 420, md: 560 },
+              overflow: 'auto',
+            }}
+          >
+            {isLoading ? (
+              <Box>
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton
+                    key={i}
+                    variant="rectangular"
+                    height={56}
+                    sx={{ mb: 1, borderRadius: 1 }}
+                  />
+                ))}
+              </Box>
+            ) : slots.length === 0 ? (
+              <Box
+                sx={{
+                  minHeight: 200,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Typography>
+                  No slots available. Please choose another date.
+                </Typography>
+              </Box>
+            ) : (
+              <List disablePadding>
+                {morningSlots.length > 0 && (
+                  <>
+                    <ListSubheader disableSticky>Morning</ListSubheader>
+                    {morningSlots.map(renderSlot)}
+                    {afternoonSlots.length > 0 && <Divider />}
+                  </>
+                )}
+                {afternoonSlots.length > 0 && (
+                  <>
+                    <ListSubheader disableSticky>Afternoon</ListSubheader>
+                    {afternoonSlots.map(renderSlot)}
+                  </>
+                )}
+              </List>
+            )}
+          </Paper>
+        </Grid>
+      </Grid>
+      <Paper
+        sx={{ position: 'sticky', bottom: 0, mt: 2, p: 2, borderRadius: 2 }}
+      >
+        <Stack direction="row" alignItems="center" justifyContent="space-between">
+          <Typography>
+            {selectedSlotId
+              ? `Selected: ${selectedLabel} on ${date.format('MMM D')}`
+              : 'No slot selected'}
+          </Typography>
+          <Button
+            variant="contained"
+            size="small"
+            disabled={!selectedSlotId || booking}
+            onClick={handleBook}
+          >
+            Book selected slot
+          </Button>
+        </Stack>
+      </Paper>
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+      >
+        <Alert
+          onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+          severity={snackbar.severity}
+          icon={
+            snackbar.severity === 'success' ? (
+              <CheckCircle fontSize="inherit" />
+            ) : undefined
+          }
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Container>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add new BookingUI page with calendar and slot list
- group morning/afternoon slots and show availability chips
- sticky booking bar with snackbar feedback for bookings

## Testing
- `npm test` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020' or newer; Navbar tests log Menu child warning, Login prop type mismatch, missing volunteer dashboard module)*

------
https://chatgpt.com/codex/tasks/task_e_68abf2e11b8c832d97cc31f0a144e96f