### PR TITLE
test: adjust volunteer reschedule status

### DIFF
--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -41,7 +41,7 @@ describe('rescheduleVolunteerBooking', () => {
       .send({ roleId: 4, date: '2025-09-01' });
 
     expect(res.status).toBe(200);
-    const updateCall = (pool.query as jest.Mock).mock.calls[4];
+    const updateCall = (pool.query as jest.Mock).mock.calls[5];
     expect(updateCall[1][3]).toBe('approved');
   });
 
@@ -62,6 +62,6 @@ describe('rescheduleVolunteerBooking', () => {
 
     expect(res.status).toBe(200);
       const updateCall = (pool.query as jest.Mock).mock.calls[5];
-    expect(updateCall[1][3]).toBe('approved');
+    expect(updateCall[1][3]).toBe('pending');
   });
 });


### PR DESCRIPTION
## Summary
- expect pending status when staff reschedules a volunteer booking
- fix query call index for volunteer reschedule test

## Testing
- `npm test -- tests/volunteerReschedule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68afe9b4449c832d8e0969a1926b826f