### PR TITLE
Rename booking route to /book-appointment

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -132,7 +132,7 @@ export default function App() {
     navGroups.push({
       label: 'Booking',
       links: [
-        { label: 'Booking Slots', to: '/slots' },
+        { label: 'Book Appointment', to: '/book-appointment' },
         { label: 'Booking History', to: '/booking-history' },
       ],
     });
@@ -149,7 +149,7 @@ export default function App() {
       navGroups.push({
         label: 'Booking',
         links: [
-          { label: 'Booking Slots', to: '/slots' },
+          { label: 'Book Appointment', to: '/book-appointment' },
           { label: 'Booking History', to: '/booking-history' },
         ],
       });
@@ -258,7 +258,7 @@ export default function App() {
                 />
               )}
               {role === 'shopper' && (
-                <Route path="/slots" element={<BookingUI shopperName={name || undefined} />} />
+                <Route path="/book-appointment" element={<BookingUI shopperName={name || undefined} />} />
               )}
               {role === 'shopper' && (
                 <Route
@@ -271,7 +271,7 @@ export default function App() {
                 />
               )}
               {role === 'volunteer' && userRole === 'shopper' && (
-                <Route path="/slots" element={<BookingUI shopperName={name || undefined} />} />
+                <Route path="/book-appointment" element={<BookingUI shopperName={name || undefined} />} />
               )}
               {role === 'volunteer' && userRole === 'shopper' && (
                 <Route

--- a/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
@@ -30,10 +30,12 @@ describe('Volunteer with shopper profile', () => {
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pass' } });
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
 
-    await waitFor(() => expect(screen.getByRole('link', { name: /Booking Slots/i })).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /Book Appointment/i })).toBeInTheDocument(),
+    );
     expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('link', { name: /Booking Slots/i }));
+    fireEvent.click(screen.getByRole('link', { name: /Book Appointment/i }));
     expect(screen.getByText(/BookingUI Component/i)).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -180,7 +180,7 @@ export default function ClientDashboard() {
                   size="small"
                   variant="contained"
                   sx={{ textTransform: 'none' }}
-                  onClick={() => navigate('/slots')}
+                  onClick={() => navigate('/book-appointment')}
                 >
                   Book now
                 </Button>
@@ -232,7 +232,7 @@ export default function ClientDashboard() {
                         size="small"
                         variant="contained"
                         sx={{ textTransform: 'none' }}
-                        onClick={() => navigate('/slots')}
+                        onClick={() => navigate('/book-appointment')}
                       >
                         Book
                       </Button>
@@ -276,7 +276,7 @@ export default function ClientDashboard() {
                 size="small"
                 variant="contained"
                 sx={{ textTransform: 'none' }}
-                onClick={() => navigate('/slots')}
+                onClick={() => navigate('/book-appointment')}
               >
                 Book Appointment
               </Button>


### PR DESCRIPTION
## Summary
- rename shopper booking route from `/slots` to `/book-appointment`
- update client dashboard links to new booking route
- adjust volunteer shopper access test for new label

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68afe0105ef0832d8c1309081efda6ff