### PR TITLE
Disable booking on holidays and weekends

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Box,
   Container,
@@ -20,16 +20,17 @@ import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { AccessTime } from '@mui/icons-material';
 import dayjs, { Dayjs } from 'dayjs';
 import { useQuery } from '@tanstack/react-query';
-import type { Slot } from '../types';
-import { getSlots, createBooking } from '../api/bookings';
+import type { Slot, Holiday } from '../types';
+import { getSlots, createBooking, getHolidays } from '../api/bookings';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
 
 // Wrappers to match required signatures
-function useSlots(date: Dayjs) {
+function useSlots(date: Dayjs, enabled: boolean) {
   const dateStr = date.format('YYYY-MM-DD');
   const { data, isFetching, refetch, error } = useQuery<Slot[]>({
     queryKey: ['slots', dateStr],
     queryFn: () => getSlots(dateStr),
+    enabled,
   });
   return { slots: data ?? [], isLoading: isFetching, refetch, error };
 }
@@ -47,15 +48,40 @@ export default function BookingUI({
   shopperName = 'John Shopper',
   initialDate = dayjs(),
 }: BookingUIProps) {
-  const [date, setDate] = useState<Dayjs>(initialDate);
+  const [date, setDate] = useState<Dayjs>(() => {
+    let d = initialDate;
+    while (d.day() === 0 || d.day() === 6) {
+      d = d.add(1, 'day');
+    }
+    return d;
+  });
   const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
-  const { slots, isLoading, refetch, error } = useSlots(date);
+  const { data: holidays = [] } = useQuery<Holiday[]>({
+    queryKey: ['holidays'],
+    queryFn: getHolidays,
+  });
+  const holidaySet = new Set(holidays.map(h => h.date));
+  const isDisabled = (d: Dayjs) =>
+    d.day() === 0 ||
+    d.day() === 6 ||
+    holidaySet.has(d.format('YYYY-MM-DD'));
+  const { slots, isLoading, refetch, error } = useSlots(date, !isDisabled(date));
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: string;
     severity: 'success' | 'error';
   }>({ open: false, message: '', severity: 'success' });
   const [booking, setBooking] = useState(false);
+
+  useEffect(() => {
+    if (!isDisabled(date)) return;
+    let next = date;
+    while (isDisabled(next)) {
+      next = next.add(1, 'day');
+    }
+    setDate(next);
+    setSelectedSlotId(null);
+  }, [date, holidays]);
 
   const morningSlots = slots.filter(s =>
     dayjs(s.startTime, 'HH:mm:ss').hour() < 12,
@@ -155,8 +181,9 @@ export default function BookingUI({
           <Paper sx={{ p: 2, borderRadius: 2 }}>
             <DateCalendar
               value={date}
+              shouldDisableDate={isDisabled}
               onChange={newDate => {
-                if (newDate) {
+                if (newDate && !isDisabled(newDate)) {
                   setDate(newDate);
                   setSelectedSlotId(null);
                 }


### PR DESCRIPTION
## Summary
- disable weekend and holiday selection in BookingUI calendar
- auto-select next available day when current date is closed

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac03770ce4832d9a0e1f18708fedf0