### PR TITLE
fix: expand slots panel width

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -149,7 +149,7 @@ export default function BookingUI({
         Available Slots for {date.format('ddd, MMM D')}
       </Typography>
       <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
+        <Grid item xs={12} md="auto">
           <Paper sx={{ p: 2, borderRadius: 2 }}>
             <DateCalendar
               value={date}
@@ -162,7 +162,7 @@ export default function BookingUI({
             />
           </Paper>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid item xs={12} md sx={{ flexGrow: 1 }}>
           <Paper
             sx={{
               p: 2,


### PR DESCRIPTION
## Summary
- make slots list expand to fill available width beside calendar

## Testing
- `npm test` *(fails: The 'import.meta' meta-property is only allowed...)*

------
https://chatgpt.com/codex/tasks/task_e_68abfbb77cc8832d9916d9ff0709dc0e