### PR TITLE
Display profile links in client update table

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/UpdateClientData.tsx
@@ -85,7 +85,7 @@ export default function UpdateClientData({ token }: { token: string }) {
         <TableHead>
           <TableRow>
             <TableCell>Client ID</TableCell>
-            <TableCell>Profile</TableCell>
+            <TableCell>Profile Link</TableCell>
             <TableCell align="right">Actions</TableCell>
           </TableRow>
         </TableHead>
@@ -99,7 +99,7 @@ export default function UpdateClientData({ token }: { token: string }) {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Profile
+                  {client.profileLink}
                 </Link>
               </TableCell>
               <TableCell align="right">


### PR DESCRIPTION
## Summary
- Show each client's profile URL in Update Client Data table
- Rename column header to Profile Link

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac90074cc4832d81dbad5aadfa5f89