### PR TITLE
Add end date handling for recurring volunteer bookings

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -80,12 +80,32 @@ test('submits weekly recurring booking', async () => {
   expect(args[3]).toEqual(expect.arrayContaining([1, 3]));
 });
 
+test('submits daily recurring booking with end date', async () => {
+  render(<VolunteerSchedule />);
+  fireEvent.mouseDown(await screen.findByLabelText(/role/i));
+  const listbox = await screen.findByRole('listbox');
+  fireEvent.click(within(listbox).getByText('Test Role'));
+  fireEvent.click(await screen.findByText('Volunteer Needed', { exact: false }));
+  fireEvent.mouseDown(screen.getByLabelText(/frequency/i));
+  const freqList = await screen.findAllByRole('listbox');
+  fireEvent.click(within(freqList[freqList.length - 1]).getByText('Daily'));
+  fireEvent.change(screen.getByLabelText(/end date/i), {
+    target: { value: '2024-12-31' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+  await waitFor(() => expect(createRecurringVolunteerBooking).toHaveBeenCalled());
+  const args = (createRecurringVolunteerBooking as jest.Mock).mock.calls[0];
+  expect(args[2]).toBe('daily');
+  expect(args[3]).toBeUndefined();
+  expect(args[4]).toBe('2024-12-31');
+});
+
 test('submits one-time booking', async () => {
   render(<VolunteerSchedule />);
   fireEvent.mouseDown(await screen.findByLabelText(/role/i));
   const listbox = await screen.findByRole('listbox');
   fireEvent.click(within(listbox).getByText('Test Role'));
-  fireEvent.click(await screen.findByText('Available'));
+  fireEvent.click(await screen.findByText('Volunteer Needed', { exact: false }));
   fireEvent.click(screen.getByRole('button', { name: /submit/i }));
   await waitFor(() => expect(requestVolunteerBooking).toHaveBeenCalled());
   expect(createRecurringVolunteerBooking).not.toHaveBeenCalled();

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -148,7 +148,7 @@ export default function VolunteerSchedule() {
           formatDate(currentDate),
           frequency,
           frequency === 'weekly' ? weekdays : undefined,
-          frequency === 'weekly' && endDate ? endDate : undefined,
+          endDate || undefined,
         );
       }
       const dateLabel = formatInTimeZone(
@@ -391,40 +391,38 @@ export default function VolunteerSchedule() {
             </Select>
           </FormControl>
           {frequency === 'weekly' && (
-            <>
-              <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap' }}>
-                {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(
-                  (d, i) => (
-                    <FormControlLabel
-                      key={d}
-                      control={
-                        <Checkbox
-                          size="small"
-                          checked={weekdays.includes(i)}
-                          onChange={() =>
-                            setWeekdays(prev =>
-                              prev.includes(i)
-                                ? prev.filter(x => x !== i)
-                                : [...prev, i],
-                            )
-                          }
-                        />
+            <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap' }}>
+              {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d, i) => (
+                <FormControlLabel
+                  key={d}
+                  control={
+                    <Checkbox
+                      size="small"
+                      checked={weekdays.includes(i)}
+                      onChange={() =>
+                        setWeekdays(prev =>
+                          prev.includes(i)
+                            ? prev.filter(x => x !== i)
+                            : [...prev, i],
+                        )
                       }
-                      label={d}
                     />
-                  ),
-                )}
-              </Box>
-              <TextField
-                label="End date"
-                type="date"
-                size="small"
-                value={endDate}
-                onChange={e => setEndDate(e.target.value)}
-                InputLabelProps={{ shrink: true }}
-                sx={{ mt: 2 }}
-              />
-            </>
+                  }
+                  label={d}
+                />
+              ))}
+            </Box>
+          )}
+          {(frequency === 'daily' || frequency === 'weekly') && (
+            <TextField
+              label="End date"
+              type="date"
+              size="small"
+              value={endDate}
+              onChange={e => setEndDate(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+              sx={{ mt: 2 }}
+            />
           )}
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
## Summary
- Show end date field for daily and weekly recurring volunteer bookings
- Pass chosen end date to recurring booking API
- Test daily recurring bookings with end dates

## Testing
- `npm test` *(fails: TypeError: mediaQueryList.addEventListener is not a function in Navbar.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aead9dd944832da4dbe7e3067561e5