### PR TITLE
fix: keep booking action bar fixed across viewports

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -138,7 +138,7 @@ export default function BookingUI({
     : '';
 
   return (
-    <Container maxWidth="lg" sx={{ pb: { xs: 9, md: 0 } }}>
+    <Container maxWidth="lg" sx={{ pb: 9 }}>
       <Toolbar />
       <Typography variant="h5" gutterBottom>
         Booking for: {shopperName}
@@ -236,7 +236,7 @@ export default function BookingUI({
       </Grid>
       <Paper
         sx={{
-          position: { xs: 'fixed', md: 'sticky' },
+          position: 'fixed',
           bottom: 0,
           left: 0,
           right: 0,


### PR DESCRIPTION
## Summary
- keep booking action bar fixed on desktop and larger screens
- ensure layout spacing for fixed action bar

## Testing
- `npm test` (fails: jest not found)
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/dayjs)


------
https://chatgpt.com/codex/tasks/task_e_68ac0328a71c832d95000fde31fda45d