### PR TITLE
Add lunch break to pantry schedule

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -206,6 +206,20 @@ export default function PantrySchedule({
   for (const s of slots) {
     displaySlots.push(s);
   }
+  if (
+    !isClosed &&
+    !displaySlots.some(
+      s => s.startTime === '12:00:00' || s.startTime === '12:30:00',
+    )
+  ) {
+    displaySlots.push({
+      id: 'lunch-break',
+      startTime: '12:00:00',
+      endTime: '13:00:00',
+      status: 'break',
+      reason: 'Lunch',
+    });
+  }
   displaySlots.sort((a, b) => a.startTime.localeCompare(b.startTime));
 
   const rows = displaySlots.map(slot => {


### PR DESCRIPTION
## Summary
- show 12–1PM as a dedicated break in the pantry schedule

## Testing
- `CI=true npm test` *(fails: property 'toBeInTheDocument' not found, worker process failed to exit)*

------
https://chatgpt.com/codex/tasks/task_e_68aea3b23a2c832d95cb4fbc3576916f