### PR TITLE
Add agency client management and schedule pages

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -6,6 +6,8 @@ import UserHistory from './pages/staff/UserHistory';
 import BookingUI from './pages/BookingUI';
 import AddClient from './pages/staff/AddClient';
 import PantrySchedule from './pages/staff/PantrySchedule';
+import AgencySchedule from './pages/agency/AgencySchedule';
+import ClientList from './pages/agency/ClientList';
 import Pending from './pages/staff/Pending';
 import Login from './pages/auth/Login';
 import StaffLogin from './pages/auth/StaffLogin';
@@ -30,7 +32,7 @@ import PantryVisits from './pages/staff/PantryVisits';
 import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import Breadcrumbs from './components/Breadcrumbs';
-import { useAuth } from './hooks/useAuth';
+import { useAuth, AgencyGuard } from './hooks/useAuth';
 import type { StaffAccess } from './types';
 
 export default function App() {
@@ -110,6 +112,14 @@ export default function App() {
         ],
       });
 
+  } else if (role === 'agency') {
+    navGroups.push({
+      label: 'Agency',
+      links: [
+        { label: 'Schedule', to: '/agency/schedule' },
+        { label: 'Clients', to: '/agency/clients' },
+      ],
+    });
   } else if (role === 'shopper') {
     navGroups.push({
       label: 'Booking',
@@ -166,6 +176,10 @@ export default function App() {
                 element={
                   role === 'volunteer' ? (
                     <VolunteerDashboard token={token} />
+                  ) : role === 'agency' ? (
+                    <AgencyGuard>
+                      <AgencySchedule />
+                    </AgencyGuard>
                   ) : isStaff ? (
                     singleAccessOnly && staffRootPath !== '/' ? (
                       <Navigate to={staffRootPath} replace />
@@ -279,6 +293,26 @@ export default function App() {
                   <Route
                     path="/volunteer/history"
                     element={<VolunteerBookingHistory token={token} />}
+                  />
+                </>
+              )}
+              {role === 'agency' && (
+                <>
+                  <Route
+                    path="/agency/schedule"
+                    element={
+                      <AgencyGuard>
+                        <AgencySchedule />
+                      </AgencyGuard>
+                    }
+                  />
+                  <Route
+                    path="/agency/clients"
+                    element={
+                      <AgencyGuard>
+                        <ClientList />
+                      </AgencyGuard>
+                    }
                   />
                 </>
               )}

--- a/MJ_FB_Frontend/src/api/agencies.ts
+++ b/MJ_FB_Frontend/src/api/agencies.ts
@@ -1,0 +1,30 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+
+export async function getMyAgencyClients() {
+  const res = await apiFetch(`${API_BASE}/agencies/me/clients`);
+  return handleResponse(res);
+}
+
+export async function addAgencyClient(
+  agencyId: number | 'me',
+  clientId: number,
+): Promise<void> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const res = await apiFetch(`${API_BASE}/agencies/${agencyId}/clients`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ clientId }),
+  });
+  await handleResponse(res);
+}
+
+export async function removeAgencyClient(
+  agencyId: number | 'me',
+  clientId: number,
+): Promise<void> {
+  const res = await apiFetch(
+    `${API_BASE}/agencies/${agencyId}/clients/${clientId}`,
+    { method: 'DELETE' },
+  );
+  await handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
 import type { Role, UserRole, StaffAccess } from '../types';
 import type { LoginResponse } from '../api/users';
 import { logout as apiLogout } from '../api/users';
@@ -98,5 +99,11 @@ export function useAuth() {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error('useAuth must be used within an AuthProvider');
   return ctx;
+}
+
+export function AgencyGuard({ children }: { children: React.ReactNode }) {
+  const { role } = useAuth();
+  if (role !== 'agency') return <Navigate to="/" replace />;
+  return <>{children}</>;
 }
 

--- a/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState, useCallback } from 'react';
+import PantrySchedule from '../staff/PantrySchedule';
+import { getMyAgencyClients } from '../../api/agencies';
+import type { Role } from '../../types';
+import { useAuth } from '../../hooks/useAuth';
+
+interface AgencyClient {
+  id: number;
+  name: string;
+  email?: string;
+}
+
+export default function AgencySchedule() {
+  const { token } = useAuth();
+  const [clients, setClients] = useState<AgencyClient[]>([]);
+
+  useEffect(() => {
+    getMyAgencyClients()
+      .then(data => {
+        const mapped = Array.isArray(data)
+          ? data.map((c: any) => ({
+              id: c.id ?? c.client_id,
+              name:
+                c.name ??
+                c.client_name ??
+                `${c.first_name ?? ''} ${c.last_name ?? ''}`.trim(),
+              email: c.email,
+            }))
+          : [];
+        setClients(mapped);
+      })
+      .catch(() => setClients([]));
+  }, []);
+
+  const clientIds = clients.map(c => c.id);
+
+  const searchAgencyUsers = useCallback(
+    async (_token: string, term: string) => {
+      const lower = term.toLowerCase();
+      return clients
+        .filter(
+          c =>
+            c.name.toLowerCase().includes(lower) ||
+            c.id.toString().includes(term),
+        )
+        .slice(0, 5);
+    },
+    [clients],
+  );
+
+  return (
+    <PantrySchedule
+      token={token}
+      clientIds={clientIds}
+      searchUsersFn={searchAgencyUsers}
+    />
+  );
+}

--- a/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import {
+  Grid,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  TextField,
+  Button,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import {
+  getMyAgencyClients,
+  addAgencyClient,
+  removeAgencyClient,
+} from '../../api/agencies';
+import { useAuth } from '../../hooks/useAuth';
+
+interface AgencyClient {
+  id: number;
+  name: string;
+  email?: string;
+}
+
+export default function ClientList() {
+  const [clients, setClients] = useState<AgencyClient[]>([]);
+  const [newClientId, setNewClientId] = useState('');
+  const [snackbar, setSnackbar] = useState<
+    { message: string; severity: 'success' | 'error' } | null
+  >(null);
+
+  useAuth(); // ensure auth context
+
+  const load = async () => {
+    try {
+      const data = await getMyAgencyClients();
+      const mapped = Array.isArray(data)
+        ? data.map((c: any) => ({
+            id: c.id ?? c.client_id,
+            name:
+              c.name ??
+              c.client_name ??
+              `${c.first_name ?? ''} ${c.last_name ?? ''}`.trim(),
+            email: c.email,
+          }))
+        : [];
+      setClients(mapped);
+    } catch {
+      setSnackbar({ message: 'Failed to load clients', severity: 'error' });
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleAdd = async () => {
+    const id = Number(newClientId);
+    if (!id) return;
+    try {
+      await addAgencyClient('me', id);
+      setNewClientId('');
+      setSnackbar({ message: 'Client added', severity: 'success' });
+      load();
+    } catch (err: any) {
+      setSnackbar({
+        message: err.message || 'Failed to add client',
+        severity: 'error',
+      });
+    }
+  };
+
+  const handleRemove = async (id: number) => {
+    try {
+      await removeAgencyClient('me', id);
+      setSnackbar({ message: 'Client removed', severity: 'success' });
+      load();
+    } catch (err: any) {
+      setSnackbar({
+        message: err.message || 'Failed to remove client',
+        severity: 'error',
+      });
+    }
+  };
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12} md={6}>
+        <Typography variant="h5" gutterBottom>
+          Clients
+        </Typography>
+        <List dense>
+          {clients.map(c => (
+            <ListItem
+              key={c.id}
+              secondaryAction={
+                <IconButton
+                  edge="end"
+                  aria-label="remove"
+                  onClick={() => handleRemove(c.id)}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              }
+            >
+              <ListItemText primary={c.name} secondary={`ID: ${c.id}`} />
+            </ListItem>
+          ))}
+          {clients.length === 0 && (
+            <Typography>No clients assigned.</Typography>
+          )}
+        </List>
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Typography variant="h5" gutterBottom>
+          Add Client
+        </Typography>
+        <TextField
+          label="Client ID"
+          value={newClientId}
+          onChange={e => setNewClientId(e.target.value)}
+          size="small"
+          fullWidth
+          sx={{ mb: 1 }}
+        />
+        <Button variant="contained" size="small" onClick={handleAdd}>
+          Add
+        </Button>
+      </Grid>
+      <FeedbackSnackbar
+        open={!!snackbar}
+        onClose={() => setSnackbar(null)}
+        message={snackbar?.message || ''}
+        severity={snackbar?.severity}
+      />
+    </Grid>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -31,7 +31,15 @@ interface User {
 
 const reginaTimeZone = 'America/Regina';
 
-export default function PantrySchedule({ token }: { token: string }) {
+export default function PantrySchedule({
+  token,
+  clientIds,
+  searchUsersFn,
+}: {
+  token: string;
+  clientIds?: number[];
+  searchUsersFn?: (token: string, search: string) => Promise<User[]>;
+}) {
   const [currentDate, setCurrentDate] = useState(() => {
     const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
     return fromZonedTime(`${todayStr}T00:00:00`, reginaTimeZone);
@@ -77,7 +85,12 @@ export default function PantrySchedule({ token }: { token: string }) {
       setBlockedSlots(blockedData);
       const filtered = bookingsData.filter((b: Booking) => {
         const bookingDate = formatInTimeZone(new Date(b.date), reginaTimeZone, 'yyyy-MM-dd');
-        return bookingDate === dateStr && ['approved', 'submitted'].includes(b.status);
+        const inClient = !clientIds || clientIds.includes(b.client_id);
+        return (
+          bookingDate === dateStr &&
+          ['approved', 'submitted'].includes(b.status) &&
+          inClient
+        );
       });
       setBookings(filtered);
     } catch (err) {
@@ -98,7 +111,7 @@ export default function PantrySchedule({ token }: { token: string }) {
   useEffect(() => {
     if (assignSlot && searchTerm.length >= 3) {
       const delay = setTimeout(() => {
-        searchUsers(token, searchTerm)
+        (searchUsersFn || searchUsers)(token, searchTerm)
           .then((data: User[]) => setUserResults(data.slice(0, 5)))
           .catch(() => setUserResults([]));
       }, 300);

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -1,4 +1,4 @@
-export type Role = 'staff' | 'shopper' | 'delivery' | 'volunteer';
+export type Role = 'staff' | 'shopper' | 'delivery' | 'volunteer' | 'agency';
 export type UserRole = 'shopper' | 'delivery';
 export type StaffRole = 'staff';
 export type StaffAccess =


### PR DESCRIPTION
## Summary
- add agency API utilities and role definition
- implement agency client list with add/remove support
- reuse PantrySchedule for agency schedule filtered by assigned clients
- protect agency pages with auth guard and wire routes/navigation

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ac097645a4832d905a6feefedcd4d4