### PR TITLE
feat: scroll to slots on mobile date select

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useEffect, type ReactNode } from 'react';
+import { useState, useEffect, useRef, type ReactNode } from 'react';
 import {
   Box,
   Container,
@@ -17,7 +17,9 @@ import {
   Toolbar,
   Skeleton,
   Link,
+  useMediaQuery,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { AccessTime } from '@mui/icons-material';
 import dayjs, { Dayjs } from 'dayjs';
@@ -82,6 +84,9 @@ export default function BookingUI({
     message: null,
   });
   const [booking, setBooking] = useState(false);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const slotsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!isDisabled(date)) return;
@@ -228,6 +233,14 @@ export default function BookingUI({
                 if (newDate && !isDisabled(newDate)) {
                   setDate(newDate);
                   setSelectedSlotId(null);
+                  if (isMobile) {
+                    setTimeout(() => {
+                      if (slotsRef.current) {
+                        slotsRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+                        slotsRef.current.scrollIntoView({ behavior: 'smooth' });
+                      }
+                    }, 0);
+                  }
                 }
               }}
               sx={{
@@ -241,6 +254,7 @@ export default function BookingUI({
         </Grid>
         <Grid item xs={12} md sx={{ flexGrow: 1 }}>
           <Paper
+            ref={slotsRef}
             sx={{
               p: 2,
               borderRadius: 2,


### PR DESCRIPTION
## Summary
- smooth-scroll to the slot list on mobile when a date is selected

## Testing
- `npm test` *(fails: TS errors in various tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acae1f0624832d8ae435f47fcbad30