### PR TITLE
feat: support recurring volunteer bookings

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import VolunteerSchedule from '../pages/volunteer-management/VolunteerSchedule';
+import VolunteerBookingHistory from '../pages/volunteer-management/VolunteerBookingHistory';
+import {
+  getVolunteerRolesForVolunteer,
+  getMyVolunteerBookings,
+  createRecurringVolunteerBooking,
+  cancelVolunteerBooking,
+  cancelRecurringVolunteerBooking,
+} from '../api/volunteers';
+import { getHolidays } from '../api/bookings';
+
+jest.mock('../api/volunteers', () => ({
+  getVolunteerRolesForVolunteer: jest.fn(),
+  getMyVolunteerBookings: jest.fn(),
+  createRecurringVolunteerBooking: jest.fn(),
+  cancelVolunteerBooking: jest.fn(),
+  cancelRecurringVolunteerBooking: jest.fn(),
+}));
+jest.mock('../api/bookings', () => ({
+  getHolidays: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2024-05-01T00:00:00Z'));
+  jest.clearAllMocks();
+  (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
+    {
+      id: 1,
+      role_id: 1,
+      name: 'Test Role',
+      start_time: '09:00:00',
+      end_time: '10:00:00',
+      max_volunteers: 1,
+      booked: 0,
+      available: 1,
+      status: 'available',
+      date: '2024-01-01',
+      category_id: 1,
+      category_name: 'Cat',
+      is_wednesday_slot: false,
+    },
+  ]);
+  (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+  (getHolidays as jest.Mock).mockResolvedValue([]);
+  (createRecurringVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
+  (cancelVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
+  (cancelRecurringVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('submits weekly recurring booking', async () => {
+  render(<VolunteerSchedule token="t" />);
+  fireEvent.mouseDown(await screen.findByLabelText(/role/i));
+  const listbox = await screen.findByRole('listbox');
+  fireEvent.click(within(listbox).getByText('Test Role'));
+  fireEvent.click(await screen.findByText('Available'));
+  fireEvent.mouseDown(screen.getByLabelText(/frequency/i));
+  const freqList = await screen.findAllByRole('listbox');
+  fireEvent.click(within(freqList[freqList.length - 1]).getByText('Weekly'));
+  fireEvent.click(screen.getByLabelText('Mon'));
+  fireEvent.click(screen.getByLabelText('Wed'));
+  fireEvent.change(screen.getByLabelText(/end date/i), {
+    target: { value: '2024-12-31' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+  await waitFor(() =>
+    expect(createRecurringVolunteerBooking).toHaveBeenCalled(),
+  );
+  const args = (createRecurringVolunteerBooking as jest.Mock).mock.calls[0];
+  expect(args[0]).toBe('t');
+  expect(args[1]).toBe(1);
+  expect(args[3]).toBe('weekly');
+  expect(args[4]).toEqual(expect.arrayContaining([1, 3]));
+});
+
+test('cancels single and recurring bookings', async () => {
+  (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
+    {
+      id: 1,
+      role_id: 1,
+      role_name: 'Role1',
+      date: '2024-05-01',
+      start_time: '09:00:00',
+      end_time: '10:00:00',
+      status: 'approved',
+      recurring_id: 5,
+    },
+    {
+      id: 2,
+      role_id: 1,
+      role_name: 'Role1',
+      date: '2024-05-08',
+      start_time: '09:00:00',
+      end_time: '10:00:00',
+      status: 'approved',
+      recurring_id: 5,
+    },
+    {
+      id: 3,
+      role_id: 2,
+      role_name: 'Role2',
+      date: '2024-05-02',
+      start_time: '11:00:00',
+      end_time: '12:00:00',
+      status: 'approved',
+    },
+  ]);
+  render(<VolunteerBookingHistory token="t" />);
+  const cancelButtons = await screen.findAllByText('Cancel');
+  fireEvent.click(cancelButtons[2]);
+  fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
+  await waitFor(() =>
+    expect(cancelVolunteerBooking).toHaveBeenCalledWith('t', 3),
+  );
+  const cancelAllButtons = await screen.findAllByText('Cancel all upcoming');
+  fireEvent.click(cancelAllButtons[0]);
+  fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
+  await waitFor(() =>
+    expect(cancelRecurringVolunteerBooking).toHaveBeenCalledWith('t', 5),
+  );
+});
+

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -71,6 +71,47 @@ export async function requestVolunteerBooking(
   await handleResponse(res);
 }
 
+export async function createRecurringVolunteerBooking(
+  _token: string,
+  roleId: number,
+  startDate: string,
+  frequency: 'one-time' | 'daily' | 'weekly',
+  weekdays?: number[],
+  endDate?: string,
+): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/volunteer-bookings/recurring`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ roleId, startDate, frequency, weekdays, endDate }),
+  });
+  await handleResponse(res);
+}
+
+export async function cancelVolunteerBooking(
+  _token: string,
+  bookingId: number,
+): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/volunteer-bookings/${bookingId}`, {
+    method: 'DELETE',
+  });
+  await handleResponse(res);
+}
+
+export async function cancelRecurringVolunteerBooking(
+  _token: string,
+  recurringId: number,
+): Promise<void> {
+  const res = await apiFetch(
+    `${API_BASE}/volunteer-bookings/recurring/${recurringId}`,
+    {
+      method: 'DELETE',
+    },
+  );
+  await handleResponse(res);
+}
+
 export async function getMyVolunteerBookings(_token: string) {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/mine`);
   const data = await handleResponse(res);

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useState } from 'react';
-import { getMyVolunteerBookings } from '../../api/volunteers';
+import { useEffect, useState, useCallback } from 'react';
+import {
+  getMyVolunteerBookings,
+  cancelVolunteerBooking,
+  cancelRecurringVolunteerBooking,
+} from '../../api/volunteers';
 import type { VolunteerBooking } from '../../types';
 import { formatTime } from '../../utils/time';
 import Page from '../../components/Page';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import {
   TableContainer,
   Paper,
@@ -11,16 +16,70 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
+import type { AlertColor } from '@mui/material';
 
 export default function VolunteerBookingHistory({ token }: { token: string }) {
   const [history, setHistory] = useState<VolunteerBooking[]>([]);
+  const [cancelBooking, setCancelBooking] =
+    useState<VolunteerBooking | null>(null);
+  const [cancelSeriesId, setCancelSeriesId] = useState<number | null>(null);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<AlertColor>('success');
 
-  useEffect(() => {
+  const loadHistory = useCallback(() => {
     getMyVolunteerBookings(token)
       .then(setHistory)
       .catch(() => {});
   }, [token]);
+
+  useEffect(() => {
+    loadHistory();
+  }, [loadHistory]);
+
+  const groups = Array.from(
+    history.reduce((map, b) => {
+      const key = b.recurring_id ?? b.id;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(b);
+      return map;
+    }, new Map<number, VolunteerBooking[]>() ).values()
+  );
+
+  async function handleCancel() {
+    if (!cancelBooking) return;
+    try {
+      await cancelVolunteerBooking(token, cancelBooking.id);
+      setSeverity('success');
+      setMessage('Booking cancelled');
+      loadHistory();
+    } catch {
+      setSeverity('error');
+      setMessage('Failed to cancel booking');
+    } finally {
+      setCancelBooking(null);
+    }
+  }
+
+  async function handleCancelSeries() {
+    if (cancelSeriesId == null) return;
+    try {
+      await cancelRecurringVolunteerBooking(token, cancelSeriesId);
+      setSeverity('success');
+      setMessage('Series cancelled');
+      loadHistory();
+    } catch {
+      setSeverity('error');
+      setMessage('Failed to cancel series');
+    } finally {
+      setCancelSeriesId(null);
+    }
+  }
 
   return (
     <Page title="Booking History">
@@ -32,22 +91,41 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
               <TableCell>Date</TableCell>
               <TableCell>Time</TableCell>
               <TableCell>Status</TableCell>
+              <TableCell>Actions</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {history.map(h => (
-              <TableRow key={h.id}>
-                <TableCell>{h.role_name}</TableCell>
-                <TableCell>{h.date}</TableCell>
-                <TableCell>
-                  {formatTime(h.start_time)} - {formatTime(h.end_time)}
-                </TableCell>
-                <TableCell>{h.status}</TableCell>
-              </TableRow>
-            ))}
+            {groups.flatMap(group =>
+              group.map(h => (
+                <TableRow key={h.id}>
+                  <TableCell>{h.role_name}</TableCell>
+                  <TableCell>{h.date}</TableCell>
+                  <TableCell>
+                    {formatTime(h.start_time)} - {formatTime(h.end_time)}
+                  </TableCell>
+                  <TableCell>{h.status}</TableCell>
+                  <TableCell>
+                    <Button
+                      size="small"
+                      onClick={() => setCancelBooking(h)}
+                    >
+                      Cancel
+                    </Button>
+                    {h.recurring_id && (
+                      <Button
+                        size="small"
+                        onClick={() => setCancelSeriesId(h.recurring_id!)}
+                      >
+                        Cancel all upcoming
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              )),
+            )}
             {history.length === 0 && (
               <TableRow>
-                <TableCell colSpan={4} align="center">
+                <TableCell colSpan={5} align="center">
                   No bookings.
                 </TableCell>
               </TableRow>
@@ -55,6 +133,51 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <Dialog open={!!cancelBooking} onClose={() => setCancelBooking(null)}>
+        <DialogTitle>Cancel Booking</DialogTitle>
+        <DialogContent dividers>
+          Cancel booking for {cancelBooking?.role_name} on {cancelBooking?.date}?
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancel} variant="outlined" color="primary">
+            Confirm
+          </Button>
+          <Button
+            onClick={() => setCancelBooking(null)}
+            variant="outlined"
+            color="primary"
+          >
+            Keep
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={cancelSeriesId != null} onClose={() => setCancelSeriesId(null)}>
+        <DialogTitle>Cancel Series</DialogTitle>
+        <DialogContent dividers>
+          Cancel all upcoming bookings in this series?
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelSeries} variant="outlined" color="primary">
+            Confirm
+          </Button>
+          <Button
+            onClick={() => setCancelSeriesId(null)}
+            variant="outlined"
+            color="primary"
+          >
+            Keep
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity={severity}
+      />
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -105,6 +105,7 @@ export interface VolunteerBooking {
   role_name: string;
   status_color?: string;
   reschedule_token?: string;
+  recurring_id?: number;
 }
 
 export interface VolunteerBookingDetail {


### PR DESCRIPTION
## Summary
- add API helpers for recurring volunteer bookings and cancellations
- support recurring booking options and series cancellation in volunteer schedule
- group booking history by series with single and bulk cancel actions
- add tests for recurring booking creation and cancellation flows

## Testing
- `npm test` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020' ...)*
- `npm test -- src/__tests__/RecurringBookings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68abf823356c832d918c75a92ddab978