### PR TITLE
Filter past volunteer slots on current day

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -217,6 +217,9 @@ export default function VolunteerSchedule() {
 
   const dateStr = formatDate(currentDate);
   const reginaDate = toZonedTime(currentDate, reginaTimeZone);
+  const today = toZonedTime(new Date(), reginaTimeZone);
+  const isToday =
+    reginaDate.toDateString() === today.toDateString();
   const dayName = formatDate(currentDate, 'dddd');
   const holidayObj = holidays.find(h => h.date === dateStr);
   const isHoliday = !!holidayObj;
@@ -231,11 +234,17 @@ export default function VolunteerSchedule() {
     (!selectedCategory || !allowedOnClosed.includes(selectedCategory));
 
   const roleSlots = selectedRoleKey
-    ? (
-        roleGroups
-          .find(g => g.category_id === Number(selectedCategoryId))
-          ?.roles.find(r => r.id === Number(selectedRoleId))?.slots || []
-      ).sort((a, b) => a.start_time.localeCompare(b.start_time))
+    ? (() => {
+        let slots =
+          roleGroups
+            .find(g => g.category_id === Number(selectedCategoryId))
+            ?.roles.find(r => r.id === Number(selectedRoleId))?.slots || [];
+        if (isToday) {
+          const nowTime = today.toTimeString().slice(0, 8);
+          slots = slots.filter(s => s.start_time > nowTime);
+        }
+        return slots.sort((a, b) => a.start_time.localeCompare(b.start_time));
+      })()
     : [];
   const maxSlots = Math.max(0, ...roleSlots.map(r => r.max_volunteers));
   const showClosedMessage = (isHoliday || isWeekend) && roleGroups.length === 0;


### PR DESCRIPTION
## Summary
- Hide elapsed volunteer slots when viewing the current day by comparing against current Regina time
- Only show upcoming slots in schedule table, preventing bookings for past times

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68afc9f57ee8832d856dc3d90186b6a8