### PR TITLE
docs: document agency setup and env vars

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -11,11 +11,11 @@ PG_HOST=localhost
 PG_PORT=5432
 # Database name
 PG_DATABASE=mj_fb_db
-# Secret used for signing JWT tokens
+# Secret used for signing JWT tokens for clients, staff, volunteers, and agencies
 # Generate a strong random value, e.g.:
 #   openssl rand -hex 32
 JWT_SECRET=
-# Secret used for signing refresh JWT tokens
+# Secret used for signing refresh JWT tokens for all roles
 JWT_REFRESH_SECRET=
 # Allowed frontend origins for CORS (comma separated)
 # Include both localhost and 127.0.0.1 for local development

--- a/MJ_FB_Frontend/.env.example
+++ b/MJ_FB_Frontend/.env.example
@@ -1,6 +1,8 @@
-# Backend API base URL
+# Backend API base URL (agency login and client assignment use this API)
 VITE_API_BASE=http://localhost:4000
 
 # Weight multipliers for surplus tracking
 VITE_BREAD_WEIGHT_MULTIPLIER=10
 VITE_CANS_WEIGHT_MULTIPLIER=20
+
+# Agency authentication relies on JWT secrets configured in `MJ_FB_Backend/.env`.


### PR DESCRIPTION
## Summary
- explain new `agencies` and `agency_clients` tables and migrations
- document JWT secrets for agency auth in `.env.example`
- add CLI/API steps for creating agencies and assigning clients

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-pg-migrate)*
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dayjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0bbb6394832da56eac59733f7ba2