### PR TITLE
Remove token handling from login flow

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -152,7 +152,7 @@ export async function refreshToken(req: Request, res: Response, next: NextFuncti
       expires: new Date(Date.now() + refreshExpiry),
       secure,
     });
-    return res.json({ token: accessToken, refreshToken: newRefreshToken });
+    return res.status(204).send();
   } catch (err) {
     logger.warn('Invalid refresh token');
     res.clearCookie('token');

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -38,12 +38,11 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       );
       const bookingsThisMonth = bookingsRes.rows[0]?.bookings_this_month ?? 0;
       const payload: AuthPayload = { id: user.id, role: user.role, type: 'user' };
-      const tokens = await issueAuthTokens(res, payload, `user:${user.id}`);
+      await issueAuthTokens(res, payload, `user:${user.id}`);
       return res.json({
         role: user.role,
         name: `${user.first_name} ${user.last_name}`,
         bookingsThisMonth,
-        ...tokens,
       });
     }
 
@@ -68,13 +67,12 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
         type: 'staff',
         access: staff.access || [],
       };
-      const tokens = await issueAuthTokens(res, payload, `staff:${staff.id}`);
+      await issueAuthTokens(res, payload, `staff:${staff.id}`);
       return res.json({
         role,
         name: `${staff.first_name} ${staff.last_name}`,
         access: staff.access || [],
         id: staff.id,
-        ...tokens,
       });
     }
 
@@ -91,13 +89,12 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       role: 'agency',
       type: 'agency',
     };
