### PR TITLE
Log registration OTP for development testing

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -143,7 +143,14 @@ export async function sendRegistrationOtp(
       `<p>Your verification code is <strong>${otp}</strong>.</p>`,
     );
 
-    return res.json({ message: 'OTP sent' });
+    logger.info(`Registration OTP for client ${clientId}: ${otp}`);
+
+    const response: { message: string; otp?: string } = { message: 'OTP sent' };
+    if (process.env.NODE_ENV === 'development') {
+      response.otp = otp;
+    }
+
+    return res.json(response);
   } catch (error) {
     logger.error('Error sending registration OTP:', error);
     next(error);


### PR DESCRIPTION
## Summary
- log registration OTPs and return them in the response when NODE_ENV=development

## Testing
- `npm test` *(fails: 5 failed, 31 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68afe337cca4832d8cfa72214ff4cd01