### PR TITLE
Use tabs for client management sections

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -285,7 +285,7 @@ export default function App() {
               )}
               {showStaff && (
                 <Route
-                  path="/pantry/client-management/*"
+                  path="/pantry/client-management"
                   element={<ClientManagement token={token} />}
                 />
               )}

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -229,7 +229,7 @@ function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRole
                   onSelect={res => {
                     if (searchType === 'user') {
                       navigate(
-                        `/pantry/client-management/history?id=${res.id}&name=${encodeURIComponent(
+                        `/pantry/client-management?tab=history&id=${res.id}&name=${encodeURIComponent(
                           res.name,
                         )}&clientId=${res.client_id}`,
                       );

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -1,31 +1,50 @@
+import { useState, useEffect } from 'react';
 import { Grid, Tabs, Tab } from '@mui/material';
-import { Link, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import AddClient from './client-management/AddClient';
 import UpdateClientData from './client-management/UpdateClientData';
 import UserHistory from './client-management/UserHistory';
 
 export default function ClientManagement({ token }: { token: string }) {
-  const location = useLocation();
-  const last = location.pathname.split('/').pop();
-  const value = last === 'update' || last === 'history' ? last : 'add';
+  const [searchParams] = useSearchParams();
+  const initial = searchParams.get('tab');
+  const [value, setValue] = useState<'add' | 'update' | 'history'>(
+    initial === 'update' || initial === 'history' ? (initial as 'update' | 'history') : 'add'
+  );
+
+  useEffect(() => {
+    const tab = searchParams.get('tab');
+    if (tab === 'add' || tab === 'update' || tab === 'history') {
+      setValue(tab);
+    }
+  }, [searchParams]);
+
+  const renderContent = () => {
+    switch (value) {
+      case 'update':
+        return <UpdateClientData token={token} />;
+      case 'history':
+        return <UserHistory token={token} />;
+      default:
+        return <AddClient token={token} />;
+    }
+  };
 
   return (
     <Grid container spacing={2}>
       <Grid item xs={12}>
-        <Tabs value={value} aria-label="client management tabs">
-          <Tab label="Add" value="add" component={Link} to="add" />
-          <Tab label="Update" value="update" component={Link} to="update" />
-          <Tab label="History" value="history" component={Link} to="history" />
+        <Tabs
+          value={value}
+          onChange={(_, newValue: 'add' | 'update' | 'history') => setValue(newValue)}
+          aria-label="client management tabs"
+        >
+          <Tab label="Add" value="add" />
+          <Tab label="Update" value="update" />
+          <Tab label="History" value="history" />
         </Tabs>
       </Grid>
-      <Grid item xs={12}>
-        <Routes>
-          <Route index element={<Navigate to="add" replace />} />
-          <Route path="add" element={<AddClient token={token} />} />
-          <Route path="update" element={<UpdateClientData token={token} />} />
-          <Route path="history" element={<UserHistory token={token} />} />
-        </Routes>
-      </Grid>
+      <Grid item xs={12}>{renderContent()}</Grid>
     </Grid>
   );
 }
+


### PR DESCRIPTION
## Summary
- Replace client management nested routes with internal tab state
- Update dashboard quick search to point to new client management tab
- Simplify client management route registration

## Testing
- `npm test` *(fails: The 'import.meta' meta-property is only allowed...)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9d097098832d9d0e202ce896a363