### PR TITLE
Add volunteer role-based booking UI

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -19,6 +19,7 @@ import Dashboard from './components/dashboard/Dashboard';
 import ClientDashboard from './pages/client/ClientDashboard';
 import VolunteerBookingHistory from './pages/volunteer-management/VolunteerBookingHistory';
 import VolunteerSchedule from './pages/volunteer-management/VolunteerSchedule';
+import VolunteerBooking from './pages/volunteer-management/VolunteerBooking';
 import WarehouseDashboard from './pages/warehouse-management/WarehouseDashboard';
 import DonationLog from './pages/warehouse-management/DonationLog';
 import TrackPigpound from './pages/warehouse-management/TrackPigpound';
@@ -314,7 +315,7 @@ export default function App() {
                 <>
                   <Route
                     path="/volunteer/schedule"
-                    element={<VolunteerSchedule token={token} />}
+                    element={<VolunteerBooking token={token} />}
                   />
                   <Route
                     path="/volunteer/history"

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -1,0 +1,199 @@
+import { useState, useEffect, useRef } from 'react';
+import {
+  Box,
+  Container,
+  Grid,
+  Paper,
+  Typography,
+  List,
+  ListItemButton,
+  ListItemText,
+  ListSubheader,
+  Divider,
+  Stack,
+  Button,
+  Skeleton,
+} from '@mui/material';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { useTheme } from '@mui/material/styles';
+import dayjs, { Dayjs } from 'dayjs';
+import { useQuery } from '@tanstack/react-query';
+import type { VolunteerRole, Holiday } from '../../types';
+import { getVolunteerRolesForVolunteer, requestVolunteerBooking } from '../../api/volunteers';
+import { getHolidays } from '../../api/bookings';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { formatTime } from '../../utils/time';
+
+function useVolunteerSlots(token: string, date: Dayjs, enabled: boolean) {
+  const dateStr = date.format('YYYY-MM-DD');
+  const { data, isFetching, refetch, error } = useQuery<VolunteerRole[]>({
+    queryKey: ['volunteer-slots', dateStr],
+    queryFn: () => getVolunteerRolesForVolunteer(token, dateStr),
+    enabled,
+  });
+  return { slots: data ?? [], isLoading: isFetching, refetch, error };
+}
+
+export default function VolunteerBooking({ token }: { token: string }) {
+  const [date, setDate] = useState<Dayjs>(() => {
+    let d = dayjs();
+    while (d.day() === 0 || d.day() === 6) d = d.add(1, 'day');
+    return d;
+  });
+  const [selected, setSelected] = useState<VolunteerRole | null>(null);
+  const { data: holidays = [] } = useQuery<Holiday[]>({
+    queryKey: ['holidays'],
+    queryFn: getHolidays,
+  });
+  const holidaySet = new Set(holidays.map(h => h.date));
+  const isDisabled = (d: Dayjs) =>
+    d.day() === 0 ||
+    d.day() === 6 ||
+    holidaySet.has(d.format('YYYY-MM-DD'));
+  const { slots, isLoading, refetch, error } = useVolunteerSlots(
+    token,
+    date,
+    !isDisabled(date),
+  );
+  const [booking, setBooking] = useState(false);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error';
+  }>({ open: false, message: '', severity: 'success' });
+  const theme = useTheme();
+  const slotsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isDisabled(date)) return;
+    let next = date;
+    while (isDisabled(next)) next = next.add(1, 'day');
+    setDate(next);
+    setSelected(null);
+  }, [date, holidays]);
+
+  const groups = slots.reduce<Record<string, VolunteerRole[]>>((acc, s) => {
+    acc[s.name] = acc[s.name] ? [...acc[s.name], s] : [s];
+    return acc;
+  }, {});
+  const roleNames = Object.keys(groups);
+
+  async function handleBook() {
+    if (!selected) return;
+    setBooking(true);
+    try {
+      await requestVolunteerBooking(token, selected.id, selected.date);
+      setSnackbar({ open: true, message: 'Request submitted', severity: 'success' });
+      setSelected(null);
+      refetch();
+    } catch {
+      setSnackbar({ open: true, message: 'Failed to request slot', severity: 'error' });
+    } finally {
+      setBooking(false);
+    }
+  }
+
+  function renderSlot(slot: VolunteerRole) {
+    const label = `${formatTime(slot.start_time)}–${formatTime(slot.end_time)}`;
+    const needed = `${slot.available} more volunteer${slot.available === 1 ? '' : 's'} needed`;
+    return (
+      <ListItemButton
+        key={slot.id}
+        disabled={slot.available === 0}
+        selected={selected?.id === slot.id}
+        onClick={() => setSelected(slot)}
+      >
+        <ListItemText primary={label} secondary={needed} />
+      </ListItemButton>
+    );
+  }
+
+  return (
+    <Container sx={{ pb: 8 }}>
+      <Grid container spacing={2} alignItems="stretch">
+        <Grid item xs={12} md={4}>
+          <Paper
+            sx={{ p: 2, borderRadius: 2, height: '100%', display: 'flex', flexDirection: 'column' }}
+          >
+            <DateCalendar
+              value={date}
+              onChange={newDate => newDate && setDate(newDate)}
+              shouldDisableDate={isDisabled}
+              sx={{ width: '100%', '& .MuiPickersSlideTransition-root': { minWidth: 0 } }}
+            />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md sx={{ flexGrow: 1 }}>
+          <Paper
+            ref={slotsRef}
+            sx={{ p: 2, borderRadius: 2, maxHeight: { xs: 420, md: 560 }, overflow: 'auto' }}
+          >
+            {isLoading ? (
+              <Box>
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} variant="rectangular" height={56} sx={{ mb: 1, borderRadius: 1 }} />
+                ))}
+              </Box>
+            ) : error ? (
+              <Box sx={{ minHeight: 200, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Typography>
+                  {error instanceof Error ? error.message : 'Error loading slots'}
+                </Typography>
+              </Box>
+            ) : roleNames.length === 0 ? (
+              <Box sx={{ minHeight: 200, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Typography>No slots available. Please choose another date.</Typography>
+              </Box>
+            ) : (
+              <List disablePadding>
+                {roleNames.map((role, idx) => (
+                  <Box key={role}>
+                    <ListSubheader disableSticky>{role}</ListSubheader>
+                    {groups[role].map(renderSlot)}
+                    {idx < roleNames.length - 1 && <Divider />}
+                  </Box>
+                ))}
+              </List>
+            )}
+          </Paper>
+        </Grid>
+      </Grid>
+      <Paper
+        sx={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          mt: 2,
+          p: 2,
+          borderRadius: { xs: 0, md: 2 },
+          zIndex: theme => theme.zIndex.appBar,
+        }}
+      >
+        <Stack direction="row" alignItems="center" justifyContent="space-between">
+          <Typography>
+            {selected
+              ? `${selected.name} • ${formatTime(selected.start_time)}–${formatTime(selected.end_time)} on ${date.format('MMM D')}`
+              : 'No slot selected'}
+          </Typography>
+          <Button
+            variant="contained"
+            size="small"
+            disabled={!selected || booking}
+            onClick={handleBook}
+          >
+            Request shift
+          </Button>
+        </Stack>
+      </Paper>
+      <FeedbackSnackbar
+        open={snackbar.open}
+        onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        duration={4000}
+      />
+    </Container>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add volunteer booking page that groups slots by volunteer role
- route volunteers to new booking page for shift requests

## Testing
- `npm test` *(fails: TypeError: mediaQueryList.addEventListener is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8c99b3f8832d9ce01331df7bbb63