### PR TITLE
feat(volunteer): show full slot message

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -95,7 +95,10 @@ export default function VolunteerBooking({ token }: { token: string }) {
 
   function renderSlot(slot: VolunteerRole) {
     const label = `${formatTime(slot.start_time)}–${formatTime(slot.end_time)}`;
-    const needed = `${slot.available} more volunteer${slot.available === 1 ? '' : 's'} needed`;
+    const needed =
+      slot.available === 0
+        ? 'We have enough volunteers for this role and shift'
+        : `${slot.available} more volunteer${slot.available === 1 ? '' : 's'} needed`;
     return (
       <ListItemButton
         key={slot.id}


### PR DESCRIPTION
## Summary
- show "We have enough volunteers for this role and shift" when a shift is full

## Testing
- `npm test` *(fails: src/pages/booking/Profile.tsx:1:8 - error TS6133: 'React' is declared but its value is never read.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9a0f8a2c832d960d78f588109364