### PR TITLE
Auto-approve rescheduled bookings within monthly limit

### DIFF
--- a/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
@@ -132,11 +132,13 @@ describe('volunteer acting as shopper', () => {
     const futureDate = new Date(Date.now() + 86400000)
       .toISOString()
       .split('T')[0];
+    (bookingUtils.countVisitsAndBookingsForMonth as jest.Mock).mockResolvedValueOnce(1);
     (bookingRepository.fetchBookingByToken as jest.Mock).mockResolvedValue({
       id: 1,
       user_id: 10,
       status: 'approved',
       slot_id: 1,
+      date: futureDate,
     });
     (bookingRepository.checkSlotCapacity as jest.Mock).mockResolvedValue(undefined);
     (bookingRepository.updateBooking as jest.Mock).mockResolvedValue(undefined);
@@ -147,6 +149,13 @@ describe('volunteer acting as shopper', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('message', 'Booking rescheduled');
+    expect(
+      (bookingRepository.updateBooking as jest.Mock).mock.calls[0][1].status,
+    ).toBe('approved');
+    expect(bookingUtils.countVisitsAndBookingsForMonth).toHaveBeenCalledWith(
+      10,
+      futureDate,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- auto-approve rescheduled bookings when monthly usage remains below two visits
- adjust volunteer shopper reschedule test for new status and usage check

## Testing
- `npm test` *(fails: Test Suites: 7 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68afd91366bc832d8905ef3bcddc56c9