### PR TITLE
Use volunteer-focused wording on schedule and dashboard

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -58,7 +58,7 @@ test('submits weekly recurring booking', async () => {
   fireEvent.mouseDown(await screen.findByLabelText(/role/i));
   const listbox = await screen.findByRole('listbox');
   fireEvent.click(within(listbox).getByText('Test Role'));
-  fireEvent.click(await screen.findByText('Available'));
+  fireEvent.click(await screen.findByText('Volunteer Needed', { exact: false }));
   fireEvent.mouseDown(screen.getByLabelText(/frequency/i));
   const freqList = await screen.findAllByRole('listbox');
   fireEvent.click(within(freqList[freqList.length - 1]).getByText('Weekly'));

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -9,9 +9,10 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
+import { ReactNode } from 'react';
 
 interface Cell {
-  content: string;
+  content: ReactNode;
   backgroundColor?: string;
   onClick?: () => void;
   colSpan?: number;

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -240,7 +240,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
                     </Button>
                   }>
                     <ListItemText
-                      primary={`${r.name} • ${formatDateLabel(r.date)} ${formatTime(r.start_time)}-${formatTime(r.end_time)} • ${r.available} spots left`}
+                      primary={`${r.name} • ${formatDateLabel(r.date)} ${formatTime(r.start_time)}-${formatTime(r.end_time)} • ${r.available} volunteer${r.available === 1 ? '' : 's'} needed`}
                     />
                   </ListItem>
                 ))}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, ReactNode } from 'react';
 import {
   getVolunteerRolesForVolunteer,
   createRecurringVolunteerBooking,
@@ -243,7 +243,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     const myBooking = bookings.find(b => b.role_id === role.id);
     const othersBooked = Math.max(0, role.booked - (myBooking ? 1 : 0));
     const cells: {
-      content: string;
+      content: ReactNode;
       backgroundColor?: string;
       onClick?: () => void;
     }[] = [];
@@ -268,7 +268,13 @@ export default function VolunteerSchedule({ token }: { token: string }) {
         });
       } else {
         cells.push({
-          content: 'Available',
+          content: (
+            <>
+              Volunteer Needed
+              <br />
+              Click Here to Book
+            </>
+          ),
           onClick: () => {
             if (!isClosed) {
               setFrequency('one-time');


### PR DESCRIPTION
## Summary
- Replace dashboard's `n spots left` with `n volunteers needed`
- Show `Volunteer Needed / Click Here to Book` in volunteer schedule cells and allow text wrapping
- Allow schedule table cells to render React nodes

## Testing
- ❌ `npm test` (failing: TypeError and TS compilation issues)

------
https://chatgpt.com/codex/tasks/task_e_68acb0b2b2c8832da816f40caec90d5d