### PR TITLE
feat: secure refresh token rotation

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -137,17 +137,20 @@ export async function refreshToken(req: Request, res: Response, next: NextFuncti
       config.jwtRefreshSecret,
       { expiresIn: '7d' },
     );
+    const secure = process.env.NODE_ENV !== 'development';
+    const refreshExpiry = 7 * 24 * 60 * 60 * 1000; // 7 days
     res.cookie('token', accessToken, {
       httpOnly: true,
       sameSite: 'strict',
       maxAge: 60 * 60 * 1000,
-      secure: process.env.NODE_ENV !== 'development',
+      secure,
     });
     res.cookie('refreshToken', newRefreshToken, {
       httpOnly: true,
       sameSite: 'strict',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
-      secure: process.env.NODE_ENV !== 'development',
+      maxAge: refreshExpiry,
+      expires: new Date(Date.now() + refreshExpiry),
+      secure,
     });
     return res.json({ token: accessToken, refreshToken: newRefreshToken });
   } catch (err) {

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -38,11 +38,12 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       );
       const bookingsThisMonth = bookingsRes.rows[0]?.bookings_this_month ?? 0;
       const payload: AuthPayload = { id: user.id, role: user.role, type: 'user' };
-      await issueAuthTokens(res, payload, `user:${user.id}`);
+      const tokens = await issueAuthTokens(res, payload, `user:${user.id}`);
       return res.json({
         role: user.role,
         name: `${user.first_name} ${user.last_name}`,
         bookingsThisMonth,
+        ...tokens,
       });
     }
 
@@ -67,12 +68,13 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
         type: 'staff',
         access: staff.access || [],
       };
-      await issueAuthTokens(res, payload, `staff:${staff.id}`);
+      const tokens = await issueAuthTokens(res, payload, `staff:${staff.id}`);
       return res.json({
         role,
         name: `${staff.first_name} ${staff.last_name}`,
         access: staff.access || [],
         id: staff.id,
+        ...tokens,
       });
     }
 
@@ -89,12 +91,13 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       role: 'agency',
       type: 'agency',
     };
-    await issueAuthTokens(res, payload, `agency:${agency.id}`);
+    const tokens = await issueAuthTokens(res, payload, `agency:${agency.id}`);
     res.json({
       role: 'agency',
       name: agency.name,
       id: agency.id,
       access: [],
+      ...tokens,
     });
   } catch (error) {
     logger.error('Error logging in:', error);

--- a/MJ_FB_Backend/src/utils/authUtils.ts
+++ b/MJ_FB_Backend/src/utils/authUtils.ts
@@ -7,8 +7,15 @@ import config from '../config';
 export type AuthPayload = {
   id: number;
   role: string;
-  type: 'user' | 'staff' | 'agency';
+  /**
+   * The category of user these tokens are for. Volunteers use the same
+   * refresh-token flow as users, staff and agencies so include them here.
+   */
+  type: 'user' | 'staff' | 'agency' | 'volunteer';
   access?: string[];
+  /** Optional fields used for volunteer/user hybrids */
+  userId?: number;
+  userRole?: string;
 };
 
 /**
@@ -33,6 +40,7 @@ export async function issueAuthTokens(
   );
 
   const secure = process.env.NODE_ENV !== 'development';
+  const refreshExpiry = 7 * 24 * 60 * 60 * 1000; // 7 days
   res.cookie('token', token, {
     httpOnly: true,
     sameSite: 'strict',
@@ -42,9 +50,12 @@ export async function issueAuthTokens(
   res.cookie('refreshToken', refreshToken, {
     httpOnly: true,
     sameSite: 'strict',
-    maxAge: 7 * 24 * 60 * 60 * 1000,
+    maxAge: refreshExpiry,
+    expires: new Date(Date.now() + refreshExpiry),
     secure,
   });
+
+  return { token, refreshToken };
 }
 
 export default issueAuthTokens;

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -157,6 +157,8 @@ describe('Volunteer login with shopper profile', () => {
       name: 'John Doe',
       userId: 9,
       userRole: 'shopper',
+      token: 'token',
+      refreshToken: 'token',
     });
     expect((jwt.sign as jest.Mock).mock.calls[0][0]).toMatchObject({
       id: 1,


### PR DESCRIPTION
## Summary
- extend auth payload to cover volunteers and optional fields
- issue auth/refresh tokens with HTTP-only cookies and explicit expiry
- add token/refresh token pair to login flows and refresh endpoint rotation

## Testing
- `npm test` *(fails: slots, agency, holidaysAccess, blockedSlots, events, bookingUtils)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8ccefbb8832dad3a72ce4c1c91f4