### PR TITLE
fix: handle null rowCount in agency client check

### DIFF
--- a/MJ_FB_Backend/src/models/agency.ts
+++ b/MJ_FB_Backend/src/models/agency.ts
@@ -29,7 +29,7 @@ export async function isAgencyClient(
     'SELECT 1 FROM agency_clients WHERE agency_id=$1 AND client_id=$2',
     [agencyId, clientId],
   );
-  return res.rowCount > 0;
+  return (res.rowCount ?? 0) > 0;
 }
 
 export async function addAgencyClient(


### PR DESCRIPTION
## Summary
- ensure agency client check handles null rowCount

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden for node-pg-migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7669754c832d8c8c39f35db2829a