### PR TITLE
Link client ID to profile and enforce cancel reason

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -7,7 +7,7 @@ import { formatTime } from '../../utils/time';
 import { formatDate, addDays } from '../../utils/date';
 import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import { Button, type AlertColor, useTheme } from '@mui/material';
+import { Button, type AlertColor, useTheme, Link } from '@mui/material';
 import { lighten } from '@mui/material/styles';
 import RescheduleDialog from '../../components/RescheduleDialog';
 
@@ -134,7 +134,7 @@ export default function PantrySchedule({
   }
 
   async function cancelSelected() {
-    if (!decisionBooking) return;
+    if (!decisionBooking || !decisionReason.trim()) return;
     try {
       await cancelBooking(decisionBooking.id.toString(), decisionReason);
       await loadData();
@@ -366,7 +366,14 @@ export default function PantrySchedule({
                 : `Cancel booking for ${decisionBooking.user_name}?`}
             </p>
             <p>
-              Client ID: {decisionBooking.client_id}<br />
+              Client ID: <Link
+                href={`https://portal.link2feed.ca/org/1605/intake/${decisionBooking.client_id}`}
+                target="_blank"
+                rel="noopener"
+              >
+                {decisionBooking.client_id}
+              </Link>
+              <br />
               Uses This Month: {decisionBooking.bookings_this_month}
             </p>
             {decisionBooking.status === 'submitted' && showRejectReason && (
@@ -418,7 +425,14 @@ export default function PantrySchedule({
               ) : (
                 <>
                   <Button onClick={openReschedule} variant="outlined" color="primary">Reschedule</Button>
-                  <Button onClick={cancelSelected} variant="outlined" color="primary">Confirm</Button>
+                  <Button
+                    onClick={cancelSelected}
+                    variant="outlined"
+                    color="primary"
+                    disabled={!decisionReason.trim()}
+                  >
+                    Confirm Cancellation
+                  </Button>
                   <Button
                     onClick={() => {
                       setDecisionBooking(null);


### PR DESCRIPTION
## Summary
- Link Client ID in Manage Booking dialog to external Link2Feed profile
- Require cancellation reason and rename confirmation button

## Testing
- `npm test` (fails: jest: not found)
- `npm install` (fails: 403 Forbidden writing write-excel-file)


------
https://chatgpt.com/codex/tasks/task_e_68afe7d01f4c832db8495aa0a9dcd61a