### PR TITLE
Remove duplicate Add Staff nav link and add return link

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -120,7 +120,6 @@ export default function App() {
         label: 'Admin',
         links: [
           { label: 'Staff', to: '/admin/staff' },
-          { label: 'Add Staff', to: '/admin/staff/create' },
         ],
       });
 

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffForm.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link as RouterLink } from 'react-router-dom';
+import { Box, Button } from '@mui/material';
 import StaffForm from '../../components/StaffForm';
 import { getStaff, createStaff, updateStaff } from '../../api/adminStaff';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -19,8 +20,11 @@ export default function AdminStaffForm() {
   }, [id]);
 
   return (
-    <>
+    <Box p={2}>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+      <Button variant="outlined" component={RouterLink} to="/admin/staff" sx={{ mb: 2 }}>
+        Back to Staff List
+      </Button>
       <StaffForm
         initial={initial}
         submitLabel={id ? 'Save' : 'Add Staff'}
@@ -45,6 +49,6 @@ export default function AdminStaffForm() {
           }
         }}
       />
-    </>
+    </Box>
   );
 }

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ control weight calculations:
 - Pages are organized into feature-based directories (e.g., booking, staff, volunteer-management, warehouse-management).
 - A shared dashboard component lives in `src/components/dashboard`.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
+- Admin staff creation page provides a link back to the staff list for easier navigation.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- Remove Add Staff item from Admin navigation menu
- Add Back to Staff List button on staff form
- Document new staff form navigation in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b083b898e8832d812eae7c7b493131