### PR TITLE
Use FormCard in password reset dialog

### DIFF
--- a/MJ_FB_Frontend/src/components/FormCard.tsx
+++ b/MJ_FB_Frontend/src/components/FormCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Paper, Stack, Typography, type PaperProps } from '@mui/material';
+import { Box, Paper, Stack, Typography, type PaperProps, type BoxProps } from '@mui/material';
 import type { FormEvent, ReactNode } from 'react';
 
 interface FormCardProps extends Omit<PaperProps<'form'>, 'onSubmit'> {
@@ -8,6 +8,7 @@ interface FormCardProps extends Omit<PaperProps<'form'>, 'onSubmit'> {
   actions?: ReactNode;
   header?: ReactNode;
   centered?: boolean;
+  boxProps?: BoxProps;
 }
 
 export default function FormCard({
@@ -17,6 +18,7 @@ export default function FormCard({
   actions,
   header,
   centered = true,
+  boxProps,
   ...paperProps
 }: FormCardProps) {
   return (
@@ -27,6 +29,7 @@ export default function FormCard({
       minHeight="100vh"
       px={2}
       py={centered ? 0 : 4}
+      {...boxProps}
     >
       <Paper component="form" onSubmit={onSubmit} sx={{ p: 3, width: '100%', maxWidth: 400 }} {...paperProps}>
         <Stack spacing={2}>

--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField } from '@mui/material';
+import { Dialog, DialogContent, Button, TextField } from '@mui/material';
 import { requestPasswordReset } from '../api/users';
 import FeedbackSnackbar from './FeedbackSnackbar';
+import FormCard from './FormCard';
 import type { AlertColor } from '@mui/material';
 
 export default function PasswordResetDialog({
@@ -41,23 +42,30 @@ export default function PasswordResetDialog({
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} component="form" onSubmit={handleSubmit}>
-        <DialogTitle>Reset Password</DialogTitle>
-        <DialogContent>
-          <TextField
-            autoFocus
-            margin="dense"
-            label={label}
-            type={type === 'staff' ? 'email' : 'text'}
-            fullWidth
-            value={identifier}
-            onChange={e => setIdentifier(e.target.value)}
-          />
+      <Dialog open={open} onClose={onClose}>
+        <DialogContent sx={{ p: 0 }}>
+          <FormCard
+            title="Reset Password"
+            onSubmit={handleSubmit}
+            actions={
+              <>
+                <Button onClick={onClose}>Cancel</Button>
+                <Button type="submit" variant="contained">Submit</Button>
+              </>
+            }
+            boxProps={{ minHeight: 'auto', p: 0 }}
+          >
+            <TextField
+              autoFocus
+              margin="dense"
+              label={label}
+              type={type === 'staff' ? 'email' : 'text'}
+              fullWidth
+              value={identifier}
+              onChange={e => setIdentifier(e.target.value)}
+            />
+          </FormCard>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={onClose}>Cancel</Button>
-          <Button type="submit" variant="contained">Submit</Button>
-        </DialogActions>
       </Dialog>
       <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity={snackbarSeverity} />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />


### PR DESCRIPTION
## Summary
- allow FormCard to accept layout props for dialogs
- wrap password reset dialog form with FormCard for consistent styling

## Testing
- `CI=true npm test -- --runInBand` *(fails: Test Suites: 11 failed, 3 passed, 14 total)*

------
https://chatgpt.com/codex/tasks/task_e_68aeabcfec50832da2126db586688c00