### PR TITLE
Add client signup workflow with OTP verification

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Pending from './pages/staff/Pending';
 import Login from './pages/auth/Login';
 import StaffLogin from './pages/auth/StaffLogin';
 import VolunteerLogin from './pages/auth/VolunteerLogin';
+import ClientSignup from './pages/auth/ClientSignup';
 import VolunteerDashboard from './pages/volunteer-management/VolunteerDashboard';
 import VolunteerManagement from './pages/volunteer-management/VolunteerManagement';
 import Dashboard from './components/dashboard/Dashboard';
@@ -72,6 +73,7 @@ export default function App() {
       { label: 'Volunteer Login', links: [{ label: 'Volunteer Login', to: '/login/volunteer' }] },
       { label: 'Staff Login', links: [{ label: 'Staff Login', to: '/login/staff' }] },
       { label: 'Agency Login', links: [{ label: 'Agency Login', to: '/login/agency' }] },
+      { label: 'Client Sign Up', links: [{ label: 'Sign Up', to: '/signup' }] },
     );
   } else if (isStaff) {
     const staffLinks = [
@@ -350,6 +352,7 @@ export default function App() {
         ) : (
           <main>
             <Routes>
+              <Route path="/signup" element={<ClientSignup />} />
                 <Route path="/login/user" element={<Login onLogin={login} />} />
                 <Route path="/login/staff" element={<StaffLogin onLogin={login} />} />
                 <Route path="/login/volunteer" element={<VolunteerLogin onLogin={login} />} />

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -82,4 +82,14 @@ describe('App authentication persistence', () => {
     );
     expect(window.location.pathname).toBe('/warehouse-management');
   });
+
+  it('renders signup page when visiting /signup', () => {
+    window.history.pushState({}, '', '/signup');
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>,
+    );
+    expect(screen.getByText(/client sign up/i)).toBeInTheDocument();
+  });
 });

--- a/MJ_FB_Frontend/src/__tests__/ClientSignup.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientSignup.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ClientSignup from '../pages/auth/ClientSignup';
+import { sendRegistrationOtp, registerUser } from '../api/users';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../api/users', () => ({
+  sendRegistrationOtp: jest.fn(),
+  registerUser: jest.fn(),
+}));
+
+describe('ClientSignup', () => {
+  beforeEach(() => {
+    (sendRegistrationOtp as jest.Mock).mockResolvedValue(undefined);
+    (registerUser as jest.Mock).mockResolvedValue(undefined);
+    mockNavigate.mockReset();
+  });
+
+  it('validates required fields', () => {
+    render(
+      <MemoryRouter>
+        <ClientSignup />
+      </MemoryRouter>
+    );
+    const submit = screen.getByRole('button', { name: /send code/i });
+    expect(submit).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'A' } });
+    fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'B' } });
+    fireEvent.change(screen.getByLabelText(/client id/i), { target: { value: '123' } });
+    fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'pass' } });
+    expect(submit).not.toBeDisabled();
+  });
+
+  it('handles OTP step and registration', async () => {
+    jest.useFakeTimers();
+    render(
+      <MemoryRouter>
+        <ClientSignup />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'A' } });
+    fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'B' } });
+    fireEvent.change(screen.getByLabelText(/client id/i), { target: { value: '123' } });
+    fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'pass' } });
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => expect(sendRegistrationOtp).toHaveBeenCalled());
+    expect(screen.getByLabelText(/otp/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/otp/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+    await waitFor(() => expect(registerUser).toHaveBeenCalled());
+    jest.runAllTimers();
+    expect(mockNavigate).toHaveBeenCalledWith('/login/user');
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -24,4 +24,14 @@ describe('Login component', () => {
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
     await waitFor(() => expect(onLogin).toHaveBeenCalled());
   });
+
+  it('includes link to signup', () => {
+    render(
+      <MemoryRouter>
+        <Login onLogin={async () => {}} />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole('link', { name: /sign up/i });
+    expect(link).toHaveAttribute('href', '/signup');
+  });
 });

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -196,3 +196,40 @@ export async function updateUserInfo(
   });
   return handleResponse(res);
 }
