### PR TITLE
feat: add reasoned volunteer booking modal

### DIFF
--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -156,14 +156,16 @@ export async function getVolunteerBookingsByRole(roleId: number) {
 
 export async function updateVolunteerBookingStatus(
   bookingId: number,
-  status: 'approved' | 'rejected' | 'cancelled'
+  status: 'approved' | 'rejected' | 'cancelled',
+  reason?: string,
 ): Promise<void> {
+  const body = reason ? { status, reason } : { status };
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/${bookingId}`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ status }),
+    body: JSON.stringify(body),
   });
   await handleResponse(res);
 }


### PR DESCRIPTION
## Summary
- add staff-style modal for volunteer bookings with approve/reject/cancel and reason input
- allow optional reason when updating volunteer booking status

## Testing
- `npm test` *(fails: EventForm type errors and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aeafda6f80832dac7c9317c9866ca5