### PR TITLE
Load warehouse years dynamically

### DIFF
--- a/MJ_FB_Frontend/src/api/warehouseOverall.ts
+++ b/MJ_FB_Frontend/src/api/warehouseOverall.ts
@@ -8,6 +8,11 @@ export interface WarehouseOverall {
   outgoingDonations: number;
 }
 
+export async function getWarehouseOverallYears(): Promise<number[]> {
+  const res = await apiFetch(`${API_BASE}/warehouse-overall/years`);
+  return handleResponse(res);
+}
+
 export async function getWarehouseOverall(year: number): Promise<WarehouseOverall[]> {
   const res = await apiFetch(`${API_BASE}/warehouse-overall?year=${year}`);
   return handleResponse(res);


### PR DESCRIPTION
## Summary
- fetch available warehouse years from new `warehouse-overall/years` endpoint
- use fetched list to initialize year filter with fallback to last 5 years
- expose API helper for loading warehouse overall years

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dayjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ac88baba90832db7f21d5acabcdc3f