### PR TITLE
Disable past rescheduling dates and expired slots

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RescheduleDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RescheduleDialog.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RescheduleDialog from '../components/RescheduleDialog';
+
+jest.mock('../api/bookings', () => ({
+  getSlots: jest.fn(),
+  rescheduleBookingByToken: jest.fn(),
+}));
+
+const { getSlots } = jest.requireMock('../api/bookings');
+
+describe('RescheduleDialog', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T10:30:00'));
+    window.matchMedia =
+      window.matchMedia ||
+      ((() => ({
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+      })) as any);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    (getSlots as jest.Mock).mockReset();
+  });
+
+  it('disables past dates', () => {
+    render(
+      <RescheduleDialog
+        open
+        rescheduleToken=""
+        onClose={() => {}}
+        onRescheduled={() => {}}
+      />,
+    );
+    const dateInput = screen.getByLabelText(/date/i);
+    expect(dateInput).toHaveAttribute('min', '2024-01-01');
+  });
+
+  it('filters out past slots for today', async () => {
+    (getSlots as jest.Mock).mockResolvedValue([
+      { id: '1', startTime: '09:00:00', endTime: '09:30:00', available: 1 },
+      { id: '2', startTime: '11:00:00', endTime: '11:30:00', available: 1 },
+    ]);
+
+    render(
+      <RescheduleDialog
+        open
+        rescheduleToken=""
+        onClose={() => {}}
+        onRescheduled={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/date/i), {
+      target: { value: '2024-01-01' },
+    });
+
+    await screen.findByText(/11:00 am/i);
+    expect(screen.queryByText(/9:00 am/i)).toBeNull();
+    expect(screen.getByText(/11:00 am/i)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -31,18 +31,28 @@ export default function RescheduleDialog({
   const [slots, setSlots] = useState<Slot[]>([]);
   const [slotId, setSlotId] = useState('');
   const [message, setMessage] = useState('');
-  const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
+  const [snackbarSeverity, setSnackbarSeverity] =
+    useState<AlertColor>('success');
+  const todayStr = new Date().toISOString().split('T')[0];
 
   useEffect(() => {
     if (open && date) {
       getSlots(date)
-        .then(setSlots)
+        .then(s => {
+          if (date === todayStr) {
+            const now = new Date();
+            s = s.filter(
+              slot => new Date(`${date}T${slot.startTime}`) > now,
+            );
+          }
+          setSlots(s);
+        })
         .catch(() => setSlots([]));
     } else {
       setSlots([]);
       setSlotId('');
     }
-  }, [open, date]);
+  }, [open, date, todayStr]);
 
   async function submit() {
     if (!date || !slotId) {
@@ -74,6 +84,7 @@ export default function RescheduleDialog({
           fullWidth
           margin="normal"
           InputLabelProps={{ shrink: true }}
+          inputProps={{ min: todayStr }}
         />
         <TextField
           select

--- a/MJ_FB_Frontend/src/components/VolunteerRescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerRescheduleDialog.tsx
@@ -27,6 +27,7 @@ export default function RescheduleDialog({
   const [roleId, setRoleId] = useState('');
   const [roles, setRoles] = useState<RoleOption[]>([]);
   const [message, setMessage] = useState('');
+  const todayStr = new Date().toISOString().split('T')[0];
 
   useEffect(() => {
     if (!open) {
@@ -64,6 +65,7 @@ export default function RescheduleDialog({
           fullWidth
           margin="normal"
           InputLabelProps={{ shrink: true }}
+          inputProps={{ min: todayStr }}
         />
         <TextField
           select


### PR DESCRIPTION
## Summary
- Prevent selecting past dates when rescheduling bookings or volunteer shifts
- Filter out time slots that have already passed on the current day
- Add unit tests for RescheduleDialog

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68afdbd03064832d8611e6c21d934001