### PR TITLE
fix(frontend): correct AdapterDayjs import

### DIFF
--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -7,7 +7,8 @@ import { theme } from './theme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { registerServiceWorker } from './registerServiceWorker';
 import { AuthProvider } from './hooks/useAuth';
-import { LocalizationProvider, AdapterDayjs } from '@mui/x-date-pickers';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 
 function Main() {
   const queryClient = new QueryClient();


### PR DESCRIPTION
## Summary
- import AdapterDayjs from its module to resolve frontend runtime error

## Testing
- `CI=true npm test -- --runInBand` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.)*

------
https://chatgpt.com/codex/tasks/task_e_68abf931c6b4832d882f028726c70fe0