### PR TITLE
feat: type authenticated user

### DIFF
--- a/MJ_FB_Backend/src/types/AuthUser.ts
+++ b/MJ_FB_Backend/src/types/AuthUser.ts
@@ -1,0 +1,11 @@
+export interface AuthUser {
+  id: string;
+  role: string;
+  type: 'user' | 'staff' | 'volunteer' | 'agency';
+  email?: string;
+  phone?: string;
+  name?: string;
+  userId?: string;
+  userRole?: 'shopper' | 'delivery';
+  access?: string[];
+}

--- a/MJ_FB_Backend/src/types/express.d.ts
+++ b/MJ_FB_Backend/src/types/express.d.ts
@@ -1,15 +1,12 @@
-declare namespace Express {
-  export interface Request {
-    user?: {
-      id: string;
-      role: 'shopper' | 'delivery' | 'staff' | 'volunteer' | 'agency';
-      type?: 'user' | 'staff' | 'volunteer' | 'agency';
-      email?: string;
-      phone?: string;
-      name?: string;
-      userId?: string;
-      userRole?: 'shopper' | 'delivery';
-      access?: string[];
-    };
+import type { AuthUser } from './AuthUser';
+
+declare global {
+  namespace Express {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Request {
+      user?: AuthUser;
+    }
   }
 }
+
+export {};


### PR DESCRIPTION
## Summary
- add AuthUser interface describing logged-in users
- type Express Request.user as AuthUser
- use AuthUser throughout auth middleware

## Testing
- `npm test` *(fails: 7 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68afc1a57d30832daba8ceb7ed2b0f22