### PR TITLE
fix: use theme background color

### DIFF
--- a/MJ_FB_Frontend/src/index.css
+++ b/MJ_FB_Frontend/src/index.css
@@ -3,7 +3,6 @@
   --e-global-color-secondary: #000000;
   --e-global-color-text: #000000;
   --e-global-color-accent: #941818;
-  --e-global-color-background: #FFFFFF;
   --e-global-typography-text-font-family: 'Golos Text', sans-serif;
 
   font-family: var(--e-global-typography-text-font-family);
@@ -11,7 +10,6 @@
   font-weight: 400;
 
   color: var(--e-global-color-text);
-  background-color: var(--e-global-color-background);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -60,7 +60,10 @@ let theme = createTheme({
     // Global CSS touches
     MuiCssBaseline: {
       styleOverrides: {
-        body: { backgroundImage: 'none' },
+        body: ({ theme }) => ({
+          backgroundImage: 'none',
+          backgroundColor: theme.palette.background.default,
+        }),
         // Crisp, accessible focus ring everywhere
         '*:focus-visible': {
           outline: `2px solid ${alpha(BRAND_PRIMARY, 0.6)}`,


### PR DESCRIPTION
## Summary
- rely on theme palette background instead of hard-coded white in index.css
- ensure MuiCssBaseline applies theme background color to body

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden fetching ts-jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b0905292e8832da4ccbc98c0d68981