### PR TITLE
Show role-targeted events on dashboards

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ClientDashboard from '../pages/client/ClientDashboard';
+import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../api/bookings';
+import { getEvents } from '../api/events';
+
+jest.mock('../api/bookings', () => ({
+  getBookingHistory: jest.fn(),
+  getSlots: jest.fn(),
+  getHolidays: jest.fn(),
+  cancelBooking: jest.fn(),
+}));
+
+jest.mock('../api/events', () => ({ getEvents: jest.fn() }));
+
+describe('ClientDashboard', () => {
+  it('shows events in News & Events section', async () => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([]);
+    (getSlots as jest.Mock).mockResolvedValue([]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({
+      today: [
+        {
+          id: 1,
+          title: 'Client Event',
+          date: new Date().toISOString(),
+          createdBy: 1,
+          createdByName: 'Staff',
+        },
+      ],
+      upcoming: [],
+      past: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <ClientDashboard />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getEvents).toHaveBeenCalled());
+    expect(screen.getByText(/Client Event/)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerDashboard from '../pages/volunteer-management/VolunteerDashboard';
+import {
+  getMyVolunteerBookings,
+  getVolunteerRolesForVolunteer,
+  requestVolunteerBooking,
+  updateVolunteerBookingStatus,
+} from '../api/volunteers';
+import { getEvents } from '../api/events';
+
+jest.mock('../api/volunteers', () => ({
+  getMyVolunteerBookings: jest.fn(),
+  getVolunteerRolesForVolunteer: jest.fn(),
+  requestVolunteerBooking: jest.fn(),
+  updateVolunteerBookingStatus: jest.fn(),
+}));
+
+jest.mock('../api/events', () => ({ getEvents: jest.fn() }));
+
+describe('VolunteerDashboard', () => {
+  it('shows events in News & Events section', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({
+      today: [
+        {
+          id: 1,
+          title: 'Volunteer Event',
+          date: new Date().toISOString(),
+          createdBy: 1,
+          createdByName: 'Staff',
+        },
+      ],
+      upcoming: [],
+      past: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getEvents).toHaveBeenCalled());
+    expect(screen.getByText(/Volunteer Event/)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -17,10 +17,12 @@ import {
 import { EventAvailable, Announcement, History } from '@mui/icons-material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../../api/bookings';
+import { getEvents, type EventGroups } from '../../api/events';
 import type { Slot, Holiday } from '../../types';
 import { formatTime, formatReginaDate, formatRegina } from '../../utils/time';
 import type { AlertColor } from '@mui/material';
 import SectionCard from '../../components/dashboard/SectionCard';
+import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 
 interface Booking {
@@ -71,6 +73,7 @@ export default function ClientDashboard() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [nextSlots, setNextSlots] = useState<NextSlot[]>([]);
   const [holidays, setHolidays] = useState<Holiday[]>([]);
+  const [events, setEvents] = useState<EventGroups>({ today: [], upcoming: [], past: [] });
   const [cancelId, setCancelId] = useState<number | null>(null);
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
@@ -99,6 +102,10 @@ export default function ClientDashboard() {
 
   useEffect(() => {
     getHolidays().then(setHolidays).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    getEvents().then(setEvents).catch(() => {});
   }, []);
 
   const today = toDate();
@@ -247,19 +254,22 @@ export default function ClientDashboard() {
           </SectionCard>
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
-          <SectionCard title="Notices" icon={<Announcement color="primary" />}>
-            <List>
-              {holidays.map(h => (
-                <ListItem key={h.date}>
-                  <ListItemText
-                    primary={`${formatDate(h.date)} ${h.reason}`}
-                  />
+          <SectionCard title="News & Events" icon={<Announcement color="primary" />}>
+            <Stack spacing={2}>
+              <EventList events={[...events.today, ...events.upcoming]} limit={5} />
+              <List>
+                {holidays.map(h => (
+                  <ListItem key={h.date}>
+                    <ListItemText
+                      primary={`${formatDate(h.date)} ${h.reason}`}
+                    />
+                  </ListItem>
+                ))}
+                <ListItem>
+                  <ListItemText primary="Walk-ins welcome — appointments get priority." />
                 </ListItem>
-              ))}
-              <ListItem>
-                <ListItemText primary="Walk-ins welcome — appointments get priority." />
-              </ListItem>
-            </List>
+              </List>
+            </Stack>
           </SectionCard>
         </Grid>
         <Grid size={12}>

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -15,6 +15,7 @@ import {
   Select,
   MenuItem,
 } from '@mui/material';
+import { Announcement } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import {
   getMyVolunteerBookings,
@@ -22,6 +23,7 @@ import {
   requestVolunteerBooking,
   updateVolunteerBookingStatus,
 } from '../../api/volunteers';
+import { getEvents, type EventGroups } from '../../api/events';
 import type { VolunteerBooking, VolunteerRole } from '../../types';
 import {
   formatTime,
@@ -34,6 +36,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import Page from '../../components/Page';
 import type { AlertColor } from '@mui/material';
 import SectionCard from '../../components/dashboard/SectionCard';
+import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 
 function formatDateLabel(dateStr: string) {
@@ -50,6 +53,7 @@ export default function VolunteerDashboard() {
   const [availability, setAvailability] = useState<VolunteerRole[]>([]);
   const [dateMode, setDateMode] = useState<'today' | 'week'>('today');
   const [roleFilter, setRoleFilter] = useState<string>('');
+  const [events, setEvents] = useState<EventGroups>({ today: [], upcoming: [], past: [] });
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
   const navigate = useNavigate();
@@ -58,6 +62,10 @@ export default function VolunteerDashboard() {
     getMyVolunteerBookings()
       .then(setBookings)
       .catch(() => setBookings([]));
+  }, []);
+
+  useEffect(() => {
+    getEvents().then(setEvents).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -282,8 +290,8 @@ export default function VolunteerDashboard() {
         </Grid>
 
         <Grid size={{ xs: 12, md: 6 }}>
-          <SectionCard title="Announcements">
-            <Typography>No announcements</Typography>
+          <SectionCard title="News & Events" icon={<Announcement color="primary" />}>
+            <EventList events={[...events.today, ...events.upcoming]} limit={5} />
           </SectionCard>
         </Grid>
 


### PR DESCRIPTION
## Summary
- Display events marked visible to clients in the client dashboard's News & Events section
- Surface volunteer-visible events in the volunteer dashboard
- Add tests ensuring dashboards render events

## Testing
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afd6a27198832da5236d6f10f1cf03