### PR TITLE
Remove hardcoded walk-in notice from client dashboard

### DIFF
--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -265,9 +265,6 @@ export default function ClientDashboard() {
                     />
                   </ListItem>
                 ))}
-                <ListItem>
-                  <ListItemText primary="Walk-ins welcome — appointments get priority." />
-                </ListItem>
               </List>
             </Stack>
           </SectionCard>


### PR DESCRIPTION
## Summary
- remove static "Walk-ins welcome — appointments get priority." event from client dashboard News & Events section

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68afd8c40810832da66cb106ce9e3ad1