### PR TITLE
feat: add online access settings in client update

### DIFF
--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -3,17 +3,17 @@ import type {
   UserProfile,
   StaffAccess,
   LoginResponse,
-} from '../types';
-import { API_BASE, apiFetch, handleResponse } from './client';
-export type { LoginResponse } from '../types';
+} from "../types";
+import { API_BASE, apiFetch, handleResponse } from "./client";
+export type { LoginResponse } from "../types";
 
 export async function loginUser(
   clientId: string,
-  password: string
+  password: string,
 ): Promise<LoginResponse> {
   const res = await apiFetch(`${API_BASE}/users/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ clientId: Number(clientId), password }),
   });
   return handleResponse(res);
@@ -21,11 +21,11 @@ export async function loginUser(
 
 export async function loginStaff(
   email: string,
-  password: string
+  password: string,
 ): Promise<LoginResponse> {
   const res = await apiFetch(`${API_BASE}/users/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email, password }),
   });
   return handleResponse(res);
@@ -36,8 +36,8 @@ export async function loginAgency(
   password: string,
 ): Promise<LoginResponse> {
   const res = await apiFetch(`${API_BASE}/users/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email, password }),
   });
   return handleResponse(res);
@@ -45,7 +45,7 @@ export async function loginAgency(
 
 export async function logout(): Promise<void> {
   const res = await apiFetch(`${API_BASE}/auth/logout`, {
-    method: 'POST',
+    method: "POST",
   });
   await handleResponse(res);
 }
@@ -56,8 +56,8 @@ export async function requestPasswordReset(data: {
   clientId?: string;
 }): Promise<void> {
   const res = await apiFetch(`${API_BASE}/auth/request-password-reset`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
   await handleResponse(res);
@@ -68,8 +68,8 @@ export async function changePassword(
   newPassword: string,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/auth/change-password`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ currentPassword, newPassword }),
   });
   await handleResponse(res);
@@ -80,12 +80,13 @@ export async function getUserProfile(): Promise<UserProfile> {
   return handleResponse(res);
 }
 
-export async function updateMyProfile(
-  data: { email?: string; phone?: string },
-): Promise<UserProfile> {
+export async function updateMyProfile(data: {
+  email?: string;
+  phone?: string;
+}): Promise<UserProfile> {
   const res = await apiFetch(`${API_BASE}/users/me`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
   return handleResponse(res);
@@ -105,19 +106,19 @@ export async function createStaff(
   password: string,
 ): Promise<void> {
   const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
+    "Content-Type": "application/json",
   };
   const res = await apiFetch(`${API_BASE}/staff`, {
-    method: 'POST',
+    method: "POST",
     headers,
-      body: JSON.stringify({
-        firstName,
-        lastName,
-        email,
-        password,
-        access,
-      }),
-    });
+    body: JSON.stringify({
+      firstName,
+      lastName,
+      email,
+      password,
+      access,
+    }),
+  });
   await handleResponse(res);
 }
 
@@ -132,9 +133,9 @@ export async function addUser(
   phone?: string,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/users/add-client`, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       firstName,
@@ -151,7 +152,9 @@ export async function addUser(
 }
 
 export async function searchUsers(search: string) {
-  const res = await apiFetch(`${API_BASE}/users/search?search=${encodeURIComponent(search)}`);
+  const res = await apiFetch(
+    `${API_BASE}/users/search?search=${encodeURIComponent(search)}`,
+  );
   return handleResponse(res);
 }
 
@@ -177,11 +180,18 @@ export async function getIncompleteUsers(): Promise<IncompleteUser[]> {
 
 export async function updateUserInfo(
   clientId: number,
-  data: { firstName: string; lastName: string; email?: string; phone?: string },
+  data: {
+    firstName: string;
+    lastName: string;
+    email?: string;
+    phone?: string;
+    onlineAccess: boolean;
+    password?: string;
+  },
 ): Promise<IncompleteUser> {
   const res = await apiFetch(`${API_BASE}/users/id/${clientId}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
   return handleResponse(res);

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 import {
   Table,
   TableHead,
@@ -13,24 +13,28 @@ import {
   TextField,
   Stack,
   Link,
-} from '@mui/material';
-import Page from '../../../components/Page';
-import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+  FormControlLabel,
+  Checkbox,
+} from "@mui/material";
+import Page from "../../../components/Page";
+import FeedbackSnackbar from "../../../components/FeedbackSnackbar";
 import {
   getIncompleteUsers,
   updateUserInfo,
   type IncompleteUser,
-} from '../../../api/users';
-import type { AlertColor } from '@mui/material';
+} from "../../../api/users";
+import type { AlertColor } from "@mui/material";
 
 export default function UpdateClientData() {
   const [clients, setClients] = useState<IncompleteUser[]>([]);
   const [selected, setSelected] = useState<IncompleteUser | null>(null);
   const [form, setForm] = useState({
-    firstName: '',
-    lastName: '',
-    email: '',
-    phone: '',
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    onlineAccess: false,
+    password: "",
   });
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -51,10 +55,12 @@ export default function UpdateClientData() {
   function handleEdit(client: IncompleteUser) {
     setSelected(client);
     setForm({
-      firstName: client.firstName || '',
-      lastName: client.lastName || '',
-      email: client.email || '',
-      phone: client.phone || '',
+      firstName: client.firstName || "",
+      lastName: client.lastName || "",
+      email: client.email || "",
+      phone: client.phone || "",
+      onlineAccess: false,
+      password: "",
     });
   }
 
@@ -66,15 +72,21 @@ export default function UpdateClientData() {
         lastName: form.lastName,
         email: form.email || undefined,
         phone: form.phone || undefined,
+        onlineAccess: form.onlineAccess,
+        password: form.onlineAccess ? form.password : undefined,
       });
-      setSnackbar({ open: true, message: 'Client updated', severity: 'success' });
+      setSnackbar({
+        open: true,
+        message: "Client updated",
+        severity: "success",
+      });
       setSelected(null);
       loadClients();
     } catch (err: unknown) {
       setSnackbar({
         open: true,
-        message: err instanceof Error ? err.message : 'Update failed',
-        severity: 'error',
+        message: err instanceof Error ? err.message : "Update failed",
+        severity: "error",
       });
     }
   }
