### PR TITLE
Reset volunteer search state when navigating away

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import VolunteerManagement from '../pages/volunteer-management/VolunteerManagement';
 import {
   getVolunteerRoles,
@@ -93,6 +95,36 @@ describe('VolunteerManagement shopper profile', () => {
     await waitFor(() =>
       expect(screen.getByLabelText(/shopper profile/i)).not.toBeChecked()
     );
+  });
+});
+
+describe('VolunteerManagement search reset', () => {
+  it('clears selected volunteer when leaving search tab', async () => {
+    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+    (searchVolunteers as jest.Mock).mockResolvedValue([mockVolunteer]);
+
+    let navigateFn: (path: string) => void = () => {};
+    function NavHelper() {
+      navigateFn = useNavigate();
+      return null;
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/volunteers/search']}>
+        <NavHelper />
+        <Routes>
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('Select Volunteer'));
+    expect(await screen.findByText(/Edit Roles for Test Vol/i)).toBeInTheDocument();
+
+    act(() => navigateFn('/volunteers/schedule'));
+    act(() => navigateFn('/volunteers/search'));
+
+    expect(screen.queryByText(/Edit Roles for Test Vol/i)).not.toBeInTheDocument();
   });
 });
 

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -74,7 +74,7 @@ interface VolunteerResult {
 
 export default function VolunteerManagement() {
   const { tab: tabParam } = useParams<{ tab?: string }>();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const tab: 'dashboard' | 'schedule' | 'search' | 'create' | 'pending' =
     tabParam === 'schedule' ||
     tabParam === 'search' ||
@@ -107,6 +107,13 @@ export default function VolunteerManagement() {
 
   const theme = useTheme();
   const approvedColor = lighten(theme.palette.success.light, 0.4);
+
+  useEffect(() => {
+    if (tab !== 'search') {
+      setSelectedVolunteer(null);
+      setSearchParams({});
+    }
+  }, [tab, setSearchParams]);
 
   const [shopperOpen, setShopperOpen] = useState(false);
   const [shopperClientId, setShopperClientId] = useState('');


### PR DESCRIPTION
## Summary
- clear selected volunteer and query params when leaving the search tab
- add regression test ensuring search tab resets when revisited

## Testing
- `npm test` *(fails: mediaQueryList.addEventListener is not a function; import.meta meta-property allowed only in ESM; and various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af50186aa4832da478a7e04f72396a