### PR TITLE
style: centralize text inputs in theme

### DIFF
--- a/MJ_FB_Frontend/src/components/EntitySearch.tsx
+++ b/MJ_FB_Frontend/src/components/EntitySearch.tsx
@@ -47,15 +47,14 @@ export default function EntitySearch({
 
   return (
     <div>
-      <TextField
-        value={query}
-        onChange={e => setQuery(e.target.value)}
-        placeholder={placeholder}
-        label="Search"
-        size="small"
-        fullWidth
-        sx={{ mb: 1 }}
-      />
+        <TextField
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder={placeholder}
+          label="Search"
+          size="small"
+          fullWidth
+        />
       {results.length > 0 ? (
         <ul style={{ listStyle: 'none', padding: 0 }}>
           {results.map(r => (

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -968,16 +968,15 @@ export default function VolunteerManagement() {
         >
           <div style={{ background: 'white', padding: 16, borderRadius: 10, width: 300 }}>
             <h4>Assign Volunteer</h4>
-            <TextField
-              type="text"
-              placeholder="Search volunteers"
-              value={assignSearch}
-              onChange={e => setAssignSearch(e.target.value)}
-              label="Search"
-              size="small"
-              fullWidth
-              sx={{ mb: 1 }}
-            />
+              <TextField
+                type="text"
+                placeholder="Search volunteers"
+                value={assignSearch}
+                onChange={e => setAssignSearch(e.target.value)}
+                label="Search"
+                size="small"
+                fullWidth
+              />
             <ul style={{ listStyle: 'none', paddingLeft: 0, maxHeight: '150px', overflowY: 'auto' }}>
               {assignResults.map(v => (
                 <li key={v.id} style={{ marginBottom: 4 }}>

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -414,15 +414,14 @@ export default function VolunteerSchedule() {
             </Box>
           )}
           {(frequency === 'daily' || frequency === 'weekly') && (
-            <TextField
-              label="End date"
-              type="date"
-              size="small"
-              value={endDate}
-              onChange={e => setEndDate(e.target.value)}
-              InputLabelProps={{ shrink: true }}
-              sx={{ mt: 2 }}
-            />
+              <TextField
+                label="End date"
+                type="date"
+                size="small"
+                value={endDate}
+                onChange={e => setEndDate(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
           )}
         </DialogContent>
         <DialogActions>
@@ -449,14 +448,13 @@ export default function VolunteerSchedule() {
         <DialogTitle>Manage Booking</DialogTitle>
         <DialogContent dividers>
           <Typography>Modify booking for {decisionBooking?.role_name}?</Typography>
-          <TextField
-            placeholder="Reason for cancellation"
-            value={decisionReason}
-            onChange={e => setDecisionReason(e.target.value)}
-            fullWidth
-            multiline
-            sx={{ mt: 1 }}
-          />
+            <TextField
+              placeholder="Reason for cancellation"
+              value={decisionReason}
+              onChange={e => setDecisionReason(e.target.value)}
+              fullWidth
+              multiline
+            />
         </DialogContent>
         <DialogActions>
           <Button

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -99,34 +99,30 @@ let theme = createTheme({
       },
     },
     MuiTextField: {
-      defaultProps: { fullWidth: true, size: 'small' },
+      defaultProps: { fullWidth: true, size: 'small', variant: 'outlined' },
       styleOverrides: {
-        root: {
-          '& .MuiInputBase-root': { borderRadius: 10 },
+        root: ({ theme }) => ({
+          marginBottom: theme.spacing(1),
+          '& .MuiOutlinedInput-root': { borderRadius: theme.shape.borderRadius },
+          '& .MuiOutlinedInput-notchedOutline': { borderRadius: theme.shape.borderRadius },
+          '& .MuiFormHelperText-root': { marginLeft: 0 },
           '& .MuiInputBase-input': { padding: '0.5rem', fontSize: '1rem' },
-        },
+        }),
       },
     },
     MuiSelect: {
-      defaultProps: { fullWidth: true, size: 'small' },
+      defaultProps: { fullWidth: true, size: 'small', variant: 'outlined' },
       styleOverrides: {
-        root: {
-          '& .MuiOutlinedInput-notchedOutline': { borderRadius: 10 },
-        },
+        root: ({ theme }) => ({
+          marginBottom: theme.spacing(1),
+          '& .MuiOutlinedInput-notchedOutline': { borderRadius: theme.shape.borderRadius },
+          '& .MuiFormHelperText-root': { marginLeft: 0 },
+        }),
         select: { padding: '0.5rem', fontSize: '1rem' },
       },
     },
     MuiFormControl: {
       defaultProps: { fullWidth: true },
-      styleOverrides: {
-        root: {
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '0.5rem',
-          '& .MuiInputBase-root': { borderRadius: 10 },
-          '& .MuiInputBase-input': { padding: '0.5rem', fontSize: '1rem' },
-        },
-      },
     },
     MuiTabs: {
       styleOverrides: {


### PR DESCRIPTION
## Summary
- define shared defaults for TextField and Select in theme
- drop inline field spacing in favor of theme overrides

## Testing
- `npm test` *(fails: "Test suite failed to run" and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb0a9f9d8832d9233240d805168ba