### PR TITLE
feat: add reusable styled tabs component

### DIFF
--- a/MJ_FB_Frontend/src/components/StyledTabs.tsx
+++ b/MJ_FB_Frontend/src/components/StyledTabs.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Paper, Tabs, Tab, Box, type SxProps, type Theme } from '@mui/material';
+
+export interface TabItem {
+  label: string;
+  icon?: React.ReactNode;
+  content: React.ReactNode;
+}
+
+interface StyledTabsProps {
+  tabs: TabItem[];
+  value?: number;
+  onChange?: (event: React.SyntheticEvent, newValue: number) => void;
+  sx?: SxProps<Theme>;
+}
+
+export default function StyledTabs({ tabs, value: valueProp, onChange, sx }: StyledTabsProps) {
+  const [internal, setInternal] = useState(0);
+  const value = valueProp ?? internal;
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    onChange?.(event, newValue);
+    if (valueProp === undefined) setInternal(newValue);
+  };
+
+  return (
+    <Paper sx={{ p: 2, ...(sx as object) }}>
+      <Tabs
+        value={value}
+        onChange={handleChange}
+        variant="scrollable"
+        scrollButtons="auto"
+        aria-label="styled tabs"
+      >
+        {tabs.map((t, i) => (
+          <Tab
+            key={i}
+            label={t.label}
+            icon={t.icon}
+            iconPosition={t.icon ? 'start' : undefined}
+            id={`tab-${i}`}
+            aria-controls={`tabpanel-${i}`}
+          />
+        ))}
+      </Tabs>
+      {tabs.map((t, i) => (
+        <div
+          key={i}
+          role="tabpanel"
+          hidden={value !== i}
+          id={`tabpanel-${i}`}
+          aria-labelledby={`tab-${i}`}
+        >
+          {value === i && <Box sx={{ pt: 2 }}>{t.content}</Box>}
+        </div>
+      ))}
+    </Paper>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Grid, Tabs, Tab } from '@mui/material';
+import StyledTabs from '../../components/StyledTabs';
 import { useSearchParams } from 'react-router-dom';
 import AddClient from './client-management/AddClient';
 import UpdateClientData from './client-management/UpdateClientData';
@@ -8,43 +8,29 @@ import UserHistory from './client-management/UserHistory';
 export default function ClientManagement() {
   const [searchParams] = useSearchParams();
   const initial = searchParams.get('tab');
-  const [value, setValue] = useState<'add' | 'update' | 'history'>(
-    initial === 'update' || initial === 'history' ? (initial as 'update' | 'history') : 'add'
-  );
+  const [tab, setTab] = useState(() => {
+    switch (initial) {
+      case 'update':
+        return 1;
+      case 'history':
+        return 2;
+      default:
+        return 0;
+    }
+  });
 
   useEffect(() => {
-    const tab = searchParams.get('tab');
-    if (tab === 'add' || tab === 'update' || tab === 'history') {
-      setValue(tab);
-    }
+    const t = searchParams.get('tab');
+    if (t === 'update') setTab(1);
+    else if (t === 'history') setTab(2);
+    else setTab(0);
   }, [searchParams]);
+  const tabs = [
+    { label: 'Add', content: <AddClient /> },
+    { label: 'Update', content: <UpdateClientData /> },
+    { label: 'History', content: <UserHistory /> },
+  ];
 
-  const renderContent = () => {
-    switch (value) {
-      case 'update':
-        return <UpdateClientData />;
-      case 'history':
-        return <UserHistory />;
-      default:
-        return <AddClient />;
-    }
-  };
-
-  return (
-    <Grid container spacing={2} direction="column">
-      <Grid item xs={12}>
-        <Tabs
-          value={value}
-          onChange={(_, newValue: 'add' | 'update' | 'history') => setValue(newValue)}
-          aria-label="client management tabs"
-        >
-          <Tab label="Add" value="add" />
-          <Tab label="Update" value="update" />
-          <Tab label="History" value="history" />
-        </Tabs>
-      </Grid>
-      <Grid item xs={12}>{renderContent()}</Grid>
-    </Grid>
-  );
+  return <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />;
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
   Box,
-  Paper,
-  Tabs,
-  Tab,
   Grid,
   Card,
   CardHeader,
@@ -31,28 +28,10 @@ import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import type { AlertColor } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import StyledTabs, { type TabItem } from '../../components/StyledTabs';
 import { getAllSlots } from '../../api/bookings';
 import { formatTime } from '../../utils/time';
 import type { Slot } from '../../types';
-
-interface TabPanelProps {
-  children?: React.ReactNode;
-  value: number;
-  index: number;
-}
-
-function TabPanel({ children, value, index }: TabPanelProps) {
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`availability-tabpanel-${index}`}
-      aria-labelledby={`availability-tab-${index}`}
-    >
-      {value === index && <Box sx={{ pt: 2 }}>{children}</Box>}
-    </div>
-  );
-}
 
 const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const weekOrdinals = ['1st', '2nd', '3rd', '4th', '5th'];
