### PR TITLE
Stack outgoing bar in warehouse composition chart

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -444,6 +444,7 @@ export default function WarehouseDashboard() {
                 <Bar
                   dataKey="outgoing"
                   name="Outgoing"
+                  stackId="a"
                   fill={theme.palette.error.main}
                 />
               </BarChart>


### PR DESCRIPTION
## Summary
- stack outgoing donations with other categories in Warehouse Dashboard composition chart

## Testing
- `npx jest src/__tests__/App.test.tsx --runInBand --watchAll=false --forceExit` *(fails: Property 'toBeInTheDocument' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68abf4148704832da7544703c451bc64