### PR TITLE
Expose App Configurations link in admin navbar

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -120,7 +120,8 @@ export default function App() {
       navGroups.push({
         label: 'Admin',
         links: [
-          { label: 'Staff', to: '/admin/staff' }
+          { label: 'Staff', to: '/admin/staff' },
+          { label: 'App Config', to: '/admin/app-config' },
         ],
       });
 

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
 
@@ -91,5 +91,19 @@ describe('App authentication persistence', () => {
       </AuthProvider>,
     );
     expect(screen.getByText(/client sign up/i)).toBeInTheDocument();
+  });
+
+  it('shows App Config link for admin staff', () => {
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Admin User');
+    localStorage.setItem('access', JSON.stringify(['admin']));
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>,
+    );
+    const adminButton = screen.getByRole('button', { name: /admin/i });
+    fireEvent.click(adminButton);
+    expect(screen.getByRole('menuitem', { name: 'App Config' })).toBeInTheDocument();
   });
 });

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
-- Configurable cart tare and surplus weight multipliers managed through Admin → App Configurations.
+- Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
 
 ## Clone and initialize submodules
 


### PR DESCRIPTION
## Summary
- surface App Config page within Admin navigation
- cover admin nav with a test for the App Config link
- document Admin menu access to App Configurations

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/write-excel-file)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08aac3cd0832db1b5a284fa2fd8bd