### PR TITLE
fix: guard rowCount in login to satisfy strict types

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -51,7 +51,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       `SELECT id, first_name, last_name, email, password, role, access FROM staff WHERE email = $1`,
       [email]
     );
-    if (staffQuery.rowCount > 0) {
+    if ((staffQuery.rowCount ?? 0) > 0) {
       const staff = staffQuery.rows[0];
       const match = await bcrypt.compare(password, staff.password);
       if (!match) {


### PR DESCRIPTION
## Summary
- handle possible null rowCount when logging in staff

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75921d20832db90242caf780a042