### PR TITLE
fix: make calendar responsive

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -159,6 +159,12 @@ export default function BookingUI({
                   setSelectedSlotId(null);
                 }
               }}
+              sx={{
+                width: '100%',
+                maxWidth: 320,
+                mx: 'auto',
+                '& .MuiPickersSlideTransition-root': { minWidth: 0 },
+              }}
             />
           </Paper>
         </Grid>


### PR DESCRIPTION
## Summary
- ensure slots calendar adjusts to mobile widths without overflowing

## Testing
- `npm test` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.)*

------
https://chatgpt.com/codex/tasks/task_e_68abfc1136c8832db368fcdf79a88c46