### PR TITLE
Fix blocked slot visibility and duplication

### DIFF
--- a/MJ_FB_Backend/src/routes/blockedSlots.ts
+++ b/MJ_FB_Backend/src/routes/blockedSlots.ts
@@ -15,8 +15,19 @@ router.get(
   authMiddleware,
   authorizeRoles('staff'),
   async (req, res) => {
-    const date = req.query.date as string;
-    if (!date) return res.status(400).json({ message: 'Date required' });
+    const date = req.query.date as string | undefined;
+    if (!date) {
+      const result = await pool.query(
+        'SELECT date, slot_id, reason FROM blocked_slots ORDER BY date, slot_id',
+      );
+      return res.json(
+        result.rows.map(r => ({
+          date: r.date,
+          slotId: Number(r.slot_id),
+          reason: r.reason ?? '',
+        })),
+      );
+    }
 
     let reginaDate: string;
     try {

--- a/MJ_FB_Backend/tests/blockedSlots.test.ts
+++ b/MJ_FB_Backend/tests/blockedSlots.test.ts
@@ -46,4 +46,16 @@ describe('GET /blocked-slots', () => {
       { slotId: 2, reason: 'weekly' },
     ]);
   });
+
+  it('lists non-recurring blocked slots when no date provided', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ date: '2024-06-18', slot_id: 1, reason: 'special' }],
+    });
+
+    const res = await request(app).get('/blocked-slots');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { date: '2024-06-18', slotId: 1, reason: 'special' },
+    ]);
+  });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -142,8 +142,11 @@ export async function getAllSlots() {
   })) as Slot[];
 }
 
-export async function getBlockedSlots(date: string): Promise<BlockedSlot[]> {
-  const res = await apiFetch(`${API_BASE}/blocked-slots?date=${encodeURIComponent(date)}`);
+export async function getBlockedSlots(date?: string): Promise<BlockedSlot[]> {
+  const url = date
+    ? `${API_BASE}/blocked-slots?date=${encodeURIComponent(date)}`
+    : `${API_BASE}/blocked-slots`;
+  const res = await apiFetch(url);
   return handleResponse(res);
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -35,6 +35,7 @@ import {
   addRecurringBlockedSlot,
   removeBlockedSlot,
   removeRecurringBlockedSlot,
+  getBlockedSlots,
   addBreak,
   removeBreak,
   getBreaks,
@@ -103,10 +104,11 @@ export default function ManageAvailability() {
   useEffect(() => {
     async function loadData() {
       try {
-        const [slots, breaksData, recurringBlocked] = await Promise.all([
+        const [slots, breaksData, recurringBlocked, blockedOnce] = await Promise.all([
           getAllSlots(),
           getBreaks(),
           getRecurringBlockedSlots(),
+          getBlockedSlots(),
         ]);
         setSlotOptions(slots);
         setBreaks(
@@ -117,14 +119,21 @@ export default function ManageAvailability() {
             reason: b.reason ?? '',
           })),
         );
-        setBlockedSlots(
-          recurringBlocked.map(b => ({
+        setBlockedSlots([
+          ...recurringBlocked.map(b => ({
             id: b.id,
             day: b.dayOfWeek,
+            week: b.weekOfMonth,
             slotId: b.slotId,
             reason: b.reason ?? '',
           })),
-        );
+          ...blockedOnce.map(b => ({
+            id: Date.parse(b.date) + b.slotId,
+            date: toDate(b.date),
+            slotId: b.slotId,
+            reason: b.reason ?? '',
+          })),
+        ]);
       } catch {
         showSnackbar('Failed to load availability data', 'error');
       }

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -50,6 +50,7 @@ export interface Holiday {
 }
 
 export interface BlockedSlot {
+  date?: string;
   slotId: number;
   reason: string;
   status?: 'blocked' | 'break';


### PR DESCRIPTION
## Summary
- Allow retrieving all one-off blocked slots by omitting the `date` query
- Load one-off blocked slots in Manage Availability and support `date` field in API/types
- Simplify pantry schedule display to rely on slot status, preventing duplicate blocked slots

## Testing
- `npm test` (backend) *(fails: slots.test.ts, bookingUtils.test.ts, events.test.ts)*
- `npm test` (frontend) *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afef86407c832d8fc804d26d0cf3ba