### PR TITLE
feat: add volunteer profile endpoint

### DIFF
--- a/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import {
   updateTrainedArea,
   loginVolunteer,
+  getVolunteerProfile,
   createVolunteer,
   searchVolunteers,
   createVolunteerShopperProfile,
@@ -12,6 +13,8 @@ import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware'
 const router = express.Router();
 
 router.post('/login', loginVolunteer);
+
+router.get('/me', authMiddleware, getVolunteerProfile);
 
 router.post(
   '/',

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -5,6 +5,7 @@ import type {
   RoleOption,
   Shift,
   VolunteerBooking,
+  UserProfile,
 } from '../types';
 import type { LoginResponse } from './users';
 
@@ -29,6 +30,11 @@ export async function loginVolunteer(
   });
   const data = await handleResponse(res);
   return data;
+}
+
+export async function getVolunteerProfile(_token: string): Promise<UserProfile> {
+  const res = await apiFetch(`${API_BASE}/volunteers/me`);
+  return handleResponse(res);
 }
 
 export async function searchVolunteers(_token: string, search: string) {

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -14,9 +14,10 @@ import {
 import { AccountCircle, Lock } from '@mui/icons-material';
 import type { Role, UserProfile } from '../../types';
 import { getUserProfile, changePassword, updateMyProfile } from '../../api/users';
+import { getVolunteerProfile } from '../../api/volunteers';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 
-export default function Profile({ token, role: _role }: { token: string; role: Role }) {
+export default function Profile({ token, role }: { token: string; role: Role }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [error, setError] = useState('');
   const [currentPassword, setCurrentPassword] = useState('');
@@ -38,14 +39,15 @@ export default function Profile({ token, role: _role }: { token: string; role: R
   }, []);
 
   useEffect(() => {
-    getUserProfile(token)
+    const loader = role === 'volunteer' ? getVolunteerProfile : getUserProfile;
+    loader(token)
       .then(p => {
         setProfile(p);
         setEmail(p.email ?? '');
         setPhone(p.phone ?? '');
       })
       .catch(e => setError(e instanceof Error ? e.message : String(e)));
-  }, [token]);
+  }, [token, role]);
 
   const initials = profile
     ? `${profile.firstName?.[0] ?? ''}${profile.lastName?.[0] ?? ''}`.toUpperCase()


### PR DESCRIPTION
## Summary
- expose `/volunteers/me` endpoint to fetch logged-in volunteer profile
- add frontend API helper for volunteer profile and load it on profile page

## Testing
- `npm test` (backend) *(fails: TypeError and other test failures)*
- `npm test` (frontend) *(fails: TypeScript import.meta error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae991762e8832da952d5cdcbf05e44