### PR TITLE
Auto approve or reject bookings based on monthly usage

### DIFF
--- a/MJ_FB_Backend/tests/agency.test.ts
+++ b/MJ_FB_Backend/tests/agency.test.ts
@@ -71,9 +71,13 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  (bookingUtils.isDateWithinCurrentOrNextMonth as jest.Mock).mockReturnValue(true);
-  (bookingUtils.countApprovedBookingsForMonth as jest.Mock).mockResolvedValue(0);
-  (bookingUtils.findUpcomingBooking as jest.Mock).mockResolvedValue(null);
+  jest
+    .spyOn(bookingUtils, 'isDateWithinCurrentOrNextMonth')
+    .mockReturnValue(true);
+  jest
+    .spyOn(bookingUtils, 'countVisitsAndBookingsForMonth')
+    .mockResolvedValue(0);
+  jest.spyOn(bookingUtils, 'findUpcomingBooking').mockResolvedValue(null);
   (pool.connect as jest.Mock).mockResolvedValue({
     query: jest.fn(),
     release: jest.fn(),

--- a/MJ_FB_Backend/tests/bookingCapacity.test.ts
+++ b/MJ_FB_Backend/tests/bookingCapacity.test.ts
@@ -15,7 +15,7 @@ jest.mock('../src/models/bookingRepository', () => ({
 jest.mock('jsonwebtoken');
 jest.mock('../src/utils/bookingUtils', () => ({
   isDateWithinCurrentOrNextMonth: jest.fn().mockReturnValue(true),
-  countApprovedBookingsForMonth: jest.fn().mockResolvedValue(0),
+  countVisitsAndBookingsForMonth: jest.fn().mockResolvedValue(0),
   findUpcomingBooking: jest.fn().mockResolvedValue(null),
   LIMIT_MESSAGE: 'limit',
 }));

--- a/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
@@ -81,7 +81,7 @@ beforeEach(() => {
   });
   (pool.query as jest.Mock).mockResolvedValue({ rows: [{ bookings_this_month: 0 }] });
   jest.spyOn(bookingUtils, 'isDateWithinCurrentOrNextMonth').mockReturnValue(true);
-  jest.spyOn(bookingUtils, 'countApprovedBookingsForMonth').mockResolvedValue(0);
+  jest.spyOn(bookingUtils, 'countVisitsAndBookingsForMonth').mockResolvedValue(0);
   jest.spyOn(bookingUtils, 'findUpcomingBooking').mockResolvedValue(null);
 });
 
@@ -101,7 +101,7 @@ describe('volunteer acting as shopper', () => {
       .send({ slotId: 1, date: today });
 
     expect(res.status).toBe(201);
-    expect(bookingUtils.countApprovedBookingsForMonth).toHaveBeenCalledWith(10, today);
+    expect(bookingUtils.countVisitsAndBookingsForMonth).toHaveBeenCalledWith(10, today);
     expect((bookingRepository.insertBooking as jest.Mock).mock.calls[0][0]).toBe(10);
   });
 


### PR DESCRIPTION
## Summary
- Auto-approve shopper bookings when combined visits and approved bookings this month are under 2; auto-reject otherwise
- Compute monthly usage with new helper that counts client visits and approved bookings
- Automatically approve or reject pending bookings based on monthly usage

## Testing
- `PG_USER=x PG_PASSWORD=x PG_HOST=localhost PG_PORT=5432 PG_DATABASE=test FRONTEND_ORIGIN=http://localhost npm test` *(fails: getMonthRange across time zones, rescheduleVolunteerBooking, GET /blocked-slots, Agency booking tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afcd1e60f0832d8ce66ef75a1b1539