### PR TITLE
Memoize slot filtering in BookingUI

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useEffect, useRef, type ReactNode } from 'react';
+import { useState, useEffect, useRef, useMemo, type ReactNode } from 'react';
 import {
   Box,
   Container,
@@ -98,11 +98,13 @@ export default function BookingUI({
     setSelectedSlotId(null);
   }, [date, holidays]);
 
-  const morningSlots = slots.filter(s =>
-    dayjs(s.startTime, 'HH:mm:ss').hour() < 12,
+  const morningSlots = useMemo(
+    () => slots.filter(s => dayjs(s.startTime, 'HH:mm:ss').hour() < 12),
+    [slots],
   );
-  const afternoonSlots = slots.filter(s =>
-    dayjs(s.startTime, 'HH:mm:ss').hour() >= 12,
+  const afternoonSlots = useMemo(
+    () => slots.filter(s => dayjs(s.startTime, 'HH:mm:ss').hour() >= 12),
+    [slots],
   );
 
   async function handleBook() {


### PR DESCRIPTION
## Summary
- Memoize morning and afternoon slot calculations in BookingUI
- Import useMemo and rely on memoized slot lists during render

## Testing
- `npm test` *(fails: Argument of type 'PickerValue' is not assignable to parameter of type 'SetStateAction<Date | null>', 'import.meta' meta-property errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68afc5e2a7d0832da834d334dc76b23c