### PR TITLE
Use unified blocked slot API for schedules

### DIFF
--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -1,5 +1,5 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
-import type { Slot, SlotsByDate, RecurringBlockedSlot } from '../types';
+import type { Slot, SlotsByDate, RecurringBlockedSlot, BlockedSlot } from '../types';
 
 export async function getSlots(date?: string) {
   let url = `${API_BASE}/slots`;
@@ -124,7 +124,7 @@ export async function getAllSlots() {
   })) as Slot[];
 }
 
-export async function getBlockedSlots(date: string) {
+export async function getBlockedSlots(date: string): Promise<BlockedSlot[]> {
   const res = await apiFetch(`${API_BASE}/blocked-slots?date=${encodeURIComponent(date)}`);
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getSlots, getBookings, getHolidays, createBookingForUser, decideBooking, cancelBooking, getBlockedSlots, getBreaks, getAllSlots } from '../../api/bookings';
+import { getSlots, getBookings, getHolidays, createBookingForUser, decideBooking, cancelBooking, getBlockedSlots, getAllSlots } from '../../api/bookings';
 import { searchUsers } from '../../api/users';
-import type { Slot, Break, Holiday, BlockedSlot } from '../../types';
+import type { Slot, Holiday, BlockedSlot } from '../../types';
 import { fromZonedTime, toZonedTime, formatInTimeZone } from 'date-fns-tz';
 import { formatTime } from '../../utils/time';
 import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
@@ -40,7 +40,6 @@ export default function PantrySchedule({ token }: { token: string }) {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [holidays, setHolidays] = useState<Holiday[]>([]);
   const [blockedSlots, setBlockedSlots] = useState<BlockedSlot[]>([]);
-  const [breaks, setBreaks] = useState<Break[]>([]);
   const [allSlots, setAllSlots] = useState<Slot[]>([]);
   const [assignSlot, setAssignSlot] = useState<Slot | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
@@ -87,7 +86,6 @@ export default function PantrySchedule({ token }: { token: string }) {
 
   useEffect(() => {
     getHolidays().then(setHolidays).catch(() => {});
-    getBreaks().then(setBreaks).catch(() => {});
     getAllSlots().then(setAllSlots).catch(() => {});
   }, []);
 
@@ -183,15 +181,16 @@ export default function PantrySchedule({ token }: { token: string }) {
   const isClosed = isHoliday || isWeekend;
 
   const slotMap = new Map(allSlots.map(s => [s.id, s]));
-  const dayBreaks = breaks.filter(b => b.dayOfWeek === reginaDate.getDay());
-  const displaySlots: (Slot & { break?: boolean; blocked?: boolean; reason?: string })[] = [];
-  for (const b of dayBreaks) {
-    const s = slotMap.get(b.slotId.toString());
-    if (s) displaySlots.push({ ...s, available: 0, break: true, reason: b.reason });
-  }
+  const displaySlots: Slot[] = [];
   for (const b of blockedSlots) {
     const s = slotMap.get(b.slotId.toString());
-    if (s) displaySlots.push({ ...s, available: 0, blocked: true, reason: b.reason });
+    if (s)
+      displaySlots.push({
+        ...s,
+        available: 0,
+        status: b.status ?? 'blocked',
+        reason: b.reason,
+      });
   }
   for (const s of slots) {
     displaySlots.push(s);
@@ -199,7 +198,7 @@ export default function PantrySchedule({ token }: { token: string }) {
   displaySlots.sort((a, b) => a.startTime.localeCompare(b.startTime));
 
   const rows = displaySlots.map(slot => {
-    if (slot.break) {
+    if (slot.status === 'break') {
       return {
         time: `${formatTime(slot.startTime)} - ${formatTime(slot.endTime)}`,
         cells: [
@@ -211,7 +210,7 @@ export default function PantrySchedule({ token }: { token: string }) {
         ],
       };
     }
-    if (slot.blocked) {
+    if (slot.status === 'blocked') {
       return {
         time: `${formatTime(slot.startTime)} - ${formatTime(slot.endTime)}`,
         cells: [

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -51,6 +51,7 @@ export interface Holiday {
 export interface BlockedSlot {
   slotId: number;
   reason: string;
+  status?: 'blocked' | 'break';
 }
 
 export interface RecurringBlockedSlot {


### PR DESCRIPTION
## Summary
- Staff PantrySchedule now uses getBlockedSlots alone for blocked and break slots
- BlockedSlot type expanded with optional status and API updated accordingly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac094c06d4832dbf5587ce35222fb9