### PR TITLE
fix: keep slot action bar visible on mobile

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -136,7 +136,7 @@ export default function BookingUI({
     : '';
 
   return (
-    <Container maxWidth="lg">
+    <Container maxWidth="lg" sx={{ pb: { xs: 9, md: 0 } }}>
       <Toolbar />
       <Typography variant="h5" gutterBottom>
         Booking for: {shopperName}
@@ -216,7 +216,16 @@ export default function BookingUI({
         </Grid>
       </Grid>
       <Paper
-        sx={{ position: 'sticky', bottom: 0, mt: 2, p: 2, borderRadius: 2 }}
+        sx={{
+          position: { xs: 'fixed', md: 'sticky' },
+          bottom: 0,
+          left: 0,
+          right: 0,
+          mt: 2,
+          p: 2,
+          borderRadius: { xs: 0, md: 2 },
+          zIndex: theme => theme.zIndex.appBar,
+        }}
       >
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Typography>


### PR DESCRIPTION
## Summary
- keep selected-slot booking bar fixed at bottom on small screens
- add padding to page to avoid overlap with fixed action bar

## Testing
- `cd MJ_FB_Frontend && npm test` *(fails: Cannot find module '../pages/volunteer/VolunteerDashboard' and TS1343 'import.meta' meta-property only allowed for specific module options)*

------
https://chatgpt.com/codex/tasks/task_e_68abfc6b6454832d862fb6413cad28da