### PR TITLE
fix: correct timezone conversion import

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -29,7 +29,7 @@ import {
   formatRegina,
   REGINA_TIMEZONE,
 } from '../../utils/time';
-import { zonedTimeToUtc } from 'date-fns-tz';
+import { fromZonedTime } from 'date-fns-tz';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import Page from '../../components/Page';
 import type { AlertColor } from '@mui/material';
@@ -91,12 +91,12 @@ export default function VolunteerDashboard() {
       .filter(b => b.status === 'approved')
       .filter(
         b =>
-          zonedTimeToUtc(`${b.date}T${b.start_time}`, REGINA_TIMEZONE) >= now,
+          fromZonedTime(`${b.date}T${b.start_time}`, REGINA_TIMEZONE) >= now,
       )
       .sort(
         (a, b) =>
-          zonedTimeToUtc(`${a.date}T${a.start_time}`, REGINA_TIMEZONE).getTime() -
-          zonedTimeToUtc(`${b.date}T${b.start_time}`, REGINA_TIMEZONE).getTime(),
+          fromZonedTime(`${a.date}T${a.start_time}`, REGINA_TIMEZONE).getTime() -
+          fromZonedTime(`${b.date}T${b.start_time}`, REGINA_TIMEZONE).getTime(),
       );
     return upcoming[0];
   }, [bookings]);


### PR DESCRIPTION
## Summary
- replace deprecated `zonedTimeToUtc` with `fromZonedTime` in VolunteerDashboard

## Testing
- `npm test` *(fails: TS errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68af513d3188832da706463c6e66a227