### PR TITLE
Validate slotId before creating bookings

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -29,13 +29,17 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
   if (!user) return res.status(401).json({ message: 'Unauthorized' });
 
   const { slotId, date, isStaffBooking } = req.body;
-  if (!slotId || !date) {
-    return res.status(400).json({ message: 'Please select a time slot and date' });
+  if (slotId === undefined || slotId === null) {
+    return res.status(400).json({ message: 'Please select a time slot' });
   }
 
   const slotIdNum = Number(slotId);
-  if (Number.isNaN(slotIdNum)) {
+  if (!Number.isInteger(slotIdNum)) {
     return res.status(400).json({ message: 'Please select a valid time slot' });
+  }
+
+  if (!date) {
+    return res.status(400).json({ message: 'Please select a date' });
   }
 
   try {

--- a/MJ_FB_Backend/tests/bookingSlotIdValidation.test.ts
+++ b/MJ_FB_Backend/tests/bookingSlotIdValidation.test.ts
@@ -1,0 +1,56 @@
+import request from 'supertest';
+import express from 'express';
+import bookingsRouter from '../src/routes/bookings';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/utils/bookingUtils', () => ({
+  isDateWithinCurrentOrNextMonth: jest.fn(),
+  countVisitsAndBookingsForMonth: jest.fn(),
+  LIMIT_MESSAGE: 'limit',
+  findUpcomingBooking: jest.fn(),
+}));
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: any, _res: express.Response, next: express.NextFunction) => {
+    req.user = { id: 1, role: 'shopper', email: 'test@example.com' };
+    next();
+  },
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  optionalAuthMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: 1, role: 'shopper', email: 'test@example.com' };
+    next();
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/bookings', bookingsRouter);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /bookings slotId validation', () => {
+  it('returns 400 for missing slotId without querying the DB', async () => {
+    const today = new Date().toISOString().split('T')[0];
+    const res = await request(app).post('/bookings').send({ date: today });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Please select a time slot');
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid slotId without querying the DB', async () => {
+    const today = new Date().toISOString().split('T')[0];
+    const res = await request(app).post('/bookings').send({ slotId: 'abc', date: today });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Please select a valid time slot');
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `slotId` is converted to a number and validated before creating a booking
- add tests for missing or invalid `slotId` to confirm the endpoint returns 400 without touching the DB

## Testing
- `npm test` *(fails: Test Suites: 5 failed, 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68afdc1a123c832dac6c92f6a09a03f1