### PR TITLE
Respect err.statusCode in error handler

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -90,7 +90,7 @@ if (process.env.NODE_ENV === 'production') {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
   logger.error('Unhandled error:', err);
-  const status = err.status || 500;
+  const status = err.status || err.statusCode || 500;
   res.status(status).json({ message: err.message || 'Internal Server Error' });
 });
 


### PR DESCRIPTION
## Summary
- handle errors with `err.status` then `err.statusCode` before defaulting to 500

## Testing
- `npm test` *(fails: 7 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68afc172dfa8832d8d19840dfc776f47