### PR TITLE
refactor: remove token params from api

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -41,7 +41,7 @@ import { useAuth, AgencyGuard } from './hooks/useAuth';
 import type { StaffAccess } from './types';
 
 export default function App() {
-  const { token, role, name, userRole, access, login, logout } = useAuth();
+  const { role, name, userRole, access, login, logout } = useAuth();
   const [loading] = useState(false);
   const [error, setError] = useState('');
   const isStaff = role === 'staff';
@@ -183,9 +183,9 @@ export default function App() {
               <Route
                 path="/"
                 element={
-                  role === 'volunteer' ? (
-                      <VolunteerDashboard token={token} />
-                  ) : role === 'agency' ? (
+                    role === 'volunteer' ? (
+                        <VolunteerDashboard />
+                    ) : role === 'agency' ? (
                     <AgencyGuard>
                       <AgencySchedule />
                     </AgencyGuard>
@@ -193,26 +193,26 @@ export default function App() {
                     singleAccessOnly && staffRootPath !== '/' ? (
                       <Navigate to={staffRootPath} replace />
                     ) : (
-                        <Dashboard role="staff" token={token} masterRoleFilter={['Pantry']} />
+                          <Dashboard role="staff" masterRoleFilter={['Pantry']} />
                     )
                   ) : (
                     <ClientDashboard />
                   )
                 }
               />
-                <Route path="/profile" element={<Profile token={token} role={role} />} />
-              {showStaff && (
-                <Route path="/pantry" element={<Dashboard role="staff" token={token} masterRoleFilter={['Pantry']} />} />
-              )}
+                <Route path="/profile" element={<Profile role={role} />} />
+                {showStaff && (
+                  <Route path="/pantry" element={<Dashboard role="staff" masterRoleFilter={['Pantry']} />} />
+                )}
               {showStaff && (
                 <Route path="/pantry/manage-availability" element={<ManageAvailability />} />
               )}
-              {showStaff && (
-                <Route path="/pantry/schedule" element={<PantrySchedule token={token} />} />
-              )}
-              {showStaff && (
-                <Route path="/pantry/visits" element={<PantryVisits token={token} />} />
-              )}
+                {showStaff && (
+                  <Route path="/pantry/schedule" element={<PantrySchedule />} />
+                )}
+                {showStaff && (
+                  <Route path="/pantry/visits" element={<PantryVisits />} />
+                )}
               {showWarehouse && (
                 <Route path="/warehouse-management" element={<WarehouseDashboard />} />
               )}
@@ -261,65 +261,63 @@ export default function App() {
               {role === 'shopper' && (
                 <Route path="/slots" element={<BookingUI shopperName={name || undefined} />} />
               )}
-              {role === 'shopper' && (
-                <Route
-                  path="/booking-history"
-                  element={
-                    <UserHistory
-                      token={token}
-                      initialUser={{ id: 0, name, client_id: 0 }}
-                    />
-                  }
-                />
-              )}
+                {role === 'shopper' && (
+                  <Route
+                    path="/booking-history"
+                    element={
+                      <UserHistory
+                        initialUser={{ id: 0, name, client_id: 0 }}
+                      />
+                    }
+                  />
+                )}
               {role === 'volunteer' && userRole === 'shopper' && (
                 <Route path="/slots" element={<BookingUI shopperName={name || undefined} />} />
               )}
-              {role === 'volunteer' && userRole === 'shopper' && (
-                <Route
-                  path="/booking-history"
-                  element={
-                    <UserHistory
-                      token={token}
-                      initialUser={{ id: 0, name, client_id: 0 }}
-                    />
-                  }
-                />
-              )}
-              {showStaff && <Route path="/pantry/add-client" element={<AddClient token={token} />} />}
-              {showStaff && (
-                <Route path="/pantry/update-client-data" element={<UpdateClientData token={token} />} />
-              )}
-              {showStaff && <Route path="/pantry/user-history" element={<UserHistory token={token} />} />}
+                {role === 'volunteer' && userRole === 'shopper' && (
+                  <Route
+                    path="/booking-history"
+                    element={
+                      <UserHistory
+                        initialUser={{ id: 0, name, client_id: 0 }}
+                      />
+                    }
+                  />
+                )}
+                {showStaff && <Route path="/pantry/add-client" element={<AddClient />} />}
+                {showStaff && (
+                  <Route path="/pantry/update-client-data" element={<UpdateClientData />} />
+                )}
+                {showStaff && <Route path="/pantry/user-history" element={<UserHistory />} />}
               {showStaff && <Route path="/pantry/pending" element={<Pending />} />}
               {isStaff && <Route path="/events" element={<Events />} />}
               {showAdmin && <Route path="/admin/staff" element={<AdminStaffList />} />}
               {showAdmin && <Route path="/admin/staff/create" element={<AdminStaffForm />} />}
               {showAdmin && <Route path="/admin/staff/:id" element={<AdminStaffForm />} />}
-              {showVolunteerManagement && (
-                <>
-                  <Route
-                    path="/volunteer-management"
-                    element={<VolunteerManagement token={token} />}
-                  />
-                  <Route
-                    path="/volunteer-management/:tab"
-                    element={<VolunteerManagement token={token} />}
-                  />
-                </>
-              )}
-              {role === 'volunteer' && (
-                <>
-                  <Route
-                    path="/volunteer/schedule"
-                    element={<VolunteerBooking token={token} />}
-                  />
-                  <Route
-                    path="/volunteer/history"
-                    element={<VolunteerBookingHistory token={token} />}
-                  />
-                </>
-              )}
+                {showVolunteerManagement && (
+                  <>
+                    <Route
+                      path="/volunteer-management"
+                      element={<VolunteerManagement />}
+                    />
+                    <Route
+                      path="/volunteer-management/:tab"
+                      element={<VolunteerManagement />}
+                    />
+                  </>
+                )}
+                {role === 'volunteer' && (
+                  <>
+                    <Route
+                      path="/volunteer/schedule"
+                      element={<VolunteerBooking />}
+                    />
+                    <Route
+                      path="/volunteer/history"
+                      element={<VolunteerBookingHistory />}
+                    />
+                  </>
+                )}
               {role === 'agency' && (
                 <>
                   <Route

--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -57,7 +57,7 @@ afterEach(() => {
 });
 
 test('submits weekly recurring booking', async () => {
-  render(<VolunteerSchedule token="t" />);
+  render(<VolunteerSchedule />);
   fireEvent.mouseDown(await screen.findByLabelText(/role/i));
   const listbox = await screen.findByRole('listbox');
   fireEvent.click(within(listbox).getByText('Test Role'));
@@ -75,14 +75,13 @@ test('submits weekly recurring booking', async () => {
     expect(createRecurringVolunteerBooking).toHaveBeenCalled(),
   );
   const args = (createRecurringVolunteerBooking as jest.Mock).mock.calls[0];
-  expect(args[0]).toBe('t');
-  expect(args[1]).toBe(1);
-  expect(args[3]).toBe('weekly');
-  expect(args[4]).toEqual(expect.arrayContaining([1, 3]));
+  expect(args[0]).toBe(1);
+  expect(args[2]).toBe('weekly');
+  expect(args[3]).toEqual(expect.arrayContaining([1, 3]));
 });
 
 test('submits one-time booking', async () => {
-  render(<VolunteerSchedule token="t" />);
+  render(<VolunteerSchedule />);
   fireEvent.mouseDown(await screen.findByLabelText(/role/i));
   const listbox = await screen.findByRole('listbox');
   fireEvent.click(within(listbox).getByText('Test Role'));
@@ -124,18 +123,18 @@ test('cancels single and recurring bookings', async () => {
       status: 'approved',
     },
   ]);
-  render(<VolunteerBookingHistory token="t" />);
+  render(<VolunteerBookingHistory />);
   const cancelButtons = await screen.findAllByText('Cancel');
   fireEvent.click(cancelButtons[2]);
   fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
   await waitFor(() =>
-    expect(cancelVolunteerBooking).toHaveBeenCalledWith('t', 3),
+    expect(cancelVolunteerBooking).toHaveBeenCalledWith(3),
   );
   const cancelAllButtons = await screen.findAllByText('Cancel all upcoming');
   fireEvent.click(cancelAllButtons[0]);
   fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
   await waitFor(() =>
-    expect(cancelRecurringVolunteerBooking).toHaveBeenCalledWith('t', 5),
+    expect(cancelRecurringVolunteerBooking).toHaveBeenCalledWith(5),
   );
 });
 

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -41,7 +41,7 @@ describe('VolunteerManagement shopper profile', () => {
     render(
       <MemoryRouter initialEntries={['/volunteers/search']}>
         <Routes>
-          <Route path="/volunteers/:tab" element={<VolunteerManagement token="t" />} />
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
         </Routes>
       </MemoryRouter>
     );
@@ -57,7 +57,6 @@ describe('VolunteerManagement shopper profile', () => {
 
     await waitFor(() =>
       expect(createVolunteerShopperProfile).toHaveBeenCalledWith(
-        't',
         1,
         '123',
         'pass',
@@ -77,7 +76,7 @@ describe('VolunteerManagement shopper profile', () => {
     render(
       <MemoryRouter initialEntries={['/volunteers/search']}>
         <Routes>
-          <Route path="/volunteers/:tab" element={<VolunteerManagement token="t" />} />
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
         </Routes>
       </MemoryRouter>
     );
@@ -89,7 +88,7 @@ describe('VolunteerManagement shopper profile', () => {
     fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
 
     await waitFor(() =>
-      expect(removeVolunteerShopperProfile).toHaveBeenCalledWith('t', 1)
+      expect(removeVolunteerShopperProfile).toHaveBeenCalledWith(1)
     );
     await waitFor(() =>
       expect(screen.getByLabelText(/shopper profile/i)).not.toBeChecked()

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -64,7 +64,6 @@ export async function requestPasswordReset(data: {
 }
 
 export async function changePassword(
-  _token: string,
   currentPassword: string,
   newPassword: string,
 ): Promise<void> {
@@ -76,7 +75,7 @@ export async function changePassword(
   await handleResponse(res);
 }
 
-export async function getUserProfile(_token: string): Promise<UserProfile> {
+export async function getUserProfile(): Promise<UserProfile> {
   const res = await apiFetch(`${API_BASE}/users/me`);
   return handleResponse(res);
 }
@@ -104,7 +103,6 @@ export async function createStaff(
   access: StaffAccess[],
   email: string,
   password: string,
-  _token?: string,
 ): Promise<void> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -124,7 +122,6 @@ export async function createStaff(
 }
 
 export async function addUser(
-  _token: string,
   firstName: string,
   lastName: string,
   clientId: string,
@@ -153,12 +150,12 @@ export async function addUser(
   await handleResponse(res);
 }
 
-export async function searchUsers(_token: string, search: string) {
+export async function searchUsers(search: string) {
   const res = await apiFetch(`${API_BASE}/users/search?search=${encodeURIComponent(search)}`);
   return handleResponse(res);
 }
 
-export async function getUserByClientId(_token: string, clientId: string) {
+export async function getUserByClientId(clientId: string) {
   const res = await apiFetch(`${API_BASE}/users/id/${clientId}`);
   return handleResponse(res);
 }
@@ -173,13 +170,12 @@ export interface IncompleteUser {
   profileLink: string;
 }
 
-export async function getIncompleteUsers(_token: string): Promise<IncompleteUser[]> {
+export async function getIncompleteUsers(): Promise<IncompleteUser[]> {
   const res = await apiFetch(`${API_BASE}/users/missing-info`);
   return handleResponse(res);
 }
 
 export async function updateUserInfo(
-  _token: string,
   clientId: number,
   data: { firstName: string; lastName: string; email?: string; phone?: string },
 ): Promise<IncompleteUser> {

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -31,7 +31,7 @@ export async function loginVolunteer(
   return data;
 }
 
-export async function searchVolunteers(_token: string, search: string) {
+export async function searchVolunteers(search: string) {
   const res = await apiFetch(
     `${API_BASE}/volunteers/search?search=${encodeURIComponent(search)}`,
   );
@@ -49,7 +49,6 @@ export async function getRoleShifts(roleId: number): Promise<Shift[]> {
 }
 
 export async function getVolunteerRolesForVolunteer(
-  _token: string,
   date: string,
 ): Promise<VolunteerRole[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-roles/mine?date=${date}`);
@@ -57,7 +56,6 @@ export async function getVolunteerRolesForVolunteer(
 }
 
 export async function requestVolunteerBooking(
-  _token: string,
   roleId: number,
   date: string
 ): Promise<void> {
@@ -72,7 +70,6 @@ export async function requestVolunteerBooking(
 }
 
 export async function createRecurringVolunteerBooking(
-  _token: string,
   roleId: number,
   startDate: string,
   frequency: 'daily' | 'weekly',
@@ -96,7 +93,6 @@ export async function createRecurringVolunteerBooking(
 }
 
 export async function cancelVolunteerBooking(
-  _token: string,
   bookingId: number,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/${bookingId}`, {
@@ -106,7 +102,6 @@ export async function cancelVolunteerBooking(
 }
 
 export async function cancelRecurringVolunteerBooking(
-  _token: string,
   recurringId: number,
 ): Promise<void> {
   const res = await apiFetch(
@@ -118,26 +113,23 @@ export async function cancelRecurringVolunteerBooking(
   await handleResponse(res);
 }
 
-export async function getMyVolunteerBookings(_token: string) {
+export async function getMyVolunteerBookings() {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/mine`);
   const data = await handleResponse(res);
   return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
 }
 
-export async function getVolunteerRoles(
-  _token: string,
-): Promise<VolunteerRoleWithShifts[]> {
+export async function getVolunteerRoles(): Promise<VolunteerRoleWithShifts[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-roles`);
   return handleResponse(res);
 }
 
-export async function getVolunteerMasterRoles(_token: string) {
+export async function getVolunteerMasterRoles() {
   const res = await apiFetch(`${API_BASE}/volunteer-master-roles`);
   return handleResponse(res);
 }
 
 export async function updateVolunteerRoleStatus(
-  _token: string,
   id: number,
   isActive: boolean,
 ) {
@@ -151,13 +143,12 @@ export async function updateVolunteerRoleStatus(
   return handleResponse(res);
 }
 
-export async function getVolunteerBookingsByRole(_token: string, roleId: number) {
+export async function getVolunteerBookingsByRole(roleId: number) {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/${roleId}`);
   return handleResponse(res);
 }
 
 export async function updateVolunteerBookingStatus(
-  _token: string,
   bookingId: number,
   status: 'approved' | 'rejected' | 'cancelled'
 ): Promise<void> {
@@ -172,7 +163,6 @@ export async function updateVolunteerBookingStatus(
 }
 
 export async function createVolunteerBookingForVolunteer(
-  _token: string,
   volunteerId: number,
   roleId: number,
   date: string
@@ -188,7 +178,6 @@ export async function createVolunteerBookingForVolunteer(
 }
 
 export async function getVolunteerBookingHistory(
-  _token: string,
   volunteerId: number,
 ) {
   const res = await apiFetch(
@@ -199,7 +188,6 @@ export async function getVolunteerBookingHistory(
 }
 
 export async function createVolunteer(
-  _token: string,
   firstName: string,
   lastName: string,
   username: string,
@@ -227,7 +215,6 @@ export async function createVolunteer(
 }
 
 export async function updateVolunteerTrainedAreas(
-  _token: string,
   id: number,
   roleIds: number[]
 ): Promise<void> {
@@ -255,7 +242,6 @@ export async function rescheduleVolunteerBookingByToken(
 }
 
 export async function createVolunteerShopperProfile(
-  _token: string,
   volunteerId: number,
   clientId: string,
   password: string,
@@ -276,7 +262,6 @@ export async function createVolunteerShopperProfile(
 }
 
 export async function removeVolunteerShopperProfile(
-  _token: string,
   volunteerId: number,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/volunteers/${volunteerId}/shopper`, {

--- a/MJ_FB_Frontend/src/components/EntitySearch.tsx
+++ b/MJ_FB_Frontend/src/components/EntitySearch.tsx
@@ -4,7 +4,6 @@ import { searchUsers } from '../api/users';
 import { searchVolunteers } from '../api/volunteers';
 
 interface EntitySearchProps {
-  token: string;
   type: 'user' | 'volunteer';
   placeholder?: string;
   onSelect: (result: any) => void;
@@ -12,7 +11,6 @@ interface EntitySearchProps {
 }
 
 export default function EntitySearch({
-  token,
   type,
   placeholder,
   onSelect,
@@ -28,7 +26,7 @@ export default function EntitySearch({
     }
     let active = true;
     const fn = type === 'user' ? searchUsers : searchVolunteers;
-    fn(token, query)
+    fn(query)
       .then(data => {
         if (active) setResults(data);
       })
@@ -36,7 +34,7 @@ export default function EntitySearch({
     return () => {
       active = false;
     };
-  }, [query, token, type]);
+  }, [query, type]);
 
   const getLabel = (r: any) =>
     type === 'user' ? `${r.name} (${r.client_id})` : r.name;

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -29,7 +29,6 @@ import VolunteerCoverageCard from './VolunteerCoverageCard';
 
 export interface DashboardProps {
   role: Role;
-  token: string;
   masterRoleFilter?: string[];
 }
 
@@ -74,7 +73,7 @@ function formatLocalDate(date: Date) {
   return date.toLocaleDateString('en-CA');
 }
 
-function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRoleFilter?: string[] }) {
+function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [volunteerCount, setVolunteerCount] = useState(0);
   const [schedule, setSchedule] = useState<{ day: string; open: number }[]>([]);
@@ -114,7 +113,7 @@ function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRole
       )
       .then(setSchedule)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   const todayStr = formatLocalDate(new Date());
   const pending = bookings.filter(b => b.status === 'submitted');
@@ -172,7 +171,6 @@ function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRole
           </Grid>
           <Grid size={12}>
             <VolunteerCoverageCard
-              token={token}
               masterRoleFilter={masterRoleFilter}
               onCoverageLoaded={data =>
                 setVolunteerCount(data.reduce((sum, c) => sum + c.filled, 0))
@@ -223,7 +221,6 @@ function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRole
             <SectionCard title="Quick Search">
               <Stack spacing={2}>
                 <EntitySearch
-                  token={token}
                   type={searchType}
                   placeholder="Search"
                   onSelect={res => {
@@ -402,9 +399,9 @@ function UserDashboard() {
   );
 }
 
-export default function Dashboard({ role, token, masterRoleFilter }: DashboardProps) {
+export default function Dashboard({ role, masterRoleFilter }: DashboardProps) {
   if (role === 'staff')
-    return <StaffDashboard token={token} masterRoleFilter={masterRoleFilter} />;
+    return <StaffDashboard masterRoleFilter={masterRoleFilter} />;
   return <UserDashboard />;
 }
 

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -12,13 +12,11 @@ interface CoverageItem {
 }
 
 interface VolunteerCoverageCardProps {
-  token: string;
   masterRoleFilter?: string[];
   onCoverageLoaded?: (data: CoverageItem[]) => void;
 }
 
 export default function VolunteerCoverageCard({
-  token,
   masterRoleFilter,
   onCoverageLoaded,
 }: VolunteerCoverageCardProps) {
@@ -27,7 +25,7 @@ export default function VolunteerCoverageCard({
   useEffect(() => {
     const todayStr = formatReginaDate(new Date());
 
-    getVolunteerRoles(token)
+    getVolunteerRoles()
       .then(roles =>
         masterRoleFilter
           ? roles.filter(r => masterRoleFilter.includes(r.category_name))
@@ -36,7 +34,7 @@ export default function VolunteerCoverageCard({
       .then(roles =>
         Promise.all(
           roles.map(async r => {
-            const bookings = await getVolunteerBookingsByRole(token, r.id);
+            const bookings = await getVolunteerBookingsByRole(r.id);
             const filled = bookings.filter(
               (b: any) =>
                 b.status === 'approved' &&
@@ -56,7 +54,7 @@ export default function VolunteerCoverageCard({
         onCoverageLoaded?.(data);
       })
       .catch(() => {});
-  }, [token, masterRoleFilter, onCoverageLoaded]);
+  }, [masterRoleFilter, onCoverageLoaded]);
 
   return (
     <SectionCard title="Volunteer Coverage">

--- a/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useCallback } from 'react';
 import PantrySchedule from '../staff/PantrySchedule';
 import { getMyAgencyClients } from '../../api/agencies';
 import type { Role } from '../../types';
-import { useAuth } from '../../hooks/useAuth';
 
 interface AgencyClient {
   id: number;
@@ -11,7 +10,6 @@ interface AgencyClient {
 }
 
 export default function AgencySchedule() {
-  const { token } = useAuth();
   const [clients, setClients] = useState<AgencyClient[]>([]);
 
   useEffect(() => {
@@ -35,7 +33,7 @@ export default function AgencySchedule() {
   const clientIds = clients.map(c => c.id);
 
   const searchAgencyUsers = useCallback(
-    async (_token: string, term: string) => {
+    async (term: string) => {
       const lower = term.toLowerCase();
       return clients
         .filter(
@@ -50,7 +48,6 @@ export default function AgencySchedule() {
 
   return (
     <PantrySchedule
-      token={token}
       clientIds={clientIds}
       searchUsersFn={searchAgencyUsers}
     />

--- a/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '../../hooks/useAuth';
 interface User { id: number; name: string; email: string; }
 
 export default function ClientBookings() {
-  const { id: agencyId, token } = useAuth();
+  const { id: agencyId } = useAuth();
   const [search, setSearch] = useState('');
   const [results, setResults] = useState<User[]>([]);
   const [selected, setSelected] = useState<User | null>(null);
@@ -21,12 +21,12 @@ export default function ClientBookings() {
       return;
     }
     const t = setTimeout(() => {
-      searchUsers(token, search)
+      searchUsers(search)
         .then(setResults)
         .catch(() => setResults([]));
     }, 300);
     return () => clearTimeout(t);
-  }, [search, token]);
+  }, [search]);
 
   async function choose(user: User) {
     if (!agencyId) return;

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -20,7 +20,6 @@ import {
 } from '@mui/material';
 import RescheduleDialog from '../../components/RescheduleDialog';
 import EntitySearch from '../../components/EntitySearch';
-import { useAuth } from '../../hooks/useAuth';
 
 const TIMEZONE = 'America/Regina';
 
@@ -44,7 +43,6 @@ interface Booking {
 }
 
 export default function ClientHistory() {
-  const { token } = useAuth();
   const [selected, setSelected] = useState<User | null>(null);
   const [filter, setFilter] = useState('all');
   const [bookings, setBookings] = useState<Booking[]>([]);
@@ -97,7 +95,6 @@ export default function ClientHistory() {
       <Box width="100%" maxWidth={800} mt={4}>
         <h2>Client History</h2>
         <EntitySearch
-          token={token}
           type="user"
           placeholder="Search by name or client ID"
           onSelect={u => setSelected(u as User)}

--- a/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
@@ -4,7 +4,7 @@ import { changePassword } from '../../api/users';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormContainer from '../../components/FormContainer';
 
-export default function ChangePasswordForm({ token }: { token: string }) {
+export default function ChangePasswordForm() {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [success, setSuccess] = useState('');
@@ -13,7 +13,7 @@ export default function ChangePasswordForm({ token }: { token: string }) {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      await changePassword(token, currentPassword, newPassword);
+      await changePassword(currentPassword, newPassword);
       setSuccess('Password updated');
       setCurrentPassword('');
       setNewPassword('');

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Container,
   Card,
@@ -16,7 +16,7 @@ import type { Role, UserProfile } from '../../types';
 import { getUserProfile, changePassword, updateMyProfile } from '../../api/users';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 
-export default function Profile({ token, role: _role }: { token: string; role: Role }) {
+export default function Profile({ role: _role }: { role: Role }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [error, setError] = useState('');
   const [currentPassword, setCurrentPassword] = useState('');
@@ -38,14 +38,14 @@ export default function Profile({ token, role: _role }: { token: string; role: R
   }, []);
 
   useEffect(() => {
-    getUserProfile(token)
+    getUserProfile()
       .then(p => {
         setProfile(p);
         setEmail(p.email ?? '');
         setPhone(p.phone ?? '');
       })
       .catch(e => setError(e instanceof Error ? e.message : String(e)));
-  }, [token]);
+  }, []);
 
   const initials = profile
     ? `${profile.firstName?.[0] ?? ''}${profile.lastName?.[0] ?? ''}`.toUpperCase()
@@ -55,7 +55,7 @@ export default function Profile({ token, role: _role }: { token: string; role: R
     setSubmitting(true);
     setPasswordError('');
     try {
-      await changePassword(token, currentPassword, newPassword);
+      await changePassword(currentPassword, newPassword);
       setToast({ open: true, message: 'Password updated.', severity: 'success' });
       setCurrentPassword('');
       setNewPassword('');

--- a/MJ_FB_Frontend/src/pages/staff/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AddClient.tsx
@@ -5,7 +5,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FeedbackModal from '../../components/FeedbackModal';
 import { Box, Button, Stack, TextField, MenuItem, Typography, FormControlLabel, Checkbox } from '@mui/material';
 
-export default function AddClient({ token }: { token: string }) {
+export default function AddClient() {
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<UserRole>('shopper');
   const [phone, setPhone] = useState('');
@@ -30,7 +30,6 @@ export default function AddClient({ token }: { token: string }) {
     }
     try {
       await addUser(
-        token,
         firstName,
         lastName,
         clientId,

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -32,13 +32,11 @@ interface User {
 const reginaTimeZone = 'America/Regina';
 
 export default function PantrySchedule({
-  token,
   clientIds,
   searchUsersFn,
 }: {
-  token: string;
   clientIds?: number[];
-  searchUsersFn?: (token: string, search: string) => Promise<User[]>;
+  searchUsersFn?: (search: string) => Promise<User[]>;
 }) {
   const [currentDate, setCurrentDate] = useState(() => {
     const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
@@ -109,7 +107,7 @@ export default function PantrySchedule({
   useEffect(() => {
     if (assignSlot && searchTerm.length >= 3) {
       const delay = setTimeout(() => {
-        (searchUsersFn || searchUsers)(token, searchTerm)
+        (searchUsersFn || searchUsers)(searchTerm)
           .then((data: User[]) => setUserResults(data.slice(0, 5)))
           .catch(() => setUserResults([]));
       }, 300);
@@ -117,7 +115,7 @@ export default function PantrySchedule({
     } else {
       setUserResults([]);
     }
-  }, [searchTerm, token, assignSlot]);
+  }, [searchTerm, assignSlot, searchUsersFn]);
 
   function changeDay(delta: number) {
     setCurrentDate(d => new Date(d.getTime() + delta * 86400000));

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -57,7 +57,7 @@ function formatDisplay(dateStr: string) {
   });
 }
 
-export default function PantryVisits({ token }: { token: string }) {
+export default function PantryVisits() {
   const [visits, setVisits] = useState<ClientVisit[]>([]);
   const [tab, setTab] = useState(() => {
     const week = startOfWeek(new Date());
@@ -119,10 +119,10 @@ export default function PantryVisits({ token }: { token: string }) {
       setClientFound(null);
       return;
     }
-    getUserByClientId(token, form.clientId)
+    getUserByClientId(form.clientId)
       .then(() => setClientFound(true))
       .catch(() => setClientFound(false));
-  }, [form.clientId, token]);
+  }, [form.clientId]);
 
   function handleSaveVisit() {
     if (!form.date || !form.weightWithCart || !form.weightWithoutCart) {
@@ -166,7 +166,7 @@ export default function PantryVisits({ token }: { token: string }) {
   async function handleCreateClient() {
     if (!form.clientId) return;
     try {
-      await addUser(token, '', '', form.clientId, 'shopper', undefined, false);
+      await addUser('', '', form.clientId, 'shopper', undefined, false);
       setClientFound(true);
       setSnackbar({ open: true, message: 'Client created', severity: 'success' });
     } catch (err: any) {

--- a/MJ_FB_Frontend/src/pages/staff/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/UpdateClientData.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../api/users';
 import type { AlertColor } from '@mui/material';
 
-export default function UpdateClientData({ token }: { token: string }) {
+export default function UpdateClientData() {
   const [clients, setClients] = useState<IncompleteUser[]>([]);
   const [selected, setSelected] = useState<IncompleteUser | null>(null);
   const [form, setForm] = useState({
@@ -39,7 +39,7 @@ export default function UpdateClientData({ token }: { token: string }) {
   } | null>(null);
 
   function loadClients() {
-    getIncompleteUsers(token)
+    getIncompleteUsers()
       .then(setClients)
       .catch(() => setClients([]));
   }
@@ -61,7 +61,7 @@ export default function UpdateClientData({ token }: { token: string }) {
   async function handleSave() {
     if (!selected) return;
     try {
-      await updateUserInfo(token, selected.clientId, {
+      await updateUserInfo(selected.clientId, {
         firstName: form.firstName,
         lastName: form.lastName,
         email: form.email || undefined,

--- a/MJ_FB_Frontend/src/pages/staff/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/UserHistory.tsx
@@ -52,10 +52,8 @@ interface Booking {
 }
 
 export default function UserHistory({
-  token,
   initialUser,
 }: {
-  token: string;
   initialUser?: User;
 }) {
   const [searchParams] = useSearchParams();
@@ -135,7 +133,6 @@ export default function UserHistory({
         <h2>{initialUser ? 'Booking History' : 'Client History'}</h2>
         {!initialUser && (
           <EntitySearch
-            token={token}
             type="user"
             placeholder="Search by name or client ID"
             onSelect={u => setSelected(u as User)}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -24,17 +24,17 @@ import { getHolidays } from '../../api/bookings';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { formatTime } from '../../utils/time';
 
-function useVolunteerSlots(token: string, date: Dayjs, enabled: boolean) {
+function useVolunteerSlots(date: Dayjs, enabled: boolean) {
   const dateStr = date.format('YYYY-MM-DD');
   const { data, isFetching, refetch, error } = useQuery<VolunteerRole[]>({
     queryKey: ['volunteer-slots', dateStr],
-    queryFn: () => getVolunteerRolesForVolunteer(token, dateStr),
+    queryFn: () => getVolunteerRolesForVolunteer(dateStr),
     enabled,
   });
   return { slots: data ?? [], isLoading: isFetching, refetch, error };
 }
 
-export default function VolunteerBooking({ token }: { token: string }) {
+export default function VolunteerBooking() {
   const [date, setDate] = useState<Dayjs>(() => {
     let d = dayjs();
     while (d.day() === 0 || d.day() === 6) d = d.add(1, 'day');
@@ -51,7 +51,6 @@ export default function VolunteerBooking({ token }: { token: string }) {
     d.day() === 6 ||
     holidaySet.has(d.format('YYYY-MM-DD'));
   const { slots, isLoading, refetch, error } = useVolunteerSlots(
-    token,
     date,
     !isDisabled(date),
   );
@@ -82,7 +81,7 @@ export default function VolunteerBooking({ token }: { token: string }) {
     if (!selected) return;
     setBooking(true);
     try {
-      await requestVolunteerBooking(token, selected.id, selected.date);
+      await requestVolunteerBooking(selected.id, selected.date);
       setSnackbar({ open: true, message: 'Request submitted', severity: 'success' });
       setSelected(null);
       refetch();

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
@@ -24,7 +24,7 @@ import {
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 
-export default function VolunteerBookingHistory({ token }: { token: string }) {
+export default function VolunteerBookingHistory() {
   const [history, setHistory] = useState<VolunteerBooking[]>([]);
   const [cancelBooking, setCancelBooking] =
     useState<VolunteerBooking | null>(null);
@@ -33,10 +33,10 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
   const [severity, setSeverity] = useState<AlertColor>('success');
 
   const loadHistory = useCallback(() => {
-    getMyVolunteerBookings(token)
+    getMyVolunteerBookings()
       .then(setHistory)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     loadHistory();
@@ -54,7 +54,7 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
   async function handleCancel() {
     if (!cancelBooking) return;
     try {
-      await cancelVolunteerBooking(token, cancelBooking.id);
+      await cancelVolunteerBooking(cancelBooking.id);
       setSeverity('success');
       setMessage('Booking cancelled');
       loadHistory();
@@ -69,7 +69,7 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
   async function handleCancelSeries() {
     if (cancelSeriesId == null) return;
     try {
-      await cancelRecurringVolunteerBooking(token, cancelSeriesId);
+      await cancelRecurringVolunteerBooking(cancelSeriesId);
       setSeverity('success');
       setMessage('Series cancelled');
       loadHistory();

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -40,7 +40,7 @@ function formatDateLabel(dateStr: string) {
   });
 }
 
-export default function VolunteerDashboard({ token }: { token: string }) {
+export default function VolunteerDashboard() {
   const [bookings, setBookings] = useState<VolunteerBooking[]>([]);
   const [availability, setAvailability] = useState<VolunteerRole[]>([]);
   const [dateMode, setDateMode] = useState<'today' | 'week'>('today');
@@ -50,10 +50,10 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    getMyVolunteerBookings(token)
+    getMyVolunteerBookings()
       .then(setBookings)
       .catch(() => setBookings([]));
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     async function loadAvailability() {
@@ -70,7 +70,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
       for (const day of days) {
         const ds = formatRegina(day, 'yyyy-MM-dd');
         try {
-          const roles = await getVolunteerRolesForVolunteer(token, ds);
+          const roles = await getVolunteerRolesForVolunteer(ds);
           all.push(...roles);
         } catch {
           // ignore
@@ -79,7 +79,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
       setAvailability(all);
     }
     loadAvailability();
-  }, [token, dateMode]);
+  }, [dateMode]);
 
   const nextShift = useMemo(() => {
     const now = new Date();
@@ -112,10 +112,10 @@ export default function VolunteerDashboard({ token }: { token: string }) {
 
   async function request(role: VolunteerRole) {
     try {
-      await requestVolunteerBooking(token, role.id, role.date);
+      await requestVolunteerBooking(role.id, role.date);
       setSnackbarSeverity('success');
       setMessage('Request submitted');
-      const data = await getMyVolunteerBookings(token);
+      const data = await getMyVolunteerBookings();
       setBookings(data);
     } catch {
       setSnackbarSeverity('error');
@@ -126,10 +126,10 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   async function cancelNext() {
     if (!nextShift) return;
     try {
-      await updateVolunteerBookingStatus(token, nextShift.id, 'cancelled');
+      await updateVolunteerBookingStatus(nextShift.id, 'cancelled');
       setSnackbarSeverity('success');
       setMessage('Booking cancelled');
-      const data = await getMyVolunteerBookings(token);
+      const data = await getMyVolunteerBookings();
       setBookings(data);
     } catch {
       setSnackbarSeverity('error');

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -70,7 +70,7 @@ interface VolunteerResult {
 }
 
 
-export default function VolunteerManagement({ token }: { token: string }) {
+export default function VolunteerManagement() {
   const { tab: tabParam } = useParams<{ tab?: string }>();
   const [searchParams] = useSearchParams();
   const tab: 'dashboard' | 'schedule' | 'search' | 'create' | 'pending' =
@@ -166,7 +166,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
   }, []);
 
   useEffect(() => {
-    getVolunteerRoles(token)
+    getVolunteerRoles()
       .then(data => {
         const flattened: RoleOption[] = data.flatMap(r =>
           r.shifts.map(s => ({
@@ -182,7 +182,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
         setRoles(flattened);
       })
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   const groupedRoles = useMemo(() => {
     const groups = new Map<string, { name: string; category_id: number }[]>();
@@ -232,7 +232,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
   useEffect(() => {
     if (selectedRole && tab === 'schedule') {
       const ids = nameToRoleIds.get(selectedRole) || [];
-      Promise.all(ids.map(id => getVolunteerBookingsByRole(token, id)))
+      Promise.all(ids.map(id => getVolunteerBookingsByRole(id)))
         .then(data => {
           setBookings(data.flat());
         })
@@ -240,7 +240,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
     } else if (!selectedRole) {
       setBookings([]);
     }
-  }, [selectedRole, token, tab, nameToRoleIds]);
+  }, [selectedRole, tab, nameToRoleIds]);
 
   // volunteer search handled via EntitySearch component
 
@@ -248,7 +248,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
     const all: VolunteerBookingDetail[] = [];
     for (const r of roles) {
       try {
-        const data = await getVolunteerBookingsByRole(token, r.id);
+        const data = await getVolunteerBookingsByRole(r.id);
         const approvedByDate: Record<string, number> = {};
         data.forEach((b: VolunteerBookingDetail) => {
           if (b.status.toLowerCase() === 'approved') {
@@ -267,7 +267,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
       }
     }
     setPending(all);
-  }, [roles, token]);
+  }, [roles]);
 
   useEffect(() => {
     if (tab === 'pending') {
@@ -287,11 +287,11 @@ export default function VolunteerManagement({ token }: { token: string }) {
 
   async function decide(id: number, status: 'approved' | 'rejected' | 'cancelled') {
     try {
-      await updateVolunteerBookingStatus(token, id, status);
+      await updateVolunteerBookingStatus(id, status);
       if (selectedRole) {
         const ids = nameToRoleIds.get(selectedRole) || [];
         const data = await Promise.all(
-          ids.map(rid => getVolunteerBookingsByRole(token, rid))
+          ids.map(rid => getVolunteerBookingsByRole(rid))
         );
         setBookings(data.flat());
       }
@@ -304,7 +304,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
 
   async function loadVolunteer(id: number, name: string): Promise<VolunteerResult> {
     try {
-      const res = await searchVolunteers(token, name);
+      const res = await searchVolunteers(name);
       const found = res.find((v: VolunteerResult) => v.id === id);
       if (found) return found;
     } catch {
@@ -341,7 +341,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
       )
     );
     try {
-      const data = await getVolunteerBookingHistory(token, vol.id);
+      const data = await getVolunteerBookingHistory(vol.id);
       setHistory(data);
     } catch {
       setHistory([]);
@@ -360,7 +360,6 @@ export default function VolunteerManagement({ token }: { token: string }) {
     try {
       setAssignMsg('');
       await createVolunteerBookingForVolunteer(
-        token,
         vol.id,
         assignSlot.id,
         formatDate(currentDate)
@@ -370,7 +369,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
       setAssignResults([]);
       const ids = nameToRoleIds.get(selectedRole) || [];
       const data = await Promise.all(
-        ids.map(id => getVolunteerBookingsByRole(token, id))
+        ids.map(id => getVolunteerBookingsByRole(id))
       );
       setBookings(data.flat());
     } catch (e) {
@@ -384,7 +383,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
       const ids = Array.from(
         new Set(trainedEdit.flatMap(name => nameToRoleIds.get(name) || []))
       );
-      await updateVolunteerTrainedAreas(token, selectedVolunteer.id, ids);
+      await updateVolunteerTrainedAreas(selectedVolunteer.id, ids);
       setEditSeverity('success');
       setEditMsg('Roles updated');
     } catch (e) {
@@ -406,7 +405,6 @@ export default function VolunteerManagement({ token }: { token: string }) {
     if (!selectedVolunteer) return;
     try {
       await createVolunteerShopperProfile(
-        token,
         selectedVolunteer.id,
         shopperClientId,
         shopperPassword,
@@ -430,7 +428,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
   async function removeShopper() {
     if (!selectedVolunteer) return;
     try {
-      await removeVolunteerShopperProfile(token, selectedVolunteer.id);
+      await removeVolunteerShopperProfile(selectedVolunteer.id);
       setEditSeverity('success');
       setEditMsg('Shopper profile removed');
       setRemoveShopperOpen(false);
@@ -462,7 +460,6 @@ export default function VolunteerManagement({ token }: { token: string }) {
         )
       );
       await createVolunteer(
-        token,
         firstName,
         lastName,
         username,
@@ -494,7 +491,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
       return;
     }
     const delay = setTimeout(() => {
-      searchVolunteers(token, assignSearch)
+      searchVolunteers(assignSearch)
         .then((data: VolunteerResult[]) => {
           const filtered = data
             .filter(v => v.trainedAreas.includes(assignSlot.id))
@@ -504,7 +501,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
         .catch(() => setAssignResults([]));
     }, 300);
     return () => clearTimeout(delay);
-  }, [assignSearch, token, assignSlot]);
+  }, [assignSearch, assignSlot]);
 
   const bookingsForDate = bookings.filter(b => {
     const bookingDate = formatInTimeZone(
@@ -566,7 +563,7 @@ export default function VolunteerManagement({ token }: { token: string }) {
     <div>
       <h2>{title}</h2>
       {tab === 'dashboard' && (
-        <Dashboard role="staff" token={token} masterRoleFilter={undefined} />
+        <Dashboard role="staff" masterRoleFilter={undefined} />
       )}
       {tab === 'schedule' && (
         <div>
@@ -601,7 +598,6 @@ export default function VolunteerManagement({ token }: { token: string }) {
         <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
           <Box width="100%" maxWidth={600} mt={4}>
             <EntitySearch
-              token={token}
               type="volunteer"
               placeholder="Search volunteers"
               onSelect={selectVolunteer}


### PR DESCRIPTION
## Summary
- remove `_token` arguments from user and volunteer API helpers
- update components and tests to use updated function signatures

## Testing
- `npm test` *(fails: mediaQueryList.addEventListener is not a function; import.meta meta-property errors; missing toBeInTheDocument matcher)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9b58cff8832d817d400d7cbdadd7