### PR TITLE
Allow same-day rebooking after visit

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingUtils.ts
+++ b/MJ_FB_Backend/src/utils/bookingUtils.ts
@@ -69,7 +69,15 @@ export async function findUpcomingBooking(
     `SELECT b.date, s.start_time, b.status
        FROM bookings b
        INNER JOIN slots s ON b.slot_id = s.id
-       WHERE b.user_id=$1 AND b.status IN ('submitted','approved') AND b.date >= CURRENT_DATE
+       WHERE b.user_id=$1
+         AND b.status IN ('submitted','approved')
+         AND b.date >= CURRENT_DATE
+         AND NOT EXISTS (
+           SELECT 1
+           FROM client_visits cv
+           INNER JOIN clients c ON cv.client_id = c.client_id
+           WHERE c.id = b.user_id AND cv.date = b.date
+         )
        ORDER BY b.date ASC
        LIMIT 1`,
     [userId],

--- a/MJ_FB_Backend/tests/findUpcomingBooking.test.ts
+++ b/MJ_FB_Backend/tests/findUpcomingBooking.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import pool from '../src/db';
+import { findUpcomingBooking } from '../src/utils/bookingUtils';
+
+jest.mock('../src/db');
+
+describe('findUpcomingBooking', () => {
+  it('ignores bookings with recorded visits', async () => {
+    const mockQuery = pool.query as unknown as jest.Mock<any>;
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    const result = await findUpcomingBooking(1);
+    expect(mockQuery).toHaveBeenCalled();
+    const query = mockQuery.mock.calls[0][0] as string;
+    expect(query).toMatch(/client_visits/);
+    expect(query).toMatch(/NOT EXISTS/);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- ignore bookings with a recorded visit when checking for existing upcoming booking
- add unit test verifying query excludes visited bookings

## Testing
- `npm test` *(fails: GET /blocked-slots includes recurring blocked slots; rescheduleVolunteerBooking tests; booking history access; holidays access; slots tests; events tests; getMonthRange tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afcc1763f4832d948f37a2e58238d6