### PR TITLE
test: add env defaults for backend

### DIFF
--- a/MJ_FB_Backend/tests/setupEnv.ts
+++ b/MJ_FB_Backend/tests/setupEnv.ts
@@ -1,4 +1,12 @@
+// Setup environment variables for tests. Add additional variables here as
+// future tests require them.
 process.env.JWT_SECRET = 'testsecret';
 process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+process.env.PG_USER = 'testuser';
+process.env.PG_PASSWORD = 'testpassword';
+process.env.PG_HOST = 'localhost';
+process.env.PG_PORT = '5432';
+process.env.PG_DATABASE = 'testdb';
+process.env.FRONTEND_ORIGIN = 'http://localhost:3000';
 
 export {};


### PR DESCRIPTION
## Summary
- provide dummy Postgres and frontend origin env vars for tests
- document expanding test env in setupEnv

## Testing
- `npm test` (fails: 3 failed, 34 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b089cb1ec0832daa93e2251e244832