@@ -90,7 +102,7 @@ export default function UpdateClientData() {
           </TableRow>
         </TableHead>
         <TableBody>
-          {clients.map(client => (
+          {clients.map((client) => (
             <TableRow key={client.clientId}>
               <TableCell>{client.clientId}</TableCell>
               <TableCell>
@@ -118,7 +130,7 @@ export default function UpdateClientData() {
 
       <Dialog open={!!selected} onClose={() => setSelected(null)}>
         <DialogTitle>
-          Edit Client -{' '}
+          Edit Client -{" "}
           {selected && (
             <Link
               href={selected.profileLink}
@@ -131,35 +143,66 @@ export default function UpdateClientData() {
         </DialogTitle>
         <DialogContent>
           <Stack spacing={2} mt={1}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={form.onlineAccess}
+                  onChange={(e) =>
+                    setForm({
+                      ...form,
+                      onlineAccess: e.target.checked,
+                      password: "",
+                    })
+                  }
+                />
+              }
+              label="Online Access"
+            />
             <TextField
               label="First Name"
               value={form.firstName}
-              onChange={e => setForm({ ...form, firstName: e.target.value })}
+              onChange={(e) => setForm({ ...form, firstName: e.target.value })}
+              required
             />
             <TextField
               label="Last Name"
               value={form.lastName}
-              onChange={e => setForm({ ...form, lastName: e.target.value })}
+              onChange={(e) => setForm({ ...form, lastName: e.target.value })}
+              required
             />
             <TextField
               label="Email (optional)"
               type="email"
               value={form.email}
-              onChange={e => setForm({ ...form, email: e.target.value })}
+              onChange={(e) => setForm({ ...form, email: e.target.value })}
             />
             <TextField
               label="Phone (optional)"
               type="tel"
               value={form.phone}
-              onChange={e => setForm({ ...form, phone: e.target.value })}
+              onChange={(e) => setForm({ ...form, phone: e.target.value })}
             />
+            {form.onlineAccess && (
+              <TextField
+                label="Password"
+                type="password"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                required
+                error={form.onlineAccess && !form.password}
+              />
+            )}
           </Stack>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setSelected(null)}>Cancel</Button>
           <Button
             onClick={handleSave}
-            disabled={!form.firstName || !form.lastName}
+            disabled={
+              !form.firstName ||
+              !form.lastName ||
+              (form.onlineAccess && !form.password)
+            }
           >
             Save
           </Button>
@@ -169,10 +212,9 @@ export default function UpdateClientData() {
       <FeedbackSnackbar
         open={!!snackbar}
         onClose={() => setSnackbar(null)}
-        message={snackbar?.message || ''}
+        message={snackbar?.message || ""}
         severity={snackbar?.severity}
       />
     </Page>
   );
 }
-


### PR DESCRIPTION
## Summary
- allow updating online access and password via API wrapper
- add online access checkbox and password field in update client dialog with validation

## Testing
- `npm test` *(fails: TS errors in existing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb4208b04832dbe92983a781ab258