### PR TITLE
test: add agency related tests

### DIFF
--- a/MJ_FB_Backend/tests/agency.test.ts
+++ b/MJ_FB_Backend/tests/agency.test.ts
@@ -1,0 +1,139 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import bookingsRouter from '../src/routes/bookings';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import * as bookingRepository from '../src/models/bookingRepository';
+import { getAgencyByEmail, isAgencyClient } from '../src/models/agency';
+import * as bookingUtils from '../src/utils/bookingUtils';
+
+jest.mock('../src/db');
+jest.mock('bcrypt');
+jest.mock('jsonwebtoken');
+jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
+jest.mock('../src/models/bookingRepository', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/models/bookingRepository'),
+  checkSlotCapacity: jest.fn(),
+  insertBooking: jest.fn(),
+  fetchBookingHistory: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../src/models/agency', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/models/agency'),
+  getAgencyByEmail: jest.fn(),
+  isAgencyClient: jest.fn(),
+}));
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: '1', role: 'agency', email: 'a@b.com' };
+    next();
+  },
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  authorizeAccess: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  optionalAuthMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: '1', role: 'agency', email: 'a@b.com' };
+    next();
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/users', usersRouter);
+app.use('/api/bookings', bookingsRouter);
+app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  res.status(err.status || 500).json({ message: err.message });
+});
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (bookingUtils.isDateWithinCurrentOrNextMonth as jest.Mock).mockReturnValue(true);
+  (bookingUtils.countApprovedBookingsForMonth as jest.Mock).mockResolvedValue(0);
+  (bookingUtils.findUpcomingBooking as jest.Mock).mockResolvedValue(null);
+  (bookingUtils.updateBookingsThisMonth as jest.Mock).mockResolvedValue(0);
+});
+
+describe('Agency login and token issuance', () => {
+  it('logs in agency and sets token cookie', async () => {
+    (getAgencyByEmail as jest.Mock).mockResolvedValue({
+      id: 1,
+      name: 'Agency One',
+      email: 'a@b.com',
+      password: 'hashed',
+      contact_info: null,
+    });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    (jwt.sign as jest.Mock).mockReturnValue('token');
+
+    const res = await request(app)
+      .post('/api/users/login')
+      .send({ email: 'a@b.com', password: 'secret' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('role', 'agency');
+    expect(jwt.sign).toHaveBeenCalled();
+    expect(res.headers['set-cookie'][0]).toMatch(/token=/);
+  });
+});
+
+describe('Agency booking creation', () => {
+  const today = new Date().toISOString().split('T')[0];
+
+  it('creates booking for associated client', async () => {
+    (isAgencyClient as jest.Mock).mockResolvedValue(true);
+    (bookingRepository.checkSlotCapacity as jest.Mock).mockResolvedValue(undefined);
+    (bookingRepository.insertBooking as jest.Mock).mockResolvedValue(undefined);
+
+    const res = await request(app)
+      .post('/api/bookings')
+      .send({ userId: 5, slotId: 1, date: today });
+
+    expect(res.status).toBe(201);
+    expect(bookingRepository.insertBooking).toHaveBeenCalled();
+  });
+
+  it('rejects booking for unassociated client', async () => {
+    (isAgencyClient as jest.Mock).mockResolvedValue(false);
+
+    const res = await request(app)
+      .post('/api/bookings')
+      .send({ userId: 5, slotId: 1, date: today });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('Booking history access control', () => {
+  it('ignores userId query for agency', async () => {
+    const res = await request(app)
+      .get('/api/bookings/history')
+      .query({ userId: 99 });
+
+    expect(res.status).toBe(200);
+    expect((bookingRepository.fetchBookingHistory as jest.Mock).mock.calls[0][0]).toBe(1);
+  });
+});
+

--- a/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import App from '../App';
+import { loginAgency } from '../api/users';
+import { AuthProvider } from '../hooks/useAuth';
+
+jest.mock('../api/users', () => ({
+  loginAgency: jest.fn(),
+}));
+
+jest.mock('../pages/agency/AgencySchedule', () => () => <div>AgencySchedule</div>);
+jest.mock('../pages/agency/ClientList', () => () => <div>AgencyClientList</div>);
+jest.mock('../pages/agency/ClientBookings', () => () => <div>AgencyClientBookings</div>);
+
+describe('Agency UI access', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.pushState({}, '', '/');
+  });
+
+  it('allows agency login and shows agency links', async () => {
+    (loginAgency as jest.Mock).mockResolvedValue({
+      role: 'agency',
+      name: 'Agency',
+      id: 1,
+    });
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    );
+
+    fireEvent.click(screen.getByText(/agency login/i));
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'a@b.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'pass' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /schedule/i })).toBeInTheDocument()
+    );
+    expect(screen.getByRole('link', { name: /clients/i })).toBeInTheDocument();
+  });
+
+  it('redirects unauthenticated users away from agency routes', async () => {
+    window.history.pushState({}, '', '/agency/schedule');
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    );
+    await waitFor(() => expect(window.location.pathname).toBe('/login/user'));
+    expect(screen.getByText(/client login/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add backend tests for agency login, bookings, and history access control
- add frontend tests for agency login and route restrictions

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - node modules)*
- `npm test` (frontend) *(fails: jest not found)*
- `npm install` (frontend) *(fails: 403 Forbidden - node modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0bbe3b4c832db8d0b688982f354c