### PR TITLE
Require credentials on login forms

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/Login.tsx
@@ -13,6 +13,10 @@ export default function AgencyLogin({
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
+  const emailError = email === '';
+  const passwordError = password === '';
+  const formInvalid = emailError || passwordError;
+
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
@@ -29,7 +33,13 @@ export default function AgencyLogin({
         onSubmit={submit}
         title="Agency Login"
         actions={
-          <Button type="submit" variant="contained" color="primary" fullWidth>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={formInvalid}
+          >
             Login
           </Button>
         }
@@ -40,6 +50,9 @@ export default function AgencyLogin({
           onChange={e => setEmail(e.target.value)}
           label="Email"
           fullWidth
+          required
+          error={emailError}
+          helperText={emailError ? 'Email is required' : ''}
         />
         <TextField
           type="password"
@@ -47,6 +60,9 @@ export default function AgencyLogin({
           onChange={e => setPassword(e.target.value)}
           label="Password"
           fullWidth
+          required
+          error={passwordError}
+          helperText={passwordError ? 'Password is required' : ''}
         />
       </FormCard>
       <FeedbackSnackbar

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -17,6 +17,10 @@ export default function Login({
   const [error, setError] = useState('');
   const [resetOpen, setResetOpen] = useState(false);
 
+  const clientIdError = clientId === '';
+  const passwordError = password === '';
+  const formInvalid = clientIdError || passwordError;
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
@@ -46,13 +50,36 @@ export default function Login({
           </Stack>
         }
         actions={
-          <Button type="submit" variant="contained" color="primary" fullWidth>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={formInvalid}
+          >
             Login
           </Button>
         }
       >
-        <TextField value={clientId} onChange={e => setClientId(e.target.value)} label="Client ID" fullWidth />
-        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
+        <TextField
+          value={clientId}
+          onChange={e => setClientId(e.target.value)}
+          label="Client ID"
+          fullWidth
+          required
+          error={clientIdError}
+          helperText={clientIdError ? 'Client ID is required' : ''}
+        />
+        <TextField
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          label="Password"
+          fullWidth
+          required
+          error={passwordError}
+          helperText={passwordError ? 'Password is required' : ''}
+        />
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">
           Forgot password?
         </Link>

--- a/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
@@ -50,6 +50,10 @@ function StaffLoginForm({
   const [error, setError] = useState(initError);
   const [resetOpen, setResetOpen] = useState(false);
 
+  const emailError = email === '';
+  const passwordError = password === '';
+  const formInvalid = emailError || passwordError;
+
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
@@ -71,7 +75,13 @@ function StaffLoginForm({
         title="Staff Login"
         header={<Link component={RouterLink} to="/login/user" underline="hover">Client Login</Link>}
         actions={
-          <Button type="submit" variant="contained" color="primary" fullWidth>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={formInvalid}
+          >
             Login
           </Button>
         }
@@ -82,8 +92,20 @@ function StaffLoginForm({
           onChange={e => setEmail(e.target.value)}
           label="Email"
           fullWidth
+          required
+          error={emailError}
+          helperText={emailError ? 'Email is required' : ''}
         />
-        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
+        <TextField
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          label="Password"
+          fullWidth
+          required
+          error={passwordError}
+          helperText={passwordError ? 'Password is required' : ''}
+        />
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">Forgot password?</Link>
       </FormCard>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="staff" />
@@ -99,6 +121,13 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   const [password, setPassword] = useState('');
   const [error, setError] = useState(initError);
   const [message, setMessage] = useState('');
+
+  const firstNameError = firstName === '';
+  const lastNameError = lastName === '';
+  const emailError = email === '';
+  const passwordError = password === '';
+  const formInvalid =
+    firstNameError || lastNameError || emailError || passwordError;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -117,15 +146,55 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
         onSubmit={submit}
         title="Create Staff Account"
         actions={
-          <Button type="submit" variant="contained" color="primary" fullWidth>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={formInvalid}
+          >
             Create Staff
           </Button>
         }
       >
-        <TextField value={firstName} onChange={e => setFirstName(e.target.value)} label="First name" fullWidth />
-        <TextField value={lastName} onChange={e => setLastName(e.target.value)} label="Last name" fullWidth />
-        <TextField type="email" value={email} onChange={e => setEmail(e.target.value)} label="Email" fullWidth />
-        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
+        <TextField
+          value={firstName}
+          onChange={e => setFirstName(e.target.value)}
+          label="First name"
+          fullWidth
+          required
+          error={firstNameError}
+          helperText={firstNameError ? 'First name is required' : ''}
+        />
+        <TextField
+          value={lastName}
+          onChange={e => setLastName(e.target.value)}
+          label="Last name"
+          fullWidth
+          required
+          error={lastNameError}
+          helperText={lastNameError ? 'Last name is required' : ''}
+        />
+        <TextField
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          label="Email"
+          fullWidth
+          required
+          error={emailError}
+          helperText={emailError ? 'Email is required' : ''}
+        />
+        <TextField
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          label="Password"
+          fullWidth
+          required
+          error={passwordError}
+          helperText={passwordError ? 'Password is required' : ''}
+        />
       </FormCard>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <FeedbackModal open={!!message} onClose={() => setMessage('')} message={message} />

--- a/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
@@ -17,6 +17,10 @@ export default function VolunteerLogin({
   const [error, setError] = useState('');
   const [resetOpen, setResetOpen] = useState(false);
 
+  const usernameError = username === '';
+  const passwordError = password === '';
+  const formInvalid = usernameError || passwordError;
+
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
@@ -34,13 +38,36 @@ export default function VolunteerLogin({
         title="Volunteer Login"
         header={<Link component={RouterLink} to="/login/user" underline="hover">Client Login</Link>}
         actions={
-          <Button type="submit" variant="contained" color="primary" fullWidth>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={formInvalid}
+          >
             Login
           </Button>
         }
       >
-        <TextField value={username} onChange={e => setUsername(e.target.value)} label="Username" fullWidth />
-        <TextField type="password" value={password} onChange={e => setPassword(e.target.value)} label="Password" fullWidth />
+        <TextField
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          label="Username"
+          fullWidth
+          required
+          error={usernameError}
+          helperText={usernameError ? 'Username is required' : ''}
+        />
+        <TextField
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          label="Password"
+          fullWidth
+          required
+          error={passwordError}
+          helperText={passwordError ? 'Password is required' : ''}
+        />
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">Forgot password?</Link>
       </FormCard>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="volunteer" />


### PR DESCRIPTION
## Summary
- enforce required fields and inline helper text on client, staff, volunteer, and agency login forms
- disable submission buttons when any required field is empty

## Testing
- `npm test` (fails: TS1343 import.meta meta-property error and other test failures)


------
https://chatgpt.com/codex/tasks/task_e_68afc34563a4832da059047990b4572e