### PR TITLE
Display no-show and visited statuses in pantry schedule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,12 @@
 - Never hard-code hex values; use theme palette (`success`, `warning`, `error`, `info`).
 - Links & Emphasis: Use the theme’s primary color for emphasis and links; do not introduce new accent colors.
 
+- Pantry schedule cells use the following colors:
+  - submitted → theme warning light,
+  - approved → rgb(228,241,228),
+  - no_show → rgb(255, 200, 200),
+  - visited → rgb(111,146,113).
+
 ### Interactions
 - Affordance: Primary action visible and enabled when valid; disabled state must include a reason (helper text or tooltip).
 - Confirmation: Only confirm destructive actions (e.g., Cancel, Reject). Use dialogs with clear verb-first buttons (“Cancel booking”, “Keep booking”).

--- a/MJ_FB_Frontend/src/__tests__/PantrySchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantrySchedule.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PantrySchedule from '../pages/staff/PantrySchedule';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+import { theme } from '../theme';
+
+jest.mock('../api/bookings', () => ({
+  getSlots: jest.fn(),
+  getBookings: jest.fn(),
+  getHolidays: jest.fn(),
+  createBookingForUser: jest.fn(),
+  decideBooking: jest.fn(),
+  cancelBooking: jest.fn(),
+}));
+
+const { getSlots, getBookings, getHolidays } = jest.requireMock('../api/bookings');
+
+function hexToRgb(hex: string) {
+  const sanitized = hex.replace('#', '');
+  const bigint = parseInt(sanitized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+describe('PantrySchedule status colors', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T10:00:00'));
+    window.matchMedia = window.matchMedia || ((() => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+    })) as any);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders cells with colors for each status', async () => {
+    (getSlots as jest.Mock).mockResolvedValue([
+      { id: '1', startTime: '09:00:00', endTime: '10:00:00' },
+    ]);
+    (getBookings as jest.Mock).mockResolvedValue([
+      { id: 1, status: 'submitted', date: '2024-01-01', slot_id: 1, user_name: 'Sub', user_id: 1, client_id: 1, bookings_this_month: 0, is_staff_booking: false, reschedule_token: '' },
+      { id: 2, status: 'approved', date: '2024-01-01', slot_id: 1, user_name: 'App', user_id: 2, client_id: 2, bookings_this_month: 0, is_staff_booking: false, reschedule_token: '' },
+      { id: 3, status: 'no_show', date: '2024-01-01', slot_id: 1, user_name: 'No', user_id: 3, client_id: 3, bookings_this_month: 0, is_staff_booking: false, reschedule_token: '' },
+      { id: 4, status: 'visited', date: '2024-01-01', slot_id: 1, user_name: 'Vis', user_id: 4, client_id: 4, bookings_this_month: 0, is_staff_booking: false, reschedule_token: '' },
+    ]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+
+    const queryClient = new QueryClient();
+    render(
+      <ThemeProvider theme={theme}>
+        <QueryClientProvider client={queryClient}>
+          <PantrySchedule />
+        </QueryClientProvider>
+      </ThemeProvider>
+    );
+
+    const submitted = await screen.findByText('Sub');
+    const approved = screen.getByText('App');
+    const noShow = screen.getByText('No');
+    const visited = screen.getByText('Vis');
+
+    expect(getComputedStyle(submitted).backgroundColor).toBe(hexToRgb(theme.palette.warning.light));
+    expect(getComputedStyle(approved).backgroundColor).toBe('rgb(228, 241, 228)');
+    expect(getComputedStyle(noShow).backgroundColor).toBe('rgb(255, 200, 200)');
+    expect(getComputedStyle(visited).backgroundColor).toBe('rgb(111, 146, 113)');
+  });
+});
+

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -16,7 +16,6 @@ import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { Button, Link, type AlertColor, useTheme, IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
-import { lighten } from '@mui/material/styles';
 import RescheduleDialog from '../../components/RescheduleDialog';
 
 interface Booking {
@@ -65,7 +64,12 @@ export default function PantrySchedule({
   const [rescheduleBooking, setRescheduleBooking] = useState<Booking | null>(null);
 
   const theme = useTheme();
-  const approvedColor = lighten(theme.palette.success.light, 0.4);
+  const statusColors: Record<string, string> = {
+    submitted: theme.palette.warning.light,
+    approved: 'rgb(228,241,228)',
+    no_show: 'rgb(255, 200, 200)',
+    visited: 'rgb(111,146,113)',
+  };
 
   const loadData = useCallback(async () => {
     const dateStr = formatDate(currentDate);
@@ -84,7 +88,7 @@ export default function PantrySchedule({
       ]);
       setSlots(slotsData);
       const filtered = bookingsData.filter((b: Booking) =>
-        ['approved', 'submitted'].includes(b.status),
+        ['approved', 'submitted', 'no_show', 'visited'].includes(b.status),
       );
       setBookings(filtered);
     } catch (err) {
@@ -237,9 +241,7 @@ export default function PantrySchedule({
         return {
           content: booking ? booking.user_name : '',
           backgroundColor: booking
-            ? booking.status === 'submitted'
-              ? theme.palette.warning.light
-              : approvedColor
+            ? statusColors[booking.status]
             : undefined,
           onClick: () => {
             if (booking) {
@@ -283,7 +285,33 @@ export default function PantrySchedule({
       {isClosed ? (
         <p style={{ textAlign: 'center' }}>Moose Jaw food bank is closed for {dayName}</p>
       ) : (
-        <VolunteerScheduleTable maxSlots={4} rows={rows} />
+        <>
+          <div style={{ display: 'flex', gap: 16, marginBottom: 8 }}>
+            {[
+              { label: 'Submitted', color: statusColors.submitted },
+              { label: 'Approved', color: statusColors.approved },
+              { label: 'No Show', color: statusColors.no_show },
+              { label: 'Visited', color: statusColors.visited },
+            ].map(item => (
+              <span
+                key={item.label}
+                style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+              >
+                <span
+                  style={{
+                    width: 16,
+                    height: 16,
+                    backgroundColor: item.color,
+                    border: '1px solid #ccc',
+                    borderRadius: 4,
+                  }}
+                />
+                {item.label}
+              </span>
+            ))}
+          </div>
+          <VolunteerScheduleTable maxSlots={4} rows={rows} />
+        </>
       )}
 
       {assignSlot && (

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ control weight calculations:
 - A shared dashboard component lives in `src/components/dashboard`.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Admin staff creation page provides a link back to the staff list for easier navigation.
+- Pantry schedule cells use color coding: yellow for submitted, rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, and rgb(111,146,113) for visited.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- Allow pantry schedule to load and display bookings with `submitted`, `approved`, `no_show`, and `visited` statuses
- Introduce fixed color mapping and in-page legend for schedule statuses
- Document schedule color legend and add tests covering each status color

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching write-excel-file)*

------
https://chatgpt.com/codex/tasks/task_e_68b08954b128832d9bcc6906d63c297a