### PR TITLE
feat: add main layout component with navigation and breadcrumbs

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -37,7 +37,7 @@ import AgencyLogin from './pages/agency/Login';
 import AgencyClientBookings from './pages/agency/ClientBookings';
 import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
-import Breadcrumbs from './components/Breadcrumbs';
+import MainLayout from './components/layout/MainLayout';
 import { useAuth, AgencyGuard } from './hooks/useAuth';
 import type { StaffAccess } from './types';
 
@@ -162,18 +162,18 @@ export default function App() {
     }
   }
 
+  const navbarProps = {
+    groups: navGroups,
+    onLogout: role ? logout : undefined,
+    name: role ? name || undefined : undefined,
+    loading,
+    role,
+    profileLinks,
+  };
+
   return (
     <BrowserRouter>
       <div className="app-container">
-    <Navbar
-      groups={navGroups}
-      onLogout={role ? logout : undefined}
-      name={role ? name || undefined : undefined}
-      loading={loading}
-      role={role}
-      profileLinks={profileLinks}
-    />
-
         <FeedbackSnackbar
           open={!!error}
           onClose={() => setError('')}
@@ -181,9 +181,8 @@ export default function App() {
           severity="error"
         />
 
-            {role ? (
-          <main>
-            <Breadcrumbs />
+        {role ? (
+          <MainLayout {...navbarProps}>
             <Routes>
               <Route
                 path="/"
@@ -355,19 +354,22 @@ export default function App() {
               )}
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
-          </main>
+          </MainLayout>
         ) : (
-          <main>
-            <Routes>
-              <Route path="/signup" element={<ClientSignup />} />
-                <Route path="/login/user" element={<Login onLogin={login} />} />
-                <Route path="/login/staff" element={<StaffLogin onLogin={login} />} />
-                <Route path="/login/volunteer" element={<VolunteerLogin onLogin={login} />} />
-                <Route path="/login/agency" element={<AgencyLogin onLogin={login} />} />
-              <Route path="/login" element={<Navigate to="/login/user" replace />} />
-              <Route path="*" element={<Navigate to="/login/user" replace />} />
-            </Routes>
-          </main>
+          <>
+            <Navbar {...navbarProps} />
+            <main>
+              <Routes>
+                <Route path="/signup" element={<ClientSignup />} />
+                  <Route path="/login/user" element={<Login onLogin={login} />} />
+                  <Route path="/login/staff" element={<StaffLogin onLogin={login} />} />
+                  <Route path="/login/volunteer" element={<VolunteerLogin onLogin={login} />} />
+                  <Route path="/login/agency" element={<AgencyLogin onLogin={login} />} />
+                <Route path="/login" element={<Navigate to="/login/user" replace />} />
+                <Route path="*" element={<Navigate to="/login/user" replace />} />
+              </Routes>
+            </main>
+          </>
         )}
       </div>
     </BrowserRouter>

--- a/MJ_FB_Frontend/src/components/Page.tsx
+++ b/MJ_FB_Frontend/src/components/Page.tsx
@@ -1,5 +1,6 @@
 import { Box, Typography, type BoxProps } from '@mui/material';
-import { useEffect, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
+import { usePageTitle } from './layout/MainLayout';
 
 interface PageProps extends BoxProps {
   title: string;
@@ -8,9 +9,7 @@ interface PageProps extends BoxProps {
 }
 
 export default function Page({ title, header, children, ...boxProps }: PageProps) {
-  useEffect(() => {
-    document.title = `MJ Foodbank - ${title}`;
-  }, [title]);
+  usePageTitle(title);
 
   return (
     <Box {...boxProps}>

--- a/MJ_FB_Frontend/src/components/layout/MainLayout.tsx
+++ b/MJ_FB_Frontend/src/components/layout/MainLayout.tsx
@@ -1,0 +1,54 @@
+import { Box } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import Navbar, { type NavGroup, type NavLink } from '../Navbar';
+import Breadcrumbs from '../Breadcrumbs';
+import PageContainer from './PageContainer';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+interface MainLayoutProps {
+  groups: NavGroup[];
+  onLogout?: () => void;
+  name?: string;
+  loading?: boolean;
+  profileLinks?: NavLink[];
+  role?: string;
+  children: ReactNode;
+}
+
+const PageTitleContext = createContext<(title: string) => void>(() => {});
+
+export function usePageTitle(title: string) {
+  const setTitle = useContext(PageTitleContext);
+  useEffect(() => {
+    setTitle(title);
+  }, [setTitle, title]);
+}
+
+export default function MainLayout({ children, ...navbarProps }: MainLayoutProps) {
+  const [title, setTitle] = useState('');
+  const theme = useTheme();
+
+  useEffect(() => {
+    document.title = title ? `MJ Foodbank - ${title}` : 'MJ Foodbank';
+  }, [title]);
+
+  useEffect(() => {
+    const previous = document.body.style.backgroundColor;
+    document.body.style.backgroundColor = theme.palette.background.default;
+    return () => {
+      document.body.style.backgroundColor = previous;
+    };
+  }, [theme]);
+
+  return (
+    <PageTitleContext.Provider value={setTitle}>
+      <Box sx={{ bgcolor: 'background.default', minHeight: '100vh' }}>
+        <Navbar {...navbarProps} />
+        <PageContainer component="main">
+          <Breadcrumbs />
+          {children}
+        </PageContainer>
+      </Box>
+    </PageTitleContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- create MainLayout wrapping Navbar, Breadcrumbs, and PageContainer
- use MainLayout for authenticated routes and provide page title hook
- integrate layout title hook into Page component

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0902e4c74832dacd14199345910b5