### PR TITLE
Handle refresh token jti mismatch gracefully

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -113,8 +113,13 @@ export async function refreshToken(req: Request, res: Response, next: NextFuncti
       'SELECT token_id FROM refresh_tokens WHERE subject=$1',
       [subject],
     );
-    if ((stored.rowCount ?? 0) === 0 || stored.rows[0].token_id !== payload.jti) {
+    if ((stored.rowCount ?? 0) === 0) {
       throw new Error('Invalid refresh token');
+    }
+    if (stored.rows[0].token_id !== payload.jti) {
+      // Token subject exists but jti mismatch – likely another request refreshed already.
+      logger.warn('Refresh token jti mismatch for %s', subject);
+      return res.status(409).send();
     }
     const newJti = randomUUID();
     await pool.query(

--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -70,7 +70,8 @@ export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {})
       }
       const refreshRes = await refreshPromise;
       refreshPromise = null;
-      if (refreshRes.ok) {
+      if (refreshRes.ok || refreshRes.status === 409) {
+        // 409 indicates another request already refreshed the tokens
         res = await fetchWithRetry(input, { credentials: 'include', ...init }, 1);
       } else if (refreshRes.status === 401) {
         clearAuthAndRedirect();

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -54,7 +54,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     (async () => {
       try {
         const res = await apiFetch(`${API_BASE}/auth/refresh`, { method: 'POST' });
-        if (res.ok) {
+        if (res.ok || res.status === 409) {
+          // 409 indicates another tab or request refreshed already
           setToken('cookie');
         } else if (res.status === 401) {
           clearAuth();
@@ -69,7 +70,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   async function login(u: LoginResponse) {
     try {
       const res = await apiFetch(`${API_BASE}/auth/refresh`, { method: 'POST' });
-      if (!res.ok) throw new Error('Invalid refresh');
+      if (!res.ok && res.status !== 409) throw new Error('Invalid refresh');
       setToken('cookie');
       setRole(u.role);
       setName(u.name);


### PR DESCRIPTION
## Summary
- detect refresh token jti mismatch and reply 409 without clearing cookies
- allow frontend to treat 409 refresh results as successful and retry requests
- handle 409 in auth provider during startup and login

## Testing
- `npm test` (fails: booking utils, events, and other suites)
- `npm test` in `MJ_FB_Frontend` (fails: multiple TypeScript and component tests)


------
https://chatgpt.com/codex/tasks/task_e_68afa0cd1ee8832d96beeca50f2ee600