### PR TITLE
Fix reschedule booking date slice error

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -295,7 +295,7 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
     if (
       booking.status === 'approved' &&
       booking.date &&
-      booking.date.slice(0, 7) === date.slice(0, 7)
+      formatReginaDate(booking.date).slice(0, 7) === date.slice(0, 7)
     ) {
       adjustedUsage -= 1;
     }


### PR DESCRIPTION
## Summary
- ensure reschedule logic handles Date objects by formatting booking.date before slicing

## Testing
- `npm test` *(fails: Test Suites: 5 failed, 31 passed, 36 total)*

------
https://chatgpt.com/codex/tasks/task_e_68afdecdcb8c832db65ce65c1605ccb9