### PR TITLE
Add headings for all pages

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -29,6 +29,7 @@ import { getSlots, createBooking, getHolidays } from '../api/bookings';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
 import FeedbackModal from '../components/FeedbackModal';
 import { Link as RouterLink } from 'react-router-dom';
+import Page from '../components/Page';
 
 // Wrappers to match required signatures
 function useSlots(date: Dayjs, enabled: boolean) {
@@ -232,7 +233,8 @@ export default function BookingUI({
     : '';
 
   return (
-    <Container maxWidth="lg" sx={{ pb: 9 }}>
+    <Page title="Book Appointment">
+      <Container maxWidth="lg" sx={{ pb: 9 }}>
       <Toolbar />
       <Typography variant="h5" gutterBottom>
         Booking for: {shopperName}
@@ -380,6 +382,7 @@ export default function BookingUI({
         severity="warning"
       />
     </Container>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,12 @@
 import Dashboard, { type DashboardProps } from '../components/dashboard/Dashboard';
+import Page from '../components/Page';
 
 export default function DashboardPage(props: DashboardProps) {
-  return <Dashboard {...props} masterRoleFilter={['Pantry']} />;
+  return (
+    <Page title="Dashboard">
+      <Dashboard {...props} masterRoleFilter={['Pantry']} />
+    </Page>
+  );
 }
 
 export { type DashboardProps };

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffForm.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link as RouterLink } from 'react-router-dom';
 import { Box, Button } from '@mui/material';
+import Page from '../../components/Page';
 import StaffForm from '../../components/StaffForm';
 import { getStaff, createStaff, updateStaff } from '../../api/adminStaff';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -20,35 +21,37 @@ export default function AdminStaffForm() {
   }, [id]);
 
   return (
-    <Box p={2}>
-      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-      <Button variant="outlined" component={RouterLink} to="/admin/staff" sx={{ mb: 2 }}>
-        Back to Staff List
-      </Button>
-      <StaffForm
-        initial={initial}
-        submitLabel={id ? 'Save' : 'Add Staff'}
-        onSubmit={async data => {
-          if (id) {
-            await updateStaff(
-              Number(id),
-              data.firstName,
-              data.lastName,
-              data.email,
-              data.access,
-              data.password,
-            );
-          } else {
-            await createStaff(
-              data.firstName,
-              data.lastName,
-              data.email,
-              data.password || '',
-              data.access,
-            );
-          }
-        }}
-      />
-    </Box>
+    <Page title={id ? 'Edit Staff' : 'Create Staff'}>
+      <Box p={2}>
+        <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+        <Button variant="outlined" component={RouterLink} to="/admin/staff" sx={{ mb: 2 }}>
+          Back to Staff List
+        </Button>
+        <StaffForm
+          initial={initial}
+          submitLabel={id ? 'Save' : 'Add Staff'}
+          onSubmit={async data => {
+            if (id) {
+              await updateStaff(
+                Number(id),
+                data.firstName,
+                data.lastName,
+                data.email,
+                data.access,
+                data.password,
+              );
+            } else {
+              await createStaff(
+                data.firstName,
+                data.lastName,
+                data.email,
+                data.password || '',
+                data.access,
+              );
+            }
+          }}
+        />
+      </Box>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
@@ -11,6 +11,7 @@ import {
   TextField,
   IconButton,
 } from '@mui/material';
+import Page from '../../components/Page';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -47,47 +48,49 @@ export default function AdminStaffList() {
   }
 
   return (
-    <Box p={2}>
-      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-      <FeedbackSnackbar open={!!success} onClose={() => setSuccess('')} message={success} />
-      <Box mb={2} display="flex" justifyContent="space-between" alignItems="center">
-        <TextField
-          label="Search"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          size="small"
-        />
-        <Button variant="contained" component={RouterLink} to="/admin/staff/create">
-          Add Staff
-        </Button>
-      </Box>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell>Email</TableCell>
-            <TableCell>Access</TableCell>
-            <TableCell align="right">Actions</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {staff.map(s => (
-            <TableRow key={s.id}>
-              <TableCell>{s.firstName} {s.lastName}</TableCell>
-              <TableCell>{s.email}</TableCell>
-              <TableCell>{s.access.join(', ')}</TableCell>
-              <TableCell align="right">
-                <IconButton component={RouterLink} to={`/admin/staff/${s.id}`} size="small" aria-label="edit">
-                  <EditIcon />
-                </IconButton>
-                <IconButton onClick={() => handleDelete(s.id)} size="small" aria-label="delete">
-                  <DeleteIcon />
-                </IconButton>
-              </TableCell>
+    <Page title="Staff List">
+      <Box p={2}>
+        <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+        <FeedbackSnackbar open={!!success} onClose={() => setSuccess('')} message={success} />
+        <Box mb={2} display="flex" justifyContent="space-between" alignItems="center">
+          <TextField
+            label="Search"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            size="small"
+          />
+          <Button variant="contained" component={RouterLink} to="/admin/staff/create">
+            Add Staff
+          </Button>
+        </Box>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Access</TableCell>
+              <TableCell align="right">Actions</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </Box>
+          </TableHead>
+          <TableBody>
+            {staff.map(s => (
+              <TableRow key={s.id}>
+                <TableCell>{s.firstName} {s.lastName}</TableCell>
+                <TableCell>{s.email}</TableCell>
+                <TableCell>{s.access.join(', ')}</TableCell>
+                <TableCell align="right">
+                  <IconButton component={RouterLink} to={`/admin/staff/${s.id}`} size="small" aria-label="edit">
+                    <EditIcon />
+                  </IconButton>
+                  <IconButton onClick={() => handleDelete(s.id)} size="small" aria-label="delete">
+                    <DeleteIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import PantrySchedule from '../staff/PantrySchedule';
+import Page from '../../components/Page';
 import { getMyAgencyClients } from '../../api/agencies';
 import type { Role } from '../../types';
 import { useAuth } from '../../hooks/useAuth';
@@ -49,10 +50,12 @@ export default function AgencySchedule() {
   );
 
   return (
-    <PantrySchedule
-      token={token}
-      clientIds={clientIds}
-      searchUsersFn={searchAgencyUsers}
-    />
+    <Page title="Agency Schedule">
+      <PantrySchedule
+        token={token}
+        clientIds={clientIds}
+        searchUsersFn={searchAgencyUsers}
+      />
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
@@ -5,6 +5,7 @@ import { searchUsers } from '../../api/users';
 import { addAgencyClient } from '../../api/agencies';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { useAuth } from '../../hooks/useAuth';
+import Page from '../../components/Page';
 
 interface User { id: number; name: string; email: string; }
 
@@ -40,7 +41,7 @@ export default function ClientBookings() {
   }
 
   return (
-    <div>
+    <Page title="Client Bookings">
       <TextField
         label="Search Clients"
         value={search}
@@ -62,6 +63,6 @@ export default function ClientBookings() {
         message={snackbar}
         severity="info"
       />
-    </div>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -21,6 +21,7 @@ import RescheduleDialog from '../../components/RescheduleDialog';
 import EntitySearch from '../../components/EntitySearch';
 import { toDate } from '../../utils/date';
 import { formatDate } from '../../utils/date';
+import Page from '../../components/Page';
 
 const TIMEZONE = 'America/Regina';
 
@@ -92,9 +93,9 @@ export default function ClientHistory() {
   } as const;
 
   return (
-    <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
-      <Box width="100%" maxWidth={800} mt={4}>
-        <h2>Client History</h2>
+    <Page title="Client History">
+      <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
+        <Box width="100%" maxWidth={800} mt={4}>
         <EntitySearch
           type="user"
           placeholder="Search by name or client ID"
@@ -218,6 +219,7 @@ export default function ClientHistory() {
         )}
       </Box>
     </Box>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
@@ -17,6 +17,7 @@ import {
   removeAgencyClient,
 } from '../../api/agencies';
 import { useAuth } from '../../hooks/useAuth';
+import Page from '../../components/Page';
 
 interface AgencyClient {
   id: number;
@@ -86,6 +87,7 @@ export default function ClientList() {
   };
 
   return (
+    <Page title="Agency Clients">
     <Grid container spacing={2}>
       <Grid item xs={12} md={6}>
         <Typography variant="h5" gutterBottom>
@@ -136,6 +138,7 @@ export default function ClientList() {
         severity={snackbar?.severity}
       />
     </Grid>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/agency/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/Login.tsx
@@ -3,6 +3,7 @@ import { loginAgency, type LoginResponse } from '../../api/users';
 import { TextField, Button } from '@mui/material';
 import FormCard from '../../components/FormCard';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import Page from '../../components/Page';
 
 export default function AgencyLogin({
   onLogin,
@@ -28,7 +29,7 @@ export default function AgencyLogin({
   }
 
   return (
-    <>
+    <Page title="Agency Login">
       <FormCard
         onSubmit={submit}
         title="Agency Login"
@@ -71,6 +72,6 @@ export default function AgencyLogin({
         message={error}
         severity="error"
       />
-    </>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { TextField, Button } from '@mui/material';
+import Page from '../../components/Page';
 import { changePassword } from '../../api/users';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
@@ -23,7 +24,7 @@ export default function ChangePasswordForm() {
   }
 
   return (
-    <>
+    <Page title="Change Password">
       <FormCard
         onSubmit={handleSubmit}
         title="Change Password"
@@ -51,6 +52,6 @@ export default function ChangePasswordForm() {
       </FormCard>
       <FeedbackSnackbar open={!!success} onClose={() => setSuccess('')} message={success} severity="success" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/auth/ClientSignup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/ClientSignup.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import FormCard from '../../components/FormCard';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { sendRegistrationOtp, registerUser } from '../../api/users';
+import Page from '../../components/Page';
 
 export default function ClientSignup() {
   const [firstName, setFirstName] = useState('');
@@ -67,7 +68,7 @@ export default function ClientSignup() {
   }
 
   return (
-    <>
+    <Page title={step === 'form' ? 'Client Sign Up' : 'Verify Email'}>
       <FormCard
         onSubmit={handleSubmit}
         title={step === 'form' ? 'Client Sign Up' : 'Verify Email'}
@@ -155,6 +156,6 @@ export default function ClientSignup() {
       </FormCard>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} />
-    </>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { loginUser } from '../../api/users';
 import type { LoginResponse } from '../../api/users';
 import { Link, TextField, Button } from '@mui/material';
+import Page from '../../components/Page';
 import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
@@ -34,7 +35,7 @@ export default function Login({
   }
 
   return (
-    <>
+    <Page title="Client Login">
       <FormCard
         onSubmit={handleSubmit}
         title="Client Login"
@@ -77,6 +78,6 @@ export default function Login({
       </FormCard>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="user" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { loginStaff, staffExists, createStaff } from '../../api/users';
 import type { LoginResponse } from '../../api/users';
 import { Typography, TextField, Link, Button } from '@mui/material';
+import Page from '../../components/Page';
 import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FeedbackModal from '../../components/FeedbackModal';
@@ -29,12 +30,21 @@ export default function StaffLogin({
       });
   }, []);
 
-  if (checking) return <Typography>Loading...</Typography>;
+  if (checking)
+    return (
+      <Page title="Staff Login">
+        <Typography>Loading...</Typography>
+      </Page>
+    );
 
-  return hasStaff ? (
-    <StaffLoginForm onLogin={onLogin} error={error} />
-  ) : (
-    <CreateStaffForm onCreated={() => setHasStaff(true)} error={error} />
+  return (
+    <Page title={hasStaff ? 'Staff Login' : 'Create Staff Account'}>
+      {hasStaff ? (
+        <StaffLoginForm onLogin={onLogin} error={error} />
+      ) : (
+        <CreateStaffForm onCreated={() => setHasStaff(true)} error={error} />
+      )}
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
@@ -6,6 +6,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
 import PasswordResetDialog from '../../components/PasswordResetDialog';
+import Page from '../../components/Page';
 
 export default function VolunteerLogin({
   onLogin,
@@ -34,7 +35,7 @@ export default function VolunteerLogin({
   }
 
   return (
-    <>
+    <Page title="Volunteer Login">
       <FormCard
         onSubmit={submit}
         title="Volunteer Login"
@@ -72,6 +73,6 @@ export default function VolunteerLogin({
       </FormCard>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="volunteer" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-    </>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -25,6 +25,7 @@ import type { AlertColor } from '@mui/material';
 import SectionCard from '../../components/dashboard/SectionCard';
 import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
+import Page from '../../components/Page';
 
 interface Booking {
   id: number;
@@ -137,7 +138,7 @@ export default function ClientDashboard() {
   }
 
   return (
-    <>
+    <Page title="Client Dashboard">
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard
@@ -346,6 +347,6 @@ export default function ClientDashboard() {
         message={message}
         severity={snackbarSeverity}
       />
-    </>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import StyledTabs from '../../components/StyledTabs';
+import Page from '../../components/Page';
 import { useSearchParams } from 'react-router-dom';
 import AddClient from './client-management/AddClient';
 import UpdateClientData from './client-management/UpdateClientData';
@@ -31,6 +32,10 @@ export default function ClientManagement() {
     { label: 'History', content: <UserHistory /> },
   ];
 
-  return <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />;
+  return (
+    <Page title="Client Management">
+      <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />
+    </Page>
+  );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -29,6 +29,7 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import type { AlertColor } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs, { type TabItem } from '../../components/StyledTabs';
+import Page from '../../components/Page';
 import {
   getAllSlots,
   addBlockedSlot,
@@ -542,18 +543,17 @@ export default function ManageAvailability() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box sx={{ maxWidth: 1000, mx: 'auto', pb: 6 }}>
-        <Typography variant="h4" fontWeight={800} gutterBottom>
-          Manage Availability
-        </Typography>
-        <StyledTabs tabs={tabs} />
-        <FeedbackSnackbar
-          open={snackbar.open}
-          message={snackbar.message}
-          severity={snackbar.severity}
-          onClose={() => setSnackbar(s => ({ ...s, open: false }))}
-        />
-      </Box>
+      <Page title="Manage Availability">
+        <Box sx={{ maxWidth: 1000, mx: 'auto', pb: 6 }}>
+          <StyledTabs tabs={tabs} />
+          <FeedbackSnackbar
+            open={snackbar.open}
+            message={snackbar.message}
+            severity={snackbar.severity}
+            onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+          />
+        </Box>
+      </Page>
     </LocalizationProvider>
   );
 }

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -17,6 +17,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { lighten } from '@mui/material/styles';
 import RescheduleDialog from '../../components/RescheduleDialog';
 import ManageBookingDialog from '../../components/ManageBookingDialog';
+import Page from '../../components/Page';
 
 interface Booking {
   id: number;
@@ -217,7 +218,7 @@ export default function PantrySchedule({
   });
 
   return (
-    <div>
+    <Page title="Pantry Schedule">
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
         <Button onClick={() => changeDay(-1)} variant="outlined" color="primary">Previous</Button>
         <h3>
@@ -326,7 +327,7 @@ export default function PantrySchedule({
           }}
         />
       )}
-    </div>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/Pending.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/Pending.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Grid, Card, CardContent, CardActions, Typography, TextField, Button } from '@mui/material';
+import Page from '../../components/Page';
 import { getBookings, decideBooking } from '../../api/bookings';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { formatTime } from '../../utils/time';
@@ -56,10 +57,7 @@ export default function Pending() {
   }
 
   return (
-    <>
-      <Typography variant="h5" gutterBottom>
-        Pending Requests
-      </Typography>
+    <Page title="Pending Requests">
       <Grid container spacing={2}>
         {bookings.map(b => (
           <Grid size={{ xs: 12, sm: 6, md: 4 }} key={b.id}>
@@ -109,7 +107,7 @@ export default function Pending() {
         )}
       </Grid>
       <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity={snackbarSeverity} />
-    </>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -4,6 +4,7 @@ import type { UserRole } from '../../../types';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import FeedbackModal from '../../../components/FeedbackModal';
 import { Box, Button, Stack, TextField, MenuItem, Typography, FormControlLabel, Checkbox } from '@mui/material';
+import Page from '../../../components/Page';
 
 export default function AddClient() {
   const [email, setEmail] = useState('');
@@ -54,18 +55,16 @@ export default function AddClient() {
   }
 
   return (
-    <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
-      <Box maxWidth={400} width="100%" mt={4}>
-        <Typography variant="h5" gutterBottom>
-          Create Client
-        </Typography>
-        <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-        <FeedbackModal open={!!success} onClose={() => setSuccess('')} message={success} />
-        <Stack spacing={2}>
-          <FormControlLabel
-            control={<Checkbox checked={onlineAccess} onChange={e => setOnlineAccess(e.target.checked)} />}
-            label="Online Access"
-          />
+    <Page title="Create Client">
+      <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
+        <Box maxWidth={400} width="100%" mt={4}>
+          <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+          <FeedbackModal open={!!success} onClose={() => setSuccess('')} message={success} />
+          <Stack spacing={2}>
+            <FormControlLabel
+              control={<Checkbox checked={onlineAccess} onChange={e => setOnlineAccess(e.target.checked)} />}
+              label="Online Access"
+            />
           <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
           <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
           <TextField label="Client ID" value={clientId} onChange={e => setClientId(e.target.value)} />
@@ -87,8 +86,9 @@ export default function AddClient() {
             Add Client
           </Button>
         </Stack>
+        </Box>
       </Box>
-    </Box>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -34,6 +34,7 @@ import EntitySearch from '../../../components/EntitySearch';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import DialogCloseButton from '../../../components/DialogCloseButton';
 import { toDate, formatDate } from '../../../utils/date';
+import Page from '../../../components/Page';
 
 const TIMEZONE = 'America/Regina';
 
@@ -185,9 +186,9 @@ export default function UserHistory({
   }
 
   return (
-    <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
-      <Box width="100%" maxWidth={800} mt={4}>
-        <h2>{initialUser ? 'Booking History' : 'Client History'}</h2>
+    <Page title={initialUser ? 'Booking History' : 'Client History'}>
+      <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
+        <Box width="100%" maxWidth={800} mt={4}>
         {!initialUser && (
           <EntitySearch
             type="user"
@@ -404,13 +405,14 @@ export default function UserHistory({
               </Button>
             </DialogActions>
           </Dialog>
-        <FeedbackSnackbar
+          <FeedbackSnackbar
           open={!!message}
           onClose={() => setMessage('')}
           message={message}
           severity={severity}
         />
+        </Box>
       </Box>
-    </Box>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -22,6 +22,7 @@ import { getVolunteerRolesForVolunteer, requestVolunteerBooking } from '../../ap
 import { getHolidays } from '../../api/bookings';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { formatTime } from '../../utils/time';
+import Page from '../../components/Page';
 
 function useVolunteerSlots(date: Dayjs, enabled: boolean) {
   const dateStr = date.format('YYYY-MM-DD');
@@ -109,8 +110,9 @@ export default function VolunteerBooking() {
   }
 
   return (
-    <Container sx={{ pb: 8 }}>
-      <Grid container spacing={2} alignItems="stretch">
+    <Page title="Volunteer Booking">
+      <Container sx={{ pb: 8 }}>
+        <Grid container spacing={2} alignItems="stretch">
         <Grid item xs={12} md={4}>
           <Paper
             sx={{ p: 2, borderRadius: 2, height: '100%', display: 'flex', flexDirection: 'column' }}
@@ -186,14 +188,15 @@ export default function VolunteerBooking() {
           </Button>
         </Stack>
       </Paper>
-      <FeedbackSnackbar
-        open={snackbar.open}
-        onClose={() => setSnackbar(s => ({ ...s, open: false }))}
-        message={snackbar.message}
-        severity={snackbar.severity}
-        duration={4000}
-      />
-    </Container>
+        <FeedbackSnackbar
+          open={snackbar.open}
+          onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+          message={snackbar.message}
+          severity={snackbar.severity}
+          duration={4000}
+        />
+      </Container>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -50,6 +50,7 @@ import Dashboard from '../../components/dashboard/Dashboard';
 import EntitySearch from '../../components/EntitySearch';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { formatDate, addDays } from '../../utils/date';
+import Page from '../../components/Page';
 
 
 
@@ -631,8 +632,7 @@ export default function VolunteerManagement() {
   const maxSlots = Math.max(0, ...roleInfos.map(r => r.max_volunteers));
 
   return (
-    <div>
-      <h2>{title}</h2>
+    <Page title={title}>
       {tab === 'dashboard' && (
         <Dashboard role="staff" masterRoleFilter={undefined} />
       )}
@@ -1251,6 +1251,6 @@ export default function VolunteerManagement() {
           onSubmit={handleReschedule}
         />
       )}
-    </div>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -18,6 +18,7 @@ import type {
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 import { formatTime } from '../../utils/time';
 import { formatDate, addDays } from '../../utils/date';
+import Page from '../../components/Page';
 import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import RescheduleDialog from '../../components/VolunteerRescheduleDialog';
@@ -307,7 +308,8 @@ export default function VolunteerSchedule() {
   });
 
   return (
-    <Box>
+    <Page title="Volunteer Schedule">
+      <Box>
       <FormControl size="small" sx={{ minWidth: 200 }}>
         <InputLabel id="role-select-label">Role</InputLabel>
         <Select
@@ -491,6 +493,7 @@ export default function VolunteerSchedule() {
         onSubmit={handleReschedule}
       />
     </Box>
+    </Page>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
@@ -19,6 +19,7 @@ import {
   type DonorDonation,
 } from '../../api/donors';
 import { formatLocaleDate } from '../../utils/date';
+import Page from '../../components/Page';
 
 export default function DonorProfile() {
   const { id } = useParams<{ id: string }>();
@@ -38,10 +39,8 @@ export default function DonorProfile() {
   }, [id]);
 
   return (
-    <Box>
-      <Typography variant="h5" gutterBottom>
-        Donor Profile
-      </Typography>
+    <Page title="Donor Profile">
+      <Box>
       {donor && (
         <Card variant="outlined" sx={{ mb: 2 }}>
           <CardContent>
@@ -93,6 +92,7 @@ export default function DonorProfile() {
         message={error}
         severity="error"
       />
-    </Box>
+      </Box>
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -57,6 +57,7 @@ import {
 import { getTopReceivers, type TopReceiver } from '../../api/outgoingReceivers';
 import { getEvents, type EventGroups } from '../../api/events';
 import type { AlertColor } from '@mui/material';
+import Page from '../../components/Page';
 
 interface MonthlyTotal {
   year: number;
@@ -271,7 +272,8 @@ export default function WarehouseDashboard() {
   ];
 
   return (
-    <Box>
+    <Page title="Warehouse Manager Dashboard">
+      <Box>
       <Stack
         direction={{ xs: 'column', md: 'row' }}
         spacing={2}
@@ -280,7 +282,6 @@ export default function WarehouseDashboard() {
         mb={2}
       >
         <Box>
-          <Typography variant="h5">Warehouse Manager Dashboard</Typography>
           <Typography variant="body2" color="text.secondary">
             Annual warehouse overview
           </Typography>
@@ -554,7 +555,8 @@ export default function WarehouseDashboard() {
         message={snackbar.message}
         severity={snackbar.severity}
       />
-    </Box>
+      </Box>
+    </Page>
   );
 }
 


### PR DESCRIPTION
## Summary
- Wrap every page in a `Page` component so each view shows a descriptive title
- Standardize client, staff, volunteer, and warehouse screens with consistent page wrappers

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden retrieving ts-jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b0904b8060832dbb59f4a2da848f0a