### PR TITLE
feat: enhance FormCard styling with customizable shadow

### DIFF
--- a/MJ_FB_Frontend/src/components/FormCard.tsx
+++ b/MJ_FB_Frontend/src/components/FormCard.tsx
@@ -1,7 +1,7 @@
 import { Box, Paper, Stack, Typography, type PaperProps, type BoxProps } from '@mui/material';
 import type { FormEvent, ReactNode } from 'react';
 
-interface FormCardProps extends Omit<PaperProps<'form'>, 'onSubmit'> {
+interface FormCardProps extends Omit<PaperProps<'form'>, 'onSubmit' | 'elevation'> {
   title: string;
   children: ReactNode;
   onSubmit: (e: FormEvent<HTMLFormElement>) => void;
@@ -9,6 +9,7 @@ interface FormCardProps extends Omit<PaperProps<'form'>, 'onSubmit'> {
   header?: ReactNode;
   centered?: boolean;
   boxProps?: BoxProps;
+  elevation?: number;
 }
 
 export default function FormCard({
@@ -19,6 +20,7 @@ export default function FormCard({
   header,
   centered = true,
   boxProps,
+  elevation = 1,
   ...paperProps
 }: FormCardProps) {
   return (
@@ -31,7 +33,13 @@ export default function FormCard({
       py={centered ? 0 : 4}
       {...boxProps}
     >
-      <Paper component="form" onSubmit={onSubmit} sx={{ p: 3, width: '100%', maxWidth: 400 }} {...paperProps}>
+      <Paper
+        component="form"
+        onSubmit={onSubmit}
+        variant="outlined"
+        sx={{ p: 3, width: '100%', maxWidth: 400, boxShadow: elevation }}
+        {...paperProps}
+      >
         <Stack spacing={2}>
           {header && <Box textAlign="center">{header}</Box>}
           <Typography variant="h5" textAlign="center">


### PR DESCRIPTION
## Summary
- add optional `elevation` prop to `FormCard` with default subtle shadow
- use outlined Paper variant with theme box shadow for consistent form emphasis

## Testing
- `npm test` (fails: sh: 1: jest: not found)
- `npm install` (fails: E403 Forbidden when fetching dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68b09073a5e8832d9f2d031e9993519c