### PR TITLE
Fix volunteer booking date filter for volunteer schedule

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -506,11 +506,17 @@ export default function VolunteerManagement({ token }: { token: string }) {
     return () => clearTimeout(delay);
   }, [assignSearch, token, assignSlot]);
 
-  const bookingsForDate = bookings.filter(
-    b =>
-      b.date === formatDate(currentDate) &&
+  const bookingsForDate = bookings.filter(b => {
+    const bookingDate = formatInTimeZone(
+      new Date(b.date),
+      reginaTimeZone,
+      'yyyy-MM-dd',
+    );
+    return (
+      bookingDate === formatDate(currentDate) &&
       ['approved', 'pending'].includes(b.status.toLowerCase())
-  );
+    );
+  });
   const rows = selectedRole
     ? roleInfos.map(role => {
         const slotBookings = bookingsForDate.filter(


### PR DESCRIPTION
## Summary
- fix volunteer schedule date filter to use Regina timezone
- highlight pending requests in first available slot using warning color

## Testing
- `npm test` *(fails: TS errors in test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68acd7988500832dbdbf4eee8286fa8c