### PR TITLE
feat: validate new password requirements

### DIFF
--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -52,7 +52,20 @@ export default function Profile({ role }: { role: Role }) {
     ? `${profile.firstName?.[0] ?? ''}${profile.lastName?.[0] ?? ''}`.toUpperCase()
     : '';
 
+  function validatePassword(pwd: string) {
+    if (pwd.length < 8) return 'Password must be at least 8 characters.';
+    if (!/\d/.test(pwd)) return 'Password must include a number.';
+    if (!/[^A-Za-z0-9]/.test(pwd)) return 'Password must include a symbol.';
+    return '';
+  }
+
   async function handleReset() {
+    const validationError = validatePassword(newPassword);
+    if (validationError) {
+      setPasswordError(validationError);
+      return;
+    }
+
     setSubmitting(true);
     setPasswordError('');
     try {
@@ -194,7 +207,10 @@ export default function Profile({ role }: { role: Role }) {
               autoComplete="current-password"
               fullWidth
               value={currentPassword}
-              onChange={e => setCurrentPassword(e.target.value)}
+              onChange={e => {
+                setCurrentPassword(e.target.value);
+                setPasswordError('');
+              }}
               disabled={submitting}
             />
             <TextField
@@ -204,7 +220,11 @@ export default function Profile({ role }: { role: Role }) {
               autoComplete="new-password"
               fullWidth
               value={newPassword}
-              onChange={e => setNewPassword(e.target.value)}
+              onChange={e => {
+                const val = e.target.value;
+                setNewPassword(val);
+                setPasswordError(validatePassword(val));
+              }}
               disabled={submitting}
               error={!!passwordError}
               helperText={passwordError}
@@ -218,7 +238,13 @@ export default function Profile({ role }: { role: Role }) {
               color="success"
               size="small"
               fullWidth
-              disabled={submitting}
+              disabled={
+                submitting ||
+                !currentPassword ||
+                !newPassword ||
+                !!validatePassword(newPassword) ||
+                !!passwordError
+              }
               startIcon={submitting ? <CircularProgress size={20} /> : null}
               onClick={handleReset}
             >


### PR DESCRIPTION
## Summary
- validate new password length, numeric and symbol requirements
- show inline validation errors and disable reset button until password is valid

## Testing
- `npm test` *(fails: TS errors in test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68afc3573b00832db5ff13aeb681f1d2