### PR TITLE
feat: auto refresh warehouse overall data

### DIFF
--- a/MJ_FB_Backend/src/controllers/warehouse/pigPoundController.ts
+++ b/MJ_FB_Backend/src/controllers/warehouse/pigPoundController.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import pool from '../../db';
 import logger from '../../utils/logger';
+import { refreshWarehouseOverall } from './warehouseOverallController';
 
 export async function listPigPounds(req: Request, res: Response, next: NextFunction) {
   try {
@@ -24,6 +25,8 @@ export async function addPigPound(req: Request, res: Response, next: NextFunctio
       'INSERT INTO pig_pound_log (date, weight) VALUES ($1, $2) RETURNING id, date, weight',
       [date, weight],
     );
+    const dt = new Date(date);
+    await refreshWarehouseOverall(dt.getUTCFullYear(), dt.getUTCMonth() + 1);
     res.status(201).json(result.rows[0]);
   } catch (error) {
     logger.error('Error adding pig pound donation:', error);
@@ -35,10 +38,23 @@ export async function updatePigPound(req: Request, res: Response, next: NextFunc
   try {
     const { id } = req.params;
     const { date, weight } = req.body;
+    const existing = await pool.query('SELECT date FROM pig_pound_log WHERE id = $1', [id]);
+    const oldDate = existing.rows[0]?.date as string | undefined;
     const result = await pool.query(
       'UPDATE pig_pound_log SET date = $1, weight = $2 WHERE id = $3 RETURNING id, date, weight',
       [date, weight, id],
     );
+    const newDt = new Date(date);
+    await refreshWarehouseOverall(newDt.getUTCFullYear(), newDt.getUTCMonth() + 1);
+    if (oldDate) {
+      const oldDt = new Date(oldDate);
+      if (
+        oldDt.getUTCFullYear() !== newDt.getUTCFullYear() ||
+        oldDt.getUTCMonth() !== newDt.getUTCMonth()
+      ) {
+        await refreshWarehouseOverall(oldDt.getUTCFullYear(), oldDt.getUTCMonth() + 1);
+      }
+    }
     res.json(result.rows[0]);
   } catch (error) {
     logger.error('Error updating pig pound donation:', error);
@@ -49,7 +65,12 @@ export async function updatePigPound(req: Request, res: Response, next: NextFunc
 export async function deletePigPound(req: Request, res: Response, next: NextFunction) {
   try {
     const { id } = req.params;
+    const existing = await pool.query('SELECT date FROM pig_pound_log WHERE id = $1', [id]);
     await pool.query('DELETE FROM pig_pound_log WHERE id = $1', [id]);
+    if (existing.rows[0]) {
+      const dt = new Date(existing.rows[0].date);
+      await refreshWarehouseOverall(dt.getUTCFullYear(), dt.getUTCMonth() + 1);
+    }
     res.json({ message: 'Deleted' });
   } catch (error) {
     logger.error('Error deleting pig pound donation:', error);

--- a/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
@@ -2,9 +2,13 @@ import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import Aggregations from '../pages/warehouse-management/Aggregations';
 
 const mockGetWarehouseOverall = jest.fn().mockResolvedValue([]);
+const mockGetWarehouseOverallYears = jest
+  .fn()
+  .mockResolvedValue([new Date().getFullYear()]);
 jest.mock('../api/warehouseOverall', () => ({
   getWarehouseOverall: (...args: unknown[]) => mockGetWarehouseOverall(...args),
-  rebuildWarehouseOverall: jest.fn(),
+  getWarehouseOverallYears: (...args: unknown[]) =>
+    mockGetWarehouseOverallYears(...args),
   exportWarehouseOverall: jest.fn(),
 }));
 

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -11,7 +11,6 @@ import {
   Select,
   MenuItem,
   Stack,
-  Button,
   CircularProgress,
   Tabs,
   Tab,
@@ -19,7 +18,6 @@ import {
 import Page from '../../components/Page';
 import {
   getWarehouseOverall,
-  rebuildWarehouseOverall,
   getWarehouseOverallYears,
   type WarehouseOverall,
 } from '../../api/warehouseOverall';
@@ -29,7 +27,6 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 export default function Aggregations() {
   const [overallRows, setOverallRows] = useState<WarehouseOverall[]>([]);
   const [overallLoading, setOverallLoading] = useState(false);
-  const [rebuilding, setRebuilding] = useState(false);
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' as 'success' | 'error' });
   const currentYear = new Date().getFullYear();
   const fallbackYears = Array.from({ length: 5 }, (_, i) => currentYear - i);
@@ -120,21 +117,6 @@ export default function Aggregations() {
     }),
     { donations: 0, surplus: 0, pigPound: 0, outgoingDonations: 0 },
   );
-
-  const handleRebuildOverall = () => {
-    setRebuilding(true);
-    rebuildWarehouseOverall(overallYear)
-      .then(() => {
-        setSnackbar({ open: true, message: 'Totals recalculated', severity: 'success' });
-        return getWarehouseOverall(overallYear);
-      })
-      .then(setOverallRows)
-      .catch(() => {
-        setSnackbar({ open: true, message: 'Failed to recalculate totals', severity: 'error' });
-      })
-      .finally(() => setRebuilding(false));
-  };
-
 
   return (
     <Page title="Aggregations">
@@ -327,14 +309,6 @@ export default function Aggregations() {
                 ))}
               </Select>
             </FormControl>
-            <Button
-              size="small"
-              variant="contained"
-              onClick={handleRebuildOverall}
-              disabled={rebuilding}
-            >
-              {rebuilding ? <CircularProgress size={20} /> : 'Calculate Overall'}
-            </Button>
           </Stack>
           <TableContainer sx={{ overflowX: 'auto' }}>
             <Table size="small">


### PR DESCRIPTION
## Summary
- add `refreshWarehouseOverall` helper to recompute monthly totals and reuse across controllers
- trigger aggregate refresh after every donation, surplus, pig pound, or outgoing donation CRUD change
- remove manual recalculation button from warehouse Aggregations page and update tests

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm test` (frontend) *(fails: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac9629a880832db19f0e4530c95bdc