### PR TITLE
feat: allow editing client details from history

### DIFF
--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -177,7 +177,14 @@ export async function getIncompleteUsers(): Promise<IncompleteUser[]> {
 
 export async function updateUserInfo(
   clientId: number,
-  data: { firstName: string; lastName: string; email?: string; phone?: string },
+  data: {
+    firstName: string;
+    lastName: string;
+    email?: string;
+    phone?: string;
+    onlineAccess?: boolean;
+    password?: string;
+  },
 ): Promise<IncompleteUser> {
   const res = await apiFetch(`${API_BASE}/users/id/${clientId}`, {
     method: 'PATCH',


### PR DESCRIPTION
## Summary
- add inline client editor in UserHistory with online access controls
- support updating online access and password via updateUserInfo

## Testing
- `npm test` *(fails: Property 'toBeInTheDocument' does not exist on type 'JestMatchers<HTMLElement>' and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb42ebdc0832d910decfa2010656b