### PR TITLE
feat: handle concurrent monthly booking limits

### DIFF
--- a/MJ_FB_Backend/tests/bookingLimit.test.ts
+++ b/MJ_FB_Backend/tests/bookingLimit.test.ts
@@ -1,0 +1,134 @@
+import request from 'supertest';
+import express from 'express';
+
+describe('booking monthly limits', () => {
+  let app: express.Express;
+  let bookingUtils: any;
+  let pool: any;
+  let bookingRepository: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/db', () => ({
+        __esModule: true,
+        default: { connect: jest.fn(), query: jest.fn() },
+      }));
+      jest.doMock('../src/models/bookingRepository', () => ({
+        __esModule: true,
+        ...jest.requireActual('../src/models/bookingRepository'),
+        checkSlotCapacity: jest.fn(),
+        insertBooking: jest.fn(),
+      }));
+      jest.doMock('../src/utils/bookingUtils', () => ({
+        isDateWithinCurrentOrNextMonth: jest.fn().mockReturnValue(true),
+        countVisitsAndBookingsForMonth: jest.fn(),
+        findUpcomingBooking: jest.fn().mockResolvedValue(null),
+        LIMIT_MESSAGE: 'limit',
+      }));
+      jest.doMock('../src/middleware/authMiddleware', () => ({
+        authMiddleware: (
+          req: any,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => {
+          req.user = {
+            id: 'v1',
+            role: 'volunteer',
+            userId: '10',
+            userRole: 'shopper',
+            email: 'vol@example.com',
+          };
+          next();
+        },
+        authorizeRoles: () => (
+          _req: express.Request,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => next(),
+        authorizeAccess: () => (
+          _req: express.Request,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => next(),
+        optionalAuthMiddleware: (
+          req: any,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => {
+          req.user = {
+            id: 'v1',
+            role: 'volunteer',
+            userId: '10',
+            userRole: 'shopper',
+            email: 'vol@example.com',
+          };
+          next();
+        },
+      }));
+      pool = require('../src/db').default;
+      bookingRepository = require('../src/models/bookingRepository');
+      bookingUtils = require('../src/utils/bookingUtils');
+      const bookingsRouter = require('../src/routes/bookings').default;
+      app = express();
+      app.use(express.json());
+      app.use('/bookings', bookingsRouter);
+      app.use(
+        (
+          err: any,
+          _req: express.Request,
+          res: express.Response,
+          _next: express.NextFunction,
+        ) => {
+          res.status(err.status || 500).json({ message: err.message });
+        },
+      );
+    });
+    (pool.connect as jest.Mock).mockResolvedValue({ query: jest.fn(), release: jest.fn() });
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [{ bookings_this_month: 0 }] });
+    (bookingRepository.checkSlotCapacity as jest.Mock).mockResolvedValue(undefined);
+    (bookingRepository.insertBooking as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('rejects third visit in current month', async () => {
+    (bookingUtils.countVisitsAndBookingsForMonth as jest.Mock).mockResolvedValue(2);
+    const today = new Date().toISOString().split('T')[0];
+    const res = await request(app).post('/bookings').send({ slotId: 1, date: today });
+    expect(res.body.status).toBe('rejected');
+    expect(res.body.message).toBe('limit');
+  });
+
+  it('allows next-month booking when current month usage is maxed', async () => {
+    (bookingUtils.countVisitsAndBookingsForMonth as jest.Mock).mockImplementation(
+      (_id: number, date: string) => {
+        const d = new Date(date);
+        const now = new Date();
+        return Promise.resolve(d.getMonth() === now.getMonth() ? 2 : 0);
+      },
+    );
+    const now = new Date();
+    const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 5)
+      .toISOString()
+      .split('T')[0];
+    const res = await request(app)
+      .post('/bookings')
+      .send({ slotId: 1, date: nextMonth });
+    expect(res.body.status).toBe('approved');
+  });
+
+  it('only approves one of two simultaneous bookings over the limit', async () => {
+    (bookingUtils.countVisitsAndBookingsForMonth as jest.Mock)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2);
+    const today = new Date().toISOString().split('T')[0];
+
+    const [res1, res2] = await Promise.all([
+      request(app).post('/bookings').send({ slotId: 1, date: today }),
+      request(app).post('/bookings').send({ slotId: 1, date: today }),
+    ]);
+
+    const statuses = [res1.body.status, res2.body.status];
+    expect(statuses).toContain('approved');
+    expect(statuses).toContain('rejected');
+  });
+});

--- a/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
@@ -101,7 +101,12 @@ describe('volunteer acting as shopper', () => {
       .send({ slotId: 1, date: today });
 
     expect(res.status).toBe(201);
-    expect(bookingUtils.countVisitsAndBookingsForMonth).toHaveBeenCalledWith(10, today);
+    expect(bookingUtils.countVisitsAndBookingsForMonth).toHaveBeenCalledWith(
+      10,
+      today,
+      expect.anything(),
+      true,
+    );
     expect((bookingRepository.insertBooking as jest.Mock).mock.calls[0][0]).toBe(10);
   });
 


### PR DESCRIPTION
## Summary
- track monthly usage based on requested booking date
- verify and insert bookings inside a serializable transaction
- test monthly limit rules and concurrent booking attempts

## Testing
- `npm test` *(fails: GET /blocked-slots includes recurring blocked slots, GET /holidays allows users to fetch holidays, getMonthRange across time zones returns correct range in UTC, Booking history access control ignores userId query for agency, DELETE /events/:id returns 400 for invalid id, rescheduleVolunteerBooking sets status to pending when volunteer reschedules)*

------
https://chatgpt.com/codex/tasks/task_e_68afd099f830832dbd14cac19646b3cc