### PR TITLE
Disable past days in booking UI

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import BookingUI from '../pages/BookingUI';
 import dayjs from 'dayjs';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -28,6 +28,10 @@ describe('BookingUI visible slots', () => {
     })) as any);
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   afterAll(() => {
     jest.useRealTimers();
   });
@@ -51,5 +55,24 @@ describe('BookingUI visible slots', () => {
     await screen.findByText(/11:00 am/i);
     expect(screen.queryByText(/9:00 am/i)).toBeNull();
     expect(screen.getByText(/11:00 am/i)).toBeInTheDocument();
+  });
+
+  it('skips past dates by advancing to today', async () => {
+    (getSlots as jest.Mock).mockResolvedValue([]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+
+    const queryClient = new QueryClient();
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <BookingUI shopperName="Test" initialDate={dayjs('2023-12-29')} />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(getSlots).toHaveBeenCalledWith('2024-01-01');
+    });
+    expect(getSlots).toHaveBeenCalledTimes(1);
   });
 });

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -58,6 +58,10 @@ export default function BookingUI({
 }: BookingUIProps) {
   const [date, setDate] = useState<Dayjs>(() => {
     let d = initialDate;
+    const today = dayjs();
+    if (d.isBefore(today, 'day')) {
+      d = today;
+    }
     while (d.day() === 0 || d.day() === 6) {
       d = d.add(1, 'day');
     }
@@ -72,6 +76,7 @@ export default function BookingUI({
   const isDisabled = (d: Dayjs) =>
     d.day() === 0 ||
     d.day() === 6 ||
+    d.isBefore(dayjs(), 'day') ||
     holidaySet.has(d.format('YYYY-MM-DD'));
   const { slots, isLoading, refetch, error } = useSlots(date, !isDisabled(date));
   const [snackbar, setSnackbar] = useState<{


### PR DESCRIPTION
## Summary
- Disable booking selection for past dates and ensure initial date defaults to today
- Add unit test to verify past dates are skipped when booking

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68afd406ee90832dacb8bddecd14745d