### PR TITLE
Hide expired booking slots on current day

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BookingUI from '../pages/BookingUI';
+import dayjs from 'dayjs';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('@mui/x-date-pickers/DateCalendar', () => ({
+  DateCalendar: () => <div />,
+}));
+
+jest.mock('../api/bookings', () => ({
+  getSlots: jest.fn(),
+  createBooking: jest.fn(),
+  getHolidays: jest.fn(),
+}));
+
+const { getSlots, getHolidays } = jest.requireMock('../api/bookings');
+
+describe('BookingUI visible slots', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T10:30:00'));
+    window.matchMedia = window.matchMedia || ((() => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+    })) as any);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('hides past slots when viewing today', async () => {
+    (getSlots as jest.Mock).mockResolvedValue([
+      { id: '1', startTime: '09:00:00', endTime: '09:30:00', available: 1 },
+      { id: '2', startTime: '11:00:00', endTime: '11:30:00', available: 1 },
+    ]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+
+    const queryClient = new QueryClient();
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <BookingUI shopperName="Test" initialDate={dayjs('2024-01-01')} />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText(/11:00 am/i);
+    expect(screen.queryByText(/9:00 am/i)).toBeNull();
+    expect(screen.getByText(/11:00 am/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Filter slots earlier than current time via memoized `visibleSlots`
- Derive morning/afternoon lists and booking logic from `visibleSlots` to prevent selecting expired slots
- Add unit test verifying past slots are hidden

## Testing
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/write-excel-file)
- `npm test` (fails: jest not found)

------
https://chatgpt.com/codex/tasks/task_e_68afc9ed3a20832d97707d60c93e1fa2