### PR TITLE
Expose profile details and allow user contact edits

### DIFF
--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -7,10 +7,16 @@ import {
   getUserByClientId,
   listUsersMissingInfo,
   updateUserByClientId,
+  updateMyProfile,
 } from '../controllers/userController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
-import { loginSchema, createUserSchema, updateUserSchema } from '../schemas/userSchemas';
+import {
+  loginSchema,
+  createUserSchema,
+  updateUserSchema,
+  updateMyProfileSchema,
+} from '../schemas/userSchemas';
 
 const router = express.Router();
 
@@ -43,6 +49,7 @@ router.get(
   listUsersMissingInfo,
 );
 router.get('/me', authMiddleware, getUserProfile);
+router.patch('/me', authMiddleware, validate(updateMyProfileSchema), updateMyProfile);
 
 
 export default router;

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -50,4 +50,16 @@ export const updateUserSchema = z.object({
   phone: z.string().optional(),
 });
 
+// Schema for users updating their own contact information. Either
+// email or phone must be provided, but both are optional.
+export const updateMyProfileSchema = z
+  .object({
+    email: z.string().email().optional(),
+    phone: z.string().optional(),
+  })
+  .refine(data => data.email !== undefined || data.phone !== undefined, {
+    message: 'email or phone required',
+    path: ['email'],
+  });
+
 

--- a/MJ_FB_Backend/src/types/express.d.ts
+++ b/MJ_FB_Backend/src/types/express.d.ts
@@ -3,7 +3,10 @@ declare namespace Express {
     user?: {
       id: string;
       role: 'shopper' | 'delivery' | 'staff' | 'volunteer' | 'agency';
+      type?: 'user' | 'staff' | 'volunteer' | 'agency';
       email?: string;
+      phone?: string;
+      name?: string;
       userId?: string;
       userRole?: 'shopper' | 'delivery';
       access?: string[];

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -81,6 +81,17 @@ export async function getUserProfile(_token: string): Promise<UserProfile> {
   return handleResponse(res);
 }
 
+export async function updateMyProfile(
+  data: { email?: string; phone?: string },
+): Promise<UserProfile> {
+  const res = await apiFetch(`${API_BASE}/users/me`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
 export async function staffExists(): Promise<boolean> {
   const res = await apiFetch(`${API_BASE}/staff/exists`);
   const data = (await handleResponse(res)) as { exists?: boolean } | undefined;

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -140,9 +140,12 @@ export interface UserProfile {
   lastName: string;
   email: string | null;
   phone: string | null;
-  clientId: number;
   role: Role;
-  bookingsThisMonth: number;
+  clientId?: number;
+  bookingsThisMonth?: number;
+  roles?: StaffAccess[];
+  username?: string;
+  trainedAreas?: string[];
 }
 
 export interface RoleOption {


### PR DESCRIPTION
## Summary
- return role-specific details from `/users/me`
- allow users to update their own email and phone
- display editable contact info on profile page

## Testing
- `npm test` (backend) *(fails: 9 failed, 18 passed)*
- `npm test` (frontend) *(fails: 8 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4630dcc832db9b65d6a715b1cfa