### PR TITLE
feat: centralize internal logins

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -70,9 +70,14 @@ export default function App() {
   if (!role) {
     navGroups.push(
       { label: 'Client Login', links: [{ label: 'Client Login', to: '/login/user' }] },
-      { label: 'Volunteer Login', links: [{ label: 'Volunteer Login', to: '/login/volunteer' }] },
-      { label: 'Staff Login', links: [{ label: 'Staff Login', to: '/login/staff' }] },
-      { label: 'Agency Login', links: [{ label: 'Agency Login', to: '/login/agency' }] },
+      {
+        label: 'Internal Login',
+        links: [
+          { label: 'Staff Login', to: '/login/staff' },
+          { label: 'Volunteer Login', to: '/login/volunteer' },
+          { label: 'Agency Login', to: '/login/agency' },
+        ],
+      },
       { label: 'Client Sign Up', links: [{ label: 'Sign Up', to: '/signup' }] },
     );
   } else if (isStaff) {

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { loginUser } from '../../api/users';
 import type { LoginResponse } from '../../api/users';
-import { Link, TextField, Stack, Button } from '@mui/material';
+import { Link, TextField, Button } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
@@ -36,19 +36,6 @@ export default function Login({
       <FormCard
         onSubmit={handleSubmit}
         title="Client Login"
-        header={
-          <Stack direction="row" spacing={2} justifyContent="center">
-            <Link component={RouterLink} to="/login/staff" underline="hover">
-              Staff Login
-            </Link>
-            <Link component={RouterLink} to="/login/volunteer" underline="hover">
-              Volunteer Login
-            </Link>
-            <Link component={RouterLink} to="/login/agency" underline="hover">
-              Agency Login
-            </Link>
-          </Stack>
-        }
         actions={
           <Button
             type="submit"


### PR DESCRIPTION
## Summary
- remove staff/volunteer/agency links from client login form
- add consolidated Internal Login menu in navbar for staff, volunteer, and agency access

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afe103e184832dbc592d10d096f781