### PR TITLE
Remove duplicate markBookingVisited definition

### DIFF
--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -310,17 +310,3 @@ export async function rescheduleBookingByToken(
   await handleResponse(res);
 }
 
-export async function markBookingNoShow(bookingId: number): Promise<void> {
-  const res = await apiFetch(`${API_BASE}/bookings/${bookingId}/no-show`, {
-    method: 'POST',
-  });
-  await handleResponse(res);
-}
-
-export async function markBookingVisited(bookingId: number): Promise<void> {
-  const res = await apiFetch(`${API_BASE}/bookings/${bookingId}/visited`, {
-    method: 'POST',
-  });
-  await handleResponse(res);
-}
-


### PR DESCRIPTION
## Summary
- Remove redundant markBookingVisited and markBookingNoShow functions to keep only the versions with optional parameters

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for ts-jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b08d3891b0832da4889fafdfef9890