### PR TITLE
chore: upgrade ts-jest for jest 30

### DIFF
--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -45,7 +45,7 @@
     "jest-environment-jsdom": "^30.0.5",
     "postcss": "^8.5.6",
     "react-calendar": "^6.0.0",
-    "ts-jest": "^29.4.1",
+    "ts-jest": "^30.0.0",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.40.0",
     "vite": "^7.1.3"


### PR DESCRIPTION
## Summary
- upgrade ts-jest to a version compatible with Jest 30 in the frontend

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b089ddc44c832d91fc113bb65d5a16