### PR TITLE
feat: manage volunteer roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,9 @@ Volunteer management coordinates role-based staffing for the food bank.
 
 ### Volunteer Master Roles
 - `GET /volunteer-master-roles` → `[ { id, name } ]`
+- `POST /volunteer-master-roles` `{ name }` → `{ id, name }`
+- `PUT /volunteer-master-roles/:id` `{ name }` → `{ id, name }`
+- `DELETE /volunteer-master-roles/:id` → `{ message: 'Deleted' }`
 
 ### Volunteer Bookings
 - `POST /volunteer-bookings` → `{ id, role_id, volunteer_id, date, status, reschedule_token, status_color }`

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerMasterRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerMasterRoleController.ts
@@ -11,3 +11,70 @@ export async function listVolunteerMasterRoles(_req: Request, res: Response, nex
     next(error);
   }
 }
+
+export async function createVolunteerMasterRole(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const { name } = req.body as { name?: string };
+  if (!name) {
+    return res.status(400).json({ message: 'name is required' });
+  }
+  try {
+    const result = await pool.query(
+      'INSERT INTO volunteer_master_roles (name) VALUES ($1) RETURNING id, name',
+      [name],
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error creating volunteer master role:', error);
+    next(error);
+  }
+}
+
+export async function updateVolunteerMasterRole(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const { id } = req.params;
+  const { name } = req.body as { name?: string };
+  if (!name) {
+    return res.status(400).json({ message: 'name is required' });
+  }
+  try {
+    const result = await pool.query(
+      'UPDATE volunteer_master_roles SET name=$1 WHERE id=$2 RETURNING id, name',
+      [name, id],
+    );
+    if ((result.rowCount ?? 0) === 0) {
+      return res.status(404).json({ message: 'Role not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error updating volunteer master role:', error);
+    next(error);
+  }
+}
+
+export async function deleteVolunteerMasterRole(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const { id } = req.params;
+  try {
+    const result = await pool.query(
+      'DELETE FROM volunteer_master_roles WHERE id=$1 RETURNING id',
+      [id],
+    );
+    if ((result.rowCount ?? 0) === 0) {
+      return res.status(404).json({ message: 'Role not found' });
+    }
+    res.json({ message: 'Deleted' });
+  } catch (error) {
+    logger.error('Error deleting volunteer master role:', error);
+    next(error);
+  }
+}

--- a/MJ_FB_Backend/src/routes/volunteer/volunteerMasterRoles.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteerMasterRoles.ts
@@ -1,9 +1,19 @@
 import { Router } from 'express';
-import { listVolunteerMasterRoles } from '../../controllers/volunteer/volunteerMasterRoleController';
+import {
+  listVolunteerMasterRoles,
+  createVolunteerMasterRole,
+  updateVolunteerMasterRole,
+  deleteVolunteerMasterRole,
+} from '../../controllers/volunteer/volunteerMasterRoleController';
 import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
 
 const router = Router();
 
-router.get('/', authMiddleware, authorizeRoles('staff'), listVolunteerMasterRoles);
+router.use(authMiddleware, authorizeRoles('staff'));
+
+router.get('/', listVolunteerMasterRoles);
+router.post('/', createVolunteerMasterRole);
+router.put('/:id', updateVolunteerMasterRole);
+router.delete('/:id', deleteVolunteerMasterRole);
 
 export default router;

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -31,6 +31,7 @@ import Exports from './pages/warehouse-management/Exports';
 import AdminStaffList from './pages/admin/AdminStaffList';
 import AdminStaffForm from './pages/admin/AdminStaffForm';
 import AppConfigurations from './pages/admin/AppConfigurations';
+import VolunteerSettings from './pages/admin/VolunteerSettings';
 import Events from './pages/events/Events';
 import PantryVisits from './pages/staff/PantryVisits';
 import AgencyLogin from './pages/agency/Login';
@@ -122,6 +123,7 @@ export default function App() {
         links: [
           { label: 'Staff', to: '/admin/staff' },
           { label: 'App Config', to: '/admin/app-config' },
+          { label: 'Volunteer Settings', to: '/admin/volunteer-settings' },
         ],
       });
 
@@ -300,6 +302,12 @@ export default function App() {
               {showAdmin && <Route path="/admin/staff/create" element={<AdminStaffForm />} />}
               {showAdmin && <Route path="/admin/staff/:id" element={<AdminStaffForm />} />}
               {showAdmin && <Route path="/admin/app-config" element={<AppConfigurations />} />}
+              {showAdmin && (
+                <Route
+                  path="/admin/volunteer-settings"
+                  element={<VolunteerSettings />}
+                />
+              )}
               {showVolunteerManagement && (
                 <>
                   <Route

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -6,6 +6,7 @@ import type {
   Shift,
   VolunteerBooking,
   UserProfile,
+  VolunteerMasterRole,
 } from '../types';
 import type { LoginResponse } from './users';
 
@@ -131,23 +132,94 @@ export async function getVolunteerRoles(): Promise<VolunteerRoleWithShifts[]> {
   return handleResponse(res);
 }
 
-export async function getVolunteerMasterRoles() {
+export async function createVolunteerRole(role: {
+  name: string;
+  startTime: string;
+  endTime: string;
+  maxVolunteers: number;
+  categoryId: number;
+  isWednesdaySlot?: boolean;
+  isActive?: boolean;
+}): Promise<VolunteerRole> {
+  const res = await apiFetch(`${API_BASE}/volunteer-roles`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(role),
+  });
+  return handleResponse(res);
+}
+
+export async function updateVolunteerRole(
+  id: number,
+  role: {
+    name: string;
+    startTime: string;
+    endTime: string;
+    maxVolunteers: number;
+    categoryId: number;
+    isWednesdaySlot?: boolean;
+  },
+): Promise<VolunteerRole> {
+  const res = await apiFetch(`${API_BASE}/volunteer-roles/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(role),
+  });
+  return handleResponse(res);
+}
+
+export async function toggleVolunteerRole(
+  id: number,
+  isActive: boolean,
+): Promise<VolunteerRole> {
+  const res = await apiFetch(`${API_BASE}/volunteer-roles/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ isActive }),
+  });
+  return handleResponse(res);
+}
+
+export async function deleteVolunteerRole(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/volunteer-roles/${id}`, {
+    method: 'DELETE',
+  });
+  await handleResponse(res);
+}
+
+export async function getVolunteerMasterRoles(): Promise<VolunteerMasterRole[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-master-roles`);
   return handleResponse(res);
 }
 
-export async function updateVolunteerRoleStatus(
-  id: number,
-  isActive: boolean,
-) {
-  const res = await apiFetch(`${API_BASE}/volunteer-roles/${id}`, {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ isActive }),
+export async function createVolunteerMasterRole(
+  name: string,
+): Promise<VolunteerMasterRole> {
+  const res = await apiFetch(`${API_BASE}/volunteer-master-roles`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
   });
   return handleResponse(res);
+}
+
+export async function updateVolunteerMasterRole(
+  id: number,
+  name: string,
+): Promise<VolunteerMasterRole> {
+  const res = await apiFetch(`${API_BASE}/volunteer-master-roles/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  return handleResponse(res);
+}
+
+export async function deleteVolunteerMasterRole(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/volunteer-master-roles/${id}`, {
+    method: 'DELETE',
+  });
+  await handleResponse(res);
 }
 
 export async function getVolunteerBookingsByRole(roleId: number) {

--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Typography,
+  IconButton,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Switch,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import Page from '../../components/Page';
+import {
+  getVolunteerMasterRoles,
+  getVolunteerRoles,
+  createVolunteerMasterRole,
+  updateVolunteerMasterRole,
+  deleteVolunteerMasterRole,
+  createVolunteerRole,
+  updateVolunteerRole,
+  toggleVolunteerRole,
+  deleteVolunteerRole,
+} from '../../api/volunteers';
+import type {
+  VolunteerMasterRole,
+  VolunteerRoleWithShifts,
+} from '../../types';
+
+interface RoleDialogState {
+  open: boolean;
+  slotId?: number;
+  name: string;
+  startTime: string;
+  endTime: string;
+  maxVolunteers: number;
+  categoryId: number;
+  isWednesday: boolean;
+}
+
+interface MasterDialogState {
+  open: boolean;
+  id?: number;
+  name: string;
+}
+
+export default function VolunteerSettings() {
+  const [masterRoles, setMasterRoles] = useState<VolunteerMasterRole[]>([]);
+  const [roles, setRoles] = useState<VolunteerRoleWithShifts[]>([]);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [roleDialog, setRoleDialog] = useState<RoleDialogState>({ open: false, name: '', startTime: '', endTime: '', maxVolunteers: 1, categoryId: 0, isWednesday: false });
+  const [masterDialog, setMasterDialog] = useState<MasterDialogState>({ open: false, name: '' });
+
+  async function load() {
+    try {
+      const [m, r] = await Promise.all([
+        getVolunteerMasterRoles(),
+        getVolunteerRoles(),
+      ]);
+      setMasterRoles(m);
+      setRoles(r);
+    } catch (err: any) {
+      setError(err.message || String(err));
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const rolesByMaster = (id: number) => roles.filter(r => r.category_id === id);
+
+  function openNewMaster() {
+    setMasterDialog({ open: true, name: '' });
+  }
+  function openEditMaster(m: VolunteerMasterRole) {
+    setMasterDialog({ open: true, id: m.id, name: m.name });
+  }
+  async function saveMaster() {
+    try {
+      if (masterDialog.id)
+        await updateVolunteerMasterRole(masterDialog.id, masterDialog.name);
+      else
+        await createVolunteerMasterRole(masterDialog.name);
+      setMasterDialog({ open: false, name: '' });
+      setSuccess('Saved');
+      load();
+    } catch (err: any) {
+      setError(err.message || String(err));
+    }
+  }
+  async function removeMaster(id: number) {
+    if (!window.confirm('Delete master role?')) return;
+    try {
+      await deleteVolunteerMasterRole(id);
+      setSuccess('Deleted');
+      load();
+    } catch (err: any) {
+      setError(err.message || String(err));
+    }
+  }
+
+  function openNewRole(categoryId: number, name = '') {
+    setRoleDialog({ open: true, categoryId, name, startTime: '', endTime: '', maxVolunteers: 1, isWednesday: false });
+  }
+  function openEditShift(role: VolunteerRoleWithShifts, slot: any) {
+    setRoleDialog({
+      open: true,
+      slotId: slot.id,
+      name: role.name,
+      startTime: slot.start_time,
+      endTime: slot.end_time,
+      maxVolunteers: role.max_volunteers,
+      categoryId: role.category_id,
+      isWednesday: slot.is_wednesday_slot,
+    });
+  }
+  async function saveRole() {
+    const { slotId, name, startTime, endTime, maxVolunteers, categoryId, isWednesday } = roleDialog;
+    try {
+      if (slotId)
+        await updateVolunteerRole(slotId, { name, startTime, endTime, maxVolunteers, categoryId, isWednesdaySlot: isWednesday });
+      else
+        await createVolunteerRole({ name, startTime, endTime, maxVolunteers, categoryId, isWednesdaySlot: isWednesday });
+      setRoleDialog({ open: false, name: '', startTime: '', endTime: '', maxVolunteers: 1, categoryId: 0, isWednesday: false });
+      setSuccess('Saved');
+      load();
+    } catch (err: any) {
+      setError(err.message || String(err));
+    }
+  }
+  async function removeRole(role: VolunteerRoleWithShifts) {
+    if (!window.confirm('Delete role and its shifts?')) return;
+    try {
+      for (const s of role.shifts) {
+        await deleteVolunteerRole(s.id);
+      }
+      setSuccess('Deleted');
+      load();
+    } catch (err: any) {
+      setError(err.message || String(err));
+    }
+  }
+  async function removeShift(id: number) {
+    if (!window.confirm('Delete shift?')) return;
+    try {
+      await deleteVolunteerRole(id);
+      setSuccess('Deleted');
+      load();
+    } catch (err: any) {
+      setError(err.message || String(err));
+    }
+  }
+  async function toggleShift(id: number, active: boolean) {
+    try {
+      await toggleVolunteerRole(id, active);
+      load();
+    } catch (err: any) {
+      setError(err.message || String(err));
+    }
+  }
+
+  return (
+    <Page title="Volunteer Settings">
+      <Box p={2}>
+        <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+        <FeedbackSnackbar open={!!success} onClose={() => setSuccess('')} message={success} />
+        <Button variant="contained" startIcon={<AddIcon />} onClick={openNewMaster} sx={{ mb: 2 }}>
+          Add Master Role
+        </Button>
+        {masterRoles.map(m => (
+          <Card key={m.id} sx={{ mb: 2 }}>
+            <CardContent>
+              <Box display="flex" justifyContent="space-between" alignItems="center">
+                <Typography variant="h6">{m.name}</Typography>
+                <Box>
+                  <IconButton onClick={() => openEditMaster(m)} size="small" aria-label="edit">
+                    <EditIcon />
+                  </IconButton>
+                  <IconButton onClick={() => removeMaster(m.id)} size="small" aria-label="delete">
+                    <DeleteIcon />
+                  </IconButton>
+                  <Button size="small" variant="contained" startIcon={<AddIcon />} onClick={() => openNewRole(m.id)} sx={{ ml: 1 }}>
+                    Add Role
+                  </Button>
+                </Box>
+              </Box>
+              {rolesByMaster(m.id).map(r => (
+                <Box key={r.role_id} mt={2}>
+                  <Box display="flex" justifyContent="space-between" alignItems="center">
+                    <Typography>{r.name}</Typography>
+                    <Box>
+                      <IconButton onClick={() => openNewRole(m.id, r.name)} size="small" aria-label="add shift">
+                        <AddIcon />
+                      </IconButton>
+                      <IconButton onClick={() => removeRole(r)} size="small" aria-label="delete role">
+                        <DeleteIcon />
+                      </IconButton>
+                    </Box>
+                  </Box>
+                  <Table size="small" sx={{ mt: 1 }}>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Start</TableCell>
+                        <TableCell>End</TableCell>
+                        <TableCell>Max</TableCell>
+                        <TableCell>Active</TableCell>
+                        <TableCell align="right">Actions</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {r.shifts.map(s => (
+                        <TableRow key={s.id}>
+                          <TableCell>{s.start_time}</TableCell>
+                          <TableCell>{s.end_time}</TableCell>
+                          <TableCell>{r.max_volunteers}</TableCell>
+                          <TableCell>
+                            <Switch
+                              checked={s.is_active}
+                              onChange={(_, checked) => toggleShift(s.id, checked)}
+                            />
+                          </TableCell>
+                          <TableCell align="right">
+                            <IconButton onClick={() => openEditShift(r, s)} size="small" aria-label="edit">
+                              <EditIcon />
+                            </IconButton>
+                            <IconButton onClick={() => removeShift(s.id)} size="small" aria-label="delete">
+                              <DeleteIcon />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </Box>
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+
+        <Dialog open={masterDialog.open} onClose={() => setMasterDialog({ open: false, name: '' })}>
+          <DialogTitle>{masterDialog.id ? 'Edit' : 'Add'} Master Role</DialogTitle>
+          <DialogContent>
+            <TextField
+              label="Name"
+              value={masterDialog.name}
+              onChange={e => setMasterDialog({ ...masterDialog, name: e.target.value })}
+              fullWidth
+              margin="dense"
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setMasterDialog({ open: false, name: '' })}>Cancel</Button>
+            <Button onClick={saveMaster} variant="contained">Save</Button>
+          </DialogActions>
+        </Dialog>
+
+        <Dialog open={roleDialog.open} onClose={() => setRoleDialog({ open: false, name: '', startTime: '', endTime: '', maxVolunteers: 1, categoryId: 0, isWednesday: false })}>
+          <DialogTitle>{roleDialog.slotId ? 'Edit' : 'Add'} Role</DialogTitle>
+          <DialogContent>
+            <TextField
+              label="Name"
+              value={roleDialog.name}
+              onChange={e => setRoleDialog({ ...roleDialog, name: e.target.value })}
+              fullWidth
+              margin="dense"
+            />
+            <TextField
+              label="Start Time"
+              value={roleDialog.startTime}
+              onChange={e => setRoleDialog({ ...roleDialog, startTime: e.target.value })}
+              fullWidth
+              margin="dense"
+            />
+            <TextField
+              label="End Time"
+              value={roleDialog.endTime}
+              onChange={e => setRoleDialog({ ...roleDialog, endTime: e.target.value })}
+              fullWidth
+              margin="dense"
+            />
+            <TextField
+              label="Max Volunteers"
+              type="number"
+              value={roleDialog.maxVolunteers}
+              onChange={e => setRoleDialog({ ...roleDialog, maxVolunteers: Number(e.target.value) })}
+              fullWidth
+              margin="dense"
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setRoleDialog({ open: false, name: '', startTime: '', endTime: '', maxVolunteers: 1, categoryId: 0, isWednesday: false })}>Cancel</Button>
+            <Button onClick={saveRole} variant="contained">Save</Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -98,6 +98,11 @@ export interface VolunteerRoleWithShifts {
   shifts: VolunteerRoleShift[];
 }
 
+export interface VolunteerMasterRole {
+  id: number;
+  name: string;
+}
+
 export interface VolunteerRoleGroup {
   category_id: number;
   category: string;

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
+- Admins can manage volunteer master roles, sub-roles, and shifts through a dedicated settings page.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Staff can record visits directly from a booking in the pantry schedule. Selecting **Visited** in the booking dialog captures cart weights and creates the visit record before marking the booking visited.


### PR DESCRIPTION
## Summary
- add CRUD controllers and routes for volunteer master roles
- expose admin API helpers and settings page for volunteer roles
- document new volunteer master role endpoints

## Testing
- `npm test` (backend) *(fails: slots.test, bookingUtils.test, events.test)*
- `npm test` (frontend) *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b092a9b090832d85f8c1bcf7c56fe0