### PR TITLE
Validate booking dates and handle invalid inputs

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -23,6 +23,13 @@ import {
 } from '../models/bookingRepository';
 import { isAgencyClient } from '../models/agency';
 
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+function isValidDateString(date: string): boolean {
+  if (!DATE_REGEX.test(date)) return false;
+  const parsed = new Date(date);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === date;
+}
+
 // --- Create booking for logged-in shopper ---
 export async function createBooking(req: Request, res: Response, next: NextFunction) {
   const user = req.user;
@@ -31,6 +38,10 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
   const { slotId, date, isStaffBooking } = req.body;
   if (!slotId || !date) {
     return res.status(400).json({ message: 'Please select a time slot and date' });
+  }
+
+  if (!isValidDateString(date)) {
+    return res.status(400).json({ message: 'Please choose a valid date' });
   }
 
   const slotIdNum = Number(slotId);
@@ -58,6 +69,11 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
       await client.query('BEGIN');
       await client.query('SELECT id FROM clients WHERE id=$1 FOR UPDATE', [userId]);
       const monthlyUsage = await countVisitsAndBookingsForMonth(userId, date, client, true);
+      if (monthlyUsage === false) {
+        await client.query('ROLLBACK');
+        client.release();
+        return res.status(400).json({ message: 'Please choose a valid date' });
+      }
       status = monthlyUsage < 2 ? 'approved' : 'rejected';
       if (status === 'approved') {
         await checkSlotCapacity(slotIdNum, date, client);
@@ -153,6 +169,9 @@ export async function decideBooking(req: Request, res: Response, next: NextFunct
     }
 
     const usage = await countVisitsAndBookingsForMonth(booking.user_id, booking.date);
+    if (usage === false) {
+      return res.status(400).json({ message: 'Please choose a valid date' });
+    }
     const decision = usage < 2 ? 'approved' : 'rejected';
     const reason = decision === 'rejected' ? LIMIT_MESSAGE : '';
 
@@ -248,6 +267,9 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
   if (!slotId || !date) {
     return res.status(400).json({ message: 'Please select a time slot and date' });
   }
+  if (!isValidDateString(date)) {
+    return res.status(400).json({ message: 'Please choose a valid date' });
+  }
   try {
     const booking = await fetchBookingByToken(token);
     if (!booking) {
@@ -262,6 +284,9 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
     await checkSlotCapacity(slotId, date);
 
     const usage = await countVisitsAndBookingsForMonth(booking.user_id, date);
+    if (usage === false) {
+      return res.status(400).json({ message: 'Please choose a valid date' });
+    }
     let adjustedUsage = usage;
     if (
       booking.status === 'approved' &&
@@ -314,6 +339,10 @@ export async function createPreapprovedBooking(
       .json({ message: 'Please provide a name, time slot, and date' });
   }
 
+  if (!isValidDateString(date)) {
+    return res.status(400).json({ message: 'Please choose a valid date' });
+  }
+
   if (!isDateWithinCurrentOrNextMonth(date)) {
     return res.status(400).json({ message: 'Please choose a valid date' });
   }
@@ -336,6 +365,10 @@ export async function createPreapprovedBooking(
     );
 
     const usage = await countVisitsAndBookingsForMonth(newUserId, date);
+    if (usage === false) {
+      await client.query('ROLLBACK');
+      return res.status(400).json({ message: 'Please choose a valid date' });
+    }
     if (usage >= 2) {
       await client.query('ROLLBACK');
       return res.status(400).json({ message: LIMIT_MESSAGE });
@@ -383,6 +416,10 @@ export async function createBookingForUser(
       .json({ message: 'Please provide a user, time slot, and date' });
   }
 
+  if (!isValidDateString(date)) {
+    return res.status(400).json({ message: 'Please choose a valid date' });
+  }
+
   const slotIdNum = Number(slotId);
   if (Number.isNaN(slotIdNum)) {
     return res.status(400).json({ message: 'Please select a valid time slot' });
@@ -401,6 +438,9 @@ export async function createBookingForUser(
       return res.status(400).json({ message: 'Please choose a valid date' });
     }
     const usage = await countVisitsAndBookingsForMonth(userId, date);
+    if (usage === false) {
+      return res.status(400).json({ message: 'Please choose a valid date' });
+    }
     if (usage >= 2) {
       return res.status(400).json({ message: LIMIT_MESSAGE });
     }

--- a/MJ_FB_Backend/tests/bookingInvalidDate.test.ts
+++ b/MJ_FB_Backend/tests/bookingInvalidDate.test.ts
@@ -1,0 +1,91 @@
+import request from 'supertest';
+import express from 'express';
+
+describe('booking date validation', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/db', () => ({
+        __esModule: true,
+        default: { connect: jest.fn(), query: jest.fn() },
+      }));
+      jest.doMock('../src/models/bookingRepository', () => ({
+        __esModule: true,
+        ...jest.requireActual('../src/models/bookingRepository'),
+        checkSlotCapacity: jest.fn(),
+        insertBooking: jest.fn(),
+      }));
+      jest.doMock('../src/middleware/authMiddleware', () => ({
+        authMiddleware: (
+          req: any,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => {
+          req.user = {
+            id: 'v1',
+            role: 'volunteer',
+            userId: '10',
+            userRole: 'shopper',
+            email: 'vol@example.com',
+          };
+          next();
+        },
+        authorizeRoles: () => (
+          _req: express.Request,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => next(),
+        authorizeAccess: () => (
+          _req: express.Request,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => next(),
+        optionalAuthMiddleware: (
+          req: any,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => {
+          req.user = {
+            id: 'v1',
+            role: 'volunteer',
+            userId: '10',
+            userRole: 'shopper',
+            email: 'vol@example.com',
+          };
+          next();
+        },
+      }));
+      jest.doMock('../src/utils/emailQueue', () => ({
+        __esModule: true,
+        enqueueEmail: jest.fn(),
+      }));
+      const bookingsRouter = require('../src/routes/bookings').default;
+      app = express();
+      app.use(express.json());
+      app.use('/bookings', bookingsRouter);
+      app.use(
+        (
+          err: any,
+          _req: express.Request,
+          res: express.Response,
+          _next: express.NextFunction,
+        ) => {
+          res.status(err.status || 500).json({ message: err.message });
+        },
+      );
+    });
+  });
+
+  it('returns 400 for malformed date', async () => {
+    const res = await request(app).post('/bookings').send({ slotId: 1, date: 'not-a-date' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for impossible date', async () => {
+    const res = await request(app).post('/bookings').send({ slotId: 1, date: '2024-02-30' });
+    expect(res.status).toBe(400);
+  });
+});
+

--- a/MJ_FB_Backend/tests/bookingUtils.test.ts
+++ b/MJ_FB_Backend/tests/bookingUtils.test.ts
@@ -34,3 +34,10 @@ describe('getMonthRange across time zones', () => {
     expect(getMonthRange(date)).toEqual({ start: '2024-02-01', end: '2024-02-29' });
   });
 });
+
+describe('isDateWithinCurrentOrNextMonth', () => {
+  it('returns false for invalid date', () => {
+    const { isDateWithinCurrentOrNextMonth } = require('../src/utils/bookingUtils');
+    expect(isDateWithinCurrentOrNextMonth('not-a-date')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Validate booking dates with strict format checks in booking controller
- Safely handle date utilities, returning `false` on parsing errors
- Test malformed booking dates for graceful `400` responses

## Testing
- `npm test` *(fails: volunteerReschedule.test.ts, blockedSlots.test.ts, events.test.ts, bookingUtils.test.ts, slots.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68afdc17a66c832da01f603998449ee3