### PR TITLE
Parallelize slot range retrieval

### DIFF
--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -146,14 +146,20 @@ export async function listSlotsRange(
       return res.status(400).json({ message: 'Invalid start date' });
     }
 
-    const results: { date: string; slots: Slot[] }[] = [];
-    for (let i = 0; i < days; i++) {
+    const dates = Array.from({ length: days }, (_, i) => {
       const d = new Date(startDate);
       d.setDate(startDate.getDate() + i);
-      const dateStr = formatReginaDate(d);
-      const slots = await getSlotsForDate(dateStr);
-      results.push({ date: dateStr, slots });
-    }
+      return formatReginaDate(d);
+    });
+
+    const slotsForDates = await Promise.all(
+      dates.map(date => getSlotsForDate(date)),
+    );
+
+    const results = dates.map((date, idx) => ({
+      date,
+      slots: slotsForDates[idx],
+    }));
 
     res.json(results);
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- fetch daily slot availability in parallel using Promise.all
- return slot results in the same order as requested dates

## Testing
- `npm test` *(fails: Test Suites: 7 failed, 22 passed, 29 total)*

------
https://chatgpt.com/codex/tasks/task_e_68afc5b96bdc832dbd042aed6e9cda0e