### PR TITLE
Delay validation until form submission for auth pages

### DIFF
--- a/MJ_FB_Frontend/src/pages/auth/ClientSignup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/ClientSignup.tsx
@@ -17,26 +17,28 @@ export default function ClientSignup() {
   const [error, setError] = useState('');
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
+  const [formSubmitted, setFormSubmitted] = useState(false);
+  const [otpSubmitted, setOtpSubmitted] = useState(false);
 
-  const firstNameError = firstName === '';
-  const lastNameError = lastName === '';
-  const clientIdError = clientId === '';
-  const emailError = email === '';
-  const passwordError = password === '';
-  const otpError = otp === '';
-
-  const formInvalid =
-    step === 'form'
-      ? firstNameError ||
-        lastNameError ||
-        clientIdError ||
-        emailError ||
-        passwordError
-      : otpError;
+  const firstNameError = formSubmitted && firstName === '';
+  const lastNameError = formSubmitted && lastName === '';
+  const clientIdError = formSubmitted && clientId === '';
+  const emailError = formSubmitted && email === '';
+  const passwordError = formSubmitted && password === '';
+  const otpError = otpSubmitted && otp === '';
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (step === 'form') {
+      setFormSubmitted(true);
+      if (
+        firstName === '' ||
+        lastName === '' ||
+        clientId === '' ||
+        email === '' ||
+        password === ''
+      )
+        return;
       try {
         await sendRegistrationOtp(clientId, email);
         setStep('otp');
@@ -44,6 +46,8 @@ export default function ClientSignup() {
         setError(err instanceof Error ? err.message : String(err));
       }
     } else {
+      setOtpSubmitted(true);
+      if (otp === '') return;
       try {
         await registerUser({
           clientId,
@@ -73,7 +77,6 @@ export default function ClientSignup() {
             variant="contained"
             color="primary"
             fullWidth
-            disabled={formInvalid}
           >
             {step === 'form' ? 'Send Code' : 'Register'}
           </Button>

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -16,13 +16,15 @@ export default function Login({
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [resetOpen, setResetOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
 
-  const clientIdError = clientId === '';
-  const passwordError = password === '';
-  const formInvalid = clientIdError || passwordError;
+  const clientIdError = submitted && clientId === '';
+  const passwordError = submitted && password === '';
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    setSubmitted(true);
+    if (clientId === '' || password === '') return;
     try {
       const user = await loginUser(clientId, password);
       await onLogin(user);
@@ -42,7 +44,6 @@ export default function Login({
             variant="contained"
             color="primary"
             fullWidth
-            disabled={formInvalid}
           >
             Login
           </Button>

--- a/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
@@ -49,13 +49,15 @@ function StaffLoginForm({
   const [password, setPassword] = useState('');
   const [error, setError] = useState(initError);
   const [resetOpen, setResetOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
 
-  const emailError = email === '';
-  const passwordError = password === '';
-  const formInvalid = emailError || passwordError;
+  const emailError = submitted && email === '';
+  const passwordError = submitted && password === '';
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
+    setSubmitted(true);
+    if (email === '' || password === '') return;
     try {
       const user = await loginStaff(email, password);
       if (user.role === 'shopper' || user.role === 'delivery') {
@@ -80,7 +82,6 @@ function StaffLoginForm({
             variant="contained"
             color="primary"
             fullWidth
-            disabled={formInvalid}
           >
             Login
           </Button>
@@ -121,16 +122,17 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   const [password, setPassword] = useState('');
   const [error, setError] = useState(initError);
   const [message, setMessage] = useState('');
+  const [submitted, setSubmitted] = useState(false);
 
-  const firstNameError = firstName === '';
-  const lastNameError = lastName === '';
-  const emailError = email === '';
-  const passwordError = password === '';
-  const formInvalid =
-    firstNameError || lastNameError || emailError || passwordError;
+  const firstNameError = submitted && firstName === '';
+  const lastNameError = submitted && lastName === '';
+  const emailError = submitted && email === '';
+  const passwordError = submitted && password === '';
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
+    setSubmitted(true);
+    if (firstName === '' || lastName === '' || email === '' || password === '') return;
     try {
       await createStaff(firstName, lastName, ['admin'], email, password);
       setMessage('Staff account created. You can login now.');
@@ -151,7 +153,6 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
             variant="contained"
             color="primary"
             fullWidth
-            disabled={formInvalid}
           >
             Create Staff
           </Button>

--- a/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
@@ -16,13 +16,15 @@ export default function VolunteerLogin({
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [resetOpen, setResetOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
 
-  const usernameError = username === '';
-  const passwordError = password === '';
-  const formInvalid = usernameError || passwordError;
+  const usernameError = submitted && username === '';
+  const passwordError = submitted && password === '';
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
+    setSubmitted(true);
+    if (username === '' || password === '') return;
     try {
       const user = await loginVolunteer(username, password);
       await onLogin(user);
@@ -43,7 +45,6 @@ export default function VolunteerLogin({
             variant="contained"
             color="primary"
             fullWidth
-            disabled={formInvalid}
           >
             Login
           </Button>


### PR DESCRIPTION
## Summary
- add `submitted` state to login/signup forms so validation errors appear only after the user submits
- prevent API calls when required fields are missing instead of disabling buttons
- split client signup validation between form and OTP steps

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68afe36ccbdc832da66e89135f6eb8f9