### PR TITLE
feat: show modal when existing booking

### DIFF
--- a/MJ_FB_Frontend/src/components/FeedbackModal.tsx
+++ b/MJ_FB_Frontend/src/components/FeedbackModal.tsx
@@ -1,10 +1,11 @@
 import type { AlertColor } from '@mui/material';
 import { Dialog, DialogContent, DialogActions, Button, Alert } from '@mui/material';
+import type { ReactNode } from 'react';
 
 interface FeedbackModalProps {
   open: boolean;
   onClose: () => void;
-  message: string;
+  message: ReactNode;
   severity?: AlertColor;
 }
 


### PR DESCRIPTION
## Summary
- display detailed booking conflict information in a modal
- expand FeedbackModal to support rich message content

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dayjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ac028b7d48832da06c7ce688eeef6b