### PR TITLE
feat: add reusable tab component

### DIFF
--- a/MJ_FB_Frontend/src/components/SectionTabs.tsx
+++ b/MJ_FB_Frontend/src/components/SectionTabs.tsx
@@ -1,0 +1,53 @@
+import { Box, Tabs, Tab } from '@mui/material';
+import { useState, type ReactNode, type ReactElement } from 'react';
+
+interface TabItem {
+  label: string;
+  icon?: ReactElement;
+  content: ReactNode;
+}
+
+interface SectionTabsProps {
+  tabs: TabItem[];
+  ariaLabel: string;
+}
+
+export default function SectionTabs({ tabs, ariaLabel }: SectionTabsProps) {
+  const [value, setValue] = useState(0);
+
+  const baseId = ariaLabel.replace(/\s+/g, '-');
+
+  return (
+    <Box>
+      <Tabs
+        value={value}
+        onChange={(_, v) => setValue(v)}
+        variant="scrollable"
+        scrollButtons="auto"
+        aria-label={ariaLabel}
+      >
+        {tabs.map((tab, i) => (
+          <Tab
+            key={tab.label}
+            label={tab.label}
+            icon={tab.icon}
+            iconPosition={tab.icon ? 'start' : undefined}
+            id={`${baseId}-tab-${i}`}
+            aria-controls={`${baseId}-tabpanel-${i}`}
+          />
+        ))}
+      </Tabs>
+      {tabs.map((tab, i) => (
+        <div
+          key={tab.label}
+          role="tabpanel"
+          hidden={value !== i}
+          id={`${baseId}-tabpanel-${i}`}
+          aria-labelledby={`${baseId}-tab-${i}`}
+        >
+          {value === i && <Box sx={{ pt: 2 }}>{tab.content}</Box>}
+        </div>
+      ))}
+    </Box>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -2,8 +2,6 @@ import { useState } from 'react';
 import {
   Box,
   Paper,
-  Tabs,
-  Tab,
   Grid,
   Card,
   CardHeader,
@@ -31,25 +29,7 @@ import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import type { AlertColor } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-
-interface TabPanelProps {
-  children?: React.ReactNode;
-  value: number;
-  index: number;
-}
-
-function TabPanel({ children, value, index }: TabPanelProps) {
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`availability-tabpanel-${index}`}
-      aria-labelledby={`availability-tab-${index}`}
-    >
-      {value === index && <Box sx={{ pt: 2 }}>{children}</Box>}
-    </div>
-  );
-}
+import SectionTabs from '../../components/SectionTabs';
 
 const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const weekOrdinals = ['1st', '2nd', '3rd', '4th', '5th'];
@@ -83,8 +63,6 @@ interface BreakItem {
 }
 
 export default function ManageAvailability() {
-  const [tab, setTab] = useState(0);
-
   const [holidays, setHolidays] = useState<HolidayItem[]>([]);
   const [holidayDate, setHolidayDate] = useState<Date | null>(new Date());
   const [holidayReason, setHolidayReason] = useState('');
@@ -183,220 +161,92 @@ export default function ManageAvailability() {
 
   const slotLabel = (id: number) => slotOptions.find(s => s.id === id)?.label || id;
 
-  return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box sx={{ maxWidth: 1000, mx: 'auto', pb: 6 }}>
-        <Typography variant="h4" fontWeight={800} gutterBottom>
-          Manage Availability
-        </Typography>
-        <Paper sx={{ p: 2 }}>
-          <Tabs
-            value={tab}
-            onChange={(_, v) => setTab(v)}
-            variant="scrollable"
-            scrollButtons="auto"
-            aria-label="availability tabs"
-          >
-            <Tab icon={<EventBusy />} iconPosition="start" label="Holidays" id="availability-tab-0" />
-            <Tab icon={<Block />} iconPosition="start" label="Blocked Slots" id="availability-tab-1" />
-            <Tab icon={<Restaurant />} iconPosition="start" label="Staff Breaks" id="availability-tab-2" />
-          </Tabs>
-
-          <TabPanel value={tab} index={0}>
-            <Card sx={{ borderRadius: 3 }}>
-              <CardHeader title="Add Holiday" />
-              <CardContent>
+  const tabs = [
+    {
+      label: 'Holidays',
+      icon: <EventBusy />,
+      content: (
+        <Card sx={{ borderRadius: 3 }}>
+          <CardHeader title="Add Holiday" />
+          <CardContent>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={4}>
+                <DatePicker
+                  label="Date"
+                  value={holidayDate}
+                  onChange={setHolidayDate}
+                  slotProps={{ textField: { fullWidth: true } }}
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="Reason"
+                  value={holidayReason}
+                  onChange={(e) => setHolidayReason(e.target.value)}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12} sm={2}>
+                <Button
+                  fullWidth
+                  variant="contained"
+                  size="small"
+                  startIcon={<Add />}
+                  onClick={handleAddHoliday}
+                >
+                  Add
+                </Button>
+              </Grid>
+            </Grid>
+          </CardContent>
+          <Divider />
+          <List>
+            {holidays.map(h => (
+              <ListItem
+                key={h.id}
+                secondaryAction={
+                  <Tooltip title="Remove">
+                    <IconButton aria-label="remove" onClick={() => handleRemoveHoliday(h.id)}>
+                      <DeleteOutline />
+                    </IconButton>
+                  </Tooltip>
+                }
+              >
+                <ListItemText primary={h.date.toLocaleDateString()} />
+                {h.reason && <Chip label={h.reason} sx={{ ml: 1 }} />}
+              </ListItem>
+            ))}
+            {holidays.length === 0 && (
+              <ListItem>
+                <ListItemText primary="No holidays" />
+              </ListItem>
+            )}
+          </List>
+        </Card>
+      ),
+    },
+    {
+      label: 'Blocked Slots',
+      icon: <Block />,
+      content: (
+        <Card sx={{ borderRadius: 3 }}>
+          <CardHeader title="Block Slot" />
+          <CardContent>
+            <Stack spacing={2}>
+              <FormControlLabel
+                control={<Checkbox checked={isRecurring} onChange={(e) => setIsRecurring(e.target.checked)} />}
+                label="Recurring"
+              />
+              {isRecurring ? (
                 <Grid container spacing={2}>
-                  <Grid item xs={12} sm={4}>
-                    <DatePicker
-                      label="Date"
-                      value={holidayDate}
-                      onChange={setHolidayDate}
-                      slotProps={{ textField: { fullWidth: true } }}
-                    />
-                  </Grid>
                   <Grid item xs={12} sm={6}>
-                    <TextField
-                      label="Reason"
-                      value={holidayReason}
-                      onChange={(e) => setHolidayReason(e.target.value)}
-                      fullWidth
-                    />
-                  </Grid>
-                  <Grid item xs={12} sm={2}>
-                    <Button
-                      fullWidth
-                      variant="contained"
-                      size="small"
-                      startIcon={<Add />}
-                      onClick={handleAddHoliday}
-                    >
-                      Add
-                    </Button>
-                  </Grid>
-                </Grid>
-              </CardContent>
-              <Divider />
-              <List>
-                {holidays.map(h => (
-                  <ListItem
-                    key={h.id}
-                    secondaryAction={
-                      <Tooltip title="Remove">
-                        <IconButton aria-label="remove" onClick={() => handleRemoveHoliday(h.id)}>
-                          <DeleteOutline />
-                        </IconButton>
-                      </Tooltip>
-                    }
-                  >
-                    <ListItemText primary={h.date.toLocaleDateString()} />
-                    {h.reason && <Chip label={h.reason} sx={{ ml: 1 }} />}
-                  </ListItem>
-                ))}
-                {holidays.length === 0 && (
-                  <ListItem>
-                    <ListItemText primary="No holidays" />
-                  </ListItem>
-                )}
-              </List>
-            </Card>
-          </TabPanel>
-
-          <TabPanel value={tab} index={1}>
-            <Card sx={{ borderRadius: 3 }}>
-              <CardHeader title="Block Slot" />
-              <CardContent>
-                <Stack spacing={2}>
-                  <FormControlLabel
-                    control={<Checkbox checked={isRecurring} onChange={(e) => setIsRecurring(e.target.checked)} />}
-                    label="Recurring"
-                  />
-                  {isRecurring ? (
-                    <Grid container spacing={2}>
-                      <Grid item xs={12} sm={6}>
-                        <FormControl fullWidth sx={{ minWidth: 200 }}>
-                          <InputLabel id="blocked-day-label">Day</InputLabel>
-                          <Select
-                            labelId="blocked-day-label"
-                            value={blockedDay}
-                            label="Day"
-                            onChange={(e) => setBlockedDay(e.target.value)}
-                            MenuProps={selectMenuProps}
-                          >
-                            {days.map((d, i) => (
-                              <MenuItem key={d} value={i}>
-                                {d}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </Grid>
-                      <Grid item xs={12} sm={6}>
-                        <FormControl fullWidth sx={{ minWidth: 200 }}>
-                          <InputLabel id="blocked-week-label">Week</InputLabel>
-                          <Select
-                            labelId="blocked-week-label"
-                            value={blockedWeek}
-                            label="Week"
-                            onChange={(e) => setBlockedWeek(e.target.value)}
-                            MenuProps={selectMenuProps}
-                          >
-                            {weekOrdinals.map((w, i) => (
-                              <MenuItem key={w} value={i + 1}>
-                                {w}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </Grid>
-                    </Grid>
-                  ) : (
-                    <DatePicker
-                      label="Date"
-                      value={blockedDate}
-                      onChange={setBlockedDate}
-                      slotProps={{ textField: { fullWidth: true } }}
-                    />
-                  )}
-                  <FormControl fullWidth>
-                    <InputLabel id="slot-label">Slot</InputLabel>
-                    <Select
-                      labelId="slot-label"
-                      value={blockedSlotId}
-                      label="Slot"
-                      onChange={(e) => setBlockedSlotId(e.target.value)}
-                      MenuProps={selectMenuProps}
-                    >
-                      {slotOptions.map((s) => (
-                        <MenuItem key={s.id} value={s.id}>
-                          {s.label}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                  <TextField
-                    label="Reason"
-                    value={blockedReason}
-                    onChange={(e) => setBlockedReason(e.target.value)}
-                    fullWidth
-                  />
-                  <Button
-                    variant="contained"
-                    size="small"
-                    startIcon={<Add />}
-                    onClick={handleAddBlocked}
-                    sx={{ alignSelf: 'flex-start' }}
-                  >
-                    Add
-                  </Button>
-                </Stack>
-              </CardContent>
-              <Divider />
-              <List>
-                {blockedSlots.map(b => (
-                  <ListItem
-                    key={b.id}
-                    secondaryAction={
-                      <Tooltip title="Remove">
-                        <IconButton aria-label="remove" onClick={() => handleRemoveBlocked(b.id)}>
-                          <DeleteOutline />
-                        </IconButton>
-                      </Tooltip>
-                    }
-                  >
-                    <ListItemText
-                      primary={
-                        b.date
-                          ? b.date.toLocaleDateString()
-                          : `${weekOrdinals[(b.week || 1) - 1]} ${days[b.day || 0]}`
-                      }
-                      secondary={slotLabel(b.slotId)}
-                    />
-                    {b.reason && <Chip label={b.reason} sx={{ ml: 1 }} />}
-                  </ListItem>
-                ))}
-                {blockedSlots.length === 0 && (
-                  <ListItem>
-                    <ListItemText primary="No blocked slots" />
-                  </ListItem>
-                )}
-              </List>
-            </Card>
-          </TabPanel>
-
-          <TabPanel value={tab} index={2}>
-            <Card sx={{ borderRadius: 3 }}>
-              <CardHeader title="Staff Breaks" />
-              <CardContent>
-                <Grid container spacing={2}>
-                  <Grid item xs={12} sm={4}>
                     <FormControl fullWidth sx={{ minWidth: 200 }}>
-                      <InputLabel id="break-day-label">Day</InputLabel>
+                      <InputLabel id="blocked-day-label">Day</InputLabel>
                       <Select
-                        labelId="break-day-label"
-                        value={breakDay}
+                        labelId="blocked-day-label"
+                        value={blockedDay}
                         label="Day"
-                        onChange={(e) => setBreakDay(e.target.value)}
+                        onChange={(e) => setBlockedDay(e.target.value)}
                         MenuProps={selectMenuProps}
                       >
                         {days.map((d, i) => (
@@ -407,69 +257,198 @@ export default function ManageAvailability() {
                       </Select>
                     </FormControl>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
+                  <Grid item xs={12} sm={6}>
                     <FormControl fullWidth sx={{ minWidth: 200 }}>
-                      <InputLabel id="break-slot-label">Slot</InputLabel>
+                      <InputLabel id="blocked-week-label">Week</InputLabel>
                       <Select
-                        labelId="break-slot-label"
-                        value={breakSlotId}
-                        label="Slot"
-                        onChange={(e) => setBreakSlotId(e.target.value)}
+                        labelId="blocked-week-label"
+                        value={blockedWeek}
+                        label="Week"
+                        onChange={(e) => setBlockedWeek(e.target.value)}
                         MenuProps={selectMenuProps}
                       >
-                        {slotOptions.map(s => (
-                          <MenuItem key={s.id} value={s.id}>
-                            {s.label}
+                        {weekOrdinals.map((w, i) => (
+                          <MenuItem key={w} value={i + 1}>
+                            {w}
                           </MenuItem>
                         ))}
                       </Select>
                     </FormControl>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
-                    <TextField
-                      label="Reason"
-                      value={breakReason}
-                      onChange={(e) => setBreakReason(e.target.value)}
-                      fullWidth
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <Button
-                      variant="contained"
-                      size="small"
-                      startIcon={<Add />}
-                      onClick={handleAddBreak}
-                    >
-                      Add
-                    </Button>
-                  </Grid>
                 </Grid>
-              </CardContent>
-              <Divider />
-              <List>
-                {breaks.map(b => (
-                  <ListItem
-                    key={b.id}
-                    secondaryAction={
-                      <Tooltip title="Remove">
-                        <IconButton aria-label="remove" onClick={() => handleRemoveBreak(b.id)}>
-                          <DeleteOutline />
-                        </IconButton>
-                      </Tooltip>
-                    }
+              ) : (
+                <DatePicker
+                  label="Date"
+                  value={blockedDate}
+                  onChange={setBlockedDate}
+                  slotProps={{ textField: { fullWidth: true } }}
+                />
+              )}
+              <FormControl fullWidth>
+                <InputLabel id="slot-label">Slot</InputLabel>
+                <Select
+                  labelId="slot-label"
+                  value={blockedSlotId}
+                  label="Slot"
+                  onChange={(e) => setBlockedSlotId(e.target.value)}
+                  MenuProps={selectMenuProps}
+                >
+                  {slotOptions.map((s) => (
+                    <MenuItem key={s.id} value={s.id}>
+                      {s.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <TextField
+                label="Reason"
+                value={blockedReason}
+                onChange={(e) => setBlockedReason(e.target.value)}
+                fullWidth
+              />
+              <Button
+                variant="contained"
+                size="small"
+                startIcon={<Add />}
+                onClick={handleAddBlocked}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                Add
+              </Button>
+            </Stack>
+          </CardContent>
+          <Divider />
+          <List>
+            {blockedSlots.map(b => (
+              <ListItem
+                key={b.id}
+                secondaryAction={
+                  <Tooltip title="Remove">
+                    <IconButton aria-label="remove" onClick={() => handleRemoveBlocked(b.id)}>
+                      <DeleteOutline />
+                    </IconButton>
+                  </Tooltip>
+                }
+              >
+                <ListItemText
+                  primary={
+                    b.date
+                      ? b.date.toLocaleDateString()
+                      : `${weekOrdinals[(b.week || 1) - 1]} ${days[b.day || 0]}`
+                  }
+                  secondary={slotLabel(b.slotId)}
+                />
+                {b.reason && <Chip label={b.reason} sx={{ ml: 1 }} />}
+              </ListItem>
+            ))}
+            {blockedSlots.length === 0 && (
+              <ListItem>
+                <ListItemText primary="No blocked slots" />
+              </ListItem>
+            )}
+          </List>
+        </Card>
+      ),
+    },
+    {
+      label: 'Staff Breaks',
+      icon: <Restaurant />,
+      content: (
+        <Card sx={{ borderRadius: 3 }}>
+          <CardHeader title="Staff Breaks" />
+          <CardContent>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={4}>
+                <FormControl fullWidth sx={{ minWidth: 200 }}>
+                  <InputLabel id="break-day-label">Day</InputLabel>
+                  <Select
+                    labelId="break-day-label"
+                    value={breakDay}
+                    label="Day"
+                    onChange={(e) => setBreakDay(e.target.value)}
+                    MenuProps={selectMenuProps}
                   >
-                    <ListItemText primary={`${days[b.day]} - ${slotLabel(b.slotId)}`} />
-                    {b.reason && <Chip label={b.reason} sx={{ ml: 1 }} />}
-                  </ListItem>
-                ))}
-                {breaks.length === 0 && (
-                  <ListItem>
-                    <ListItemText primary="No breaks" />
-                  </ListItem>
-                )}
-              </List>
-            </Card>
-          </TabPanel>
+                    {days.map((d, i) => (
+                      <MenuItem key={d} value={i}>
+                        {d}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <FormControl fullWidth sx={{ minWidth: 200 }}>
+                  <InputLabel id="break-slot-label">Slot</InputLabel>
+                  <Select
+                    labelId="break-slot-label"
+                    value={breakSlotId}
+                    label="Slot"
+                    onChange={(e) => setBreakSlotId(e.target.value)}
+                    MenuProps={selectMenuProps}
+                  >
+                    {slotOptions.map(s => (
+                      <MenuItem key={s.id} value={s.id}>
+                        {s.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <TextField
+                  label="Reason"
+                  value={breakReason}
+                  onChange={(e) => setBreakReason(e.target.value)}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Button
+                  variant="contained"
+                  size="small"
+                  startIcon={<Add />}
+                  onClick={handleAddBreak}
+                >
+                  Add
+                </Button>
+              </Grid>
+            </Grid>
+          </CardContent>
+          <Divider />
+          <List>
+            {breaks.map(b => (
+              <ListItem
+                key={b.id}
+                secondaryAction={
+                  <Tooltip title="Remove">
+                    <IconButton aria-label="remove" onClick={() => handleRemoveBreak(b.id)}>
+                      <DeleteOutline />
+                    </IconButton>
+                  </Tooltip>
+                }
+              >
+                <ListItemText primary={`${days[b.day]} - ${slotLabel(b.slotId)}`} />
+                {b.reason && <Chip label={b.reason} sx={{ ml: 1 }} />}
+              </ListItem>
+            ))}
+            {breaks.length === 0 && (
+              <ListItem>
+                <ListItemText primary="No breaks" />
+              </ListItem>
+            )}
+          </List>
+        </Card>
+      ),
+    },
+  ];
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box sx={{ maxWidth: 1000, mx: 'auto', pb: 6 }}>
+        <Typography variant="h4" fontWeight={800} gutterBottom>
+          Manage Availability
+        </Typography>
+        <Paper sx={{ p: 2 }}>
+          <SectionTabs ariaLabel="availability tabs" tabs={tabs} />
         </Paper>
         <FeedbackSnackbar
           open={snackbar.open}


### PR DESCRIPTION
## Summary
- extract tab UI into reusable `SectionTabs` component for consistent styling
- refactor Manage Availability page to leverage the new tab component

## Testing
- `npm test` (fails: Test Suites: 8 failed, 5 passed)


------
https://chatgpt.com/codex/tasks/task_e_68aea4027d00832dadab4967a228d5b9