### PR TITLE
Fix Regina date parsing for slot availability

### DIFF
--- a/MJ_FB_Backend/src/utils/dateUtils.ts
+++ b/MJ_FB_Backend/src/utils/dateUtils.ts
@@ -1,12 +1,24 @@
 const REGINA_TZ = 'America/Regina';
+const REGINA_OFFSET = '-06:00';
+
+function toReginaDate(date: string | Date): Date {
+  if (typeof date === 'string') {
+    // If no time component is provided, treat the string as a Regina local date
+    if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return new Date(`${date}T00:00:00${REGINA_OFFSET}`);
+    }
+    return new Date(date);
+  }
+  return date;
+}
 
 export function formatReginaDate(date: string | Date): string {
-  const d = typeof date === 'string' ? new Date(date) : date;
+  const d = toReginaDate(date);
   return new Intl.DateTimeFormat('en-CA', { timeZone: REGINA_TZ }).format(d);
 }
 
 export function formatReginaDateTime(date: string | Date): string {
-  const d = typeof date === 'string' ? new Date(date) : date;
+  const d = toReginaDate(date);
   const options: Intl.DateTimeFormatOptions = {
     timeZone: REGINA_TZ,
     year: 'numeric',

--- a/MJ_FB_Backend/tests/dateUtils.test.ts
+++ b/MJ_FB_Backend/tests/dateUtils.test.ts
@@ -1,0 +1,13 @@
+import { formatReginaDate, reginaStartOfDayISO } from '../src/utils/dateUtils';
+
+describe('formatReginaDate', () => {
+  it('interprets YYYY-MM-DD strings in Regina timezone', () => {
+    expect(formatReginaDate('2024-08-26')).toBe('2024-08-26');
+  });
+});
+
+describe('reginaStartOfDayISO', () => {
+  it('returns midnight in Regina for given date string', () => {
+    expect(reginaStartOfDayISO('2024-08-26')).toBe('2024-08-26T00:00:00-06:00');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure YYYY-MM-DD strings are interpreted in Regina timezone
- add tests covering date utility behaviour

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden for node-pg-migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68abfd860320832d90c9cf06e5999418