-    const tokens = await issueAuthTokens(res, payload, `agency:${agency.id}`);
+    await issueAuthTokens(res, payload, `agency:${agency.id}`);
     res.json({
       role: 'agency',
       name: agency.name,
       id: agency.id,
       access: [],
-      ...tokens,
     });
   } catch (error) {
     logger.error('Error logging in:', error);

--- a/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
+++ b/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
@@ -10,7 +10,7 @@ const app = express();
 app.use('/auth', authRouter);
 
 describe('POST /auth/refresh', () => {
-  it('preserves volunteer user fields when refreshing token', async () => {
+    it('preserves volunteer user fields when refreshing token', async () => {
     const payload = {
       id: 1,
       role: 'volunteer',
@@ -24,16 +24,24 @@ describe('POST /auth/refresh', () => {
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ token_id: 'oldjti' }] })
       .mockResolvedValueOnce({});
 
-    const res = await request(app)
-      .post('/auth/refresh')
-      .set('Cookie', `refreshToken=${refreshToken}`);
+      const res = await request(app)
+        .post('/auth/refresh')
+        .set('Cookie', `refreshToken=${refreshToken}`);
 
-    expect(res.status).toBe(200);
-    const decoded = jwt.verify(res.body.token, process.env.JWT_SECRET!) as any;
-    expect(decoded.userId).toBe(9);
-    expect(decoded.userRole).toBe('shopper');
-    const decodedRefresh = jwt.verify(res.body.refreshToken, process.env.JWT_REFRESH_SECRET!) as any;
-    expect(decodedRefresh.userId).toBe(9);
-    expect(decodedRefresh.userRole).toBe('shopper');
+      expect(res.status).toBe(204);
+      const cookies = res.headers['set-cookie'] as string[];
+      expect(cookies).toBeDefined();
+      const accessCookie = cookies.find(c => c.startsWith('token='));
+      const refreshCookie = cookies.find(c => c.startsWith('refreshToken='));
+      expect(accessCookie).toBeDefined();
+      expect(refreshCookie).toBeDefined();
+      const accessToken = accessCookie!.split('token=')[1].split(';')[0];
+      const newRefreshToken = refreshCookie!.split('refreshToken=')[1].split(';')[0];
+      const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
+      expect(decoded.userId).toBe(9);
+      expect(decoded.userRole).toBe('shopper');
+      const decodedRefresh = jwt.verify(newRefreshToken, process.env.JWT_REFRESH_SECRET!) as any;
+      expect(decodedRefresh.userId).toBe(9);
+      expect(decodedRefresh.userRole).toBe('shopper');
+    });
   });
-});

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -67,7 +67,7 @@ export default function App() {
   const profileLinks: NavLink[] | undefined = isStaff
     ? [{ label: 'Events', to: '/events' }]
     : undefined;
-  if (!token) {
+  if (!role) {
     navGroups.push(
       { label: 'Client Login', links: [{ label: 'Client Login', to: '/login/user' }] },
       { label: 'Volunteer Login', links: [{ label: 'Volunteer Login', to: '/login/volunteer' }] },
@@ -160,14 +160,14 @@ export default function App() {
   return (
     <BrowserRouter>
       <div className="app-container">
-        <Navbar
-          groups={navGroups}
-          onLogout={token ? logout : undefined}
-          name={token ? name || undefined : undefined}
-          loading={loading}
-          role={role}
-          profileLinks={profileLinks}
-        />
+    <Navbar
+      groups={navGroups}
+      onLogout={role ? logout : undefined}
+      name={role ? name || undefined : undefined}
+      loading={loading}
+      role={role}
+      profileLinks={profileLinks}
+    />
 
         <FeedbackSnackbar
           open={!!error}
@@ -176,7 +176,7 @@ export default function App() {
           severity="error"
         />
 
-          {token ? (
+            {role ? (
           <main>
             <Breadcrumbs />
             <Routes>
@@ -184,7 +184,7 @@ export default function App() {
                 path="/"
                 element={
                   role === 'volunteer' ? (
-                    <VolunteerDashboard token={token} />
+                      <VolunteerDashboard token={token} />
                   ) : role === 'agency' ? (
                     <AgencyGuard>
                       <AgencySchedule />
@@ -193,14 +193,14 @@ export default function App() {
                     singleAccessOnly && staffRootPath !== '/' ? (
                       <Navigate to={staffRootPath} replace />
                     ) : (
-                      <Dashboard role="staff" token={token} masterRoleFilter={['Pantry']} />
+                        <Dashboard role="staff" token={token} masterRoleFilter={['Pantry']} />
                     )
                   ) : (
                     <ClientDashboard />
                   )
                 }
               />
-              <Route path="/profile" element={<Profile token={token} role={role} />} />
+                <Route path="/profile" element={<Profile token={token} role={role} />} />
               {showStaff && (
                 <Route path="/pantry" element={<Dashboard role="staff" token={token} masterRoleFilter={['Pantry']} />} />
               )}

--- a/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
@@ -13,6 +13,12 @@ jest.mock('../pages/agency/ClientBookings', () => () => <div>AgencyClientBooking
 
 describe('Agency UI access', () => {
   beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
     localStorage.clear();
     window.history.pushState({}, '', '/');
   });

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -17,6 +17,12 @@ jest.mock('../api/bookings', () => ({
 
 describe('App authentication persistence', () => {
   beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
     localStorage.clear();
     window.history.pushState({}, '', '/');
   });
@@ -30,8 +36,7 @@ describe('App authentication persistence', () => {
     expect(screen.getByText(/user login/i)).toBeInTheDocument();
   });
 
-  it('keeps user logged in when token exists', () => {
-    localStorage.setItem('token', 'testtoken');
+  it('keeps user logged in when role exists', () => {
     localStorage.setItem('role', 'shopper');
     localStorage.setItem('name', 'Test User');
     render(
@@ -43,7 +48,6 @@ describe('App authentication persistence', () => {
   });
 
   it('redirects staff with only pantry access to pantry dashboard', () => {
-    localStorage.setItem('token', 'testtoken');
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');
     localStorage.setItem('access', JSON.stringify(['pantry']));
@@ -56,7 +60,6 @@ describe('App authentication persistence', () => {
   });
 
   it('redirects staff with only volunteer management access', () => {
-    localStorage.setItem('token', 'testtoken');
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');
     localStorage.setItem('access', JSON.stringify(['volunteer_management']));
@@ -69,7 +72,6 @@ describe('App authentication persistence', () => {
   });
 
   it('redirects staff with only warehouse access', () => {
-    localStorage.setItem('token', 'testtoken');
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');
     localStorage.setItem('access', JSON.stringify(['warehouse']));

--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -31,21 +31,15 @@ export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {})
         method: 'POST',
         credentials: 'include',
       });
-      if (refreshRes.ok) {
-        try {
-          const data = await refreshRes.clone().json();
-          if (data?.token) localStorage.setItem('token', data.token);
-        } catch {
-          // ignore
+        if (refreshRes.ok) {
+          res = await fetch(input, { credentials: 'include', ...init });
+          if (res.status === 401) clearAuthAndRedirect();
+        } else {
+          clearAuthAndRedirect();
         }
-        res = await fetch(input, { credentials: 'include', ...init });
-        if (res.status === 401) clearAuthAndRedirect();
-      } else {
+      } catch {
         clearAuthAndRedirect();
       }
-    } catch {
-      clearAuthAndRedirect();
-    }
   }
   return res;
 }
@@ -74,7 +68,6 @@ export async function handleResponse(res: Response) {
 export { API_BASE };
 
 function clearAuthAndRedirect() {
-  localStorage.removeItem('token');
   localStorage.removeItem('role');
   localStorage.removeItem('name');
   localStorage.removeItem('userRole');


### PR DESCRIPTION
## Summary
- Stop returning token and refreshToken in user login and refresh endpoints; rely on cookies
- Drop all localStorage token storage and infer auth state from role
- Use role-based checks in frontend to determine session state

## Testing
- `npm test` (backend) *(fails: Invalid input: expected string, received undefined)*
- `npm test` (frontend) *(fails: Property 'toBeInTheDocument' does not exist on type 'JestMatchers')*

------
https://chatgpt.com/codex/tasks/task_e_68ae953394d8832da6987b61bf4c125e