### PR TITLE
Add warehouse overall years endpoint

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -58,3 +58,9 @@ Every donor in the system is included even if they have no donations in that yea
 without records report `0`.
 
 
+
+## Warehouse Overall Available Years Endpoint
+
+`GET /warehouse-overall/years`
+
+Returns an array of years for which warehouse summary data exists, ordered from most recent to oldest.

--- a/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
+++ b/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
@@ -20,6 +20,16 @@ export async function listWarehouseOverall(req: Request, res: Response, next: Ne
   }
 }
 
+export async function listAvailableYears(req: Request, res: Response, next: NextFunction) {
+  try {
+    const result = await pool.query('SELECT DISTINCT year FROM warehouse_overall ORDER BY year DESC');
+    res.json(result.rows.map(r => r.year));
+  } catch (error) {
+    logger.error('Error listing warehouse overall years:', error);
+    next(error);
+  }
+}
+
 export async function exportWarehouseOverall(req: Request, res: Response, next: NextFunction) {
   try {
     const year = parseInt((req.query.year as string) ?? '', 10) || new Date().getFullYear();

--- a/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
@@ -1,5 +1,10 @@
 import { Router } from 'express';
-import { listWarehouseOverall, rebuildWarehouseOverall, exportWarehouseOverall } from '../../controllers/warehouse/warehouseOverallController';
+import {
+  listWarehouseOverall,
+  rebuildWarehouseOverall,
+  exportWarehouseOverall,
+  listAvailableYears,
+} from '../../controllers/warehouse/warehouseOverallController';
 import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware';
 
 const router = Router();
@@ -7,5 +12,6 @@ const router = Router();
 router.get('/', listWarehouseOverall);
 router.post('/rebuild', authMiddleware, authorizeAccess('warehouse'), rebuildWarehouseOverall);
 router.get('/export', exportWarehouseOverall);
+router.get('/years', listAvailableYears);
 
 export default router;

--- a/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import express from 'express';
+import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+
+const app = express();
+app.use('/warehouse-overall', warehouseOverallRoutes);
+
+describe('GET /warehouse-overall/years', () => {
+  it('lists available years in descending order', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ year: 2024 }, { year: 2023 }],
+    });
+
+    const res = await request(app).get('/warehouse-overall/years');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([2024, 2023]);
+    expect(pool.query).toHaveBeenCalledWith(
+      'SELECT DISTINCT year FROM warehouse_overall ORDER BY year DESC',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `listAvailableYears` controller to return distinct warehouse years
- expose new `GET /warehouse-overall/years` route
- document years endpoint and test route handling

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac86939cf8832d94e97cc74b949160