### PR TITLE
Fix mobile menu fragment warning in Navbar

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -162,60 +162,65 @@ export default function Navbar({
                 </Box>
               ))}
               {onLogout &&
-                (name ? (
-                  <>
-                    <MenuItem disabled sx={menuItemStyles}>
-                      Hello, {name}
-                    </MenuItem>
-                    {role === 'staff' &&
-                      profileLinks?.map(({ label, to }) => (
-                        <MenuItem
-                          key={to}
-                          component={RouterLink}
-                          to={to}
-                          onClick={() => {
-                            setMobileAnchorEl(null);
-                          }}
-                          disabled={loading}
-                          sx={menuItemStyles}
-                        >
-                          {label}
-                        </MenuItem>
-                      ))}
-                    <MenuItem
-                      component={RouterLink}
-                      to="/profile"
-                      onClick={() => {
-                        setMobileAnchorEl(null);
-                      }}
-                      disabled={loading}
-                      sx={menuItemStyles}
-                    >
-                      Profile
-                    </MenuItem>
-                    <MenuItem
-                      onClick={() => {
-                        setMobileAnchorEl(null);
-                        onLogout();
-                      }}
-                      disabled={loading}
-                      sx={menuItemStyles}
-                    >
-                      Logout
-                    </MenuItem>
-                  </>
-                ) : (
-                  <MenuItem
-                    onClick={() => {
-                      setMobileAnchorEl(null);
-                      onLogout();
-                    }}
-                    disabled={loading}
-                    sx={menuItemStyles}
-                  >
-                    Logout
-                  </MenuItem>
-                ))}
+                (name
+                  ? [
+                      <MenuItem key="hello" disabled sx={menuItemStyles}>
+                        Hello, {name}
+                      </MenuItem>,
+                      ...(role === 'staff'
+                        ? (profileLinks?.map(({ label, to }) => (
+                            <MenuItem
+                              key={to}
+                              component={RouterLink}
+                              to={to}
+                              onClick={() => {
+                                setMobileAnchorEl(null);
+                              }}
+                              disabled={loading}
+                              sx={menuItemStyles}
+                            >
+                              {label}
+                            </MenuItem>
+                          )) ?? [])
+                        : []),
+                      <MenuItem
+                        key="profile"
+                        component={RouterLink}
+                        to="/profile"
+                        onClick={() => {
+                          setMobileAnchorEl(null);
+                        }}
+                        disabled={loading}
+                        sx={menuItemStyles}
+                      >
+                        Profile
+                      </MenuItem>,
+                      <MenuItem
+                        key="logout"
+                        onClick={() => {
+                          setMobileAnchorEl(null);
+                          onLogout();
+                        }}
+                        disabled={loading}
+                        sx={menuItemStyles}
+                      >
+                        Logout
+                      </MenuItem>,
+                    ]
+                  : [
+                      <MenuItem
+                        key="logout"
+                        onClick={() => {
+                          setMobileAnchorEl(null);
+                          onLogout();
+                        }}
+                        disabled={loading}
+                        sx={menuItemStyles}
+                      >
+                        Logout
+                      </MenuItem>,
+                    ])
+              }
             </Menu>
           </>
         ) : (


### PR DESCRIPTION
## Summary
- avoid React Fragment inside `<Menu>` by returning an array of `MenuItem`s in mobile navbar

## Testing
- `npm test` (fails: TypeScript compilation errors in unrelated tests, mediaQuery issues, missing modules, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68ac9e68050c832dadae78f650a9504b