### PR TITLE
feat(frontend): add reusable form component

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/FormCard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/FormCard.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import FormCard from '../components/FormCard';
+
+describe('FormCard', () => {
+  it('renders title inside form element', () => {
+    const { getByText, container } = render(
+      <FormCard title="Test" onSubmit={() => {}}>
+        <div />
+      </FormCard>,
+    );
+    const form = container.querySelector('form');
+    expect(form).toBeTruthy();
+    const titleEl = getByText('Test');
+    expect(form?.contains(titleEl)).toBe(true);
+  });
+});

--- a/MJ_FB_Frontend/src/components/FormCard.tsx
+++ b/MJ_FB_Frontend/src/components/FormCard.tsx
@@ -1,0 +1,25 @@
+import { Box, Paper, Stack, Typography, type PaperProps } from '@mui/material';
+import type { FormEvent, ReactNode } from 'react';
+
+interface FormCardProps extends Omit<PaperProps<'form'>, 'onSubmit'> {
+  title: string;
+  children: ReactNode;
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void;
+  actions?: ReactNode;
+}
+
+export default function FormCard({ title, children, onSubmit, actions, ...paperProps }: FormCardProps) {
+  return (
+    <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+      <Paper component="form" onSubmit={onSubmit} sx={{ p: 3, width: '100%', maxWidth: 400 }} {...paperProps}>
+        <Stack spacing={2}>
+          <Typography variant="h5" textAlign="center">
+            {title}
+          </Typography>
+          {children}
+          {actions && <Box>{actions}</Box>}
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add `FormCard` component for consistent form layout
- test that `FormCard` renders its title inside the form

## Testing
- `npm test` (fails: TS config and other existing tests)

------
https://chatgpt.com/codex/tasks/task_e_68aea44dc528832db6aa142287156a71