@@ -81,8 +60,6 @@ interface BreakItem {
 }
 
 export default function ManageAvailability() {
-  const [tab, setTab] = useState(0);
-
   const [holidays, setHolidays] = useState<HolidayItem[]>([]);
   const [holidayDate, setHolidayDate] = useState<Date | null>(new Date());
   const [holidayReason, setHolidayReason] = useState('');
@@ -197,221 +174,92 @@ export default function ManageAvailability() {
     setBreaks(prev => prev.filter(b => b.id !== id));
     showSnackbar('Break removed', 'error');
   };
-
-  return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box sx={{ maxWidth: 1000, mx: 'auto', pb: 6 }}>
-        <Typography variant="h4" fontWeight={800} gutterBottom>
-          Manage Availability
-        </Typography>
-        <Paper sx={{ p: 2 }}>
-          <Tabs
-            value={tab}
-            onChange={(_, v) => setTab(v)}
-            variant="scrollable"
-            scrollButtons="auto"
-            aria-label="availability tabs"
-          >
-            <Tab icon={<EventBusy />} iconPosition="start" label="Holidays" id="availability-tab-0" />
-            <Tab icon={<Block />} iconPosition="start" label="Blocked Slots" id="availability-tab-1" />
-            <Tab icon={<Restaurant />} iconPosition="start" label="Staff Breaks" id="availability-tab-2" />
-          </Tabs>
-
-          <TabPanel value={tab} index={0}>
-            <Card sx={{ borderRadius: 3 }}>
-              <CardHeader title="Add Holiday" />
-              <CardContent>
+  const tabs: TabItem[] = [
+    {
+      label: 'Holidays',
+      icon: <EventBusy />,
+      content: (
+        <Card sx={{ borderRadius: 3 }}>
+          <CardHeader title="Add Holiday" />
+          <CardContent>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={4}>
+                <DatePicker
+                  label="Date"
+                  value={holidayDate}
+                  onChange={setHolidayDate}
+                  slotProps={{ textField: { fullWidth: true } }}
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="Reason"
+                  value={holidayReason}
+                  onChange={(e) => setHolidayReason(e.target.value)}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12} sm={2}>
+                <Button
+                  fullWidth
+                  variant="contained"
+                  size="small"
+                  startIcon={<Add />}
+                  onClick={handleAddHoliday}
+                >
+                  Add
+                </Button>
+              </Grid>
+            </Grid>
+          </CardContent>
+          <Divider />
+          <List>
+            {holidays.map(h => (
+              <ListItem
+                key={h.id}
+                secondaryAction={
+                  <Tooltip title="Remove">
+                    <IconButton aria-label="remove" onClick={() => handleRemoveHoliday(h.id)}>
+                      <DeleteOutline />
+                    </IconButton>
+                  </Tooltip>
+                }
+              >
+                <ListItemText primary={h.date.toLocaleDateString()} />
+                {h.reason && <Chip label={h.reason} sx={{ ml: 1 }} />}
+              </ListItem>
+            ))}
+            {holidays.length === 0 && (
+              <ListItem>
+                <ListItemText primary="No holidays" />
+              </ListItem>
+            )}
+          </List>
+        </Card>
+      ),
+    },
+    {
+      label: 'Blocked Slots',
+      icon: <Block />,
+      content: (
+        <Card sx={{ borderRadius: 3 }}>
+          <CardHeader title="Block Slot" />
+          <CardContent>
+            <Stack spacing={2}>
+              <FormControlLabel
+                control={<Checkbox checked={isRecurring} onChange={(e) => setIsRecurring(e.target.checked)} />}
+                label="Recurring"
+              />
+              {isRecurring ? (
                 <Grid container spacing={2}>
-                  <Grid item xs={12} sm={4}>
-                    <DatePicker
-                      label="Date"
-                      value={holidayDate}
-                      onChange={setHolidayDate}
-                      slotProps={{ textField: { fullWidth: true } }}
-                    />
-                  </Grid>
                   <Grid item xs={12} sm={6}>
-                    <TextField
-                      label="Reason"
-                      value={holidayReason}
-                      onChange={(e) => setHolidayReason(e.target.value)}
-                      fullWidth
-                    />
-                  </Grid>
-                  <Grid item xs={12} sm={2}>
-                    <Button
-                      fullWidth
-                      variant="contained"
-                      size="small"
-                      startIcon={<Add />}
-                      onClick={handleAddHoliday}
-                    >
-                      Add
-                    </Button>
-                  </Grid>
-                </Grid>
-              </CardContent>
-              <Divider />
-              <List>
-                {holidays.map(h => (
-                  <ListItem
-                    key={h.id}
-                    secondaryAction={
-                      <Tooltip title="Remove">
-                        <IconButton aria-label="remove" onClick={() => handleRemoveHoliday(h.id)}>
-                          <DeleteOutline />
-                        </IconButton>
-                      </Tooltip>
-                    }
-                  >
-                    <ListItemText primary={h.date.toLocaleDateString()} />
-                    {h.reason && <Chip label={h.reason} sx={{ ml: 1 }} />}
-                  </ListItem>
-                ))}
-                {holidays.length === 0 && (
-                  <ListItem>
-                    <ListItemText primary="No holidays" />
-                  </ListItem>
-                )}
-              </List>
-            </Card>
-          </TabPanel>
-
-          <TabPanel value={tab} index={1}>
-            <Card sx={{ borderRadius: 3 }}>
-              <CardHeader title="Block Slot" />
-              <CardContent>
-                <Stack spacing={2}>
-                  <FormControlLabel
-                    control={<Checkbox checked={isRecurring} onChange={(e) => setIsRecurring(e.target.checked)} />}
-                    label="Recurring"
-                  />
-                  {isRecurring ? (
-                    <Grid container spacing={2}>
-                      <Grid item xs={12} sm={6}>
-                        <FormControl fullWidth sx={{ minWidth: 200 }}>
-                          <InputLabel id="blocked-day-label">Day</InputLabel>
-                          <Select
-                            labelId="blocked-day-label"
-                            value={blockedDay}
-                            label="Day"
-                            onChange={(e) => setBlockedDay(e.target.value)}
-                            MenuProps={selectMenuProps}
-                          >
-                            {days.map((d, i) => (
-                              <MenuItem key={d} value={i}>
-                                {d}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </Grid>
-                      <Grid item xs={12} sm={6}>
-                        <FormControl fullWidth sx={{ minWidth: 200 }}>
-                          <InputLabel id="blocked-week-label">Week</InputLabel>
-                          <Select
-                            labelId="blocked-week-label"
-                            value={blockedWeek}
-                            label="Week"
-                            onChange={(e) => setBlockedWeek(e.target.value)}
-                            MenuProps={selectMenuProps}
-                          >
-                            {weekOrdinals.map((w, i) => (
-                              <MenuItem key={w} value={i + 1}>
-                                {w}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </Grid>
-                    </Grid>
-                  ) : (
-                    <DatePicker
-                      label="Date"
-                      value={blockedDate}
-                      onChange={setBlockedDate}
-                      slotProps={{ textField: { fullWidth: true } }}
-                    />
-                  )}
-                  <FormControl fullWidth>
-                    <InputLabel id="slot-label">Slot</InputLabel>
-                    <Select
-                      labelId="slot-label"
-                      value={blockedSlotId}
-                      label="Slot"
-                      onChange={(e) => setBlockedSlotId(e.target.value)}
-                      MenuProps={selectMenuProps}
-                    >
-                      {slotOptions.map(s => (
-                        <MenuItem key={s.id} value={s.id}>
-                          {slotLabel(Number(s.id))}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                  <TextField
-                    label="Reason"
-                    value={blockedReason}
-                    onChange={(e) => setBlockedReason(e.target.value)}
-                    fullWidth
-                  />
-                  <Button
-                    variant="contained"
-                    size="small"
-                    startIcon={<Add />}
-                    onClick={handleAddBlocked}
-                    sx={{ alignSelf: 'flex-start' }}
-                  >
-                    Add
-                  </Button>
-                </Stack>
-              </CardContent>
-              <Divider />
-              <List>
-                {blockedSlots.map(b => (
-                  <ListItem
-                    key={b.id}
-                    secondaryAction={
-                      <Tooltip title="Remove">
-                        <IconButton aria-label="remove" onClick={() => handleRemoveBlocked(b.id)}>
-                          <DeleteOutline />
-                        </IconButton>
-                      </Tooltip>
-                    }
-                  >
-                    <ListItemText
-                      primary={
-                        b.date
-                          ? b.date.toLocaleDateString()
-                          : `${weekOrdinals[(b.week || 1) - 1]} ${days[b.day || 0]}`
-                      }
-                      secondary={slotLabel(b.slotId)}
-                    />
-                    {b.reason && <Chip label={b.reason} sx={{ ml: 1 }} />}
-                  </ListItem>
-                ))}
-                {blockedSlots.length === 0 && (
-                  <ListItem>
-                    <ListItemText primary="No blocked slots" />
-                  </ListItem>
-                )}
-              </List>
-            </Card>
-          </TabPanel>
-
-          <TabPanel value={tab} index={2}>
-            <Card sx={{ borderRadius: 3 }}>
-              <CardHeader title="Staff Breaks" />
-              <CardContent>
-                <Grid container spacing={2}>
-                  <Grid item xs={12} sm={4}>
                     <FormControl fullWidth sx={{ minWidth: 200 }}>
-                      <InputLabel id="break-day-label">Day</InputLabel>
+                      <InputLabel id="blocked-day-label">Day</InputLabel>
                       <Select
-                        labelId="break-day-label"
-                        value={breakDay}
+                        labelId="blocked-day-label"
+                        value={blockedDay}
                         label="Day"
-                        onChange={(e) => setBreakDay(e.target.value)}
+                        onChange={(e) => setBlockedDay(e.target.value)}
                         MenuProps={selectMenuProps}
                       >
                         {days.map((d, i) => (
@@ -422,70 +270,198 @@ export default function ManageAvailability() {
                       </Select>
                     </FormControl>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
+                  <Grid item xs={12} sm={6}>
                     <FormControl fullWidth sx={{ minWidth: 200 }}>
-                      <InputLabel id="break-slot-label">Slot</InputLabel>
+                      <InputLabel id="blocked-week-label">Week</InputLabel>
                       <Select
-                        labelId="break-slot-label"
-                        value={breakSlotId}
-                        label="Slot"
-                        onChange={(e) => setBreakSlotId(e.target.value)}
+                        labelId="blocked-week-label"
+                        value={blockedWeek}
+                        label="Week"
+                        onChange={(e) => setBlockedWeek(e.target.value)}
                         MenuProps={selectMenuProps}
                       >
-                        {slotOptions.map(s => (
-                          <MenuItem key={s.id} value={s.id}>
-                            {slotLabel(Number(s.id))}
+                        {weekOrdinals.map((w, i) => (
+                          <MenuItem key={w} value={i + 1}>
+                            {w}
                           </MenuItem>
                         ))}
                       </Select>
                     </FormControl>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
-                    <TextField
-                      label="Reason"
-                      value={breakReason}
-                      onChange={(e) => setBreakReason(e.target.value)}
-                      fullWidth
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <Button
-                      variant="contained"
-                      size="small"
-                      startIcon={<Add />}
-                      onClick={handleAddBreak}
-                    >
-                      Add
-                    </Button>
-                  </Grid>
                 </Grid>
-              </CardContent>
-              <Divider />
-              <List>
-                {breaks.map(b => (
-                  <ListItem
-                    key={b.id}
-                    secondaryAction={
-                      <Tooltip title="Remove">
-                        <IconButton aria-label="remove" onClick={() => handleRemoveBreak(b.id)}>
-                          <DeleteOutline />
-                        </IconButton>
-                      </Tooltip>
-                    }
+              ) : (
+                <DatePicker
+                  label="Date"
+                  value={blockedDate}
+                  onChange={setBlockedDate}
+                  slotProps={{ textField: { fullWidth: true } }}
+                />
+              )}
+              <FormControl fullWidth>
+                <InputLabel id="slot-label">Slot</InputLabel>
+                <Select
+                  labelId="slot-label"
+                  value={blockedSlotId}
+                  label="Slot"
+                  onChange={(e) => setBlockedSlotId(e.target.value)}
+                  MenuProps={selectMenuProps}
+                >
+                  {slotOptions.map(s => (
+                    <MenuItem key={s.id} value={s.id}>
+                      {slotLabel(Number(s.id))}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <TextField
+                label="Reason"
+                value={blockedReason}
+                onChange={(e) => setBlockedReason(e.target.value)}
+                fullWidth
+              />
+              <Button
+                variant="contained"
+                size="small"
+                startIcon={<Add />}
+                onClick={handleAddBlocked}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                Add
+              </Button>
+            </Stack>
+          </CardContent>
+          <Divider />
+          <List>
+            {blockedSlots.map(b => (
+              <ListItem
+                key={b.id}
+                secondaryAction={
+                  <Tooltip title="Remove">
+                    <IconButton aria-label="remove" onClick={() => handleRemoveBlocked(b.id)}>
+                      <DeleteOutline />
+                    </IconButton>
+                  </Tooltip>
+                }
+              >
+                <ListItemText
+                  primary={
+                    b.date
+                      ? b.date.toLocaleDateString()
+                      : `${weekOrdinals[(b.week || 1) - 1]} ${days[b.day || 0]}`
+                  }
+                  secondary={slotLabel(b.slotId)}
+                />
+                {b.reason && <Chip label={b.reason} sx={{ ml: 1 }} />}
+              </ListItem>
+            ))}
+            {blockedSlots.length === 0 && (
+              <ListItem>
+                <ListItemText primary="No blocked slots" />
+              </ListItem>
+            )}
+          </List>
+        </Card>
+      ),
+    },
+    {
+      label: 'Staff Breaks',
+      icon: <Restaurant />,
+      content: (
+        <Card sx={{ borderRadius: 3 }}>
+          <CardHeader title="Staff Breaks" />
+          <CardContent>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={4}>
+                <FormControl fullWidth sx={{ minWidth: 200 }}>
+                  <InputLabel id="break-day-label">Day</InputLabel>
+                  <Select
+                    labelId="break-day-label"
+                    value={breakDay}
+                    label="Day"
+                    onChange={(e) => setBreakDay(e.target.value)}
+                    MenuProps={selectMenuProps}
                   >
-                    <ListItemText primary={`${days[b.day]} - ${slotLabel(b.slotId)}`} />
-                    {b.reason && <Chip label={b.reason} sx={{ ml: 1 }} />}
-                  </ListItem>
-                ))}
-                {breaks.length === 0 && (
-                  <ListItem>
-                    <ListItemText primary="No breaks" />
-                  </ListItem>
-                )}
-              </List>
-            </Card>
-          </TabPanel>
-        </Paper>
+                    {days.map((d, i) => (
+                      <MenuItem key={d} value={i}>
+                        {d}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <FormControl fullWidth sx={{ minWidth: 200 }}>
+                  <InputLabel id="break-slot-label">Slot</InputLabel>
+                  <Select
+                    labelId="break-slot-label"
+                    value={breakSlotId}
+                    label="Slot"
+                    onChange={(e) => setBreakSlotId(e.target.value)}
+                    MenuProps={selectMenuProps}
+                  >
+                    {slotOptions.map(s => (
+                      <MenuItem key={s.id} value={s.id}>
+                        {slotLabel(Number(s.id))}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <TextField
+                  label="Reason"
+                  value={breakReason}
+                  onChange={(e) => setBreakReason(e.target.value)}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Button
+                  variant="contained"
+                  size="small"
+                  startIcon={<Add />}
+                  onClick={handleAddBreak}
+                >
+                  Add
+                </Button>
+              </Grid>
+            </Grid>
+          </CardContent>
+          <Divider />
+          <List>
+            {breaks.map(b => (
+              <ListItem
+                key={b.id}
+                secondaryAction={
+                  <Tooltip title="Remove">
+                    <IconButton aria-label="remove" onClick={() => handleRemoveBreak(b.id)}>
+                      <DeleteOutline />
+                    </IconButton>
+                  </Tooltip>
+                }
+              >
+                <ListItemText primary={`${days[b.day]} - ${slotLabel(b.slotId)}`} />
+                {b.reason && <Chip label={b.reason} sx={{ ml: 1 }} />}
+              </ListItem>
+            ))}
+            {breaks.length === 0 && (
+              <ListItem>
+                <ListItemText primary="No breaks" />
+              </ListItem>
+            )}
+          </List>
+        </Card>
+      ),
+    },
+  ];
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box sx={{ maxWidth: 1000, mx: 'auto', pb: 6 }}>
+        <Typography variant="h4" fontWeight={800} gutterBottom>
+          Manage Availability
+        </Typography>
+        <StyledTabs tabs={tabs} />
         <FeedbackSnackbar
           open={snackbar.open}
           message={snackbar.message}

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -6,8 +6,6 @@ import {
   DialogContent,
   DialogActions,
   TextField,
-  Tabs,
-  Tab,
   Table,
   TableHead,
   TableRow,
@@ -23,6 +21,7 @@ import {
 import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import StyledTabs from '../../components/StyledTabs';
 import {
   getClientVisits,
   createClientVisit,
@@ -174,6 +173,86 @@ export default function PantryVisits() {
     }
   }
 
+  const table = (
+    <TableContainer sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Date</TableCell>
+            <TableCell>Client ID</TableCell>
+            <TableCell>Client Name</TableCell>
+            <TableCell>Profile</TableCell>
+            <TableCell>Weight With Cart</TableCell>
+            <TableCell>Weight Without Cart</TableCell>
+            <TableCell>Pet Item</TableCell>
+            <TableCell align="right"></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {visits.map(v => (
+            <TableRow key={v.id}>
+              <TableCell>{formatDisplay(v.date)}</TableCell>
+              <TableCell>{v.clientId ?? 'N/A'}</TableCell>
+              <TableCell>{v.clientName ?? ''}</TableCell>
+              <TableCell>
+                {v.clientId ? (
+                  <a
+                    href={`https://portal.link2feed.ca/org/1605/intake/${v.clientId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Link
+                  </a>
+                ) : (
+                  'N/A'
+                )}
+              </TableCell>
+              <TableCell>{v.weightWithCart}</TableCell>
+              <TableCell>{v.weightWithoutCart}</TableCell>
+              <TableCell>{v.petItem}</TableCell>
+              <TableCell align="right">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setEditing(v);
+                    setForm({
+                      date: format(new Date(v.date)),
+                      anonymous: v.anonymous,
+                      clientId: v.clientId ? String(v.clientId) : '',
+                      weightWithCart: String(v.weightWithCart),
+                      weightWithoutCart: String(v.weightWithoutCart),
+                      petItem: String(v.petItem),
+                    });
+                    setAutoWeight(true);
+                    setRecordOpen(true);
+                  }}
+                  aria-label="Edit visit"
+                >
+                  <Edit fontSize="small" />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setToDelete(v);
+                    setDeleteOpen(true);
+                  }}
+                  aria-label="Delete visit"
+                >
+                  <Delete fontSize="small" />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  const tabs = weekDates.map(d => ({
+    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    content: table,
+  }));
+
   return (
     <Page
       title="Pantry Visits"
@@ -209,83 +288,7 @@ export default function PantryVisits() {
         </Stack>
       }
     >
-      <Tabs value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }}>
-        {weekDates.map((d, i) => (
-          <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
-        ))}
-      </Tabs>
-      <TableContainer sx={{ overflowX: 'auto' }}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Date</TableCell>
-              <TableCell>Client ID</TableCell>
-              <TableCell>Client Name</TableCell>
-              <TableCell>Profile</TableCell>
-              <TableCell>Weight With Cart</TableCell>
-              <TableCell>Weight Without Cart</TableCell>
-              <TableCell>Pet Item</TableCell>
-              <TableCell align="right"></TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {visits.map(v => (
-              <TableRow key={v.id}>
-                <TableCell>{formatDisplay(v.date)}</TableCell>
-                <TableCell>{v.clientId ?? 'N/A'}</TableCell>
-                <TableCell>{v.clientName ?? ''}</TableCell>
-                <TableCell>
-                  {v.clientId ? (
-                    <a
-                      href={`https://portal.link2feed.ca/org/1605/intake/${v.clientId}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Link
-                    </a>
-                  ) : (
-                    'N/A'
-                  )}
-                </TableCell>
-                <TableCell>{v.weightWithCart}</TableCell>
-                <TableCell>{v.weightWithoutCart}</TableCell>
-                <TableCell>{v.petItem}</TableCell>
-                <TableCell align="right">
-                  <IconButton
-                    size="small"
-                    onClick={() => {
-                      setEditing(v);
-                      setForm({
-                        date: format(new Date(v.date)),
-                        anonymous: v.anonymous,
-                        clientId: v.clientId ? String(v.clientId) : '',
-                        weightWithCart: String(v.weightWithCart),
-                        weightWithoutCart: String(v.weightWithoutCart),
-                        petItem: String(v.petItem),
-                      });
-                      setAutoWeight(true);
-                      setRecordOpen(true);
-                    }}
-                    aria-label="Edit visit"
-                  >
-                    <Edit fontSize="small" />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    onClick={() => {
-                      setToDelete(v);
-                      setDeleteOpen(true);
-                    }}
-                    aria-label="Delete visit"
-                  >
-                    <Delete fontSize="small" />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Visit' : 'Record Visit'}</DialogTitle>

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -12,8 +12,6 @@ import {
   MenuItem,
   Stack,
   CircularProgress,
-  Tabs,
-  Tab,
 } from '@mui/material';
 import Page from '../../components/Page';
 import {
@@ -23,6 +21,7 @@ import {
 } from '../../api/warehouseOverall';
 import { getDonorAggregations, type DonorAggregation } from '../../api/donations';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import StyledTabs from '../../components/StyledTabs';
 
 export default function Aggregations() {
   const [overallRows, setOverallRows] = useState<WarehouseOverall[]>([]);
@@ -118,155 +117,95 @@ export default function Aggregations() {
     { donations: 0, surplus: 0, pigPound: 0, outgoingDonations: 0 },
   );
 
-  return (
-    <Page title="Aggregations">
-      <Tabs value={tab} onChange={(_, newValue) => setTab(newValue)} sx={{ mb: 2 }}>
-        <Tab label="Donor Aggregations" />
-        <Tab label="Yearly Overall Aggregations" />
-      </Tabs>
-      {tab === 0 ? (
-        <>
-          <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-            <FormControl size="small" sx={{ minWidth: 120 }}>
-              <InputLabel id="donor-year-label">Year</InputLabel>
-              <Select
-                labelId="donor-year-label"
-                label="Year"
-                value={donorYear}
-                onChange={e => setDonorYear(Number(e.target.value))}
+  const donorContent = (
+    <>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel id="donor-year-label">Year</InputLabel>
+          <Select
+            labelId="donor-year-label"
+            label="Year"
+            value={donorYear}
+            onChange={e => setDonorYear(Number(e.target.value))}
+          >
+            {years.map(y => (
+              <MenuItem key={y} value={y}>
+                {y}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Stack>
+      <TableContainer sx={{ overflow: 'auto', maxHeight: 400 }}>
+        <Table size="small" stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell
+                sx={{
+                  position: 'sticky',
+                  left: 0,
+                  zIndex: 3,
+                  backgroundColor: 'background.paper',
+                }}
               >
-                {years.map(y => (
-                  <MenuItem key={y} value={y}>
-                    {y}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Stack>
-          <TableContainer sx={{ overflow: 'auto', maxHeight: 400 }}>
-            <Table size="small" stickyHeader>
-              <TableHead>
-                <TableRow>
-                  <TableCell
-                    sx={{
-                      position: 'sticky',
-                      left: 0,
-                      zIndex: 3,
-                      backgroundColor: 'background.paper',
-                    }}
-                  >
-                    Donor
-                  </TableCell>
-                  {monthNames.map((name, idx) => (
-                    <TableCell
-                      key={idx}
-                      align="right"
-                      sx={{
-                        top: 0,
-                        zIndex: 2,
-                        backgroundColor: 'background.paper',
-                      }}
-                    >
-                      {name}
-                    </TableCell>
-                  ))}
-                  <TableCell
-                    align="right"
-                    sx={{
-                      position: 'sticky',
-                      right: 0,
-                      top: 0,
-                      zIndex: 3,
-                      backgroundColor: 'background.paper',
-                    }}
-                  >
-                    Total
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {donorLoading ? (
-                  <TableRow>
-                    <TableCell colSpan={monthNames.length + 2} align="center">
-                      <CircularProgress size={24} />
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  (() => {
-                    const monthTotals = Array(12).fill(0);
-                    donorRows.forEach(d =>
-                      d.monthlyTotals.forEach((v, i) => {
-                        monthTotals[i] += v;
-                      }),
-                    );
-                    return (
-                      <>
-                        {donorRows.map(d => {
-                          const hasDonation = d.total > 0;
-                          return (
-                            <TableRow key={d.donor}>
-                              <TableCell
-                                sx={{
-                                  position: 'sticky',
-                                  left: 0,
-                                  zIndex: 2,
-                                  backgroundColor: 'background.paper',
-                                  fontWeight: hasDonation ? 'bold' : undefined,
-                                }}
-                              >
-                                {d.donor}
-                              </TableCell>
-                              {d.monthlyTotals.map((value, idx) => (
-                                <TableCell
-                                  key={idx}
-                                  align="right"
-                                  sx={{
-                                    fontWeight: value > 0 ? 'bold' : undefined,
-                                  }}
-                                >
-                                  {value}
-                                </TableCell>
-                              ))}
-                              <TableCell
-                                align="right"
-                                sx={{
-                                  position: 'sticky',
-                                  right: 0,
-                                  zIndex: 2,
-                                  backgroundColor: 'background.paper',
-                                  fontWeight: hasDonation ? 'bold' : undefined,
-                                }}
-                              >
-                                {d.total}
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                        <TableRow>
+                Donor
+              </TableCell>
+              {monthNames.map((name, idx) => (
+                <TableCell
+                  key={idx}
+                  align="right"
+                  sx={{ top: 0, zIndex: 2, backgroundColor: 'background.paper' }}
+                >
+                  {name}
+                </TableCell>
+              ))}
+              <TableCell
+                align="right"
+                sx={{ position: 'sticky', right: 0, top: 0, zIndex: 3, backgroundColor: 'background.paper' }}
+              >
+                Total
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {donorLoading ? (
+              <TableRow>
+                <TableCell colSpan={monthNames.length + 2} align="center">
+                  <CircularProgress size={24} />
+                </TableCell>
+              </TableRow>
+            ) : (
+              (() => {
+                const monthTotals = Array(12).fill(0);
+                donorRows.forEach(d =>
+                  d.monthlyTotals.forEach((v, i) => {
+                    monthTotals[i] += v;
+                  }),
+                );
+                return (
+                  <>
+                    {donorRows.map(d => {
+                      const hasDonation = d.total > 0;
+                      return (
+                        <TableRow key={d.donor}>
                           <TableCell
                             sx={{
                               position: 'sticky',
                               left: 0,
-                              bottom: 0,
-                              zIndex: 3,
+                              zIndex: 2,
                               backgroundColor: 'background.paper',
-                              fontWeight: 'bold',
+                              fontWeight: hasDonation ? 'bold' : undefined,
                             }}
                           >
-                            Total
+                            {d.donor}
                           </TableCell>
-                          {monthTotals.map((total, idx) => (
+                          {d.monthlyTotals.map((value, idx) => (
                             <TableCell
                               key={idx}
                               align="right"
-                              sx={{
-                                bottom: 0,
-                                position: 'sticky',
-                                backgroundColor: 'background.paper',
-                                fontWeight: 'bold',
-                              }}
+                              sx={{ fontWeight: value > 0 ? 'bold' : undefined }}
                             >
-                              {total}
+                              {value}
                             </TableCell>
                           ))}
                           <TableCell
@@ -274,85 +213,138 @@ export default function Aggregations() {
                             sx={{
                               position: 'sticky',
                               right: 0,
-                              bottom: 0,
-                              zIndex: 3,
+                              zIndex: 2,
                               backgroundColor: 'background.paper',
-                              fontWeight: 'bold',
+                              fontWeight: hasDonation ? 'bold' : undefined,
                             }}
                           >
-                            {monthTotals.reduce((a, b) => a + b, 0)}
+                            {d.total}
                           </TableCell>
                         </TableRow>
-                      </>
-                    );
-                  })()
-                )}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </>
-      ) : (
-        <>
-          <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-            <FormControl size="small" sx={{ minWidth: 120 }}>
-              <InputLabel id="overall-year-label">Year</InputLabel>
-              <Select
-                labelId="overall-year-label"
-                label="Year"
-                value={overallYear}
-                onChange={e => setOverallYear(Number(e.target.value))}
-              >
-                {years.map(y => (
-                  <MenuItem key={y} value={y}>
-                    {y}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Stack>
-          <TableContainer sx={{ overflowX: 'auto' }}>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Month</TableCell>
-                  <TableCell align="right">Donations</TableCell>
-                  <TableCell align="right">Surplus</TableCell>
-                  <TableCell align="right">Pig Pound</TableCell>
-                  <TableCell align="right">Outgoing Donations</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {overallLoading ? (
-                  <TableRow>
-                    <TableCell colSpan={5} align="center">
-                      <CircularProgress size={24} />
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  <>
-                    {overallData.map((r, idx) => (
-                      <TableRow key={idx}>
-                        <TableCell>{monthNames[r.month - 1]}</TableCell>
-                        <TableCell align="right">{r.donations}</TableCell>
-                        <TableCell align="right">{r.surplus}</TableCell>
-                        <TableCell align="right">{r.pigPound}</TableCell>
-                        <TableCell align="right">{r.outgoingDonations}</TableCell>
-                      </TableRow>
-                    ))}
+                      );
+                    })}
                     <TableRow>
-                      <TableCell>Total</TableCell>
-                      <TableCell align="right">{totals.donations}</TableCell>
-                      <TableCell align="right">{totals.surplus}</TableCell>
-                      <TableCell align="right">{totals.pigPound}</TableCell>
-                      <TableCell align="right">{totals.outgoingDonations}</TableCell>
+                      <TableCell
+                        sx={{
+                          position: 'sticky',
+                          left: 0,
+                          bottom: 0,
+                          zIndex: 3,
+                          backgroundColor: 'background.paper',
+                          fontWeight: 'bold',
+                        }}
+                      >
+                        Total
+                      </TableCell>
+                      {monthTotals.map((total, idx) => (
+                        <TableCell
+                          key={idx}
+                          align="right"
+                          sx={{
+                            bottom: 0,
+                            position: 'sticky',
+                            backgroundColor: 'background.paper',
+                            fontWeight: 'bold',
+                          }}
+                        >
+                          {total}
+                        </TableCell>
+                      ))}
+                      <TableCell
+                        align="right"
+                        sx={{
+                          position: 'sticky',
+                          right: 0,
+                          bottom: 0,
+                          zIndex: 3,
+                          backgroundColor: 'background.paper',
+                          fontWeight: 'bold',
+                        }}
+                      >
+                        {monthTotals.reduce((a, b) => a + b, 0)}
+                      </TableCell>
                     </TableRow>
                   </>
-                )}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </>
-      )}
+                );
+              })()
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
+
+  const overallContent = (
+    <>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel id="overall-year-label">Year</InputLabel>
+          <Select
+            labelId="overall-year-label"
+            label="Year"
+            value={overallYear}
+            onChange={e => setOverallYear(Number(e.target.value))}
+          >
+            {years.map(y => (
+              <MenuItem key={y} value={y}>
+                {y}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Stack>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Month</TableCell>
+              <TableCell align="right">Donations</TableCell>
+              <TableCell align="right">Surplus</TableCell>
+              <TableCell align="right">Pig Pound</TableCell>
+              <TableCell align="right">Outgoing Donations</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {overallLoading ? (
+              <TableRow>
+                <TableCell colSpan={5} align="center">
+                  <CircularProgress size={24} />
+                </TableCell>
+              </TableRow>
+            ) : (
+              <>
+                {overallData.map((r, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell>{monthNames[r.month - 1]}</TableCell>
+                    <TableCell align="right">{r.donations}</TableCell>
+                    <TableCell align="right">{r.surplus}</TableCell>
+                    <TableCell align="right">{r.pigPound}</TableCell>
+                    <TableCell align="right">{r.outgoingDonations}</TableCell>
+                  </TableRow>
+                ))}
+                <TableRow>
+                  <TableCell>Total</TableCell>
+                  <TableCell align="right">{totals.donations}</TableCell>
+                  <TableCell align="right">{totals.surplus}</TableCell>
+                  <TableCell align="right">{totals.pigPound}</TableCell>
+                  <TableCell align="right">{totals.outgoingDonations}</TableCell>
+                </TableRow>
+              </>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
+
+  const tabs = [
+    { label: 'Donor Aggregations', content: donorContent },
+    { label: 'Yearly Overall Aggregations', content: overallContent },
+  ];
+
+  return (
+    <Page title="Aggregations">
+      <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
       <FeedbackSnackbar
         open={snackbar.open}
         onClose={() => setSnackbar({ ...snackbar, open: false })}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -7,8 +7,6 @@ import {
   DialogActions,
   DialogContentText,
   TextField,
-  Tabs,
-  Tab,
   Table,
   TableHead,
   TableRow,
@@ -22,6 +20,7 @@ import {
 import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import StyledTabs from '../../components/StyledTabs';
 import { getDonors, createDonor } from '../../api/donors';
 import { getDonations, createDonation, updateDonation, deleteDonation } from '../../api/donations';
 import type { Donor } from '../../api/donors';
@@ -121,51 +120,17 @@ export default function DonationLog() {
     setNewDonorOpen(false);
   }
 
-  return (
-    <Page
-      title="Donation Log"
-      header={
-        <Stack direction="row" spacing={1} mb={2}>
-          <Button
-            size="small"
-            variant="contained"
-            onClick={e => {
-              (e.currentTarget as HTMLButtonElement).blur();
-              setForm({ date: format(selectedDate), donorId: null, weight: '' });
-              setEditing(null);
-              setRecordOpen(true);
-            }}
-          >
-            Record Donation
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={e => {
-              (e.currentTarget as HTMLButtonElement).blur();
-              setNewDonorOpen(true);
-            }}
-          >
-            Add Donor
-          </Button>
-        </Stack>
-      }
-    >
-      <Tabs value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }}>
-        {weekDates.map((d, i) => (
-          <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
-        ))}
-      </Tabs>
-      <TableContainer sx={{ overflowX: 'auto' }}>
-        <Table size="small">
-          <TableHead>
+  const table = (
+    <TableContainer sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
           <TableRow>
             <TableCell>Donor</TableCell>
             <TableCell>Weight (lbs)</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
-          </TableHead>
-          <TableBody>
+        </TableHead>
+        <TableBody>
           {donations.map(d => (
             <TableRow key={d.id}>
               <TableCell>{d.donor}</TableCell>
@@ -197,9 +162,47 @@ export default function DonationLog() {
               </TableCell>
             </TableRow>
           ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  const tabs = weekDates.map(d => ({
+    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    content: table,
+  }));
+
+  return (
+    <Page
+      title="Donation Log"
+      header={
+        <Stack direction="row" spacing={1} mb={2}>
+          <Button
+            size="small"
+            variant="contained"
+            onClick={e => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              setForm({ date: format(selectedDate), donorId: null, weight: '' });
+              setEditing(null);
+              setRecordOpen(true);
+            }}
+          >
+            Record Donation
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={e => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              setNewDonorOpen(true);
+            }}
+          >
+            Add Donor
+          </Button>
+        </Stack>
+      }
+    >
+      <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Donation' : 'Record Donation'}</DialogTitle>

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
@@ -7,8 +7,6 @@ import {
   DialogActions,
   DialogContentText,
   TextField,
-  Tabs,
-  Tab,
   Table,
   TableHead,
   TableRow,
@@ -22,6 +20,7 @@ import {
 import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import StyledTabs from '../../components/StyledTabs';
 import { getOutgoingReceivers, createOutgoingReceiver } from '../../api/outgoingReceivers';
 import { getOutgoingDonations, createOutgoingDonation, updateOutgoingDonation, deleteOutgoingDonation } from '../../api/outgoingDonations';
 import type { OutgoingReceiver } from '../../api/outgoingReceivers';
@@ -131,6 +130,67 @@ export default function TrackOutgoingDonations() {
       });
   }
 
+  const table = (
+    <TableContainer sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Date</TableCell>
+            <TableCell>Receiver</TableCell>
+            <TableCell>Weight (lbs)</TableCell>
+            <TableCell>Note</TableCell>
+            <TableCell align="right"></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {donations.map(d => (
+            <TableRow key={d.id}>
+              <TableCell>
+                {new Date(d.date).toLocaleDateString(undefined, {
+                  weekday: 'short',
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </TableCell>
+              <TableCell>{d.receiver}</TableCell>
+              <TableCell>{d.weight} lbs</TableCell>
+              <TableCell>{d.note}</TableCell>
+              <TableCell align="right">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setEditing(d);
+                    setForm({ date: normalize(d.date), receiverId: d.receiverId, weight: String(d.weight), note: d.note || '' });
+                    setRecordOpen(true);
+                  }}
+                  aria-label="Edit outgoing donation"
+                >
+                  <Edit fontSize="small" />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setToDelete(d);
+                    setDeleteOpen(true);
+                  }}
+                  aria-label="Delete outgoing donation"
+                >
+                  <Delete fontSize="small" />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  const tabs = weekDates.map(d => ({
+    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    content: table,
+  }));
+
   return (
     <Page
       title="Track Outgoing Donations"
@@ -160,57 +220,7 @@ export default function TrackOutgoingDonations() {
         </Stack>
       }
     >
-      <Tabs value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }}>
-        {weekDates.map((d, i) => (
-          <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
-        ))}
-      </Tabs>
-      <TableContainer sx={{ overflowX: 'auto' }}>
-        <Table size="small">
-          <TableHead>
-          <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell>Receiver</TableCell>
-            <TableCell>Weight (lbs)</TableCell>
-            <TableCell>Note</TableCell>
-            <TableCell align="right"></TableCell>
-          </TableRow>
-          </TableHead>
-          <TableBody>
-          {donations.map(d => (
-            <TableRow key={d.id}>
-              <TableCell>
-                {new Date(d.date).toLocaleDateString(undefined, {
-                  weekday: 'short',
-                  year: 'numeric',
-                  month: 'short',
-                  day: 'numeric',
-                })}
-              </TableCell>
-              <TableCell>{d.receiver}</TableCell>
-              <TableCell>{d.weight} lbs</TableCell>
-              <TableCell>{d.note}</TableCell>
-              <TableCell align="right">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setEditing(d);
-                    setForm({ date: normalize(d.date), receiverId: d.receiverId, weight: String(d.weight), note: d.note || '' });
-                    setRecordOpen(true);
-                  }}
-                  aria-label="Edit outgoing donation"
-                >
-                  <Edit fontSize="small" />
-                </IconButton>
-                <IconButton size="small" onClick={() => { setToDelete(d); setDeleteOpen(true); }} aria-label="Delete outgoing donation">
-                  <Delete fontSize="small" />
-                </IconButton>
-              </TableCell>
-            </TableRow>
-          ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Outgoing Donation' : 'Record Outgoing Donation'}</DialogTitle>

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
@@ -15,12 +15,11 @@ import {
   Stack,
   TextField,
   IconButton,
-  Tabs,
-  Tab,
 } from '@mui/material';
 import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import StyledTabs from '../../components/StyledTabs';
 import {
   getPigPounds,
   createPigPound,
@@ -108,38 +107,17 @@ export default function TrackPigpound() {
       );
   }
 
-  return (
-    <Page
-      title="Track Pigpound"
-      header={
-        <Button
-          size="small"
-          variant="contained"
-          onClick={() => {
-            setForm({ date: format(selectedDate), weight: '' });
-            setEditing(null);
-            setRecordOpen(true);
-          }}
-        >
-          Record Pig Pound Donation
-        </Button>
-      }
-    >
-      <Tabs value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }}>
-        {weekDates.map((d, i) => (
-          <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
-        ))}
-      </Tabs>
-      <TableContainer sx={{ overflowX: 'auto' }}>
-        <Table size="small">
-          <TableHead>
+  const table = (
+    <TableContainer sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
           <TableRow>
             <TableCell>Date</TableCell>
             <TableCell>Weight (lbs)</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
-          </TableHead>
-          <TableBody>
+        </TableHead>
+        <TableBody>
           {entries.length === 0 ? (
             <TableRow>
               <TableCell colSpan={3} align="center">
@@ -158,7 +136,7 @@ export default function TrackPigpound() {
                     size="small"
                     onClick={() => {
                       setEditing(e);
-                      setForm({ date: e.date, weight: String(e.weight) });
+                      setForm({ date: format(new Date(e.date)), weight: String(e.weight) });
                       setRecordOpen(true);
                     }}
                     aria-label="Edit entry"
@@ -179,9 +157,34 @@ export default function TrackPigpound() {
               </TableRow>
             ))
           )}
-          </TableBody>
-        </Table>
-      </TableContainer>
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  const tabs = weekDates.map(d => ({
+    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    content: table,
+  }));
+
+  return (
+    <Page
+      title="Track Pigpound"
+      header={
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => {
+            setForm({ date: format(selectedDate), weight: '' });
+            setEditing(null);
+            setRecordOpen(true);
+          }}
+        >
+          Record Pig Pound Donation
+        </Button>
+      }
+    >
+      <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog
         open={recordOpen}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
@@ -15,12 +15,11 @@ import {
   TextField,
   MenuItem,
   IconButton,
-  Tabs,
-  Tab,
 } from '@mui/material';
 import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import StyledTabs from '../../components/StyledTabs';
 import {
   getSurplus,
   createSurplus,
@@ -113,31 +112,10 @@ export default function TrackSurplus() {
       .catch(err => setSnackbar({ open: true, message: err.message || 'Failed to save surplus' }));
   }
 
-  return (
-    <Page
-      title="Track Surplus"
-      header={
-        <Button
-          size="small"
-          variant="contained"
-          onClick={() => {
-            setForm({ date: format(selectedDate), type: 'BREAD', count: '' });
-            setEditing(null);
-            setRecordOpen(true);
-          }}
-        >
-          Record Surplus
-        </Button>
-      }
-    >
-      <Tabs value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }}>
-        {weekDates.map((d, i) => (
-          <Tab key={i} label={d.toLocaleDateString(undefined, { weekday: 'short' })} />
-        ))}
-      </Tabs>
-      <TableContainer sx={{ overflowX: 'auto' }}>
-        <Table size="small">
-          <TableHead>
+  const table = (
+    <TableContainer sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
           <TableRow>
             <TableCell>Date</TableCell>
             <TableCell>Type</TableCell>
@@ -145,8 +123,8 @@ export default function TrackSurplus() {
             <TableCell>Weight (lbs)</TableCell>
             <TableCell align="right"></TableCell>
           </TableRow>
-          </TableHead>
-          <TableBody>
+        </TableHead>
+        <TableBody>
           {filteredRecords.map(r => (
             <TableRow key={r.id}>
               <TableCell>
@@ -185,9 +163,34 @@ export default function TrackSurplus() {
               </TableCell>
             </TableRow>
           ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  const tabs = weekDates.map(d => ({
+    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    content: table,
+  }));
+
+  return (
+    <Page
+      title="Track Surplus"
+      header={
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => {
+            setForm({ date: format(selectedDate), type: 'BREAD', count: '' });
+            setEditing(null);
+            setRecordOpen(true);
+          }}
+        >
+          Record Surplus
+        </Button>
+      }
+    >
+      <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
         <DialogTitle>{editing ? 'Edit Surplus' : 'Record Surplus'}</DialogTitle>


### PR DESCRIPTION
## Summary
- create `StyledTabs` wrapper for consistent tab styling
- refactor availability, client management, visits, and warehouse pages to use shared tabs

## Testing
- `npm test` *(fails: Argument of type 'PickerValue'... and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aea586ae78832d8ce121b93ebbb6bd