### PR TITLE
fix: add Link import to manage booking dialog

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -7,7 +7,7 @@ import { formatTime } from '../../utils/time';
 import { formatDate, addDays } from '../../utils/date';
 import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import { Button, type AlertColor, useTheme, IconButton } from '@mui/material';
+import { Button, Link, type AlertColor, useTheme, IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { lighten } from '@mui/material/styles';
 import RescheduleDialog from '../../components/RescheduleDialog';


### PR DESCRIPTION
## Summary
- import Link component in PantrySchedule to render user profile link

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68afe9abe418832da34df2c8606b9a7a