### PR TITLE
feat(frontend): export tables with write-excel-file

### DIFF
--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -24,7 +24,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",
-    "recharts": "^3.1.2"
+    "recharts": "^3.1.2",
+    "write-excel-file": "^4.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",

--- a/MJ_FB_Frontend/src/utils/exportTableToExcel.ts
+++ b/MJ_FB_Frontend/src/utils/exportTableToExcel.ts
@@ -1,12 +1,9 @@
+import writeXlsxFile from 'write-excel-file';
+
 export function exportTableToExcel(table: HTMLTableElement, filename: string) {
-  const html = table.outerHTML;
-  const blob = new Blob(['\ufeff', html], { type: 'application/vnd.ms-excel' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = `${filename}.xls`;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  const data = Array.from(table.rows).map((row) =>
+    Array.from(row.cells).map((cell) => ({ value: cell.textContent || '' }))
+  );
+
+  void writeXlsxFile(data, { fileName: `${filename}.xlsx` });
 }


### PR DESCRIPTION
## Summary
- switch table export util to use write-excel-file
- declare write-excel-file dependency

## Testing
- `npm test` *(fails: Argument type mismatch in EventForm and other existing test issues)*

------
https://chatgpt.com/codex/tasks/task_e_68afc19dac40832d8c6a6402b8ea497d