### PR TITLE
Show profile link in client update page

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -282,7 +282,7 @@ export async function listUsersMissingInfo(
 ) {
   try {
     const result = await pool.query(
-      `SELECT id, client_id, first_name, last_name, email, phone
+      `SELECT id, client_id, first_name, last_name, email, phone, profile_link
        FROM clients
        WHERE first_name IS NULL AND last_name IS NULL
        ORDER BY client_id ASC`,
@@ -294,6 +294,7 @@ export async function listUsersMissingInfo(
       lastName: row.last_name,
       email: row.email,
       phone: row.phone,
+      profileLink: row.profile_link,
     }));
     res.json(users);
   } catch (error) {
@@ -322,7 +323,7 @@ export async function updateUserByClientId(
       `UPDATE clients
        SET first_name = $1, last_name = $2, email = $3, phone = $4
        WHERE client_id = $5
-       RETURNING id, client_id, first_name, last_name, email, phone`,
+       RETURNING id, client_id, first_name, last_name, email, phone, profile_link`,
       [firstName, lastName, email || null, phone || null, clientId],
     );
     if ((result.rowCount ?? 0) === 0) {
@@ -336,6 +337,7 @@ export async function updateUserByClientId(
       lastName: row.last_name,
       email: row.email,
       phone: row.phone,
+      profileLink: row.profile_link,
     });
   } catch (error) {
     logger.error('Error updating user info:', error);

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -159,6 +159,7 @@ export interface IncompleteUser {
   lastName: string | null;
   email: string | null;
   phone: string | null;
+  profileLink: string;
 }
 
 export async function getIncompleteUsers(_token: string): Promise<IncompleteUser[]> {

--- a/MJ_FB_Frontend/src/pages/staff/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/UpdateClientData.tsx
@@ -12,6 +12,7 @@ import {
   DialogActions,
   TextField,
   Stack,
+  Link,
 } from '@mui/material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -84,6 +85,7 @@ export default function UpdateClientData({ token }: { token: string }) {
         <TableHead>
           <TableRow>
             <TableCell>Client ID</TableCell>
+            <TableCell>Profile</TableCell>
             <TableCell align="right">Actions</TableCell>
           </TableRow>
         </TableHead>
@@ -91,6 +93,15 @@ export default function UpdateClientData({ token }: { token: string }) {
           {clients.map(client => (
             <TableRow key={client.clientId}>
               <TableCell>{client.clientId}</TableCell>
+              <TableCell>
+                <Link
+                  href={client.profileLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Profile
+                </Link>
+              </TableCell>
               <TableCell align="right">
                 <Button
                   size="small"
@@ -106,7 +117,18 @@ export default function UpdateClientData({ token }: { token: string }) {
       </Table>
 
       <Dialog open={!!selected} onClose={() => setSelected(null)}>
-        <DialogTitle>Edit Client</DialogTitle>
+        <DialogTitle>
+          Edit Client -{' '}
+          {selected && (
+            <Link
+              href={selected.profileLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {selected.clientId}
+            </Link>
+          )}
+        </DialogTitle>
         <DialogContent>
           <Stack spacing={2} mt={1}>
             <TextField


### PR DESCRIPTION
## Summary
- expose `profileLink` on user listing and update endpoints
- display client profile link in update client data table
- show profile link in Edit Client dialog title

## Testing
- `npm test` *(backend: jest not found)*
- `npm test` *(frontend: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8dd0c6b8832da9dfb6c6aff431eb