### PR TITLE
Add recurring booking listing endpoint

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -474,6 +474,28 @@ export async function createRecurringVolunteerBooking(
   }
 }
 
+export async function listMyRecurringVolunteerBookings(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const user = req.user;
+  if (!user) return res.status(401).json({ message: 'Unauthorized' });
+  try {
+    const result = await pool.query(
+      `SELECT id, slot_id AS role_id, start_date, end_date, pattern, days_of_week
+       FROM volunteer_recurring_bookings
+       WHERE volunteer_id=$1 AND active
+       ORDER BY start_date`,
+      [user.id],
+    );
+    res.json(result.rows);
+  } catch (error) {
+    logger.error('Error listing recurring volunteer bookings:', error);
+    next(error);
+  }
+}
+
 export async function cancelVolunteerBookingOccurrence(
   req: Request,
   res: Response,

--- a/MJ_FB_Backend/src/routes/volunteer/volunteerBookings.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteerBookings.ts
@@ -4,6 +4,7 @@ import {
   listVolunteerBookings,
   listVolunteerBookingsByRole,
   listMyVolunteerBookings,
+  listMyRecurringVolunteerBookings,
   updateVolunteerBookingStatus,
   listVolunteerBookingsByVolunteer,
   createVolunteerBookingForVolunteer,
@@ -32,6 +33,12 @@ router.post(
   authMiddleware,
   authorizeRoles('volunteer'),
   createRecurringVolunteerBooking,
+);
+router.get(
+  '/recurring',
+  authMiddleware,
+  authorizeRoles('volunteer'),
+  listMyRecurringVolunteerBookings,
 );
 router.get('/mine', authMiddleware, authorizeRoles('volunteer'), listMyVolunteerBookings);
 router.get(

--- a/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
@@ -45,4 +45,31 @@ describe('recurring volunteer bookings', () => {
     const firstCall = (pool.query as jest.Mock).mock.calls[0][0];
     expect(firstCall).toMatch(/UPDATE volunteer_bookings SET status='cancelled'/);
   });
+
+  it('lists recurring bookings', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          role_id: 2,
+          start_date: '2025-01-01',
+          end_date: '2025-01-10',
+          pattern: 'daily',
+          days_of_week: [],
+        },
+      ],
+    });
+    const res = await request(app).get('/volunteer-bookings/recurring');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: 1,
+        role_id: 2,
+        start_date: '2025-01-01',
+        end_date: '2025-01-10',
+        pattern: 'daily',
+        days_of_week: [],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- allow volunteers to retrieve their recurring booking series via GET /volunteer-bookings/recurring
- expose new controller for listing recurring bookings and wire route
- cover recurring booking listing with tests

## Testing
- `npm test` *(fails: bookingUtils, slots, agency, events, blockedSlots)*

------
https://chatgpt.com/codex/tasks/task_e_68acaf83eca8832dbbcc940b0b8979e7