+
+export async function sendRegistrationOtp(
+  clientId: string,
+  email: string,
+): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/users/register/otp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ clientId: Number(clientId), email }),
+  });
+  await handleResponse(res);
+}
+
+export async function registerUser(data: {
+  clientId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  password: string;
+  otp: string;
+}): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/users/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      clientId: Number(data.clientId),
+      firstName: data.firstName,
+      lastName: data.lastName,
+      email: data.email,
+      phone: data.phone,
+      password: data.password,
+      otp: data.otp,
+    }),
+  });
+  await handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/pages/auth/ClientSignup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/ClientSignup.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { Button, TextField, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import FormCard from '../../components/FormCard';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { sendRegistrationOtp, registerUser } from '../../api/users';
+
+export default function ClientSignup() {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [otp, setOtp] = useState('');
+  const [step, setStep] = useState<'form' | 'otp'>('form');
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  const firstNameError = firstName === '';
+  const lastNameError = lastName === '';
+  const clientIdError = clientId === '';
+  const emailError = email === '';
+  const passwordError = password === '';
+  const otpError = otp === '';
+
+  const formInvalid =
+    step === 'form'
+      ? firstNameError ||
+        lastNameError ||
+        clientIdError ||
+        emailError ||
+        passwordError
+      : otpError;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (step === 'form') {
+      try {
+        await sendRegistrationOtp(clientId, email);
+        setStep('otp');
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } else {
+      try {
+        await registerUser({
+          clientId,
+          firstName,
+          lastName,
+          email,
+          phone: phone || undefined,
+          password,
+          otp,
+        });
+        setMessage('Account created. You can login now.');
+        setTimeout(() => navigate('/login/user'), 1000);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    }
+  }
+
+  return (
+    <>
+      <FormCard
+        onSubmit={handleSubmit}
+        title={step === 'form' ? 'Client Sign Up' : 'Verify Email'}
+        actions={
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={formInvalid}
+          >
+            {step === 'form' ? 'Send Code' : 'Register'}
+          </Button>
+        }
+      >
+        {step === 'form' ? (
+          <>
+            <TextField
+              value={firstName}
+              onChange={e => setFirstName(e.target.value)}
+              label="First name"
+              fullWidth
+              required
+              error={firstNameError}
+              helperText={firstNameError ? 'First name is required' : ''}
+            />
+            <TextField
+              value={lastName}
+              onChange={e => setLastName(e.target.value)}
+              label="Last name"
+              fullWidth
+              required
+              error={lastNameError}
+              helperText={lastNameError ? 'Last name is required' : ''}
+            />
+            <TextField
+              value={clientId}
+              onChange={e => setClientId(e.target.value)}
+              label="Client ID"
+              fullWidth
+              required
+              error={clientIdError}
+              helperText={clientIdError ? 'Client ID is required' : ''}
+            />
+            <TextField
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              label="Email"
+              fullWidth
+              required
+              error={emailError}
+              helperText={emailError ? 'Email is required' : ''}
+            />
+            <TextField
+              value={phone}
+              onChange={e => setPhone(e.target.value)}
+              label="Phone (optional)"
+              fullWidth
+            />
+            <TextField
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              label="Password"
+              fullWidth
+              required
+              error={passwordError}
+              helperText={passwordError ? 'Password is required' : ''}
+            />
+          </>
+        ) : (
+          <>
+            <Typography>Enter the verification code sent to your email.</Typography>
+            <TextField
+              value={otp}
+              onChange={e => setOtp(e.target.value)}
+              label="OTP"
+              fullWidth
+              required
+              error={otpError}
+              helperText={otpError ? 'OTP is required' : ''}
+            />
+          </>
+        )}
+      </FormCard>
+      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+      <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} />
+    </>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -83,6 +83,9 @@ export default function Login({
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">
           Forgot password?
         </Link>
+        <Link component={RouterLink} to="/signup" underline="hover">
+          Need an account? Sign up
+        </Link>
       </FormCard>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="user" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />


### PR DESCRIPTION
## Summary
- add API helpers for registration OTP and user creation
- implement client sign-up page with OTP flow and navigation
- link sign-up from login and navbar, add route and tests

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/write-excel-file)*
- `npm test` *(fails: sh: 1: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68afd6c5a484832d9b0c7ffa1a961c79