### PR TITLE
Consolidate client management into unified page

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Profile from './pages/booking/Profile';
 import ManageAvailability from './pages/staff/ManageAvailability';
-import UserHistory from './pages/staff/UserHistory';
+import UserHistory from './pages/staff/client-management/UserHistory';
+import ClientManagement from './pages/staff/ClientManagement';
 import BookingUI from './pages/BookingUI';
-import AddClient from './pages/staff/AddClient';
 import PantrySchedule from './pages/staff/PantrySchedule';
 import AgencySchedule from './pages/agency/AgencySchedule';
 import ClientList from './pages/agency/ClientList';
@@ -31,7 +31,6 @@ import AdminStaffList from './pages/admin/AdminStaffList';
 import AdminStaffForm from './pages/admin/AdminStaffForm';
 import Events from './pages/events/Events';
 import PantryVisits from './pages/staff/PantryVisits';
-import UpdateClientData from './pages/staff/UpdateClientData';
 import AgencyLogin from './pages/agency/Login';
 import AgencyClientBookings from './pages/agency/ClientBookings';
 import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
@@ -80,9 +79,7 @@ export default function App() {
       { label: 'Manage Availability', to: '/pantry/manage-availability' },
       { label: 'Pantry Schedule', to: '/pantry/schedule' },
       { label: 'Pantry Visits', to: '/pantry/visits' },
-      { label: 'Add Client', to: '/pantry/add-client' },
-      { label: 'Update Client Data', to: '/pantry/update-client-data' },
-      { label: 'Client History', to: '/pantry/user-history' },
+      { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Pending', to: '/pantry/pending' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
@@ -286,11 +283,12 @@ export default function App() {
                   }
                 />
               )}
-              {showStaff && <Route path="/pantry/add-client" element={<AddClient token={token} />} />}
               {showStaff && (
-                <Route path="/pantry/update-client-data" element={<UpdateClientData token={token} />} />
+                <Route
+                  path="/pantry/client-management/*"
+                  element={<ClientManagement token={token} />}
+                />
               )}
-              {showStaff && <Route path="/pantry/user-history" element={<UserHistory token={token} />} />}
               {showStaff && <Route path="/pantry/pending" element={<Pending />} />}
               {isStaff && <Route path="/events" element={<Events />} />}
               {showAdmin && <Route path="/admin/staff" element={<AdminStaffList />} />}

--- a/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
@@ -6,11 +6,11 @@ jest.mock('../api/volunteers', () => ({
   loginVolunteer: jest.fn(),
 }));
 
-jest.mock('../pages/volunteer/VolunteerDashboard', () => () => <div>VolunteerDashboard</div>);
-jest.mock('../pages/volunteer/VolunteerSchedule', () => () => <div>VolunteerSchedule</div>);
-jest.mock('../pages/volunteer/VolunteerBookingHistory', () => () => <div>VolunteerHistory</div>);
+jest.mock('../pages/volunteer-management/VolunteerDashboard', () => () => <div>VolunteerDashboard</div>);
+jest.mock('../pages/volunteer-management/VolunteerSchedule', () => () => <div>VolunteerSchedule</div>);
+jest.mock('../pages/volunteer-management/VolunteerBookingHistory', () => () => <div>VolunteerHistory</div>);
 jest.mock('../pages/BookingUI', () => () => <div>BookingUI Component</div>);
-jest.mock('../pages/staff/UserHistory', () => () => <div>BookingHistory Component</div>);
+jest.mock('../pages/staff/client-management/UserHistory', () => () => <div>BookingHistory Component</div>);
 
 
 describe('Volunteer with shopper profile', () => {

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -229,7 +229,7 @@ function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRole
                   onSelect={res => {
                     if (searchType === 'user') {
                       navigate(
-                        `/pantry/user-history?id=${res.id}&name=${encodeURIComponent(
+                        `/pantry/client-management/history?id=${res.id}&name=${encodeURIComponent(
                           res.name,
                         )}&clientId=${res.client_id}`,
                       );

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -1,0 +1,31 @@
+import { Grid, Tabs, Tab } from '@mui/material';
+import { Link, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import AddClient from './client-management/AddClient';
+import UpdateClientData from './client-management/UpdateClientData';
+import UserHistory from './client-management/UserHistory';
+
+export default function ClientManagement({ token }: { token: string }) {
+  const location = useLocation();
+  const last = location.pathname.split('/').pop();
+  const value = last === 'update' || last === 'history' ? last : 'add';
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12}>
+        <Tabs value={value} aria-label="client management tabs">
+          <Tab label="Add" value="add" component={Link} to="add" />
+          <Tab label="Update" value="update" component={Link} to="update" />
+          <Tab label="History" value="history" component={Link} to="history" />
+        </Tabs>
+      </Grid>
+      <Grid item xs={12}>
+        <Routes>
+          <Route index element={<Navigate to="add" replace />} />
+          <Route path="add" element={<AddClient token={token} />} />
+          <Route path="update" element={<UpdateClientData token={token} />} />
+          <Route path="history" element={<UserHistory token={token} />} />
+        </Routes>
+      </Grid>
+    </Grid>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { addUser } from '../../api/users';
-import type { UserRole } from '../../types';
-import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import FeedbackModal from '../../components/FeedbackModal';
+import { addUser } from '../../../api/users';
+import type { UserRole } from '../../../types';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import FeedbackModal from '../../../components/FeedbackModal';
 import { Box, Button, Stack, TextField, MenuItem, Typography, FormControlLabel, Checkbox } from '@mui/material';
 
 export default function AddClient({ token }: { token: string }) {

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -14,13 +14,13 @@ import {
   Stack,
   Link,
 } from '@mui/material';
-import Page from '../../components/Page';
-import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import Page from '../../../components/Page';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import {
   getIncompleteUsers,
   updateUserInfo,
   type IncompleteUser,
-} from '../../api/users';
+} from '../../../api/users';
 import type { AlertColor } from '@mui/material';
 
 export default function UpdateClientData({ token }: { token: string }) {

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { getBookingHistory, cancelBooking } from '../../api/bookings';
+import { getBookingHistory, cancelBooking } from '../../../api/bookings';
 import { formatInTimeZone } from 'date-fns-tz';
-import { formatTime } from '../../utils/time';
+import { formatTime } from '../../../utils/time';
 import {
   Box,
   Button,
@@ -26,9 +26,9 @@ import {
   useTheme,
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
-import RescheduleDialog from '../../components/RescheduleDialog';
-import EntitySearch from '../../components/EntitySearch';
-import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import RescheduleDialog from '../../../components/RescheduleDialog';
+import EntitySearch from '../../../components/EntitySearch';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 
 const TIMEZONE = 'America/Regina';
 


### PR DESCRIPTION
## Summary
- Introduce `ClientManagement` page with tabs for adding clients, updating records, and viewing history
- Replace separate pantry links with a single Client Management route and update dashboard quick search
- Adjust tests and imports to use new client-management structure

## Testing
- `npm test` *(fails: mediaQueryList.addEventListener is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9a8f60bc832da25bb0b8575f7a74