### PR TITLE
Fetch CSRF token when missing

### DIFF
--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -8,7 +8,15 @@ function getCsrfToken() {
 
 export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}) {
   const headers = new Headers(init.headers || {});
-  const csrf = getCsrfToken();
+  let csrf = getCsrfToken();
+  if (!csrf) {
+    try {
+      await fetch(`${API_BASE}/auth/csrf-token`, { credentials: 'include' });
+      csrf = getCsrfToken();
+    } catch {
+      /* ignore token fetch errors */
+    }
+  }
   if (csrf) headers.set('X-CSRF-Token', csrf);
   init.headers = headers;
 


### PR DESCRIPTION
## Summary
- Automatically request a CSRF token when none is present before sending API requests

## Testing
- `npm test` *(fails: TS type errors in test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9b467a98832da726a25215d89b62