### PR TITLE
Remove redundant token parameters

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -40,7 +40,7 @@ import { useAuth, AgencyGuard } from './hooks/useAuth';
 import type { StaffAccess } from './types';
 
 export default function App() {
-  const { token, role, name, userRole, access, login, logout } = useAuth();
+  const { role, name, userRole, access, login, logout } = useAuth();
   const [loading] = useState(false);
   const [error, setError] = useState('');
   const isStaff = role === 'staff';
@@ -181,7 +181,7 @@ export default function App() {
                 path="/"
                 element={
                   role === 'volunteer' ? (
-                      <VolunteerDashboard token={token} />
+                      <VolunteerDashboard />
                   ) : role === 'agency' ? (
                     <AgencyGuard>
                       <AgencySchedule />
@@ -190,25 +190,25 @@ export default function App() {
                     singleAccessOnly && staffRootPath !== '/' ? (
                       <Navigate to={staffRootPath} replace />
                     ) : (
-                        <Dashboard role="staff" token={token} masterRoleFilter={['Pantry']} />
+                        <Dashboard role="staff" masterRoleFilter={['Pantry']} />
                     )
                   ) : (
                     <ClientDashboard />
                   )
                 }
               />
-                <Route path="/profile" element={<Profile token={token} role={role} />} />
+                <Route path="/profile" element={<Profile role={role} />} />
               {showStaff && (
-                <Route path="/pantry" element={<Dashboard role="staff" token={token} masterRoleFilter={['Pantry']} />} />
+                <Route path="/pantry" element={<Dashboard role="staff" masterRoleFilter={['Pantry']} />} />
               )}
               {showStaff && (
                 <Route path="/pantry/manage-availability" element={<ManageAvailability />} />
               )}
               {showStaff && (
-                <Route path="/pantry/schedule" element={<PantrySchedule token={token} />} />
+                <Route path="/pantry/schedule" element={<PantrySchedule />} />
               )}
               {showStaff && (
-                <Route path="/pantry/visits" element={<PantryVisits token={token} />} />
+                <Route path="/pantry/visits" element={<PantryVisits />} />
               )}
               {showWarehouse && (
                 <Route path="/warehouse-management" element={<WarehouseDashboard />} />
@@ -263,7 +263,6 @@ export default function App() {
                   path="/booking-history"
                   element={
                     <UserHistory
-                      token={token}
                       initialUser={{ id: 0, name, client_id: 0 }}
                     />
                   }
@@ -277,7 +276,6 @@ export default function App() {
                   path="/booking-history"
                   element={
                     <UserHistory
-                      token={token}
                       initialUser={{ id: 0, name, client_id: 0 }}
                     />
                   }
@@ -286,7 +284,7 @@ export default function App() {
               {showStaff && (
                 <Route
                   path="/pantry/client-management"
-                  element={<ClientManagement token={token} />}
+                  element={<ClientManagement />}
                 />
               )}
               {showStaff && <Route path="/pantry/pending" element={<Pending />} />}
@@ -298,11 +296,11 @@ export default function App() {
                 <>
                   <Route
                     path="/volunteer-management"
-                    element={<VolunteerManagement token={token} />}
+                    element={<VolunteerManagement />}
                   />
                   <Route
                     path="/volunteer-management/:tab"
-                    element={<VolunteerManagement token={token} />}
+                    element={<VolunteerManagement />}
                   />
                 </>
               )}
@@ -310,11 +308,11 @@ export default function App() {
                 <>
                   <Route
                     path="/volunteer/schedule"
-                    element={<VolunteerBooking token={token} />}
+                    element={<VolunteerBooking />}
                   />
                   <Route
                     path="/volunteer/history"
-                    element={<VolunteerBookingHistory token={token} />}
+                    element={<VolunteerBookingHistory />}
                   />
                 </>
               )}

--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -57,7 +57,7 @@ afterEach(() => {
 });
 
 test('submits weekly recurring booking', async () => {
-  render(<VolunteerSchedule token="t" />);
+  render(<VolunteerSchedule />);
   fireEvent.mouseDown(await screen.findByLabelText(/role/i));
   const listbox = await screen.findByRole('listbox');
   fireEvent.click(within(listbox).getByText('Test Role'));
@@ -75,14 +75,13 @@ test('submits weekly recurring booking', async () => {
     expect(createRecurringVolunteerBooking).toHaveBeenCalled(),
   );
   const args = (createRecurringVolunteerBooking as jest.Mock).mock.calls[0];
-  expect(args[0]).toBe('t');
-  expect(args[1]).toBe(1);
-  expect(args[3]).toBe('weekly');
-  expect(args[4]).toEqual(expect.arrayContaining([1, 3]));
+  expect(args[0]).toBe(1);
+  expect(args[2]).toBe('weekly');
+  expect(args[3]).toEqual(expect.arrayContaining([1, 3]));
 });
 
 test('submits one-time booking', async () => {
-  render(<VolunteerSchedule token="t" />);
+  render(<VolunteerSchedule />);
   fireEvent.mouseDown(await screen.findByLabelText(/role/i));
   const listbox = await screen.findByRole('listbox');
   fireEvent.click(within(listbox).getByText('Test Role'));
@@ -124,18 +123,18 @@ test('cancels single and recurring bookings', async () => {
       status: 'approved',
     },
   ]);
-  render(<VolunteerBookingHistory token="t" />);
+  render(<VolunteerBookingHistory />);
   const cancelButtons = await screen.findAllByText('Cancel');
   fireEvent.click(cancelButtons[2]);
   fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
   await waitFor(() =>
-    expect(cancelVolunteerBooking).toHaveBeenCalledWith('t', 3),
+    expect(cancelVolunteerBooking).toHaveBeenCalledWith(3),
   );
   const cancelAllButtons = await screen.findAllByText('Cancel all upcoming');
   fireEvent.click(cancelAllButtons[0]);
   fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
   await waitFor(() =>
-    expect(cancelRecurringVolunteerBooking).toHaveBeenCalledWith('t', 5),
+    expect(cancelRecurringVolunteerBooking).toHaveBeenCalledWith(5),
   );
 });
 

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -41,7 +41,7 @@ describe('VolunteerManagement shopper profile', () => {
     render(
       <MemoryRouter initialEntries={['/volunteers/search']}>
         <Routes>
-          <Route path="/volunteers/:tab" element={<VolunteerManagement token="t" />} />
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
         </Routes>
       </MemoryRouter>
     );
@@ -57,7 +57,6 @@ describe('VolunteerManagement shopper profile', () => {
 
     await waitFor(() =>
       expect(createVolunteerShopperProfile).toHaveBeenCalledWith(
-        't',
         1,
         '123',
         'pass',
@@ -77,7 +76,7 @@ describe('VolunteerManagement shopper profile', () => {
     render(
       <MemoryRouter initialEntries={['/volunteers/search']}>
         <Routes>
-          <Route path="/volunteers/:tab" element={<VolunteerManagement token="t" />} />
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
         </Routes>
       </MemoryRouter>
     );
@@ -89,7 +88,7 @@ describe('VolunteerManagement shopper profile', () => {
     fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
 
     await waitFor(() =>
-      expect(removeVolunteerShopperProfile).toHaveBeenCalledWith('t', 1)
+      expect(removeVolunteerShopperProfile).toHaveBeenCalledWith(1)
     );
     await waitFor(() =>
       expect(screen.getByLabelText(/shopper profile/i)).not.toBeChecked()

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -64,7 +64,6 @@ export async function requestPasswordReset(data: {
 }
 
 export async function changePassword(
-  _token: string,
   currentPassword: string,
   newPassword: string,
 ): Promise<void> {
@@ -76,7 +75,7 @@ export async function changePassword(
   await handleResponse(res);
 }
 
-export async function getUserProfile(_token: string): Promise<UserProfile> {
+export async function getUserProfile(): Promise<UserProfile> {
   const res = await apiFetch(`${API_BASE}/users/me`);
   return handleResponse(res);
 }
@@ -104,7 +103,6 @@ export async function createStaff(
   access: StaffAccess[],
   email: string,
   password: string,
-  _token?: string,
 ): Promise<void> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -124,7 +122,6 @@ export async function createStaff(
 }
 
 export async function addUser(
-  _token: string,
   firstName: string,
   lastName: string,
   clientId: string,
@@ -153,12 +150,12 @@ export async function addUser(
   await handleResponse(res);
 }
 
-export async function searchUsers(_token: string, search: string) {
+export async function searchUsers(search: string) {
   const res = await apiFetch(`${API_BASE}/users/search?search=${encodeURIComponent(search)}`);
   return handleResponse(res);
 }
 
-export async function getUserByClientId(_token: string, clientId: string) {
+export async function getUserByClientId(clientId: string) {
   const res = await apiFetch(`${API_BASE}/users/id/${clientId}`);
   return handleResponse(res);
 }
@@ -173,13 +170,12 @@ export interface IncompleteUser {
   profileLink: string;
 }
 
-export async function getIncompleteUsers(_token: string): Promise<IncompleteUser[]> {
+export async function getIncompleteUsers(): Promise<IncompleteUser[]> {
   const res = await apiFetch(`${API_BASE}/users/missing-info`);
   return handleResponse(res);
 }
 
 export async function updateUserInfo(
-  _token: string,
   clientId: number,
   data: { firstName: string; lastName: string; email?: string; phone?: string },
 ): Promise<IncompleteUser> {

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -32,12 +32,12 @@ export async function loginVolunteer(
   return data;
 }
 
-export async function getVolunteerProfile(_token: string): Promise<UserProfile> {
+export async function getVolunteerProfile(): Promise<UserProfile> {
   const res = await apiFetch(`${API_BASE}/volunteers/me`);
   return handleResponse(res);
 }
 
-export async function searchVolunteers(_token: string, search: string) {
+export async function searchVolunteers(search: string) {
   const res = await apiFetch(
     `${API_BASE}/volunteers/search?search=${encodeURIComponent(search)}`,
   );
@@ -55,7 +55,6 @@ export async function getRoleShifts(roleId: number): Promise<Shift[]> {
 }
 
 export async function getVolunteerRolesForVolunteer(
-  _token: string,
   date: string,
 ): Promise<VolunteerRole[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-roles/mine?date=${date}`);
@@ -63,7 +62,6 @@ export async function getVolunteerRolesForVolunteer(
 }
 
 export async function requestVolunteerBooking(
-  _token: string,
   roleId: number,
   date: string
 ): Promise<void> {
@@ -78,7 +76,6 @@ export async function requestVolunteerBooking(
 }
 
 export async function createRecurringVolunteerBooking(
-  _token: string,
   roleId: number,
   startDate: string,
   frequency: 'daily' | 'weekly',
@@ -102,7 +99,6 @@ export async function createRecurringVolunteerBooking(
 }
 
 export async function cancelVolunteerBooking(
-  _token: string,
   bookingId: number,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/${bookingId}`, {
@@ -112,7 +108,6 @@ export async function cancelVolunteerBooking(
 }
 
 export async function cancelRecurringVolunteerBooking(
-  _token: string,
   recurringId: number,
 ): Promise<void> {
   const res = await apiFetch(
@@ -124,26 +119,23 @@ export async function cancelRecurringVolunteerBooking(
   await handleResponse(res);
 }
 
-export async function getMyVolunteerBookings(_token: string) {
+export async function getMyVolunteerBookings() {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/mine`);
   const data = await handleResponse(res);
   return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
 }
 
-export async function getVolunteerRoles(
-  _token: string,
-): Promise<VolunteerRoleWithShifts[]> {
+export async function getVolunteerRoles(): Promise<VolunteerRoleWithShifts[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-roles`);
   return handleResponse(res);
 }
 
-export async function getVolunteerMasterRoles(_token: string) {
+export async function getVolunteerMasterRoles() {
   const res = await apiFetch(`${API_BASE}/volunteer-master-roles`);
   return handleResponse(res);
 }
 
 export async function updateVolunteerRoleStatus(
-  _token: string,
   id: number,
   isActive: boolean,
 ) {
@@ -157,13 +149,12 @@ export async function updateVolunteerRoleStatus(
   return handleResponse(res);
 }
 
-export async function getVolunteerBookingsByRole(_token: string, roleId: number) {
+export async function getVolunteerBookingsByRole(roleId: number) {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/${roleId}`);
   return handleResponse(res);
 }
 
 export async function updateVolunteerBookingStatus(
-  _token: string,
   bookingId: number,
   status: 'approved' | 'rejected' | 'cancelled'
 ): Promise<void> {
@@ -178,7 +169,6 @@ export async function updateVolunteerBookingStatus(
 }
 
 export async function createVolunteerBookingForVolunteer(
-  _token: string,
   volunteerId: number,
   roleId: number,
   date: string
@@ -194,7 +184,6 @@ export async function createVolunteerBookingForVolunteer(
 }
 
 export async function getVolunteerBookingHistory(
-  _token: string,
   volunteerId: number,
 ) {
   const res = await apiFetch(
@@ -205,7 +194,6 @@ export async function getVolunteerBookingHistory(
 }
 
 export async function createVolunteer(
-  _token: string,
   firstName: string,
   lastName: string,
   username: string,
@@ -233,7 +221,6 @@ export async function createVolunteer(
 }
 
 export async function updateVolunteerTrainedAreas(
-  _token: string,
   id: number,
   roleIds: number[]
 ): Promise<void> {
@@ -261,7 +248,6 @@ export async function rescheduleVolunteerBookingByToken(
 }
 
 export async function createVolunteerShopperProfile(
-  _token: string,
   volunteerId: number,
   clientId: string,
   password: string,
@@ -282,7 +268,6 @@ export async function createVolunteerShopperProfile(
 }
 
 export async function removeVolunteerShopperProfile(
-  _token: string,
   volunteerId: number,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/volunteers/${volunteerId}/shopper`, {

--- a/MJ_FB_Frontend/src/components/EntitySearch.tsx
+++ b/MJ_FB_Frontend/src/components/EntitySearch.tsx
@@ -4,7 +4,6 @@ import { searchUsers } from '../api/users';
 import { searchVolunteers } from '../api/volunteers';
 
 interface EntitySearchProps {
-  token: string;
   type: 'user' | 'volunteer';
   placeholder?: string;
   onSelect: (result: any) => void;
@@ -12,7 +11,6 @@ interface EntitySearchProps {
 }
 
 export default function EntitySearch({
-  token,
   type,
   placeholder,
   onSelect,
@@ -28,7 +26,7 @@ export default function EntitySearch({
     }
     let active = true;
     const fn = type === 'user' ? searchUsers : searchVolunteers;
-    fn(token, query)
+    fn(query)
       .then(data => {
         if (active) setResults(data);
       })
@@ -36,7 +34,7 @@ export default function EntitySearch({
     return () => {
       active = false;
     };
-  }, [query, token, type]);
+  }, [query, type]);
 
   const getLabel = (r: any) =>
     type === 'user' ? `${r.name} (${r.client_id})` : r.name;

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -29,7 +29,6 @@ import VolunteerCoverageCard from './VolunteerCoverageCard';
 
 export interface DashboardProps {
   role: Role;
-  token: string;
   masterRoleFilter?: string[];
 }
 
@@ -74,7 +73,7 @@ function formatLocalDate(date: Date) {
   return date.toLocaleDateString('en-CA');
 }
 
-function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRoleFilter?: string[] }) {
+function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [volunteerCount, setVolunteerCount] = useState(0);
   const [schedule, setSchedule] = useState<{ day: string; open: number }[]>([]);
@@ -114,7 +113,7 @@ function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRole
       )
       .then(setSchedule)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   const todayStr = formatLocalDate(new Date());
   const pending = bookings.filter(b => b.status === 'submitted');
@@ -172,7 +171,6 @@ function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRole
           </Grid>
           <Grid size={12}>
             <VolunteerCoverageCard
-              token={token}
               masterRoleFilter={masterRoleFilter}
               onCoverageLoaded={data =>
                 setVolunteerCount(data.reduce((sum, c) => sum + c.filled, 0))
@@ -223,7 +221,6 @@ function StaffDashboard({ token, masterRoleFilter }: { token: string; masterRole
             <SectionCard title="Quick Search">
               <Stack spacing={2}>
                 <EntitySearch
-                  token={token}
                   type={searchType}
                   placeholder="Search"
                   onSelect={res => {
@@ -402,9 +399,9 @@ function UserDashboard() {
   );
 }
 
-export default function Dashboard({ role, token, masterRoleFilter }: DashboardProps) {
+export default function Dashboard({ role, masterRoleFilter }: DashboardProps) {
   if (role === 'staff')
-    return <StaffDashboard token={token} masterRoleFilter={masterRoleFilter} />;
+    return <StaffDashboard masterRoleFilter={masterRoleFilter} />;
   return <UserDashboard />;
 }
 

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -12,13 +12,11 @@ interface CoverageItem {
 }
 
 interface VolunteerCoverageCardProps {
-  token: string;
   masterRoleFilter?: string[];
   onCoverageLoaded?: (data: CoverageItem[]) => void;
 }
 
 export default function VolunteerCoverageCard({
-  token,
   masterRoleFilter,
   onCoverageLoaded,
 }: VolunteerCoverageCardProps) {
@@ -27,7 +25,7 @@ export default function VolunteerCoverageCard({
   useEffect(() => {
     const todayStr = formatReginaDate(new Date());
 
-    getVolunteerRoles(token)
+    getVolunteerRoles()
       .then(roles =>
         masterRoleFilter
           ? roles.filter(r => masterRoleFilter.includes(r.category_name))
@@ -36,7 +34,7 @@ export default function VolunteerCoverageCard({
       .then(roles =>
         Promise.all(
           roles.map(async r => {
-            const bookings = await getVolunteerBookingsByRole(token, r.id);
+            const bookings = await getVolunteerBookingsByRole(r.id);
             const filled = bookings.filter(
               (b: any) =>
                 b.status === 'approved' &&
@@ -56,7 +54,7 @@ export default function VolunteerCoverageCard({
         onCoverageLoaded?.(data);
       })
       .catch(() => {});
-  }, [token, masterRoleFilter, onCoverageLoaded]);
+  }, [masterRoleFilter, onCoverageLoaded]);
 
   return (
     <SectionCard title="Volunteer Coverage">

--- a/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '../../hooks/useAuth';
 interface User { id: number; name: string; email: string; }
 
 export default function ClientBookings() {
-  const { id: agencyId, token } = useAuth();
+  const { id: agencyId } = useAuth();
   const [search, setSearch] = useState('');
   const [results, setResults] = useState<User[]>([]);
   const [selected, setSelected] = useState<User | null>(null);
@@ -21,12 +21,12 @@ export default function ClientBookings() {
       return;
     }
     const t = setTimeout(() => {
-      searchUsers(token, search)
+      searchUsers(search)
         .then(setResults)
         .catch(() => setResults([]));
     }, 300);
     return () => clearTimeout(t);
-  }, [search, token]);
+  }, [search]);
 
   async function choose(user: User) {
     if (!agencyId) return;

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -20,7 +20,6 @@ import {
 } from '@mui/material';
 import RescheduleDialog from '../../components/RescheduleDialog';
 import EntitySearch from '../../components/EntitySearch';
-import { useAuth } from '../../hooks/useAuth';
 
 const TIMEZONE = 'America/Regina';
 
@@ -44,7 +43,6 @@ interface Booking {
 }
 
 export default function ClientHistory() {
-  const { token } = useAuth();
   const [selected, setSelected] = useState<User | null>(null);
   const [filter, setFilter] = useState('all');
   const [bookings, setBookings] = useState<Booking[]>([]);
@@ -97,7 +95,6 @@ export default function ClientHistory() {
       <Box width="100%" maxWidth={800} mt={4}>
         <h2>Client History</h2>
         <EntitySearch
-          token={token}
           type="user"
           placeholder="Search by name or client ID"
           onSelect={u => setSelected(u as User)}

--- a/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
@@ -4,7 +4,7 @@ import { changePassword } from '../../api/users';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormContainer from '../../components/FormContainer';
 
-export default function ChangePasswordForm({ token }: { token: string }) {
+export default function ChangePasswordForm() {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [success, setSuccess] = useState('');
@@ -13,7 +13,7 @@ export default function ChangePasswordForm({ token }: { token: string }) {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      await changePassword(token, currentPassword, newPassword);
+      await changePassword(currentPassword, newPassword);
       setSuccess('Password updated');
       setCurrentPassword('');
       setNewPassword('');

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Container,
   Card,
@@ -17,7 +17,7 @@ import { getUserProfile, changePassword, updateMyProfile } from '../../api/users
 import { getVolunteerProfile } from '../../api/volunteers';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 
-export default function Profile({ token, role }: { token: string; role: Role }) {
+export default function Profile({ role }: { role: Role }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [error, setError] = useState('');
   const [currentPassword, setCurrentPassword] = useState('');
@@ -40,14 +40,14 @@ export default function Profile({ token, role }: { token: string; role: Role }) 
 
   useEffect(() => {
     const loader = role === 'volunteer' ? getVolunteerProfile : getUserProfile;
-    loader(token)
+    loader()
       .then(p => {
         setProfile(p);
         setEmail(p.email ?? '');
         setPhone(p.phone ?? '');
       })
       .catch(e => setError(e instanceof Error ? e.message : String(e)));
-  }, [token, role]);
+  }, [role]);
 
   const initials = profile
     ? `${profile.firstName?.[0] ?? ''}${profile.lastName?.[0] ?? ''}`.toUpperCase()
@@ -57,7 +57,7 @@ export default function Profile({ token, role }: { token: string; role: Role }) 
     setSubmitting(true);
     setPasswordError('');
     try {
-      await changePassword(token, currentPassword, newPassword);
+      await changePassword(currentPassword, newPassword);
       setToast({ open: true, message: 'Password updated.', severity: 'success' });
       setCurrentPassword('');
       setNewPassword('');

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -5,7 +5,7 @@ import AddClient from './client-management/AddClient';
 import UpdateClientData from './client-management/UpdateClientData';
 import UserHistory from './client-management/UserHistory';
 
-export default function ClientManagement({ token }: { token: string }) {
+export default function ClientManagement() {
   const [searchParams] = useSearchParams();
   const initial = searchParams.get('tab');
   const [value, setValue] = useState<'add' | 'update' | 'history'>(
@@ -22,11 +22,11 @@ export default function ClientManagement({ token }: { token: string }) {
   const renderContent = () => {
     switch (value) {
       case 'update':
-        return <UpdateClientData token={token} />;
+        return <UpdateClientData />;
       case 'history':
-        return <UserHistory token={token} />;
+        return <UserHistory />;
       default:
-        return <AddClient token={token} />;
+        return <AddClient />;
     }
   };
 

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -32,13 +32,11 @@ interface User {
 const reginaTimeZone = 'America/Regina';
 
 export default function PantrySchedule({
-  token,
   clientIds,
   searchUsersFn,
 }: {
-  token: string;
   clientIds?: number[];
-  searchUsersFn?: (token: string, search: string) => Promise<User[]>;
+  searchUsersFn?: (search: string) => Promise<User[]>;
 }) {
   const [currentDate, setCurrentDate] = useState(() => {
     const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
@@ -109,7 +107,7 @@ export default function PantrySchedule({
   useEffect(() => {
     if (assignSlot && searchTerm.length >= 3) {
       const delay = setTimeout(() => {
-        (searchUsersFn || searchUsers)(token, searchTerm)
+        (searchUsersFn || searchUsers)(searchTerm)
           .then((data: User[]) => setUserResults(data.slice(0, 5)))
           .catch(() => setUserResults([]));
       }, 300);
@@ -117,7 +115,7 @@ export default function PantrySchedule({
     } else {
       setUserResults([]);
     }
-  }, [searchTerm, token, assignSlot]);
+  }, [searchTerm, assignSlot]);
 
   function changeDay(delta: number) {
     setCurrentDate(d => new Date(d.getTime() + delta * 86400000));

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -57,7 +57,7 @@ function formatDisplay(dateStr: string) {
   });
 }
 
-export default function PantryVisits({ token }: { token: string }) {
+export default function PantryVisits() {
   const [visits, setVisits] = useState<ClientVisit[]>([]);
   const [tab, setTab] = useState(() => {
     const week = startOfWeek(new Date());
@@ -119,10 +119,10 @@ export default function PantryVisits({ token }: { token: string }) {
       setClientFound(null);
       return;
     }
-    getUserByClientId(token, form.clientId)
+    getUserByClientId(form.clientId)
       .then(() => setClientFound(true))
       .catch(() => setClientFound(false));
-  }, [form.clientId, token]);
+  }, [form.clientId]);
 
   function handleSaveVisit() {
     if (!form.date || !form.weightWithCart || !form.weightWithoutCart) {
@@ -166,11 +166,11 @@ export default function PantryVisits({ token }: { token: string }) {
   async function handleCreateClient() {
     if (!form.clientId) return;
     try {
-      await addUser(token, '', '', form.clientId, 'shopper', undefined, false);
+      await addUser('', '', form.clientId, 'shopper', undefined, false);
       setClientFound(true);
       setSnackbar({ open: true, message: 'Client created', severity: 'success' });
-    } catch (err: any) {
-      setSnackbar({ open: true, message: err.message || 'Failed to create client', severity: 'error' });
+    } catch (err: unknown) {
+      setSnackbar({ open: true, message: err instanceof Error ? err.message : 'Failed to create client', severity: 'error' });
     }
   }
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -5,7 +5,7 @@ import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import FeedbackModal from '../../../components/FeedbackModal';
 import { Box, Button, Stack, TextField, MenuItem, Typography, FormControlLabel, Checkbox } from '@mui/material';
 
-export default function AddClient({ token }: { token: string }) {
+export default function AddClient() {
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<UserRole>('shopper');
   const [phone, setPhone] = useState('');
@@ -30,7 +30,6 @@ export default function AddClient({ token }: { token: string }) {
     }
     try {
       await addUser(
-        token,
         firstName,
         lastName,
         clientId,

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../../api/users';
 import type { AlertColor } from '@mui/material';
 
-export default function UpdateClientData({ token }: { token: string }) {
+export default function UpdateClientData() {
   const [clients, setClients] = useState<IncompleteUser[]>([]);
   const [selected, setSelected] = useState<IncompleteUser | null>(null);
   const [form, setForm] = useState({
@@ -39,7 +39,7 @@ export default function UpdateClientData({ token }: { token: string }) {
   } | null>(null);
 
   function loadClients() {
-    getIncompleteUsers(token)
+    getIncompleteUsers()
       .then(setClients)
       .catch(() => setClients([]));
   }
@@ -61,7 +61,7 @@ export default function UpdateClientData({ token }: { token: string }) {
   async function handleSave() {
     if (!selected) return;
     try {
-      await updateUserInfo(token, selected.clientId, {
+      await updateUserInfo(selected.clientId, {
         firstName: form.firstName,
         lastName: form.lastName,
         email: form.email || undefined,
@@ -70,10 +70,10 @@ export default function UpdateClientData({ token }: { token: string }) {
       setSnackbar({ open: true, message: 'Client updated', severity: 'success' });
       setSelected(null);
       loadClients();
-    } catch (err: any) {
+    } catch (err: unknown) {
       setSnackbar({
         open: true,
-        message: err.message || 'Update failed',
+        message: err instanceof Error ? err.message : 'Update failed',
         severity: 'error',
       });
     }

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -52,10 +52,8 @@ interface Booking {
 }
 
 export default function UserHistory({
-  token,
   initialUser,
 }: {
-  token: string;
   initialUser?: User;
 }) {
   const [searchParams] = useSearchParams();
@@ -135,7 +133,6 @@ export default function UserHistory({
         <h2>{initialUser ? 'Booking History' : 'Client History'}</h2>
         {!initialUser && (
           <EntitySearch
-            token={token}
             type="user"
             placeholder="Search by name or client ID"
             onSelect={u => setSelected(u as User)}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -15,7 +15,6 @@ import {
   Skeleton,
 } from '@mui/material';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
-import { useTheme } from '@mui/material/styles';
 import dayjs, { Dayjs } from 'dayjs';
 import { useQuery } from '@tanstack/react-query';
 import type { VolunteerRole, Holiday } from '../../types';
@@ -24,17 +23,17 @@ import { getHolidays } from '../../api/bookings';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { formatTime } from '../../utils/time';
 
-function useVolunteerSlots(token: string, date: Dayjs, enabled: boolean) {
+function useVolunteerSlots(date: Dayjs, enabled: boolean) {
   const dateStr = date.format('YYYY-MM-DD');
   const { data, isFetching, refetch, error } = useQuery<VolunteerRole[]>({
     queryKey: ['volunteer-slots', dateStr],
-    queryFn: () => getVolunteerRolesForVolunteer(token, dateStr),
+    queryFn: () => getVolunteerRolesForVolunteer(dateStr),
     enabled,
   });
   return { slots: data ?? [], isLoading: isFetching, refetch, error };
 }
 
-export default function VolunteerBooking({ token }: { token: string }) {
+export default function VolunteerBooking() {
   const [date, setDate] = useState<Dayjs>(() => {
     let d = dayjs();
     while (d.day() === 0 || d.day() === 6) d = d.add(1, 'day');
@@ -51,7 +50,6 @@ export default function VolunteerBooking({ token }: { token: string }) {
     d.day() === 6 ||
     holidaySet.has(d.format('YYYY-MM-DD'));
   const { slots, isLoading, refetch, error } = useVolunteerSlots(
-    token,
     date,
     !isDisabled(date),
   );
@@ -61,7 +59,6 @@ export default function VolunteerBooking({ token }: { token: string }) {
     message: string;
     severity: 'success' | 'error';
   }>({ open: false, message: '', severity: 'success' });
-  const theme = useTheme();
   const slotsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -82,7 +79,7 @@ export default function VolunteerBooking({ token }: { token: string }) {
     if (!selected) return;
     setBooking(true);
     try {
-      await requestVolunteerBooking(token, selected.id, selected.date);
+      await requestVolunteerBooking(selected.id, selected.date);
       setSnackbar({ open: true, message: 'Request submitted', severity: 'success' });
       setSelected(null);
       refetch();

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
@@ -24,7 +24,7 @@ import {
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 
-export default function VolunteerBookingHistory({ token }: { token: string }) {
+export default function VolunteerBookingHistory() {
   const [history, setHistory] = useState<VolunteerBooking[]>([]);
   const [cancelBooking, setCancelBooking] =
     useState<VolunteerBooking | null>(null);
@@ -33,10 +33,10 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
   const [severity, setSeverity] = useState<AlertColor>('success');
 
   const loadHistory = useCallback(() => {
-    getMyVolunteerBookings(token)
+    getMyVolunteerBookings()
       .then(setHistory)
       .catch(() => {});
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     loadHistory();
@@ -54,7 +54,7 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
   async function handleCancel() {
     if (!cancelBooking) return;
     try {
-      await cancelVolunteerBooking(token, cancelBooking.id);
+      await cancelVolunteerBooking(cancelBooking.id);
       setSeverity('success');
       setMessage('Booking cancelled');
       loadHistory();
@@ -69,7 +69,7 @@ export default function VolunteerBookingHistory({ token }: { token: string }) {
   async function handleCancelSeries() {
     if (cancelSeriesId == null) return;
     try {
-      await cancelRecurringVolunteerBooking(token, cancelSeriesId);
+      await cancelRecurringVolunteerBooking(cancelSeriesId);
       setSeverity('success');
       setMessage('Series cancelled');
       loadHistory();

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -40,7 +40,7 @@ function formatDateLabel(dateStr: string) {
   });
 }
 
-export default function VolunteerDashboard({ token }: { token: string }) {
+export default function VolunteerDashboard() {
   const [bookings, setBookings] = useState<VolunteerBooking[]>([]);
   const [availability, setAvailability] = useState<VolunteerRole[]>([]);
   const [dateMode, setDateMode] = useState<'today' | 'week'>('today');
@@ -50,10 +50,10 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    getMyVolunteerBookings(token)
+    getMyVolunteerBookings()
       .then(setBookings)
       .catch(() => setBookings([]));
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     async function loadAvailability() {
@@ -70,7 +70,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
       for (const day of days) {
         const ds = formatRegina(day, 'yyyy-MM-dd');
         try {
-          const roles = await getVolunteerRolesForVolunteer(token, ds);
+          const roles = await getVolunteerRolesForVolunteer(ds);
           all.push(...roles);
         } catch {
           // ignore
@@ -79,7 +79,7 @@ export default function VolunteerDashboard({ token }: { token: string }) {
       setAvailability(all);
     }
     loadAvailability();
-  }, [token, dateMode]);
+  }, [dateMode]);
 
   const nextShift = useMemo(() => {
     const now = new Date();
@@ -110,12 +110,12 @@ export default function VolunteerDashboard({ token }: { token: string }) {
     return Array.from(map.entries());
   }, [availability]);
 
-  async function request(role: VolunteerRole) {
+async function request(role: VolunteerRole) {
     try {
-      await requestVolunteerBooking(token, role.id, role.date);
+      await requestVolunteerBooking(role.id, role.date);
       setSnackbarSeverity('success');
       setMessage('Request submitted');
-      const data = await getMyVolunteerBookings(token);
+      const data = await getMyVolunteerBookings();
       setBookings(data);
     } catch {
       setSnackbarSeverity('error');
@@ -126,10 +126,10 @@ export default function VolunteerDashboard({ token }: { token: string }) {
   async function cancelNext() {
     if (!nextShift) return;
     try {
-      await updateVolunteerBookingStatus(token, nextShift.id, 'cancelled');
+      await updateVolunteerBookingStatus(nextShift.id, 'cancelled');
       setSnackbarSeverity('success');
       setMessage('Booking cancelled');
-      const data = await getMyVolunteerBookings(token);
+      const data = await getMyVolunteerBookings();
       setBookings(data);
     } catch {
       setSnackbarSeverity('error');

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -43,7 +43,7 @@ import type { AlertColor } from '@mui/material';
 
 const reginaTimeZone = 'America/Regina';
 
-export default function VolunteerSchedule({ token }: { token: string }) {
+export default function VolunteerSchedule() {
   const [currentDate, setCurrentDate] = useState(() => {
     const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
     return fromZonedTime(`${todayStr}T00:00:00`, reginaTimeZone);
@@ -77,8 +77,8 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     const holiday = holidays.some(h => h.date === dateStr);
     try {
       const [roleData, bookingData] = await Promise.all([
-        getVolunteerRolesForVolunteer(token, dateStr),
-        getMyVolunteerBookings(token),
+        getVolunteerRolesForVolunteer(dateStr),
+        getMyVolunteerBookings(),
       ]);
       const disallowed = weekend || holiday
         ? ['Pantry', 'Warehouse', 'Administrative']
@@ -120,7 +120,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     } catch (err) {
       console.error(err);
     }
-  }, [currentDate, token, holidays]);
+  }, [currentDate, holidays]);
 
   useEffect(() => {
     getHolidays().then(setHolidays).catch(() => {});
@@ -139,13 +139,11 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     try {
       if (frequency === 'one-time') {
         await requestVolunteerBooking(
-          token,
           requestRole.id,
           formatDate(currentDate),
         );
       } else {
         await createRecurringVolunteerBooking(
-          token,
           requestRole.id,
           formatDate(currentDate),
           frequency,
@@ -174,7 +172,7 @@ export default function VolunteerSchedule({ token }: { token: string }) {
   async function cancelSelected() {
     if (!decisionBooking) return;
     try {
-      await cancelVolunteerBooking(token, decisionBooking.id);
+      await cancelVolunteerBooking(decisionBooking.id);
       setSnackbarSeverity('success');
       setMessage('Booking cancelled');
       await loadData();
@@ -191,7 +189,6 @@ export default function VolunteerSchedule({ token }: { token: string }) {
     if (!decisionBooking?.recurring_id) return;
     try {
       await cancelRecurringVolunteerBooking(
-        token,
         decisionBooking.recurring_id,
       );
       setSnackbarSeverity('success');

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -84,7 +84,7 @@ function kpiDelta(curr: number, prev?: number) {
 export default function WarehouseDashboard() {
   const theme = useTheme();
   const navigate = useNavigate();
-  const { token, id } = useAuth();
+  const { id } = useAuth();
   const searchRef = useRef<HTMLInputElement>(null);
   const [years, setYears] = useState<number[]>([]);
   const [year, setYear] = useState<number>();
@@ -94,7 +94,7 @@ export default function WarehouseDashboard() {
   const [donors, setDonors] = useState<TopDonor[]>([]);
   const [receivers, setReceivers] = useState<TopReceiver[]>([]);
   const [events, setEvents] = useState<EventGroups>({ today: [], upcoming: [], past: [] });
-  const [loadingTotals, setLoadingTotals] = useState(false);
+  const [, setLoadingTotals] = useState(false);
   const [loadingRebuild, setLoadingRebuild] = useState(false);
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -198,8 +198,6 @@ export default function WarehouseDashboard() {
   const currentTotals = totals.find(t => t.month === currentMonth);
   const prevTotals = totals.find(t => t.month === currentMonth - 1);
 
-  const incoming = currentTotals?.donationsLbs ?? 0;
-  const prevIncoming = prevTotals?.donationsLbs ?? 0;
   const totalIncoming =
     (currentTotals?.donationsLbs ?? 0) +
     (currentTotals?.surplusLbs ?? 0) +
@@ -255,8 +253,9 @@ export default function WarehouseDashboard() {
       await rebuildWarehouseOverall(year!);
       setSnackbar({ open: true, message: 'Rebuilt aggregates' });
       loadData(year!);
-    } catch (err: any) {
-      setSnackbar({ open: true, message: err.message || 'Rebuild failed', severity: 'error' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Rebuild failed';
+      setSnackbar({ open: true, message, severity: 'error' });
     } finally {
       setLoadingRebuild(false);
     }
@@ -534,7 +533,7 @@ export default function WarehouseDashboard() {
             </Stack>
           </CardContent>
         </Card>
-        <VolunteerCoverageCard token={token} masterRoleFilter={['Warehouse']} />
+        <VolunteerCoverageCard masterRoleFilter={['Warehouse']} />
       </Box>
 
       <Card variant="outlined" sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- drop unused `_token` args from user and volunteer API helpers
- update components, hooks, and tests to call new signatures
- strip token plumbing from dashboard and pantry flows

## Testing
- `npm run lint` *(fails: Unexpected any & other eslint errors in existing code)*
- `npm test` *(fails: TypeScript compile errors and failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9ed8e1b8832d82c9b1dd81012e6f