### PR TITLE
refactor: centralize date utilities

### DIFF
--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -9,6 +9,7 @@ import { registerServiceWorker } from './registerServiceWorker';
 import { AuthProvider } from './hooks/useAuth';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from './utils/date';
 
 function Main() {
   const queryClient = new QueryClient();
@@ -16,7 +17,7 @@ function Main() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <LocalizationProvider dateAdapter={AdapterDayjs} dateLibInstance={dayjs}>
           <ThemeProvider theme={theme}>
             <CssBaseline />
             <App />

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getBookingHistory } from '../../api/bookings';
-import { formatInTimeZone } from 'date-fns-tz';
 import { formatTime } from '../../utils/time';
 import {
   Box,
@@ -20,6 +19,8 @@ import {
 } from '@mui/material';
 import RescheduleDialog from '../../components/RescheduleDialog';
 import EntitySearch from '../../components/EntitySearch';
+import { toDate } from '../../utils/date';
+import { formatDate } from '../../utils/date';
 
 const TIMEZONE = 'America/Regina';
 
@@ -64,8 +65,8 @@ export default function ClientHistory() {
       .then(data => {
         const sorted = [...data].sort(
           (a, b) =>
-            new Date(b.created_at).getTime() -
-            new Date(a.created_at).getTime(),
+          toDate(b.created_at).getTime() -
+            toDate(a.created_at).getTime(),
         );
         setBookings(sorted);
         setPage(1);
@@ -140,8 +141,8 @@ export default function ClientHistory() {
                     const startTime = b.start_time ? formatTime(b.start_time) : 'N/A';
                     const endTime = b.end_time ? formatTime(b.end_time) : 'N/A';
                     const formattedDate =
-                      b.date && !isNaN(new Date(b.date).getTime())
-                        ? formatInTimeZone(`${b.date}`, TIMEZONE, 'MMM d, yyyy')
+                      b.date && !isNaN(toDate(b.date).getTime())
+                        ? formatDate(b.date, 'MMM D, YYYY')
                         : 'N/A';
                     return (
                       <TableRow key={b.id}>

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -21,6 +21,7 @@ import type { Slot, Holiday } from '../../types';
 import { formatTime, formatReginaDate, formatRegina } from '../../utils/time';
 import type { AlertColor } from '@mui/material';
 import SectionCard from '../../components/dashboard/SectionCard';
+import { toDate } from '../../utils/date';
 
 interface Booking {
   id: number;
@@ -37,7 +38,7 @@ interface NextSlot {
 }
 
 function formatDate(dateStr: string) {
-  const d = new Date(dateStr);
+  const d = toDate(dateStr);
   return formatReginaDate(d, { month: 'short', day: 'numeric' });
 }
 
@@ -79,10 +80,10 @@ export default function ClientDashboard() {
   }, []);
 
   useEffect(() => {
-    const today = new Date();
+    const today = toDate();
     Promise.all(
       [...Array(7)].map(async (_, i) => {
-        const d = new Date(today);
+        const d = toDate(today);
         d.setDate(today.getDate() + i);
         const dateStr = formatRegina(d, 'yyyy-MM-dd');
         const slots = (await getSlots(dateStr)) as Slot[];
@@ -98,15 +99,15 @@ export default function ClientDashboard() {
     getHolidays().then(setHolidays).catch(() => {});
   }, []);
 
-  const today = new Date();
+  const today = toDate();
   const approved = bookings
-    .filter(b => b.status === 'approved' && new Date(b.date) >= today)
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    .filter(b => b.status === 'approved' && toDate(b.date) >= today)
+    .sort((a, b) => toDate(a.date).getTime() - toDate(b.date).getTime());
   const next = approved[0];
   const pending = bookings.filter(b => b.status === 'submitted' || b.status === 'pending');
   const history = bookings
     .filter(b => b.status !== 'submitted')
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    .sort((a, b) => toDate(b.date).getTime() - toDate(a.date).getTime());
 
   async function confirmCancel() {
     if (cancelId === null) return;

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -32,6 +32,7 @@ import StyledTabs, { type TabItem } from '../../components/StyledTabs';
 import { getAllSlots } from '../../api/bookings';
 import { formatTime } from '../../utils/time';
 import type { Slot } from '../../types';
+import { formatLocaleDate, toDate } from '../../utils/date';
 
 const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const weekOrdinals = ['1st', '2nd', '3rd', '4th', '5th'];
@@ -61,11 +62,11 @@ interface BreakItem {
 
 export default function ManageAvailability() {
   const [holidays, setHolidays] = useState<HolidayItem[]>([]);
-  const [holidayDate, setHolidayDate] = useState<Date | null>(new Date());
+  const [holidayDate, setHolidayDate] = useState<Date | null>(toDate());
   const [holidayReason, setHolidayReason] = useState('');
 
   const [blockedSlots, setBlockedSlots] = useState<BlockedSlotItem[]>([]);
-  const [blockedDate, setBlockedDate] = useState<Date | null>(new Date());
+  const [blockedDate, setBlockedDate] = useState<Date | null>(toDate());
   const [blockedSlotId, setBlockedSlotId] = useState('');
   const [blockedReason, setBlockedReason] = useState('');
   const [isRecurring, setIsRecurring] = useState(false);
@@ -225,7 +226,7 @@ export default function ManageAvailability() {
                   </Tooltip>
                 }
               >
-                <ListItemText primary={h.date.toLocaleDateString()} />
+                <ListItemText primary={formatLocaleDate(h.date)} />
                 {h.reason && <Chip label={h.reason} sx={{ ml: 1 }} />}
               </ListItem>
             ))}
@@ -346,7 +347,7 @@ export default function ManageAvailability() {
                 <ListItemText
                   primary={
                     b.date
-                      ? b.date.toLocaleDateString()
+                      ? formatLocaleDate(b.date)
                       : `${weekOrdinals[(b.week || 1) - 1]} ${days[b.day || 0]}`
                   }
                   secondary={slotLabel(b.slotId)}

--- a/MJ_FB_Frontend/src/pages/staff/Pending.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/Pending.tsx
@@ -4,6 +4,7 @@ import { getBookings, decideBooking } from '../../api/bookings';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { formatTime } from '../../utils/time';
 import type { AlertColor } from '@mui/material';
+import { formatLocaleDate } from '../../utils/date';
 
 interface Booking {
   id: number;
@@ -68,7 +69,7 @@ export default function Pending() {
                 <Typography variant="body2">Client ID: {b.client_id ?? 'N/A'}</Typography>
                 <Typography variant="body2">Uses this month: {b.bookings_this_month ?? 0}</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {new Date(b.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}{' '}
+                  {formatLocaleDate(b.date, { month: 'short', day: 'numeric', year: 'numeric' })}{' '}
                   {formatTime(b.start_time || b.startTime || '')} - {formatTime(b.end_time || b.endTime || '')}
                 </Typography>
                 <TextField

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { getBookingHistory, cancelBooking } from '../../../api/bookings';
 import { getUserByClientId, updateUserInfo } from '../../../api/users';
-import { formatInTimeZone } from 'date-fns-tz';
 import { formatTime } from '../../../utils/time';
 import {
   Box,
@@ -33,6 +32,7 @@ import type { AlertColor } from '@mui/material';
 import RescheduleDialog from '../../../components/RescheduleDialog';
 import EntitySearch from '../../../components/EntitySearch';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import { toDate, formatDate } from '../../../utils/date';
 
 const TIMEZONE = 'America/Regina';
 
@@ -90,7 +90,7 @@ export default function UserHistory({
     return getBookingHistory(opts)
       .then(data => {
         const sorted = [...data].sort(
-          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+          (a, b) => toDate(b.created_at).getTime() - toDate(a.created_at).getTime()
         );
         setBookings(sorted);
         setPage(1);
@@ -240,8 +240,8 @@ export default function UserHistory({
                     const startTime = b.start_time ? formatTime(b.start_time) : 'N/A';
                     const endTime = b.end_time ? formatTime(b.end_time) : 'N/A';
                     const formattedDate =
-                      b.date && !isNaN(new Date(b.date).getTime())
-                        ? formatInTimeZone(`${b.date}`, TIMEZONE, 'MMM d, yyyy')
+                      b.date && !isNaN(toDate(b.date).getTime())
+                        ? formatDate(b.date, 'MMM D, YYYY')
                         : 'N/A';
                     return (
                       <TableRow key={b.id}>

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -28,9 +28,10 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import Page from '../../components/Page';
 import type { AlertColor } from '@mui/material';
 import SectionCard from '../../components/dashboard/SectionCard';
+import { toDate } from '../../utils/date';
 
 function formatDateLabel(dateStr: string) {
-  const d = new Date(dateStr);
+  const d = toDate(dateStr);
   return formatReginaDate(d, {
     weekday: 'short',
     month: 'short',
@@ -55,11 +56,11 @@ export default function VolunteerDashboard() {
 
   useEffect(() => {
     async function loadAvailability() {
-      const today = new Date();
+      const today = toDate();
       const days =
         dateMode === 'week'
           ? Array.from({ length: 7 }, (_, i) => {
-              const d = new Date(today);
+              const d = toDate(today);
               d.setDate(d.getDate() + i);
               return d;
             })
@@ -80,14 +81,14 @@ export default function VolunteerDashboard() {
   }, [dateMode]);
 
   const nextShift = useMemo(() => {
-    const now = new Date();
+  const now = toDate();
     const upcoming = bookings
       .filter(b => b.status === 'approved')
-      .filter(b => new Date(`${b.date}T${b.start_time}`) >= now)
+      .filter(b => toDate(`${b.date}T${b.start_time}`) >= now)
       .sort(
         (a, b) =>
-          new Date(`${a.date}T${a.start_time}`).getTime() -
-          new Date(`${b.date}T${b.start_time}`).getTime(),
+          toDate(`${a.date}T${a.start_time}`).getTime() -
+          toDate(`${b.date}T${b.start_time}`).getTime(),
       );
     return upcoming[0];
   }, [bookings]);

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -16,7 +16,7 @@ import {
 import type { VolunteerBookingDetail } from '../../types';
 import { formatTime } from '../../utils/time';
 import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
-import { fromZonedTime, formatInTimeZone } from 'date-fns-tz';
+import { fromZonedTime } from 'date-fns-tz';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
 import RescheduleDialog from '../../components/VolunteerRescheduleDialog';
@@ -48,6 +48,7 @@ import { lighten } from '@mui/material/styles';
 import Dashboard from '../../components/dashboard/Dashboard';
 import EntitySearch from '../../components/EntitySearch';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import { formatDate, addDays } from '../../utils/date';
 
 
 
@@ -149,14 +150,12 @@ export default function VolunteerManagement() {
 
   const reginaTimeZone = 'America/Regina';
   const [currentDate, setCurrentDate] = useState(() => {
-    const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
+    const todayStr = formatDate();
     return fromZonedTime(`${todayStr}T00:00:00`, reginaTimeZone);
   });
 
-  const formatDate = (date: Date) => formatInTimeZone(date, reginaTimeZone, 'yyyy-MM-dd');
-
   function changeDay(delta: number) {
-    setCurrentDate(d => new Date(d.getTime() + delta * 86400000));
+    setCurrentDate(d => addDays(d, delta));
   }
 
   useEffect(() => {
@@ -540,11 +539,7 @@ export default function VolunteerManagement() {
   }, [assignSearch, assignSlot]);
 
   const bookingsForDate = bookings.filter(b => {
-    const bookingDate = formatInTimeZone(
-      new Date(b.date),
-      reginaTimeZone,
-      'yyyy-MM-dd',
-    );
+    const bookingDate = formatDate(b.date);
     return (
       bookingDate === formatDate(currentDate) &&
       ['approved', 'pending'].includes(b.status.toLowerCase())

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -15,8 +15,9 @@ import type {
   VolunteerBooking,
   VolunteerRoleGroup,
 } from '../../types';
-import { fromZonedTime, toZonedTime, formatInTimeZone } from 'date-fns-tz';
+import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 import { formatTime } from '../../utils/time';
+import { formatDate, addDays } from '../../utils/date';
 import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import RescheduleDialog from '../../components/VolunteerRescheduleDialog';
@@ -45,7 +46,7 @@ const reginaTimeZone = 'America/Regina';
 
 export default function VolunteerSchedule() {
   const [currentDate, setCurrentDate] = useState(() => {
-    const todayStr = formatInTimeZone(new Date(), reginaTimeZone, 'yyyy-MM-dd');
+    const todayStr = formatDate();
     return fromZonedTime(`${todayStr}T00:00:00`, reginaTimeZone);
   });
   const [bookings, setBookings] = useState<VolunteerBooking[]>([]);
@@ -66,9 +67,6 @@ export default function VolunteerSchedule() {
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
   const theme = useTheme();
   const approvedColor = lighten(theme.palette.success.light, 0.4);
-
-  const formatDate = (date: Date) =>
-    formatInTimeZone(date, reginaTimeZone, 'yyyy-MM-dd');
 
   const loadData = useCallback(async () => {
     const dateStr = formatDate(currentDate);
@@ -131,7 +129,7 @@ export default function VolunteerSchedule() {
   }, [loadData]);
 
   function changeDay(delta: number) {
-    setCurrentDate(d => new Date(d.getTime() + delta * 86400000));
+    setCurrentDate(d => addDays(d, delta));
   }
 
   async function submitRequest() {
@@ -151,11 +149,7 @@ export default function VolunteerSchedule() {
           endDate || undefined,
         );
       }
-      const dateLabel = formatInTimeZone(
-        currentDate,
-        reginaTimeZone,
-        'EEE, MMM d',
-      );
+      const dateLabel = formatDate(currentDate, 'ddd, MMM D');
       const timeLabel = `${formatTime(requestRole.start_time)}–${formatTime(
         requestRole.end_time,
       )}`;
@@ -223,7 +217,7 @@ export default function VolunteerSchedule() {
 
   const dateStr = formatDate(currentDate);
   const reginaDate = toZonedTime(currentDate, reginaTimeZone);
-  const dayName = formatInTimeZone(currentDate, reginaTimeZone, 'EEEE');
+  const dayName = formatDate(currentDate, 'dddd');
   const holidayObj = holidays.find(h => h.date === dateStr);
   const isHoliday = !!holidayObj;
   const isWeekend = reginaDate.getDay() === 0 || reginaDate.getDay() === 6;

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -22,12 +22,13 @@ import {
 import { getDonorAggregations, type DonorAggregation } from '../../api/donations';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
+import { toDate } from '../../utils/date';
 
 export default function Aggregations() {
   const [overallRows, setOverallRows] = useState<WarehouseOverall[]>([]);
   const [overallLoading, setOverallLoading] = useState(false);
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' as 'success' | 'error' });
-  const currentYear = new Date().getFullYear();
+  const currentYear = toDate().getFullYear();
   const fallbackYears = Array.from({ length: 5 }, (_, i) => currentYear - i);
   const [years, setYears] = useState<number[]>(fallbackYears);
   const [overallYear, setOverallYear] = useState(fallbackYears[0]);

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -25,9 +25,10 @@ import { getDonors, createDonor } from '../../api/donors';
 import { getDonations, createDonation, updateDonation, deleteDonation } from '../../api/donations';
 import type { Donor } from '../../api/donors';
 import type { Donation } from '../../api/donations';
+import { formatLocaleDate, toDate, formatDate, addDays } from '../../utils/date';
 
 function startOfWeek(date: Date) {
-  const d = new Date(date);
+  const d = toDate(date);
   const day = d.getDay();
   const diff = d.getDate() - day + (day === 0 ? -6 : 1); // Monday as first day
   d.setDate(diff);
@@ -36,15 +37,15 @@ function startOfWeek(date: Date) {
 }
 
 function format(date: Date) {
-  return date.toISOString().split('T')[0];
+  return formatDate(date);
 }
 
 export default function DonationLog() {
   const [donations, setDonations] = useState<Donation[]>([]);
   const [donors, setDonors] = useState<Donor[]>([]);
   const [tab, setTab] = useState(() => {
-    const week = startOfWeek(new Date());
-    const today = new Date();
+    const week = startOfWeek(toDate());
+    const today = toDate();
     return Math.floor((today.getTime() - week.getTime()) / (24 * 60 * 60 * 1000));
   });
   const [recordOpen, setRecordOpen] = useState(false);
@@ -55,16 +56,12 @@ export default function DonationLog() {
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
 
   const weekDates = useMemo(() => {
-    const start = startOfWeek(new Date());
-    return Array.from({ length: 7 }, (_, i) => {
-      const d = new Date(start);
-      d.setDate(start.getDate() + i);
-      return d;
-    });
+    const start = startOfWeek(toDate());
+    return Array.from({ length: 7 }, (_, i) => addDays(start, i));
   }, []);
 
   const [form, setForm] = useState<{ date: string; donorId: number | null; weight: string }>({
-    date: format(new Date()),
+    date: formatDate(),
     donorId: null,
     weight: '',
   });
@@ -168,7 +165,7 @@ export default function DonationLog() {
   );
 
   const tabs = weekDates.map(d => ({
-    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    label: formatLocaleDate(d, { weekday: 'short' }),
     content: table,
   }));
 

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
@@ -18,6 +18,7 @@ import {
   type DonorDetail,
   type DonorDonation,
 } from '../../api/donors';
+import { formatLocaleDate } from '../../utils/date';
 
 export default function DonorProfile() {
   const { id } = useParams<{ id: string }>();
@@ -49,7 +50,7 @@ export default function DonorProfile() {
               Total: {donor.totalLbs.toLocaleString()} lbs
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Last Donation: {donor.lastDonationISO ? new Date(donor.lastDonationISO).toLocaleDateString() : 'N/A'}
+              Last Donation: {donor.lastDonationISO ? formatLocaleDate(donor.lastDonationISO) : 'N/A'}
             </Typography>
           </CardContent>
         </Card>
@@ -69,7 +70,7 @@ export default function DonorProfile() {
             <TableBody>
               {donations.map(d => (
                 <TableRow key={d.id}>
-                  <TableCell>{new Date(d.date).toLocaleDateString()}</TableCell>
+                  <TableCell>{formatLocaleDate(d.date)}</TableCell>
                   <TableCell>{d.weight}</TableCell>
                 </TableRow>
               ))}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Exports.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Exports.tsx
@@ -16,9 +16,10 @@ import {
   exportWarehouseOverall,
 } from '../../api/warehouseOverall';
 import { exportDonorAggregations } from '../../api/donations';
+import { toDate } from '../../utils/date';
 
 export default function Exports() {
-  const currentYear = new Date().getFullYear();
+  const currentYear = toDate().getFullYear();
   const fallbackYears = Array.from({ length: 5 }, (_, i) => currentYear - i);
   const [years, setYears] = useState<number[]>(fallbackYears);
   const [year, setYear] = useState(fallbackYears[0]);

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
@@ -25,9 +25,10 @@ import { getOutgoingReceivers, createOutgoingReceiver } from '../../api/outgoing
 import { getOutgoingDonations, createOutgoingDonation, updateOutgoingDonation, deleteOutgoingDonation } from '../../api/outgoingDonations';
 import type { OutgoingReceiver } from '../../api/outgoingReceivers';
 import type { OutgoingDonation } from '../../api/outgoingDonations';
+import { formatLocaleDate, toDate, formatDate, addDays } from '../../utils/date';
 
 function startOfWeek(date: Date) {
-  const d = new Date(date);
+  const d = toDate(date);
   const day = d.getDay();
   const diff = d.getDate() - day + (day === 0 ? -6 : 1);
   d.setDate(diff);
@@ -36,7 +37,7 @@ function startOfWeek(date: Date) {
 }
 
 function format(date: Date) {
-  return date.toISOString().split('T')[0];
+  return formatDate(date);
 }
 
 function normalize(date: string) {
@@ -47,8 +48,8 @@ export default function TrackOutgoingDonations() {
   const [donations, setDonations] = useState<OutgoingDonation[]>([]);
   const [receivers, setReceivers] = useState<OutgoingReceiver[]>([]);
   const [tab, setTab] = useState(() => {
-    const week = startOfWeek(new Date());
-    const today = new Date();
+    const week = startOfWeek(toDate());
+    const today = toDate();
     return Math.floor((today.getTime() - week.getTime()) / (24 * 60 * 60 * 1000));
   });
   const [recordOpen, setRecordOpen] = useState(false);
@@ -59,16 +60,12 @@ export default function TrackOutgoingDonations() {
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
 
   const weekDates = useMemo(() => {
-    const start = startOfWeek(new Date());
-    return Array.from({ length: 7 }, (_, i) => {
-      const d = new Date(start);
-      d.setDate(start.getDate() + i);
-      return d;
-    });
+    const start = startOfWeek(toDate());
+    return Array.from({ length: 7 }, (_, i) => addDays(start, i));
   }, []);
 
   const [form, setForm] = useState<{ date: string; receiverId: number | null; weight: string; note: string }>({
-    date: format(new Date()),
+    date: formatDate(),
     receiverId: null,
     weight: '',
     note: '',
@@ -146,7 +143,7 @@ export default function TrackOutgoingDonations() {
           {donations.map(d => (
             <TableRow key={d.id}>
               <TableCell>
-                {new Date(d.date).toLocaleDateString(undefined, {
+                {formatLocaleDate(d.date, {
                   weekday: 'short',
                   year: 'numeric',
                   month: 'short',
@@ -187,7 +184,7 @@ export default function TrackOutgoingDonations() {
   );
 
   const tabs = weekDates.map(d => ({
-    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    label: formatLocaleDate(d, { weekday: 'short' }),
     content: table,
   }));
 

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
@@ -27,9 +27,10 @@ import {
   deletePigPound,
   type PigPound,
 } from '../../api/pigPounds';
+import { formatLocaleDate, toDate, formatDate, addDays } from '../../utils/date';
 
 function startOfWeek(date: Date) {
-  const d = new Date(date);
+  const d = toDate(date);
   const day = d.getDay();
   const diff = d.getDate() - day + (day === 0 ? -6 : 1);
   d.setDate(diff);
@@ -38,29 +39,25 @@ function startOfWeek(date: Date) {
 }
 
 function format(date: Date) {
-  return date.toISOString().split('T')[0];
+  return formatDate(date);
 }
 
 export default function TrackPigpound() {
   const [entries, setEntries] = useState<PigPound[]>([]);
   const [tab, setTab] = useState(() => {
-    const week = startOfWeek(new Date());
-    const today = new Date();
+    const week = startOfWeek(toDate());
+    const today = toDate();
     return Math.floor((today.getTime() - week.getTime()) / (24 * 60 * 60 * 1000));
   });
   const weekDates = useMemo(() => {
-    const start = startOfWeek(new Date());
-    return Array.from({ length: 7 }, (_, i) => {
-      const d = new Date(start);
-      d.setDate(start.getDate() + i);
-      return d;
-    });
+    const start = startOfWeek(toDate());
+    return Array.from({ length: 7 }, (_, i) => addDays(start, i));
   }, []);
   const selectedDate = weekDates[tab];
   const [recordOpen, setRecordOpen] = useState(false);
   const [editing, setEditing] = useState<PigPound | null>(null);
   const [form, setForm] = useState<{ date: string; weight: string }>({
-    date: format(new Date()),
+    date: formatDate(),
     weight: '',
   });
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -128,7 +125,7 @@ export default function TrackPigpound() {
             entries.map(e => (
               <TableRow key={e.id}>
                 <TableCell>
-                  {new Date(e.date).toLocaleDateString('en-CA')}
+                  {formatLocaleDate(e.date)}
                 </TableCell>
                 <TableCell>{e.weight} lbs</TableCell>
                 <TableCell align="right">
@@ -136,7 +133,7 @@ export default function TrackPigpound() {
                     size="small"
                     onClick={() => {
                       setEditing(e);
-                      setForm({ date: format(new Date(e.date)), weight: String(e.weight) });
+                      setForm({ date: formatDate(e.date), weight: String(e.weight) });
                       setRecordOpen(true);
                     }}
                     aria-label="Edit entry"
@@ -163,7 +160,7 @@ export default function TrackPigpound() {
   );
 
   const tabs = weekDates.map(d => ({
-    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    label: formatLocaleDate(d, { weekday: 'short' }),
     content: table,
   }));
 

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
@@ -27,9 +27,10 @@ import {
   deleteSurplus,
   type Surplus,
 } from '../../api/surplus';
+import { formatLocaleDate, toDate, formatDate, addDays } from '../../utils/date';
 
 function startOfWeek(date: Date) {
-  const d = new Date(date);
+  const d = toDate(date);
   const day = d.getDay();
   const diff = d.getDate() - day + (day === 0 ? -6 : 1); // Monday as first day
   d.setDate(diff);
@@ -38,7 +39,7 @@ function startOfWeek(date: Date) {
 }
 
 function format(date: Date) {
-  return date.toISOString().split('T')[0];
+  return formatDate(date);
 }
 
 function normalize(date: string) {
@@ -50,16 +51,12 @@ const CANS_MULTIPLIER = Number(import.meta.env.VITE_CANS_WEIGHT_MULTIPLIER) || 2
 
 export default function TrackSurplus() {
   const weekDates = useMemo(() => {
-    const start = startOfWeek(new Date());
-    return Array.from({ length: 7 }, (_, i) => {
-      const d = new Date(start);
-      d.setDate(start.getDate() + i);
-      return d;
-    });
+    const start = startOfWeek(toDate());
+    return Array.from({ length: 7 }, (_, i) => addDays(start, i));
   }, []);
   const [tab, setTab] = useState(() => {
-    const week = startOfWeek(new Date());
-    const today = new Date();
+    const week = startOfWeek(toDate());
+    const today = toDate();
     return Math.floor((today.getTime() - week.getTime()) / (24 * 60 * 60 * 1000));
   });
   const selectedDate = weekDates[tab];
@@ -128,7 +125,7 @@ export default function TrackSurplus() {
           {filteredRecords.map(r => (
             <TableRow key={r.id}>
               <TableCell>
-                {new Date(r.date).toLocaleDateString(undefined, {
+                {formatLocaleDate(r.date, {
                   weekday: 'short',
                   year: 'numeric',
                   month: 'short',
@@ -169,7 +166,7 @@ export default function TrackSurplus() {
   );
 
   const tabs = weekDates.map(d => ({
-    label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+    label: formatLocaleDate(d, { weekday: 'short' }),
     content: table,
   }));
 

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -38,6 +38,7 @@ import {
   Bar,
 } from 'recharts';
 import { useNavigate } from 'react-router-dom';
+import { formatLocaleDate, toDate } from '../../utils/date';
 import { useAuth } from '../../hooks/useAuth';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import VolunteerCoverageCard from '../../components/dashboard/VolunteerCoverageCard';
@@ -68,7 +69,7 @@ interface MonthlyTotal {
 
 
 function monthName(m: number) {
-  return new Date(2000, m - 1).toLocaleString(undefined, { month: 'short' });
+  return formatLocaleDate(`${2000}-${String(m).padStart(2, '0')}-01`, { month: 'short' });
 }
 
 function fmtLbs(n?: number) {
@@ -120,7 +121,7 @@ export default function WarehouseDashboard() {
         setYears(ys);
         setYear(ys[0]);
       } catch {
-        const currentYear = new Date().getFullYear();
+        const currentYear = toDate().getFullYear();
         const fallback = Array.from({ length: 5 }, (_, i) => currentYear - i);
         setYears(fallback);
         setYear(fallback[0]);
@@ -187,7 +188,7 @@ export default function WarehouseDashboard() {
   }, [year]);
 
   const currentMonth = useMemo(() => {
-    const thisMonth = new Date().getMonth() + 1;
+    const thisMonth = toDate().getMonth() + 1;
     const monthsWithData = totals
       .filter(t => t.donationsLbs || t.surplusLbs || t.pigPoundLbs || t.outgoingLbs)
       .map(t => t.month);
@@ -472,7 +473,7 @@ export default function WarehouseDashboard() {
                     <Box>
                       <Typography variant="body2">{d.name}</Typography>
                       <Typography variant="caption" color="text.secondary">
-                        Last: {new Date(d.lastDonationISO).toLocaleDateString()}
+                        Last: {formatLocaleDate(d.lastDonationISO)}
                       </Typography>
                     </Box>
                     <Typography variant="body2">{fmtLbs(d.totalLbs)}</Typography>
@@ -500,7 +501,7 @@ export default function WarehouseDashboard() {
                     <Box>
                       <Typography variant="body2">{r.name}</Typography>
                       <Typography variant="caption" color="text.secondary">
-                        Last: {new Date(r.lastPickupISO).toLocaleDateString()}
+                        Last: {formatLocaleDate(r.lastPickupISO)}
                       </Typography>
                     </Box>
                     <Typography variant="body2">{fmtLbs(r.totalLbs)}</Typography>

--- a/MJ_FB_Frontend/src/utils/date.ts
+++ b/MJ_FB_Frontend/src/utils/date.ts
@@ -1,0 +1,36 @@
+import dayjs, { ConfigType } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export const REGINA_TIMEZONE = 'America/Regina';
+
+dayjs.tz.setDefault(REGINA_TIMEZONE);
+
+export function toDayjs(input?: ConfigType) {
+  return dayjs(input).tz();
+}
+
+export function toDate(input?: ConfigType) {
+  return toDayjs(input).toDate();
+}
+
+export function formatDate(input?: ConfigType, fmt = 'YYYY-MM-DD') {
+  return toDayjs(input).format(fmt);
+}
+
+export function formatLocaleDate(
+  input?: ConfigType,
+  options: Intl.DateTimeFormatOptions = {},
+  locale = 'en-CA',
+) {
+  return toDayjs(input).toDate().toLocaleDateString(locale, { timeZone: REGINA_TIMEZONE, ...options });
+}
+
+export function addDays(input: ConfigType, amount: number) {
+  return toDayjs(input).add(amount, 'day').toDate();
+}
+
+export default dayjs;


### PR DESCRIPTION
## Summary
- add Day.js-based helpers for timezone-aware date handling
- update LocalizationProvider to use Day.js with timezone plugin
- replace ad-hoc date formatting and direct Date usage across pages

## Testing
- `npm test` *(fails: TS errors and unresolved test warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af4f862984832d8fea98a9170146cd