### PR TITLE
Set CSRF cookie secure flag for production

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -188,7 +188,7 @@ export async function logout(req: Request, res: Response, next: NextFunction) {
 
 export function csrfToken(_req: Request, res: Response) {
   const token = randomUUID();
-  const secure = process.env.NODE_ENV !== 'development';
+  const secure = process.env.NODE_ENV === 'production';
   res.cookie('csrfToken', token, {
     sameSite: 'strict',
     secure,


### PR DESCRIPTION
## Summary
- ensure csrf cookie only uses secure flag in production

## Testing
- `npm test` *(fails: Invalid input expected string for PG_USER etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68afc19320f8832d95006ce7e541bbad