### PR TITLE
Handle possible null rowCount from pg

### DIFF
--- a/MJ_FB_Backend/src/controllers/admin/adminStaffController.ts
+++ b/MJ_FB_Backend/src/controllers/admin/adminStaffController.ts
@@ -31,7 +31,7 @@ export async function getStaff(req: Request, res: Response, next: NextFunction) 
       'SELECT id, first_name, last_name, email, access FROM staff WHERE id = $1',
       [id],
     );
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Staff not found' });
     }
     const r = result.rows[0];
@@ -56,7 +56,7 @@ export async function createStaff(req: Request, res: Response, next: NextFunctio
   const { firstName, lastName, email, password, access = ['pantry'] } = parsed.data;
   try {
     const emailCheck = await pool.query('SELECT id FROM staff WHERE email = $1', [email]);
-    if (emailCheck.rowCount && emailCheck.rowCount > 0) {
+    if ((emailCheck.rowCount ?? 0) > 0) {
       return res.status(400).json({ message: 'Email already exists' });
     }
     const hashed = await bcrypt.hash(password, 10);
@@ -94,7 +94,7 @@ export async function updateStaff(req: Request, res: Response, next: NextFunctio
       values.push(id);
     }
     const result = await pool.query(query, values);
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Staff not found' });
     }
     res.json({ message: 'Staff updated' });
@@ -109,7 +109,7 @@ export async function deleteStaff(req: Request, res: Response, next: NextFunctio
   if (!id) return res.status(400).json({ message: 'Invalid ID' });
   try {
     const result = await pool.query('DELETE FROM staff WHERE id = $1', [id]);
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Staff not found' });
     }
     res.json({ message: 'Staff deleted' });

--- a/MJ_FB_Backend/src/controllers/admin/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/admin/staffController.ts
@@ -44,7 +44,7 @@ export async function createStaff(
 
   try {
     const emailCheck = await pool.query('SELECT id FROM staff WHERE email = $1', [email]);
-    if (emailCheck.rowCount && emailCheck.rowCount > 0) {
+    if ((emailCheck.rowCount ?? 0) > 0) {
       return res.status(400).json({ message: 'Email already exists' });
     }
 

--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -22,17 +22,17 @@ export async function requestPasswordReset(
     if (email) {
       const staffRes = await pool.query('SELECT id FROM staff WHERE email=$1', [email]);
       const volRes = await pool.query('SELECT id FROM volunteers WHERE email=$1', [email]);
-      if (staffRes.rowCount || volRes.rowCount) {
+      if ((staffRes.rowCount ?? 0) > 0 || (volRes.rowCount ?? 0) > 0) {
         logger.info(`Password reset requested for ${email}`);
       }
     } else if (username) {
       const volRes = await pool.query('SELECT id FROM volunteers WHERE username=$1', [username]);
-      if (volRes.rowCount) {
+      if ((volRes.rowCount ?? 0) > 0) {
         logger.info(`Password reset requested for volunteer ${username}`);
       }
     } else if (clientId) {
       const userRes = await pool.query('SELECT id FROM clients WHERE client_id=$1', [clientId]);
-      if (userRes.rowCount) {
+      if ((userRes.rowCount ?? 0) > 0) {
         logger.info(`Password reset requested for client ${clientId}`);
       }
     }
@@ -70,7 +70,7 @@ export async function changePassword(
       `SELECT password FROM ${table} WHERE id=$1`,
       [user.id],
     );
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'User not found' });
     }
     const match = await bcrypt.compare(currentPassword, result.rows[0].password);
@@ -112,7 +112,7 @@ export async function refreshToken(req: Request, res: Response, next: NextFuncti
       'SELECT token_id FROM refresh_tokens WHERE subject=$1',
       [subject],
     );
-    if (stored.rowCount === 0 || stored.rows[0].token_id !== payload.jti) {
+    if ((stored.rowCount ?? 0) === 0 || stored.rows[0].token_id !== payload.jti) {
       throw new Error('Invalid refresh token');
     }
     const newJti = randomUUID();

--- a/MJ_FB_Backend/src/controllers/donorController.ts
+++ b/MJ_FB_Backend/src/controllers/donorController.ts
@@ -63,7 +63,8 @@ export async function getDonor(req: Request, res: Response, next: NextFunction) 
        GROUP BY d.id, d.name`,
       [id],
     );
-    if (result.rowCount === 0) return res.status(404).json({ message: 'Donor not found' });
+    if ((result.rowCount ?? 0) === 0)
+      return res.status(404).json({ message: 'Donor not found' });
     res.json(result.rows[0]);
   } catch (error) {
     logger.error('Error fetching donor:', error);

--- a/MJ_FB_Backend/src/controllers/eventController.ts
+++ b/MJ_FB_Backend/src/controllers/eventController.ts
@@ -94,7 +94,7 @@ export async function deleteEvent(req: Request, res: Response, next: NextFunctio
   }
   try {
     const result = await pool.query('DELETE FROM events WHERE id = $1', [id]);
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Event not found' });
     }
     res.json({ message: 'Deleted' });

--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -117,7 +117,7 @@ export async function listSlots(req: Request, res: Response, next: NextFunction)
       'SELECT reason FROM holidays WHERE date = $1',
       [reginaDate],
     );
-    if (holidayResult.rowCount > 0) {
+    if ((holidayResult.rowCount ?? 0) > 0) {
       const reason = holidayResult.rows[0].reason || 'Holiday';
       return res
         .status(400)

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -22,7 +22,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
         `SELECT id, first_name, last_name, role, password FROM clients WHERE client_id = $1 AND online_access = true`,
         [clientId]
       );
-      if (userQuery.rowCount === 0) {
+      if ((userQuery.rowCount ?? 0) === 0) {
         return res.status(401).json({ message: 'Invalid credentials' });
       }
       const user = userQuery.rows[0];
@@ -143,13 +143,13 @@ export async function createUser(req: Request, res: Response, next: NextFunction
 
   try {
     const check = await pool.query('SELECT id FROM clients WHERE client_id = $1', [clientId]);
-    if (check.rowCount && check.rowCount > 0) {
+    if ((check.rowCount ?? 0) > 0) {
       return res.status(400).json({ message: 'Client ID already exists' });
     }
 
     if (email) {
       const emailCheck = await pool.query('SELECT id FROM clients WHERE email = $1', [email]);
-      if (emailCheck.rowCount && emailCheck.rowCount > 0) {
+      if ((emailCheck.rowCount ?? 0) > 0) {
         return res.status(400).json({ message: 'Email already exists' });
       }
     }
@@ -224,7 +224,7 @@ export async function getUserByClientId(req: Request, res: Response, next: NextF
        FROM clients WHERE client_id = $1`,
       [clientId]
     );
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'User not found' });
     }
     const row = result.rows[0];
@@ -252,7 +252,7 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
        FROM clients WHERE id = $1`,
       [user.id]
     );
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'User not found' });
     }
     const row = result.rows[0];

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -36,7 +36,7 @@ export async function createVolunteerBooking(
        WHERE vs.slot_id = $1 AND vs.is_active`,
       [roleId]
     );
-    if (slotRes.rowCount === 0) {
+    if ((slotRes.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Role not found' });
     }
     const slot = slotRes.rows[0];
@@ -45,7 +45,7 @@ export async function createVolunteerBooking(
       'SELECT 1 FROM volunteer_trained_roles WHERE volunteer_id = $1 AND role_id = $2',
       [user.id, slot.role_id]
     );
-    if (volRes.rowCount === 0) {
+    if ((volRes.rowCount ?? 0) === 0) {
       return res.status(400).json({ message: 'Not trained for this role' });
     }
 
@@ -116,7 +116,7 @@ export async function createVolunteerBookingForVolunteer(
        WHERE vs.slot_id = $1 AND vs.is_active`,
       [roleId]
     );
-    if (slotRes.rowCount === 0) {
+    if ((slotRes.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Role not found' });
     }
     const slot = slotRes.rows[0];
@@ -125,7 +125,7 @@ export async function createVolunteerBookingForVolunteer(
       'SELECT 1 FROM volunteer_trained_roles WHERE volunteer_id = $1 AND role_id = $2',
       [volunteerId, slot.role_id]
     );
-    if (trainedRes.rowCount === 0) {
+    if ((trainedRes.rowCount ?? 0) === 0) {
       return res.status(400).json({ message: 'Volunteer not trained for this role' });
     }
 
@@ -304,7 +304,7 @@ export async function updateVolunteerBookingStatus(
     const bookingRes = await pool.query('SELECT * FROM volunteer_bookings WHERE id=$1', [
       id,
     ]);
-    if (bookingRes.rowCount === 0) {
+    if ((bookingRes.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Booking not found' });
     }
     const booking = bookingRes.rows[0];
@@ -363,7 +363,7 @@ export async function rescheduleVolunteerBooking(
       'SELECT * FROM volunteer_bookings WHERE reschedule_token = $1',
       [token],
     );
-    if (bookingRes.rowCount === 0) {
+    if ((bookingRes.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Booking not found' });
     }
     const booking = bookingRes.rows[0];
@@ -374,7 +374,7 @@ export async function rescheduleVolunteerBooking(
        WHERE slot_id = $1 AND is_active`,
       [roleId],
     );
-    if (slotRes.rowCount === 0) {
+    if ((slotRes.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Role not found' });
     }
     const slot = slotRes.rows[0];
@@ -383,7 +383,7 @@ export async function rescheduleVolunteerBooking(
       'SELECT 1 FROM volunteer_trained_roles WHERE volunteer_id = $1 AND role_id = $2',
       [booking.volunteer_id, slot.role_id],
     );
-    if (trainedRes.rowCount === 0) {
+    if ((trainedRes.rowCount ?? 0) === 0) {
       return res.status(400).json({ message: 'Volunteer not trained for this role' });
     }
 
@@ -486,7 +486,7 @@ export async function cancelVolunteerBookingOccurrence(
        RETURNING id, slot_id, volunteer_id, date, status, recurring_id`,
       [id],
     );
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Booking not found' });
     }
     const booking = result.rows[0];

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -60,7 +60,7 @@ export async function loginVolunteer(req: Request, res: Response, next: NextFunc
          WHERE v.username = $1`,
       [username]
     );
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
     const volunteer = result.rows[0];
@@ -155,7 +155,7 @@ export async function createVolunteer(
     const usernameCheck = await pool.query('SELECT id FROM volunteers WHERE username=$1', [
       username,
     ]);
-    if (usernameCheck.rowCount && usernameCheck.rowCount > 0) {
+    if ((usernameCheck.rowCount ?? 0) > 0) {
       return res.status(400).json({ message: 'Username already exists' });
     }
 
@@ -163,7 +163,7 @@ export async function createVolunteer(
       const emailCheck = await pool.query('SELECT id FROM volunteers WHERE email=$1', [
         email,
       ]);
-      if (emailCheck.rowCount && emailCheck.rowCount > 0) {
+      if ((emailCheck.rowCount ?? 0) > 0) {
         return res.status(400).json({ message: 'Email already exists' });
       }
     }
@@ -221,14 +221,14 @@ export async function createVolunteerShopperProfile(
       `SELECT first_name, last_name, email, phone FROM volunteers WHERE id = $1`,
       [id],
     );
-    if (volRes.rowCount === 0) {
+    if ((volRes.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Volunteer not found' });
     }
     const clientCheck = await pool.query(
       `SELECT id FROM clients WHERE client_id = $1`,
       [clientId],
     );
-    if (clientCheck.rowCount && clientCheck.rowCount > 0) {
+    if ((clientCheck.rowCount ?? 0) > 0) {
       return res.status(400).json({ message: 'Client ID already exists' });
     }
     const hashed = await bcrypt.hash(password, 10);
@@ -269,7 +269,7 @@ export async function removeVolunteerShopperProfile(
       `SELECT user_id FROM volunteers WHERE id = $1`,
       [id],
     );
-    if (volRes.rowCount === 0 || !volRes.rows[0].user_id) {
+    if ((volRes.rowCount ?? 0) === 0 || !volRes.rows[0].user_id) {
       return res.status(404).json({ message: 'Shopper profile not found' });
     }
     const userId = volRes.rows[0].user_id;

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -169,7 +169,7 @@ export async function updateVolunteerRole(
        RETURNING role_id, slot_id, is_active`,
       [startTime, endTime, maxVolunteers, isWednesdaySlot || false, id]
     );
-    if (slotRes.rowCount === 0) {
+    if ((slotRes.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Role not found' });
     }
     const roleId = slotRes.rows[0].role_id;
@@ -217,7 +217,7 @@ export async function updateVolunteerRoleStatus(
                   vs.max_volunteers, vr.category_id, vs.is_wednesday_slot, vs.is_active, vmr.name AS category_name`,
       [isActive, id]
     );
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Role not found' });
     }
     res.json(result.rows[0]);
@@ -234,7 +234,7 @@ export async function deleteVolunteerRole(req: Request, res: Response, next: Nex
       `DELETE FROM volunteer_slots WHERE slot_id = $1 RETURNING slot_id`,
       [id]
     );
-    if (result.rowCount === 0) {
+    if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Role not found' });
     }
     res.json({ message: 'Role deleted' });
@@ -260,7 +260,7 @@ export async function listVolunteerRolesForVolunteer(
       'SELECT role_id FROM volunteer_trained_roles WHERE volunteer_id=$1',
       [user.id]
     );
-    if (volunteerRes.rowCount === 0) {
+    if ((volunteerRes.rowCount ?? 0) === 0) {
       return res.json([]);
     }
     const roleIds = volunteerRes.rows.map(r => r.role_id);

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -47,7 +47,7 @@ async function authenticate(req: Request): Promise<AuthResult> {
         'SELECT id, first_name, last_name, email, role FROM staff WHERE id = $1',
         [id],
       );
-      if (staffRes.rowCount === 0) {
+      if ((staffRes.rowCount ?? 0) === 0) {
         return { status: 'invalid' };
       }
       return {
@@ -68,7 +68,7 @@ async function authenticate(req: Request): Promise<AuthResult> {
           'SELECT id, first_name, last_name, email, role, phone FROM clients WHERE id = $1',
           [id],
         );
-      if (userRes.rowCount && userRes.rowCount > 0) {
+      if ((userRes.rowCount ?? 0) > 0) {
         return {
           status: 'ok',
           user: {
@@ -89,7 +89,7 @@ async function authenticate(req: Request): Promise<AuthResult> {
         'SELECT id, first_name, last_name, email FROM volunteers WHERE id = $1',
         [id],
       );
-      if (volRes.rowCount === 0) {
+      if ((volRes.rowCount ?? 0) === 0) {
         return { status: 'invalid' };
       }
       return {
@@ -111,7 +111,7 @@ async function authenticate(req: Request): Promise<AuthResult> {
         'SELECT id, name, email FROM agencies WHERE id = $1',
         [id],
       );
-      if (agRes.rowCount === 0) {
+      if ((agRes.rowCount ?? 0) === 0) {
         return { status: 'invalid' };
       }
       return {

--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -22,7 +22,7 @@ export async function checkSlotCapacity(
     'SELECT max_capacity FROM slots WHERE id = $1 FOR UPDATE',
     [slotId],
   );
-  if (slotRes.rowCount === 0) {
+  if ((slotRes.rowCount ?? 0) === 0) {
     throw new SlotCapacityError('Invalid slot');
   }
   const approvedCountRes = await client.query(

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -14,7 +14,7 @@ export async function setupDatabase() {
   const adminClient = new Client({ ...dbConfig, database: 'postgres' });
   await adminClient.connect();
   const dbExists = await adminClient.query('SELECT 1 FROM pg_database WHERE datname = $1', [dbName]);
-  if (dbExists.rowCount === 0) {
+  if ((dbExists.rowCount ?? 0) === 0) {
     await adminClient.query(`CREATE DATABASE ${dbName}`);
     console.log(`Created database ${dbName}`);
   }
@@ -33,7 +33,7 @@ export async function setupDatabase() {
       SELECT column_name FROM information_schema.columns
       WHERE table_name = 'volunteers' AND column_name = 'user_id';
     `);
-    if (userIdRes.rowCount === 0) {
+    if ((userIdRes.rowCount ?? 0) === 0) {
       await client.query(
         `ALTER TABLE volunteers ADD COLUMN user_id integer REFERENCES public.clients(id);`,
       );
@@ -42,7 +42,7 @@ export async function setupDatabase() {
       SELECT column_name FROM information_schema.columns
       WHERE table_name = 'staff' AND column_name = 'access';
     `);
-    if (staffAccessRes.rowCount === 0) {
+    if ((staffAccessRes.rowCount ?? 0) === 0) {
       await client.query(
         `ALTER TABLE staff ADD COLUMN access text[] NOT NULL DEFAULT '{}'::text[] CHECK (access <@ ARRAY['pantry','volunteer_management','warehouse','admin']);`
       );
@@ -51,7 +51,7 @@ export async function setupDatabase() {
       SELECT column_name FROM information_schema.columns
       WHERE table_name = 'clients' AND column_name = 'profile_link';
     `);
-    if (profileLinkRes.rowCount === 0) {
+    if ((profileLinkRes.rowCount ?? 0) === 0) {
       await client.query(`ALTER TABLE clients ADD COLUMN profile_link text;`);
       await client.query(
         `UPDATE clients SET profile_link = 'https://portal.link2feed.ca/org/1605/intake/' || client_id;`
@@ -65,7 +65,7 @@ export async function setupDatabase() {
       SELECT column_name FROM information_schema.columns
       WHERE table_name = 'events' AND column_name = 'visible_to_clients';
     `);
-    if (eventVisClientRes.rowCount === 0) {
+    if ((eventVisClientRes.rowCount ?? 0) === 0) {
       await client.query(
         `ALTER TABLE events ADD COLUMN visible_to_clients boolean NOT NULL DEFAULT false;`
       );
@@ -75,7 +75,7 @@ export async function setupDatabase() {
       SELECT column_name FROM information_schema.columns
       WHERE table_name = 'events' AND column_name = 'visible_to_volunteers';
     `);
-    if (eventVisVolRes.rowCount === 0) {
+    if ((eventVisVolRes.rowCount ?? 0) === 0) {
       await client.query(
         `ALTER TABLE events ADD COLUMN visible_to_volunteers boolean NOT NULL DEFAULT false;`
       );
@@ -102,7 +102,7 @@ export async function setupDatabase() {
       SELECT column_name FROM information_schema.columns
       WHERE table_name = 'volunteer_bookings' AND column_name = 'recurring_id';
     `);
-    if (recurringIdRes.rowCount === 0) {
+    if ((recurringIdRes.rowCount ?? 0) === 0) {
       await client.query(
         `ALTER TABLE volunteer_bookings ADD COLUMN recurring_id integer REFERENCES public.volunteer_recurring_bookings(id);`
       );
@@ -431,7 +431,7 @@ CREATE TABLE IF NOT EXISTS volunteer_bookings (
     SELECT column_name FROM information_schema.columns
     WHERE table_name = 'volunteer_slots' AND column_name = 'max_volunteers';
   `);
-  if (maxVolRes.rowCount === 0) {
+  if ((maxVolRes.rowCount ?? 0) === 0) {
     await client.query(
       `ALTER TABLE volunteer_slots ADD COLUMN max_volunteers integer NOT NULL DEFAULT 1;`
     );


### PR DESCRIPTION
## Summary
- Safely handle potentially null `rowCount` values returned by `pg` queries using the nullish coalescing operator.
- Apply the fix across controllers, middleware, database setup, and repositories to avoid TypeScript compile errors.

## Testing
- `npm install` *(fails: 403 Forbidden for node-pg-migrate)*
- `npm test` *(fails: jest not found due to installation failure)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7a5dfcd8832da8d2778def96c92c