### PR TITLE
fix: add dayjs dependency for booking UI

### DIFF
--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.85.5",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
+    "dayjs": "^1.11.11",
     "prettier": "^3.6.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- add `dayjs` to frontend dependencies for booking UI

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dayjs)*
- `npm test` *(fails: Test Suites: 7 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68abf67ecdc8832dabf070bcd8d1b43f