### PR TITLE
Handle null rowCount in slot listing

### DIFF
--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -114,7 +114,7 @@ export async function listSlots(req: Request, res: Response, next: NextFunction)
       'SELECT reason FROM holidays WHERE date = $1',
       [reginaDate],
     );
-    if ((holidayResult.rowCount ?? 0) > 0) {
+    if (holidayResult.rows.length > 0) {
       return res.json([]);
     }
     const slotsWithAvailability = await getSlotsForDate(reginaDate);


### PR DESCRIPTION
## Summary
- Use `rows.length` when checking holidays to avoid null `rowCount` values

## Testing
- `npm test` *(fails: bookingUtils.test.ts, agency.test.ts, blockedSlots.test.ts, holidaysAccess.test.ts, events.test.ts, slots.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae93fbbd3c832da7c5bbb850406c90