### PR TITLE
Handle closed days in slot listing

### DIFF
--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -107,21 +107,15 @@ export async function listSlots(req: Request, res: Response, next: NextFunction)
   try {
     const reginaDate = formatReginaDate(date);
     const dateObj = new Date(reginaStartOfDayISO(reginaDate));
-    const day = dateObj.getDay();
-    if (day === 0 || day === 6) {
-      return res
-        .status(400)
-        .json({ message: 'Moose Jaw Food Bank is closed on weekends' });
+    if (isNaN(dateObj.getTime())) {
+      return res.status(400).json({ message: 'Invalid date' });
     }
     const holidayResult = await pool.query(
       'SELECT reason FROM holidays WHERE date = $1',
       [reginaDate],
     );
     if ((holidayResult.rowCount ?? 0) > 0) {
-      const reason = holidayResult.rows[0].reason || 'Holiday';
-      return res
-        .status(400)
-        .json({ message: `Moose Jaw Food Bank is closed: ${reason}` });
+      return res.json([]);
     }
     const slotsWithAvailability = await getSlotsForDate(reginaDate);
     res.json(slotsWithAvailability);

--- a/MJ_FB_Backend/tests/slots.test.ts
+++ b/MJ_FB_Backend/tests/slots.test.ts
@@ -38,6 +38,7 @@ describe('GET /slots applies slot rules', () => {
 
   it('uses weekday rules', async () => {
     (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({
         rows: [
           { id: 1, start_time: '09:00:00', end_time: '09:30:00', max_capacity: 10 },
@@ -47,6 +48,7 @@ describe('GET /slots applies slot rules', () => {
           { id: 5, start_time: '14:30:00', end_time: '15:00:00', max_capacity: 10 },
         ],
       })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
@@ -62,6 +64,7 @@ describe('GET /slots applies slot rules', () => {
 
   it('uses Wednesday rules', async () => {
     (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({
         rows: [
           { id: 1, start_time: '09:30:00', end_time: '10:00:00', max_capacity: 10 },
@@ -69,6 +72,7 @@ describe('GET /slots applies slot rules', () => {
           { id: 3, start_time: '18:30:00', end_time: '19:00:00', max_capacity: 10 },
         ],
       })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
@@ -84,6 +88,7 @@ describe('GET /slots applies slot rules', () => {
 
   it('marks slots blocked from recurring entries', async () => {
     (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({
         rows: [
           { id: 1, start_time: '09:30:00', end_time: '10:00:00', max_capacity: 5 },
@@ -107,5 +112,27 @@ describe('GET /slots applies slot rules', () => {
         status: 'blocked',
       },
     ]);
+  });
+});
+
+describe('GET /slots closed days', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty array on weekends', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const res = await request(app).get('/slots').query({ date: '2024-06-16' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+    expect((pool.query as jest.Mock)).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty array on holidays', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1, rows: [{ reason: 'Holiday' }] });
+    const res = await request(app).get('/slots').query({ date: '2024-06-18' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+    expect((pool.query as jest.Mock)).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Return an empty array instead of 400 for weekend/holiday slot requests
- Expand slot tests for weekends and holidays

## Testing
- `npm test` *(fails: Type errors in warehouseOverallController and multiple existing failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e4f210c832d968690ce5718a9fc