### PR TITLE
Filter bookings by date and client IDs

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -105,7 +105,15 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
 export async function listBookings(req: Request, res: Response, next: NextFunction) {
   try {
     const status = (req.query.status as string)?.toLowerCase();
-    const rows = await repoFetchBookings(status);
+    const date = req.query.date as string | undefined;
+    const clientIdsParam = req.query.clientIds as string | undefined;
+    const clientIds = clientIdsParam
+      ? clientIdsParam
+          .split(',')
+          .map((id) => Number(id.trim()))
+          .filter((n) => !Number.isNaN(n))
+      : undefined;
+    const rows = await repoFetchBookings(status, date, clientIds);
     res.json(rows);
   } catch (error) {
     logger.error('Error listing bookings:', error);

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -4,6 +4,7 @@ import {
   insertBooking,
   updateBooking,
   SlotCapacityError,
+  fetchBookings,
 } from '../src/models/bookingRepository';
 
 jest.mock('../src/db');
@@ -60,5 +61,13 @@ describe('bookingRepository', () => {
       'UPDATE bookings SET status=$2, request_data=$3 WHERE id=$1',
       [1, 'cancelled', 'reason'],
     );
+  });
+
+  it('fetchBookings applies optional filters', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    await fetchBookings('approved', '2024-01-01', [1, 2]);
+    const call = (pool.query as jest.Mock).mock.calls[0];
+    expect(call[0]).toMatch(/b.status = \$1 AND b.date = \$2 AND u.client_id = ANY\(\$3\)/);
+    expect(call[1]).toEqual(['approved', '2024-01-01', [1, 2]]);
   });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -73,9 +73,14 @@ function normalizeBooking(b: BookingResponse) {
   };
 }
 
-export async function getBookings(opts: { status?: string } = {}) {
+export async function getBookings(
+  opts: { status?: string; date?: string; clientIds?: number[] } = {},
+) {
   const params = new URLSearchParams();
   if (opts.status) params.append('status', opts.status);
+  if (opts.date) params.append('date', opts.date);
+  if (opts.clientIds && opts.clientIds.length)
+    params.append('clientIds', opts.clientIds.join(','));
   const query = params.toString();
   const res = await apiFetch(`${API_BASE}/bookings${query ? `?${query}` : ''}`);
   const data = await handleResponse(res);

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -74,25 +74,19 @@ export default function PantrySchedule({
     try {
       const [slotsData, bookingsData, blockedData] = await Promise.all([
         getSlots(dateStr),
-        getBookings(),
+        getBookings({ date: dateStr, clientIds }),
         getBlockedSlots(dateStr),
       ]);
       setSlots(slotsData);
       setBlockedSlots(blockedData);
-      const filtered = bookingsData.filter((b: Booking) => {
-        const bookingDate = formatDate(b.date);
-        const inClient = !clientIds || clientIds.includes(b.client_id);
-        return (
-          bookingDate === dateStr &&
-          ['approved', 'submitted'].includes(b.status) &&
-          inClient
-        );
-      });
+      const filtered = bookingsData.filter((b: Booking) =>
+        ['approved', 'submitted'].includes(b.status),
+      );
       setBookings(filtered);
     } catch (err) {
       console.error(err);
     }
-  }, [currentDate, holidays]);
+  }, [currentDate, holidays, clientIds]);
 
   useEffect(() => {
     getHolidays().then(setHolidays).catch(() => {});


### PR DESCRIPTION
## Summary
- allow `/bookings` endpoint to filter by date and optional client IDs
- forward date/client filter from frontend and use current date in PantrySchedule

## Testing
- `npm test` *(MJ_FB_Backend, failed: Invalid input: expected string, received undefined)*
- `npm test` *(MJ_FB_Frontend, failed: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext')*


------
https://chatgpt.com/codex/tasks/task_e_68afc5da0f20832d83cff973f14fcae5