### PR TITLE
Add month names and totals to warehouse export

### DIFF
--- a/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
@@ -39,8 +39,11 @@ describe('GET /warehouse-overall/export', () => {
       'Surplus',
       'Pig Pound',
       'Outgoing Donations',
+      'Total',
     ]);
-    expect(rows[1]).toEqual([1, 10, 2, 1, 0]);
-    expect(rows[2]).toEqual([2, 5, 3, 0, 1]);
+    expect(rows[1]).toEqual(['January', 10, 2, 1, 0, 13]);
+    expect(rows[2]).toEqual(['February', 5, 3, 0, 1, 9]);
+    expect(rows[3]).toEqual(['March', 0, 0, 0, 0, 0]);
+    expect(rows[13]).toEqual(['Total', 15, 5, 1, 1, 22]);
   });
 });


### PR DESCRIPTION
## Summary
- include all months and a totals column in warehouse overall export
- add totals row and adjust tests for new spreadsheet format

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac98f44da0832d8b4ec211963088d4