### PR TITLE
feat: enqueue booking emails

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -8,7 +8,7 @@ import {
   LIMIT_MESSAGE,
   findUpcomingBooking,
 } from '../utils/bookingUtils';
-import { sendEmail } from '../utils/emailUtils';
+import { enqueueEmail } from '../utils/emailQueue';
 import logger from '../utils/logger';
 import {
   SlotCapacityError,
@@ -85,7 +85,7 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
     }
     client.release();
 
-    await sendEmail(
+    enqueueEmail(
       user.email || 'test@example.com',
       'Appointment request received',
       `Booking request submitted for ${date}`,
@@ -170,7 +170,7 @@ export async function decideBooking(req: Request, res: Response, next: NextFunct
       });
     }
 
-    await sendEmail(
+    enqueueEmail(
       'test@example.com',
       `Booking ${decision}d`,
       `Booking ${bookingId} has been ${decision}d`,
@@ -211,7 +211,7 @@ export async function cancelBooking(req: Request, res: Response, next: NextFunct
 
     await updateBooking(Number(bookingId), { status: 'cancelled', request_data: reason });
 
-    await sendEmail(
+    enqueueEmail(
       'test@example.com',
       'Booking cancelled',
       `Booking ${bookingId} was cancelled`,
@@ -253,7 +253,7 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
       status: newStatus,
     });
 
-    await sendEmail(
+    enqueueEmail(
       'test@example.com',
       'Booking rescheduled',
       `Booking ${booking.id} was rescheduled`,

--- a/MJ_FB_Backend/src/utils/emailQueue.ts
+++ b/MJ_FB_Backend/src/utils/emailQueue.ts
@@ -1,0 +1,31 @@
+import logger from './logger';
+import { sendEmail } from './emailUtils';
+
+interface EmailJob {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+const queue: EmailJob[] = [];
+let processing = false;
+
+export function enqueueEmail(to: string, subject: string, body: string): void {
+  queue.push({ to, subject, body });
+  processQueue().catch((err) => logger.error('Email queue processing error:', err));
+}
+
+async function processQueue(): Promise<void> {
+  if (processing) return;
+  processing = true;
+  while (queue.length > 0) {
+    const job = queue.shift()!;
+    try {
+      await sendEmail(job.to, job.subject, job.body);
+    } catch (err) {
+      logger.error('Failed to send email job:', err);
+    }
+  }
+  processing = false;
+}
+


### PR DESCRIPTION
## Summary
- queue outgoing emails using a simple in-memory job processor
- enqueue email jobs from booking controller so API returns immediately

## Testing
- `npm test` *(fails: bookingUtils, agency, volunteerReschedule, holidaysAccess, slots, events)*

------
https://chatgpt.com/codex/tasks/task_e_68afc5eac408832d8239e2af5f832b58