### PR TITLE
Add user registration endpoint with OTP

### DIFF
--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import {
   loginUser,
+  registerUser,
   createUser,
   searchUsers,
   getUserProfile,
@@ -13,6 +14,7 @@ import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import {
   loginSchema,
+  registerSchema,
   createUserSchema,
   updateUserSchema,
   updateMyProfileSchema,
@@ -20,6 +22,7 @@ import {
 
 const router = express.Router();
 
+router.post('/register', validate(registerSchema), registerUser);
 router.post('/login', validate(loginSchema), loginUser);
 router.post(
   '/add-client',

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -18,6 +18,20 @@ export const loginSchema = z
     path: ['email'],
   });
 
+// Schema for the self‑service registration endpoint. All fields are required
+// except for phone. clientId is coerced to a number and checked against the
+// valid range used throughout the app. Password complexity is enforced via
+// the shared passwordSchema. An OTP must also be provided.
+export const registerSchema = z.object({
+  clientId: z.coerce.number().int().min(1).max(9_999_999),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  email: z.string().email(),
+  phone: z.string().optional(),
+  password: passwordSchema,
+  otp: z.string().min(1),
+});
+
 // Schema for creating a user. Validates all required fields and
 // basic constraints like clientId range and role values.
 export const createUserSchema = z

--- a/MJ_FB_Backend/tests/register.test.ts
+++ b/MJ_FB_Backend/tests/register.test.ts
@@ -1,0 +1,100 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+
+jest.mock('../src/db');
+jest.mock('bcrypt');
+jest.mock('jsonwebtoken');
+jest.mock('../src/utils/bookingUtils', () => ({}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/users', usersRouter);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/users/register', () => {
+  it('registers a user with valid data', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1, online_access: false, role: 'shopper' }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ otp: '123456' }] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1, role: 'shopper', first_name: 'Jane', last_name: 'Doe' }] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+    (jwt.sign as jest.Mock).mockReturnValue('token');
+
+    const res = await request(app).post('/api/users/register').send({
+      clientId: 123,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      phone: '123',
+      password: 'Secret1!',
+      otp: '123456',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ role: 'shopper', name: 'Jane Doe' });
+  });
+
+  it('rejects duplicate registration attempts', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 1, online_access: true, role: 'shopper' }],
+    });
+
+    const res = await request(app).post('/api/users/register').send({
+      clientId: 123,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      password: 'Secret1!',
+      otp: '123456',
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid otp', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1, online_access: false, role: 'shopper' }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ otp: '654321' }] });
+
+    const res = await request(app).post('/api/users/register').send({
+      clientId: 123,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      password: 'Secret1!',
+      otp: '123456',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ message: 'Invalid OTP' });
+  });
+
+  it('rejects weak passwords', async () => {
+    const res = await request(app).post('/api/users/register').send({
+      clientId: 123,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      password: 'weak',
+      otp: '123456',
+    });
+    expect(res.status).toBe(400);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add registerSchema for client self-registration including OTP and password complexity
- implement registerUser controller to verify OTP, hash password, and issue auth tokens
- expose /register route and tests for various registration outcomes

## Testing
- `npm test` *(fails: agency.test.ts, volunteerReschedule.test.ts, slots.test.ts, holidaysAccess.test.ts, bookingUtils.test.ts, events.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68afd6afdfc8832db878247e308e1602