### PR TITLE
feat: enforce volunteer booking uniqueness

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -183,7 +183,10 @@ export async function createVolunteerBookingForVolunteer(
     delete booking.slot_id;
     booking.status_color = statusColor(booking.status);
     res.status(201).json(booking);
-  } catch (error) {
+  } catch (error: any) {
+    if (error.code === '23505') {
+      return res.status(400).json({ message: 'Already booked for this shift' });
+    }
     logger.error('Error creating volunteer booking for volunteer:', error);
     next(error);
   }

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -494,6 +494,19 @@ CREATE TABLE IF NOT EXISTS volunteer_bookings (
     `CREATE UNIQUE INDEX IF NOT EXISTS volunteer_slots_unique_role_time ON volunteer_slots (role_id, start_time, end_time);`
   );
 
+  // Remove duplicate volunteer bookings and enforce uniqueness
+  await client.query(`
+    DELETE FROM volunteer_bookings a
+    USING volunteer_bookings b
+    WHERE a.id > b.id
+      AND a.volunteer_id = b.volunteer_id
+      AND a.slot_id = b.slot_id
+      AND a.date = b.date;
+  `);
+  await client.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS volunteer_bookings_unique_volunteer_slot_date ON volunteer_bookings (volunteer_id, slot_id, date);`
+  );
+
   // Create indexes for faster lookups on bookings and volunteer_bookings
   await client.query(
     `CREATE INDEX IF NOT EXISTS bookings_user_id_idx ON bookings (user_id);`

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -415,6 +415,13 @@ export default function VolunteerManagement() {
     addTraining: boolean,
   ) {
     if (!assignSlot || !selectedRole) return;
+    const slotBookings = bookingsForDate.filter(
+      b => b.role_id === assignSlot.id,
+    );
+    if (slotBookings.some(b => b.volunteer_id === vol.id)) {
+      setAssignMsg('Volunteer already booked for this shift');
+      return;
+    }
     try {
       setAssignMsg('');
       if (addTraining) {


### PR DESCRIPTION
## Summary
- ensure volunteer bookings are unique per volunteer/slot/date and clean up duplicates
- return 400 when staff attempt to book a volunteer for an already-booked slot/date
- prevent duplicate volunteer assignments on the management page

## Testing
- `npm test` (backend) *(fails: bookingUtils, slots, events, blockedSlots, agency, etc.)*
- `npm test` (frontend) *(fails: multiple test suite errors and TS compilation issues)*

------
https://chatgpt.com/codex/tasks/task_e_68af604a7620832d9f8a09a80097679f