### PR TITLE
feat: add csrf protection middleware

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -29,6 +29,7 @@ import eventsRoutes from './routes/events';
 import agenciesRoutes from './routes/agencies';
 import { initializeSlots } from './data';
 import logger from './utils/logger';
+import csrfMiddleware from './middleware/csrf';
 
 const app = express();
 
@@ -40,6 +41,7 @@ app.use(cors({
 }));
 
 app.use(express.json());
+app.use(csrfMiddleware);
 
 initializeSlots();
 

--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -184,3 +184,13 @@ export async function logout(req: Request, res: Response, next: NextFunction) {
     next(err);
   }
 }
+
+export function csrfToken(_req: Request, res: Response) {
+  const token = randomUUID();
+  const secure = process.env.NODE_ENV !== 'development';
+  res.cookie('csrfToken', token, {
+    sameSite: 'strict',
+    secure,
+  });
+  res.json({ csrfToken: token });
+}

--- a/MJ_FB_Backend/src/middleware/csrf.ts
+++ b/MJ_FB_Backend/src/middleware/csrf.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import cookie from 'cookie';
+
+export default function csrfMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+    return next();
+  }
+  const headerToken = req.headers['x-csrf-token'];
+  const header = req.headers.cookie;
+  let cookieToken: string | undefined;
+  if (header) {
+    const cookies = cookie.parse(header);
+    cookieToken = cookies.csrfToken;
+  }
+  if (!headerToken || !cookieToken || headerToken !== cookieToken) {
+    return res.status(403).json({ message: 'Invalid CSRF token' });
+  }
+  return next();
+}

--- a/MJ_FB_Backend/src/routes/auth.ts
+++ b/MJ_FB_Backend/src/routes/auth.ts
@@ -4,6 +4,7 @@ import {
   changePassword,
   refreshToken,
   logout,
+  csrfToken,
 } from '../controllers/authController';
 import { authMiddleware } from '../middleware/authMiddleware';
 
@@ -13,5 +14,6 @@ router.post('/request-password-reset', requestPasswordReset);
 router.post('/change-password', authMiddleware, changePassword);
 router.post('/refresh', refreshToken);
 router.post('/logout', logout);
+router.get('/csrf-token', csrfToken);
 
 export default router;

--- a/MJ_FB_Backend/tests/csrf.test.ts
+++ b/MJ_FB_Backend/tests/csrf.test.ts
@@ -1,0 +1,38 @@
+import request from 'supertest';
+import express from 'express';
+import csrfMiddleware from '../src/middleware/csrf';
+import { csrfToken } from '../src/controllers/authController';
+
+const app = express();
+app.use(express.json());
+app.get('/csrf-token', csrfToken);
+app.post('/protected', csrfMiddleware, (_req, res) => res.json({ ok: true }));
+
+describe('CSRF middleware', () => {
+  it('allows request with valid CSRF token', async () => {
+    const tokenRes = await request(app).get('/csrf-token');
+    const token = tokenRes.body.csrfToken;
+    const cookie = tokenRes.headers['set-cookie'][0].split(';')[0];
+    const res = await request(app)
+      .post('/protected')
+      .set('Cookie', cookie)
+      .set('x-csrf-token', token);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects request with invalid CSRF token', async () => {
+    const tokenRes = await request(app).get('/csrf-token');
+    const cookie = tokenRes.headers['set-cookie'][0].split(';')[0];
+    const res = await request(app)
+      .post('/protected')
+      .set('Cookie', cookie)
+      .set('x-csrf-token', 'wrong');
+    expect(res.status).toBe(403);
+    expect(res.body.message).toBe('Invalid CSRF token');
+  });
+
+  it('rejects request without CSRF token', async () => {
+    const res = await request(app).post('/protected');
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add CSRF middleware verifying `x-csrf-token` header against cookie
- expose `/auth/csrf-token` endpoint to issue tokens
- apply CSRF checks across state-changing routes
- cover valid and invalid CSRF scenarios in tests

## Testing
- `PG_USER=foo PG_PASSWORD=bar PG_HOST=localhost PG_PORT=5432 PG_DATABASE=test FRONTEND_ORIGIN=http://localhost JWT_SECRET=test JWT_REFRESH_SECRET=test npm test` *(fails: 6 failed, 22 passed, 28 total)*

------
https://chatgpt.com/codex/tasks/task_e_68ae96800fd4832d86995460a15b8ec0