### PR TITLE
Delay client lookup until 4 digits

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -115,7 +115,7 @@ export default function PantryVisits({ token }: { token: string }) {
   }, [form.weightWithCart, cartTare, autoWeight, recordOpen]);
 
   useEffect(() => {
-    if (!form.clientId) {
+    if (!form.clientId || form.clientId.length < 4) {
       setClientFound(null);
       return;
     }


### PR DESCRIPTION
## Summary
- defer client lookup until at least four digits entered when recording pantry visits

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dayjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8cb6463c832d871386dc7623b324