### PR TITLE
Add cancel option for volunteer bookings in staff schedule

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -1127,7 +1127,7 @@ export default function VolunteerManagement() {
                 style={{ width: '100%', marginTop: 8 }}
               />
             )}
-            {decisionBooking.status.toLowerCase() !== 'pending' && (
+            {(!showRejectReason || decisionBooking.status.toLowerCase() !== 'pending') && (
               <textarea
                 placeholder="Reason for cancellation"
                 value={decisionReason}
@@ -1181,6 +1181,7 @@ export default function VolunteerManagement() {
                   </Button>
                   <Button
                     onClick={() => {
+                      decide(decisionBooking.id, 'cancelled', decisionReason);
                       setDecisionBooking(null);
                       setDecisionReason('');
                       setShowRejectReason(false);
@@ -1188,7 +1189,18 @@ export default function VolunteerManagement() {
                     variant="outlined"
                     color="primary"
                   >
-                    Cancel
+                    Cancel Booking
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      setDecisionBooking(null);
+                      setDecisionReason('');
+                      setShowRejectReason(false);
+                    }}
+                    variant="outlined"
+                    color="primary"
+                  >
+                    Close
                   </Button>
                 </>
               ) : (
@@ -1213,7 +1225,7 @@ export default function VolunteerManagement() {
                     variant="outlined"
                     color="primary"
                   >
-                    Confirm
+                    Cancel Booking
                   </Button>
                   <Button
                     onClick={() => {
@@ -1223,7 +1235,7 @@ export default function VolunteerManagement() {
                     variant="outlined"
                     color="primary"
                   >
-                    Cancel
+                    Close
                   </Button>
                 </>
               )}


### PR DESCRIPTION
## Summary
- add explicit Cancel Booking actions so staff can cancel pending or approved volunteer shifts
- show reason field when cancelling a booking

## Testing
- `npm test` *(fails: Argument of type 'PickerValue' is not assignable..., import.meta meta-property errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af53812578832d97b94123c1bae329