### PR TITLE
Replace cancel buttons with close icons

### DIFF
--- a/MJ_FB_Frontend/src/components/ConfirmDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { Dialog, DialogActions, DialogContent, Button, Typography } from '@mui/material';
+import DialogCloseButton from './DialogCloseButton';
 
 interface ConfirmDialogProps {
   message: string;
@@ -11,13 +12,13 @@ interface ConfirmDialogProps {
 export default function ConfirmDialog({ message, onConfirm, onCancel, children }: ConfirmDialogProps) {
   return (
     <Dialog open onClose={onCancel}>
+      <DialogCloseButton onClose={onCancel} />
       <DialogContent>
         <Typography>{message}</Typography>
         {children}
       </DialogContent>
       <DialogActions>
         <Button onClick={onConfirm} variant="outlined" color="primary">Confirm</Button>
-        <Button onClick={onCancel} variant="outlined" color="primary">Cancel</Button>
       </DialogActions>
     </Dialog>
   );

--- a/MJ_FB_Frontend/src/components/DialogCloseButton.tsx
+++ b/MJ_FB_Frontend/src/components/DialogCloseButton.tsx
@@ -1,0 +1,14 @@
+import { IconButton } from '@mui/material';
+import Close from '@mui/icons-material/Close';
+
+export default function DialogCloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <IconButton
+      aria-label="close"
+      onClick={onClose}
+      sx={{ position: 'absolute', top: 8, right: 8 }}
+    >
+      <Close />
+    </IconButton>
+  );
+}

--- a/MJ_FB_Frontend/src/components/EventForm.tsx
+++ b/MJ_FB_Frontend/src/components/EventForm.tsx
@@ -16,6 +16,7 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import { createEvent } from '../api/events';
 import { searchStaff, type StaffOption } from '../api/staff';
+import DialogCloseButton from './DialogCloseButton';
 
 interface EventFormProps {
   open: boolean;
@@ -110,6 +111,7 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
   return (
     <>
       <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogCloseButton onClose={onClose} />
         <DialogTitle>Create Event</DialogTitle>
         <DialogContent>
           <TextField
@@ -181,9 +183,6 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose} variant="outlined" color="primary">
-            Cancel
-          </Button>
           <Button onClick={submit} variant="contained" color="primary">
             Create
           </Button>

--- a/MJ_FB_Frontend/src/components/FeedbackModal.tsx
+++ b/MJ_FB_Frontend/src/components/FeedbackModal.tsx
@@ -1,5 +1,6 @@
 import type { AlertColor } from '@mui/material';
-import { Dialog, DialogContent, DialogActions, Button, Alert } from '@mui/material';
+import { Dialog, DialogContent, Alert } from '@mui/material';
+import DialogCloseButton from './DialogCloseButton';
 import type { ReactNode } from 'react';
 
 interface FeedbackModalProps {
@@ -12,12 +13,10 @@ interface FeedbackModalProps {
 export default function FeedbackModal({ open, onClose, message, severity = 'success' }: FeedbackModalProps) {
   return (
     <Dialog open={open} onClose={onClose}>
+      <DialogCloseButton onClose={onClose} />
       <DialogContent>
         <Alert severity={severity}>{message}</Alert>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} variant="outlined" color="primary">Close</Button>
-      </DialogActions>
     </Dialog>
   );
 }

--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -4,6 +4,7 @@ import { requestPasswordReset } from '../api/users';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormCard from './FormCard';
 import type { AlertColor } from '@mui/material';
+import DialogCloseButton from './DialogCloseButton';
 
 export default function PasswordResetDialog({
   open,
@@ -44,6 +45,7 @@ export default function PasswordResetDialog({
   return (
     <>
       <Dialog open={open} onClose={onClose} aria-labelledby="password-reset-dialog-title">
+        <DialogCloseButton onClose={onClose} />
         <DialogTitle id="password-reset-dialog-title" sx={{ display: 'none' }}>
           {formTitle}
         </DialogTitle>
@@ -51,12 +53,7 @@ export default function PasswordResetDialog({
           <FormCard
             title={formTitle}
             onSubmit={handleSubmit}
-            actions={
-              <>
-                <Button onClick={onClose}>Cancel</Button>
-                <Button type="submit" variant="contained">Submit</Button>
-              </>
-            }
+            actions={<Button type="submit" variant="contained">Submit</Button>}
             boxProps={{ minHeight: 'auto', p: 0 }}
           >
             <TextField

--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { getSlots, rescheduleBookingByToken } from '../api/bookings';
 import { formatTime } from '../utils/time';
 import FeedbackSnackbar from './FeedbackSnackbar';
+import DialogCloseButton from './DialogCloseButton';
 import type { Slot } from '../types';
 import type { AlertColor } from '@mui/material';
 
@@ -74,6 +75,7 @@ export default function RescheduleDialog({
 
   return (
     <Dialog open={open} onClose={onClose}>
+      <DialogCloseButton onClose={onClose} />
       <DialogTitle>Reschedule Booking</DialogTitle>
       <DialogContent>
         <TextField
@@ -109,9 +111,6 @@ export default function RescheduleDialog({
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} variant="outlined" color="primary">
-          Cancel
-        </Button>
         <Button onClick={submit} variant="outlined" color="primary">
           Reschedule
         </Button>

--- a/MJ_FB_Frontend/src/components/VolunteerRescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerRescheduleDialog.tsx
@@ -11,6 +11,7 @@ import {
 import FeedbackSnackbar from './FeedbackSnackbar';
 import { getRoles } from '../api/volunteers';
 import type { RoleOption } from '../types';
+import DialogCloseButton from './DialogCloseButton';
 
 interface RescheduleDialogProps {
   open: boolean;
@@ -55,6 +56,7 @@ export default function RescheduleDialog({
 
   return (
     <Dialog open={open} onClose={onClose}>
+      <DialogCloseButton onClose={onClose} />
       <DialogTitle>Reschedule Booking</DialogTitle>
       <DialogContent>
         <TextField
@@ -89,9 +91,6 @@ export default function RescheduleDialog({
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} variant="outlined" color="primary">
-          Cancel
-        </Button>
         <Button onClick={handleSubmit} variant="outlined" color="primary">
           Submit
         </Button>

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import { EventAvailable, Announcement, History } from '@mui/icons-material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../../api/bookings';
 import { getEvents, type EventGroups } from '../../api/events';
 import type { Slot, Holiday } from '../../types';
@@ -320,30 +321,24 @@ export default function ClientDashboard() {
           </SectionCard>
         </Grid>
       </Grid>
-      <Dialog open={cancelId !== null} onClose={() => setCancelId(null)}>
-        <DialogTitle>Cancel booking</DialogTitle>
-        <DialogContent>
-          <Typography>Are you sure you want to cancel this booking?</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            size="small"
-            sx={{ textTransform: 'none' }}
-            onClick={() => setCancelId(null)}
-          >
-            Keep booking
-          </Button>
-          <Button
-            size="small"
-            color="error"
-            variant="contained"
-            sx={{ textTransform: 'none' }}
-            onClick={confirmCancel}
-          >
-            Cancel booking
-          </Button>
-        </DialogActions>
-      </Dialog>
+        <Dialog open={cancelId !== null} onClose={() => setCancelId(null)}>
+          <DialogCloseButton onClose={() => setCancelId(null)} />
+          <DialogTitle>Cancel booking</DialogTitle>
+          <DialogContent>
+            <Typography>Are you sure you want to cancel this booking?</Typography>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              size="small"
+              color="error"
+              variant="contained"
+              sx={{ textTransform: 'none' }}
+              onClick={confirmCancel}
+            >
+              Cancel booking
+            </Button>
+          </DialogActions>
+        </Dialog>
       <FeedbackSnackbar
         open={!!message}
         onClose={() => setMessage('')}

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -22,6 +22,7 @@ import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import {
   getClientVisits,
   createClientVisit,
@@ -288,6 +289,7 @@ export default function PantryVisits() {
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
+        <DialogCloseButton onClose={() => { setRecordOpen(false); setEditing(null); }} />
         <DialogTitle>{editing ? 'Edit Visit' : 'Record Visit'}</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <Stack spacing={2} mt={1}>
@@ -344,7 +346,6 @@ export default function PantryVisits() {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => { setRecordOpen(false); setEditing(null); }}>Cancel</Button>
           <Button onClick={handleSaveVisit} disabled={!form.weightWithCart || !form.weightWithoutCart || !form.clientId}>
             Save
           </Button>
@@ -352,12 +353,12 @@ export default function PantryVisits() {
       </Dialog>
 
       <Dialog open={deleteOpen} onClose={() => { setDeleteOpen(false); setToDelete(null); }}>
+        <DialogCloseButton onClose={() => { setDeleteOpen(false); setToDelete(null); }} />
         <DialogTitle>Delete Visit</DialogTitle>
         <DialogContent>
           Are you sure you want to delete this visit?
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => { setDeleteOpen(false); setToDelete(null); }}>Cancel</Button>
           <Button
             onClick={() => {
               if (toDelete) {

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -18,6 +18,7 @@ import {
 } from "@mui/material";
 import Page from "../../../components/Page";
 import FeedbackSnackbar from "../../../components/FeedbackSnackbar";
+import DialogCloseButton from "../../../components/DialogCloseButton";
 import {
   getIncompleteUsers,
   updateUserInfo,
@@ -129,6 +130,7 @@ export default function UpdateClientData() {
       </Table>
 
       <Dialog open={!!selected} onClose={() => setSelected(null)}>
+        <DialogCloseButton onClose={() => setSelected(null)} />
         <DialogTitle>
           Edit Client -{" "}
           {selected && (
@@ -194,20 +196,19 @@ export default function UpdateClientData() {
             )}
           </Stack>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setSelected(null)}>Cancel</Button>
-          <Button
-            onClick={handleSave}
-            disabled={
-              !form.firstName ||
-              !form.lastName ||
-              (form.onlineAccess && !form.password)
-            }
-          >
-            Save
-          </Button>
-        </DialogActions>
-      </Dialog>
+          <DialogActions>
+            <Button
+              onClick={handleSave}
+              disabled={
+                !form.firstName ||
+                !form.lastName ||
+                (form.onlineAccess && !form.password)
+              }
+            >
+              Save
+            </Button>
+          </DialogActions>
+        </Dialog>
 
       <FeedbackSnackbar
         open={!!snackbar}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -32,6 +32,7 @@ import type { AlertColor } from '@mui/material';
 import RescheduleDialog from '../../../components/RescheduleDialog';
 import EntitySearch from '../../../components/EntitySearch';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import DialogCloseButton from '../../../components/DialogCloseButton';
 import { toDate, formatDate } from '../../../utils/date';
 
 const TIMEZONE = 'America/Regina';
@@ -324,10 +325,11 @@ export default function UserHistory({
             }}
           />
         )}
-        {editOpen && (
-          <Dialog open={editOpen} onClose={() => setEditOpen(false)}>
-            <DialogTitle>Edit Client</DialogTitle>
-            <DialogContent>
+          {editOpen && (
+            <Dialog open={editOpen} onClose={() => setEditOpen(false)}>
+              <DialogCloseButton onClose={() => setEditOpen(false)} />
+              <DialogTitle>Edit Client</DialogTitle>
+              <DialogContent>
               <Stack spacing={2} mt={1}>
                 <FormControlLabel
                   control={
@@ -374,47 +376,34 @@ export default function UserHistory({
                 )}
               </Stack>
             </DialogContent>
+              <DialogActions>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleSaveClient}
+                  disabled={!form.firstName || !form.lastName}
+                >
+                  Save
+                </Button>
+              </DialogActions>
+            </Dialog>
+          )}
+          <Dialog open={cancelId !== null} onClose={() => setCancelId(null)}>
+            <DialogCloseButton onClose={() => setCancelId(null)} />
+            <DialogTitle>Cancel booking</DialogTitle>
+            <DialogContent>
+              <Typography>Are you sure you want to cancel this booking?</Typography>
+            </DialogContent>
             <DialogActions>
               <Button
-                variant="outlined"
-                color="primary"
-                onClick={() => setEditOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button
+                color="error"
                 variant="contained"
-                color="primary"
-                onClick={handleSaveClient}
-                disabled={!form.firstName || !form.lastName}
+                onClick={confirmCancel}
               >
-                Save
+                Cancel booking
               </Button>
             </DialogActions>
           </Dialog>
-        )}
-        <Dialog open={cancelId !== null} onClose={() => setCancelId(null)}>
-          <DialogTitle>Cancel booking</DialogTitle>
-          <DialogContent>
-            <Typography>Are you sure you want to cancel this booking?</Typography>
-          </DialogContent>
-          <DialogActions>
-            <Button
-              variant="outlined"
-              color="primary"
-              onClick={() => setCancelId(null)}
-            >
-              Keep booking
-            </Button>
-            <Button
-              color="error"
-              variant="contained"
-              onClick={confirmCancel}
-            >
-              Cancel booking
-            </Button>
-          </DialogActions>
-        </Dialog>
         <FeedbackSnackbar
           open={!!message}
           onClose={() => setMessage('')}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
@@ -8,6 +8,7 @@ import type { VolunteerBooking } from '../../types';
 import { formatTime } from '../../utils/time';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import {
   TableContainer,
   Paper,
@@ -135,6 +136,7 @@ export default function VolunteerBookingHistory() {
       </TableContainer>
 
       <Dialog open={!!cancelBooking} onClose={() => setCancelBooking(null)}>
+        <DialogCloseButton onClose={() => setCancelBooking(null)} />
         <DialogTitle>Cancel Booking</DialogTitle>
         <DialogContent dividers>
           Cancel booking for {cancelBooking?.role_name} on {cancelBooking?.date}?
@@ -143,17 +145,11 @@ export default function VolunteerBookingHistory() {
           <Button onClick={handleCancel} variant="outlined" color="primary">
             Confirm
           </Button>
-          <Button
-            onClick={() => setCancelBooking(null)}
-            variant="outlined"
-            color="primary"
-          >
-            Keep
-          </Button>
         </DialogActions>
       </Dialog>
 
       <Dialog open={cancelSeriesId != null} onClose={() => setCancelSeriesId(null)}>
+        <DialogCloseButton onClose={() => setCancelSeriesId(null)} />
         <DialogTitle>Cancel Series</DialogTitle>
         <DialogContent dividers>
           Cancel all upcoming bookings in this series?
@@ -161,13 +157,6 @@ export default function VolunteerBookingHistory() {
         <DialogActions>
           <Button onClick={handleCancelSeries} variant="outlined" color="primary">
             Confirm
-          </Button>
-          <Button
-            onClick={() => setCancelSeriesId(null)}
-            variant="outlined"
-            color="primary"
-          >
-            Keep
           </Button>
         </DialogActions>
       </Dialog>

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -20,6 +20,7 @@ import { fromZonedTime } from 'date-fns-tz';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
 import RescheduleDialog from '../../components/VolunteerRescheduleDialog';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import {
   Box,
   Button,
@@ -952,11 +953,12 @@ export default function VolunteerManagement() {
         </div>
       )}
 
-      {shopperOpen && (
-        <Dialog open onClose={() => setShopperOpen(false)}>
-          <DialogContent>
-            <TextField
-              label="Client ID"
+        {shopperOpen && (
+          <Dialog open onClose={() => setShopperOpen(false)}>
+            <DialogCloseButton onClose={() => setShopperOpen(false)} />
+            <DialogContent>
+              <TextField
+                label="Client ID"
               value={shopperClientId}
               onChange={e => setShopperClientId(e.target.value)}
               fullWidth
@@ -991,16 +993,13 @@ export default function VolunteerManagement() {
               margin="dense"
             />
           </DialogContent>
-          <DialogActions>
-            <Button onClick={createShopper} variant="contained" color="primary" size="small">
-              Create
-            </Button>
-            <Button onClick={() => setShopperOpen(false)} variant="outlined" color="primary" size="small">
-              Cancel
-            </Button>
-          </DialogActions>
-        </Dialog>
-      )}
+            <DialogActions>
+              <Button onClick={createShopper} variant="contained" color="primary" size="small">
+                Create
+              </Button>
+            </DialogActions>
+          </Dialog>
+        )}
 
       {removeShopperOpen && (
         <ConfirmDialog

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -21,6 +21,7 @@ import { formatDate, addDays } from '../../utils/date';
 import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import RescheduleDialog from '../../components/VolunteerRescheduleDialog';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import {
   Box,
   FormControl,
@@ -372,9 +373,10 @@ export default function VolunteerSchedule() {
         </Typography>
       ) : null}
 
-      <Dialog open={!!requestRole} onClose={() => setRequestRole(null)}>
-        <DialogTitle>Request Booking</DialogTitle>
-        <DialogContent dividers>
+        <Dialog open={!!requestRole} onClose={() => setRequestRole(null)}>
+          <DialogCloseButton onClose={() => setRequestRole(null)} />
+          <DialogTitle>Request Booking</DialogTitle>
+          <DialogContent dividers>
           <Typography sx={{ mb: 2 }}>
             Request booking for {requestRole?.name}?
           </Typography>
@@ -427,30 +429,27 @@ export default function VolunteerSchedule() {
               />
           )}
         </DialogContent>
-        <DialogActions>
-          <Button onClick={submitRequest} variant="outlined" color="primary">
-            Submit
-          </Button>
-          <Button
-            onClick={() => setRequestRole(null)}
-            variant="outlined"
-            color="primary"
-          >
-            Cancel
-          </Button>
-        </DialogActions>
-      </Dialog>
+          <DialogActions>
+            <Button onClick={submitRequest} variant="outlined" color="primary">
+              Submit
+            </Button>
+          </DialogActions>
+        </Dialog>
 
-      <Dialog
-        open={!!decisionBooking}
-        onClose={() => {
-          setDecisionBooking(null);
-          setDecisionReason('');
-        }}
-      >
-        <DialogTitle>Manage Booking</DialogTitle>
-        <DialogContent dividers>
-          <Typography>Modify booking for {decisionBooking?.role_name}?</Typography>
+        <Dialog
+          open={!!decisionBooking}
+          onClose={() => {
+            setDecisionBooking(null);
+            setDecisionReason('');
+          }}
+        >
+          <DialogCloseButton onClose={() => {
+            setDecisionBooking(null);
+            setDecisionReason('');
+          }} />
+          <DialogTitle>Manage Booking</DialogTitle>
+          <DialogContent dividers>
+            <Typography>Modify booking for {decisionBooking?.role_name}?</Typography>
             <TextField
               placeholder="Reason for cancellation"
               value={decisionReason}
@@ -459,42 +458,32 @@ export default function VolunteerSchedule() {
               multiline
             />
         </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              setRescheduleBooking(decisionBooking);
-              setDecisionBooking(null);
-              setDecisionReason('');
-            }}
-            variant="outlined"
-            color="primary"
-          >
-            Reschedule
-          </Button>
-          {decisionBooking?.recurring_id && (
+          <DialogActions>
             <Button
-              onClick={cancelSeries}
+              onClick={() => {
+                setRescheduleBooking(decisionBooking);
+                setDecisionBooking(null);
+                setDecisionReason('');
+              }}
               variant="outlined"
               color="primary"
             >
-              Cancel All Upcoming
+              Reschedule
             </Button>
-          )}
-          <Button onClick={cancelSelected} variant="outlined" color="primary">
-            Cancel Booking
-          </Button>
-          <Button
-            onClick={() => {
-              setDecisionBooking(null);
-              setDecisionReason('');
-            }}
-            variant="outlined"
-            color="primary"
-          >
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
+            {decisionBooking?.recurring_id && (
+              <Button
+                onClick={cancelSeries}
+                variant="outlined"
+                color="primary"
+              >
+                Cancel All Upcoming
+              </Button>
+            )}
+            <Button onClick={cancelSelected} variant="outlined" color="primary">
+              Cancel Booking
+            </Button>
+          </DialogActions>
+        </Dialog>
 
       <RescheduleDialog
         open={!!rescheduleBooking}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -21,6 +21,7 @@ import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import { getDonors, createDonor } from '../../api/donors';
 import { getDonations, createDonation, updateDonation, deleteDonation } from '../../api/donations';
 import type { Donor } from '../../api/donors';
@@ -202,6 +203,7 @@ export default function DonationLog() {
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
+        <DialogCloseButton onClose={() => { setRecordOpen(false); setEditing(null); }} />
         <DialogTitle>{editing ? 'Edit Donation' : 'Record Donation'}</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <Stack spacing={2} mt={1}>
@@ -229,7 +231,6 @@ export default function DonationLog() {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => { setRecordOpen(false); setEditing(null); }}>Cancel</Button>
           <Button onClick={handleSaveDonation} disabled={!form.donorId || !form.weight}>
             Save
           </Button>
@@ -237,12 +238,12 @@ export default function DonationLog() {
       </Dialog>
 
       <Dialog open={deleteOpen} onClose={() => { setDeleteOpen(false); setToDelete(null); }}>
+        <DialogCloseButton onClose={() => { setDeleteOpen(false); setToDelete(null); }} />
         <DialogTitle>Delete Donation</DialogTitle>
         <DialogContent>
           <DialogContentText>Are you sure you want to delete this donation?</DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => { setDeleteOpen(false); setToDelete(null); }}>Cancel</Button>
           <Button
             onClick={() => {
               if (toDelete) {
@@ -266,6 +267,7 @@ export default function DonationLog() {
       </Dialog>
 
       <Dialog open={newDonorOpen} onClose={() => setNewDonorOpen(false)}>
+        <DialogCloseButton onClose={() => setNewDonorOpen(false)} />
         <DialogTitle>Add Donor</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <TextField
@@ -276,7 +278,6 @@ export default function DonationLog() {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setNewDonorOpen(false)}>Cancel</Button>
           <Button onClick={handleAddDonor} disabled={!donorName}>Save</Button>
         </DialogActions>
       </Dialog>

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
@@ -21,6 +21,7 @@ import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import { getOutgoingReceivers, createOutgoingReceiver } from '../../api/outgoingReceivers';
 import { getOutgoingDonations, createOutgoingDonation, updateOutgoingDonation, deleteOutgoingDonation } from '../../api/outgoingDonations';
 import type { OutgoingReceiver } from '../../api/outgoingReceivers';
@@ -220,6 +221,7 @@ export default function TrackOutgoingDonations() {
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
+        <DialogCloseButton onClose={() => { setRecordOpen(false); setEditing(null); }} />
         <DialogTitle>{editing ? 'Edit Outgoing Donation' : 'Record Outgoing Donation'}</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <Stack spacing={2} mt={1}>
@@ -253,18 +255,17 @@ export default function TrackOutgoingDonations() {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => { setRecordOpen(false); setEditing(null); }}>Cancel</Button>
           <Button onClick={handleSaveDonation} disabled={!form.receiverId || !form.weight}>Save</Button>
         </DialogActions>
       </Dialog>
 
       <Dialog open={deleteOpen} onClose={() => { setDeleteOpen(false); setToDelete(null); }}>
+        <DialogCloseButton onClose={() => { setDeleteOpen(false); setToDelete(null); }} />
         <DialogTitle>Delete Outgoing Donation</DialogTitle>
         <DialogContent>
           <DialogContentText>Are you sure you want to delete this outgoing donation?</DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => { setDeleteOpen(false); setToDelete(null); }}>Cancel</Button>
           <Button
             onClick={() => {
               if (toDelete) {
@@ -288,6 +289,7 @@ export default function TrackOutgoingDonations() {
       </Dialog>
 
       <Dialog open={newReceiverOpen} onClose={() => setNewReceiverOpen(false)}>
+        <DialogCloseButton onClose={() => setNewReceiverOpen(false)} />
         <DialogTitle>Add Donation Receiver</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <TextField
@@ -298,7 +300,6 @@ export default function TrackOutgoingDonations() {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setNewReceiverOpen(false)}>Cancel</Button>
           <Button onClick={handleAddReceiver} disabled={!receiverName}>Save</Button>
         </DialogActions>
       </Dialog>

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
@@ -20,6 +20,7 @@ import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import {
   getPigPounds,
   createPigPound,
@@ -183,15 +184,19 @@ export default function TrackPigpound() {
     >
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
-      <Dialog
-        open={recordOpen}
-        onClose={() => {
-          setRecordOpen(false);
-          setEditing(null);
-        }}
-      >
-        <DialogTitle>{editing ? 'Edit Entry' : 'Record Entry'}</DialogTitle>
-        <DialogContent sx={{ pt: 2 }}>
+        <Dialog
+          open={recordOpen}
+          onClose={() => {
+            setRecordOpen(false);
+            setEditing(null);
+          }}
+        >
+          <DialogCloseButton onClose={() => {
+            setRecordOpen(false);
+            setEditing(null);
+          }} />
+          <DialogTitle>{editing ? 'Edit Entry' : 'Record Entry'}</DialogTitle>
+          <DialogContent sx={{ pt: 2 }}>
           <Stack spacing={2} mt={1}>
             <TextField
               label="Date"
@@ -208,67 +213,55 @@ export default function TrackPigpound() {
             />
           </Stack>
         </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              setRecordOpen(false);
-              setEditing(null);
-            }}
-          >
-            Cancel
-          </Button>
-          <Button onClick={handleSave} disabled={!form.date || !form.weight}>
-            Save
-          </Button>
-        </DialogActions>
-      </Dialog>
+          <DialogActions>
+            <Button onClick={handleSave} disabled={!form.date || !form.weight}>
+              Save
+            </Button>
+          </DialogActions>
+        </Dialog>
 
-      <Dialog
-        open={deleteOpen}
-        onClose={() => {
-          setDeleteOpen(false);
-          setToDelete(null);
-        }}
-      >
-        <DialogTitle>Delete Entry</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Are you sure you want to delete this entry?
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              setDeleteOpen(false);
-              setToDelete(null);
-            }}
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={() => {
-              if (toDelete) {
-                deletePigPound(toDelete.id)
-                  .then(() => {
-                    setSnackbar({ open: true, message: 'Entry deleted' });
-                    setDeleteOpen(false);
-                    setToDelete(null);
-                    load();
-                  })
-                  .catch(err =>
-                    setSnackbar({
-                      open: true,
-                      message: err.message || 'Failed to delete entry',
-                    }),
-                  );
-              }
-            }}
-            autoFocus
-          >
-            Delete
-          </Button>
-        </DialogActions>
-      </Dialog>
+        <Dialog
+          open={deleteOpen}
+          onClose={() => {
+            setDeleteOpen(false);
+            setToDelete(null);
+          }}
+        >
+          <DialogCloseButton onClose={() => {
+            setDeleteOpen(false);
+            setToDelete(null);
+          }} />
+          <DialogTitle>Delete Entry</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              Are you sure you want to delete this entry?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
+                if (toDelete) {
+                  deletePigPound(toDelete.id)
+                    .then(() => {
+                      setSnackbar({ open: true, message: 'Entry deleted' });
+                      setDeleteOpen(false);
+                      setToDelete(null);
+                      load();
+                    })
+                    .catch(err =>
+                      setSnackbar({
+                        open: true,
+                        message: err.message || 'Failed to delete entry',
+                      }),
+                    );
+                }
+              }}
+              autoFocus
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
 
       <FeedbackSnackbar
         open={snackbar.open}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
@@ -20,6 +20,7 @@ import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
+import DialogCloseButton from '../../components/DialogCloseButton';
 import {
   getSurplus,
   createSurplus,
@@ -190,6 +191,7 @@ export default function TrackSurplus() {
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
+        <DialogCloseButton onClose={() => { setRecordOpen(false); setEditing(null); }} />
         <DialogTitle>{editing ? 'Edit Surplus' : 'Record Surplus'}</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <Stack spacing={2} mt={1}>
@@ -219,16 +221,15 @@ export default function TrackSurplus() {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => { setRecordOpen(false); setEditing(null); }}>Cancel</Button>
           <Button onClick={handleSave} disabled={!form.date || !form.count}>Save</Button>
         </DialogActions>
       </Dialog>
 
       <Dialog open={deleteOpen} onClose={() => { setDeleteOpen(false); setToDelete(null); }}>
+        <DialogCloseButton onClose={() => { setDeleteOpen(false); setToDelete(null); }} />
         <DialogTitle>Delete Surplus</DialogTitle>
         <DialogContent>Are you sure you want to delete this surplus record?</DialogContent>
         <DialogActions>
-          <Button onClick={() => { setDeleteOpen(false); setToDelete(null); }}>Cancel</Button>
           <Button
             onClick={() => {
               if (toDelete) {


### PR DESCRIPTION
## Summary
- replace cancel/close buttons in dialogs with an X icon
- provide reusable `DialogCloseButton` component for consistent dialog closing

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68afec227f80832db1421796f044663b