### PR TITLE
feat(frontend): add recurring blocked slots API

### DIFF
--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -1,5 +1,5 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
-import type { Slot, SlotsByDate } from '../types';
+import type { Slot, SlotsByDate, RecurringBlockedSlot } from '../types';
 
 export async function getSlots(date?: string) {
   let url = `${API_BASE}/slots`;
@@ -146,6 +146,34 @@ export async function addBlockedSlot(
 
 export async function removeBlockedSlot(date: string, slotId: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/blocked-slots/${encodeURIComponent(date)}/${slotId}`, {
+    method: 'DELETE',
+  });
+  await handleResponse(res);
+}
+
+export async function getRecurringBlockedSlots(): Promise<RecurringBlockedSlot[]> {
+  const res = await apiFetch(`${API_BASE}/recurring-blocked-slots`);
+  return handleResponse(res);
+}
+
+export async function addRecurringBlockedSlot(
+  dayOfWeek: number,
+  weekOfMonth: number,
+  slotId: number,
+  reason: string,
+): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/recurring-blocked-slots`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ dayOfWeek, weekOfMonth, slotId, reason }),
+  });
+  await handleResponse(res);
+}
+
+export async function removeRecurringBlockedSlot(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/recurring-blocked-slots/${id}`, {
     method: 'DELETE',
   });
   await handleResponse(res);

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -53,6 +53,14 @@ export interface BlockedSlot {
   reason: string;
 }
 
+export interface RecurringBlockedSlot {
+  id: number;
+  dayOfWeek: number;
+  weekOfMonth: number;
+  slotId: number;
+  reason: string;
+}
+
 export interface VolunteerRole {
   id: number;
   role_id: number;


### PR DESCRIPTION
## Summary
- add API helpers to fetch, add, and remove recurring blocked slots
- declare RecurringBlockedSlot interface for the new API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac087d1e7c832db7e143832ab61434