### PR TITLE
Add slot management endpoints and admin settings page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
 - Document new environment variables in the repository README and `.env.example` files.
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.
 - App-level settings such as cart tare and surplus weight multipliers live in the `app_config` table and are editable via the Admin → App Configurations page. Fetch these values from the backend rather than hard-coding or using environment variables.
+- Staff can create, update, and delete slots via `POST /slots`, `PUT /slots/:id`, and `DELETE /slots/:id`. The frontend exposes these through the Admin → Pantry Settings page.
 
 ## UI Rules & Design System (Global)
 

--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -211,3 +211,61 @@ export async function listAllSlots(
     next(error);
   }
 }
+
+export async function createSlot(req: Request, res: Response, next: NextFunction) {
+  const { startTime, endTime, maxCapacity } = req.body;
+  try {
+    const result = await pool.query(
+      'INSERT INTO slots (start_time, end_time, max_capacity) VALUES ($1, $2, $3) RETURNING id, start_time, end_time, max_capacity',
+      [startTime, endTime, maxCapacity],
+    );
+    const slot = result.rows[0];
+    res.status(201).json({
+      id: slot.id.toString(),
+      startTime: slot.start_time,
+      endTime: slot.end_time,
+      maxCapacity: slot.max_capacity,
+    });
+  } catch (error) {
+    logger.error('Error creating slot:', error);
+    next(error);
+  }
+}
+
+export async function updateSlot(req: Request, res: Response, next: NextFunction) {
+  const { startTime, endTime, maxCapacity } = req.body;
+  const { id } = req.params;
+  try {
+    const result = await pool.query(
+      'UPDATE slots SET start_time = $1, end_time = $2, max_capacity = $3 WHERE id = $4 RETURNING id, start_time, end_time, max_capacity',
+      [startTime, endTime, maxCapacity, id],
+    );
+    if (result.rowCount === 0) {
+      return res.status(404).json({ message: 'Slot not found' });
+    }
+    const slot = result.rows[0];
+    res.json({
+      id: slot.id.toString(),
+      startTime: slot.start_time,
+      endTime: slot.end_time,
+      maxCapacity: slot.max_capacity,
+    });
+  } catch (error) {
+    logger.error('Error updating slot:', error);
+    next(error);
+  }
+}
+
+export async function deleteSlot(req: Request, res: Response, next: NextFunction) {
+  const { id } = req.params;
+  try {
+    const result = await pool.query('DELETE FROM slots WHERE id = $1', [id]);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ message: 'Slot not found' });
+    }
+    res.json({ message: 'Deleted' });
+  } catch (error) {
+    logger.error('Error deleting slot:', error);
+    next(error);
+  }
+}

--- a/MJ_FB_Backend/src/routes/slots.ts
+++ b/MJ_FB_Backend/src/routes/slots.ts
@@ -1,26 +1,40 @@
 import express from 'express';
-import { listSlots, listAllSlots, listSlotsRange } from '../controllers/slotController';
+import {
+  listSlots,
+  listAllSlots,
+  listSlotsRange,
+  createSlot,
+  updateSlot,
+  deleteSlot,
+} from '../controllers/slotController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import { validate, validateParams } from '../middleware/validate';
+import {
+  createSlotSchema,
+  updateSlotSchema,
+  slotIdParamSchema,
+} from '../schemas/slotSchemas';
 
 const router = express.Router();
 
-router.get(
-  '/all',
+router.get('/all', authMiddleware, authorizeRoles('staff'), listAllSlots);
+router.get('/', authMiddleware, authorizeRoles('shopper', 'delivery', 'staff'), listSlots);
+router.get('/range', authMiddleware, authorizeRoles('shopper', 'delivery', 'staff'), listSlotsRange);
+router.post('/', authMiddleware, authorizeRoles('staff'), validate(createSlotSchema), createSlot);
+router.put(
+  '/:id',
   authMiddleware,
   authorizeRoles('staff'),
-  listAllSlots,
+  validateParams(slotIdParamSchema),
+  validate(updateSlotSchema),
+  updateSlot,
 );
-router.get(
-  '/',
+router.delete(
+  '/:id',
   authMiddleware,
-  authorizeRoles('shopper', 'delivery', 'staff'),
-  listSlots,
-);
-router.get(
-  '/range',
-  authMiddleware,
-  authorizeRoles('shopper', 'delivery', 'staff'),
-  listSlotsRange,
+  authorizeRoles('staff'),
+  validateParams(slotIdParamSchema),
+  deleteSlot,
 );
 
 export default router;

--- a/MJ_FB_Backend/src/schemas/slotSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/slotSchemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const createSlotSchema = z.object({
+  startTime: z.string().min(1),
+  endTime: z.string().min(1),
+  maxCapacity: z.coerce.number().int().positive(),
+});
+
+export const updateSlotSchema = createSlotSchema;
+
+export const slotIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+export type CreateSlotInput = z.infer<typeof createSlotSchema>;
+export type UpdateSlotInput = z.infer<typeof updateSlotSchema>;
+export type SlotIdParams = z.infer<typeof slotIdParamSchema>;

--- a/MJ_FB_Backend/tests/slotCrud.test.ts
+++ b/MJ_FB_Backend/tests/slotCrud.test.ts
@@ -1,0 +1,65 @@
+import request from 'supertest';
+import express from 'express';
+import slotsRouter from '../src/routes/slots';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/slots', slotsRouter);
+
+describe('slot management', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a slot', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        { id: 1, start_time: '09:00:00', end_time: '09:30:00', max_capacity: 5 },
+      ],
+    });
+    const res = await request(app)
+      .post('/slots')
+      .send({ startTime: '09:00:00', endTime: '09:30:00', maxCapacity: 5 });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      id: '1',
+      startTime: '09:00:00',
+      endTime: '09:30:00',
+      maxCapacity: 5,
+    });
+    expect(pool.query).toHaveBeenCalledWith(
+      'INSERT INTO slots (start_time, end_time, max_capacity) VALUES ($1, $2, $3) RETURNING id, start_time, end_time, max_capacity',
+      ['09:00:00', '09:30:00', 5],
+    );
+  });
+
+  it('updates slot capacity', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [
+        { id: 1, start_time: '09:00:00', end_time: '09:30:00', max_capacity: 8 },
+      ],
+    });
+    const res = await request(app)
+      .put('/slots/1')
+      .send({ startTime: '09:00:00', endTime: '09:30:00', maxCapacity: 8 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: '1',
+      startTime: '09:00:00',
+      endTime: '09:30:00',
+      maxCapacity: 8,
+    });
+    expect(pool.query).toHaveBeenCalledWith(
+      'UPDATE slots SET start_time = $1, end_time = $2, max_capacity = $3 WHERE id = $4 RETURNING id, start_time, end_time, max_capacity',
+      ['09:00:00', '09:30:00', 8, 1],
+    );
+  });
+});

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -12,6 +12,7 @@ export async function getSlots(date?: string, includePast = false) {
     id: String(s.id),
     startTime: s.startTime ?? s.start_time,
     endTime: s.endTime ?? s.end_time,
+    maxCapacity: s.maxCapacity ?? s.max_capacity,
     available: s.available,
     reason: s.reason,
     status: s.status,
@@ -38,6 +39,7 @@ export async function getSlotsRange(
       id: String(s.id),
       startTime: s.startTime ?? s.start_time,
       endTime: s.endTime ?? s.end_time,
+      maxCapacity: s.maxCapacity ?? s.max_capacity,
       available: s.available,
       reason: s.reason,
       status: s.status,
@@ -129,17 +131,6 @@ export async function removeHoliday(date: string): Promise<void> {
     method: 'DELETE',
   });
   await handleResponse(res);
-}
-
-export async function getAllSlots() {
-  const res = await apiFetch(`${API_BASE}/slots/all`);
-  const data = await handleResponse(res);
-  return data.map((s: any) => ({
-    id: String(s.id),
-    startTime: s.startTime ?? s.start_time,
-    endTime: s.endTime ?? s.end_time,
-    available: s.available,
-  })) as Slot[];
 }
 
 export async function getBlockedSlots(date?: string): Promise<BlockedSlot[]> {

--- a/MJ_FB_Frontend/src/api/slots.ts
+++ b/MJ_FB_Frontend/src/api/slots.ts
@@ -1,0 +1,48 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+import type { Slot } from '../types';
+
+export async function getAllSlots(): Promise<Slot[]> {
+  const res = await apiFetch(`${API_BASE}/slots/all`);
+  const data = await handleResponse(res);
+  return data.map((s: any) => ({
+    id: String(s.id),
+    startTime: s.startTime ?? s.start_time,
+    endTime: s.endTime ?? s.end_time,
+    maxCapacity: s.maxCapacity ?? s.max_capacity,
+  }));
+}
+
+export async function createSlot(startTime: string, endTime: string, maxCapacity: number): Promise<Slot> {
+  const res = await apiFetch(`${API_BASE}/slots`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ startTime, endTime, maxCapacity }),
+  });
+  const s = await handleResponse(res);
+  return {
+    id: String(s.id),
+    startTime: s.startTime ?? s.start_time,
+    endTime: s.endTime ?? s.end_time,
+    maxCapacity: s.maxCapacity ?? s.max_capacity,
+  };
+}
+
+export async function updateSlot(id: number, startTime: string, endTime: string, maxCapacity: number): Promise<Slot> {
+  const res = await apiFetch(`${API_BASE}/slots/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ startTime, endTime, maxCapacity }),
+  });
+  const s = await handleResponse(res);
+  return {
+    id: String(s.id),
+    startTime: s.startTime ?? s.start_time,
+    endTime: s.endTime ?? s.end_time,
+    maxCapacity: s.maxCapacity ?? s.max_capacity,
+  };
+}
+
+export async function deleteSlot(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/slots/${id}`, { method: 'DELETE' });
+  await handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TextField,
+  Button,
+  IconButton,
+} from '@mui/material';
+import { DeleteOutline } from '@mui/icons-material';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { getAllSlots, createSlot, updateSlot, deleteSlot } from '../../api/slots';
+import type { Slot } from '../../types';
+
+export default function PantrySettings() {
+  const [slots, setSlots] = useState<Slot[]>([]);
+  const [newSlot, setNewSlot] = useState({ startTime: '', endTime: '', maxCapacity: '' });
+  const [snackbar, setSnackbar] = useState({
+    open: false,
+    message: '',
+    severity: 'success' as 'success' | 'error',
+  });
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    try {
+      setSlots(await getAllSlots());
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const handleChange = (id: string, value: string) => {
+    setSlots(prev =>
+      prev.map(s => (s.id === id ? { ...s, maxCapacity: Number(value) } : s)),
+    );
+  };
+
+  async function handleSave(slot: Slot) {
+    try {
+      await updateSlot(Number(slot.id), slot.startTime, slot.endTime, slot.maxCapacity);
+      setSnackbar({ open: true, message: 'Slot updated', severity: 'success' });
+    } catch (err: any) {
+      setSnackbar({
+        open: true,
+        message: err.message || 'Failed to update slot',
+        severity: 'error',
+      });
+    }
+  }
+
+  async function handleDelete(id: string) {
+    try {
+      await deleteSlot(Number(id));
+      setSlots(prev => prev.filter(s => s.id !== id));
+      setSnackbar({ open: true, message: 'Slot deleted', severity: 'success' });
+    } catch (err: any) {
+      setSnackbar({
+        open: true,
+        message: err.message || 'Failed to delete slot',
+        severity: 'error',
+      });
+    }
+  }
+
+  async function handleAdd() {
+    try {
+      const slot = await createSlot(
+        newSlot.startTime,
+        newSlot.endTime,
+        Number(newSlot.maxCapacity),
+      );
+      setSlots(prev => [...prev, slot]);
+      setNewSlot({ startTime: '', endTime: '', maxCapacity: '' });
+      setSnackbar({ open: true, message: 'Slot created', severity: 'success' });
+    } catch (err: any) {
+      setSnackbar({
+        open: true,
+        message: err.message || 'Failed to create slot',
+        severity: 'error',
+      });
+    }
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader title="Pantry Settings" />
+        <CardContent>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Time</TableCell>
+                <TableCell>Max Capacity</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {slots.map(slot => (
+                <TableRow key={slot.id}>
+                  <TableCell>{slot.startTime}-{slot.endTime}</TableCell>
+                  <TableCell>
+                    <TextField
+                      type="number"
+                      size="small"
+                      value={slot.maxCapacity}
+                      onChange={e => handleChange(slot.id, e.target.value)}
+                      InputProps={{ inputProps: { min: 1 } }}
+                    />
+                  </TableCell>
+                  <TableCell align="right">
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleSave(slot)}
+                      sx={{ mr: 1 }}
+                    >
+                      Save
+                    </Button>
+                    <IconButton
+                      aria-label="delete"
+                      size="small"
+                      onClick={() => handleDelete(slot.id)}
+                    >
+                      <DeleteOutline fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+              <TableRow>
+                <TableCell>
+                  <TextField
+                    label="Start"
+                    size="small"
+                    value={newSlot.startTime}
+                    onChange={e => setNewSlot({ ...newSlot, startTime: e.target.value })}
+                    InputLabelProps={{ shrink: true }}
+                  />
+                  <TextField
+                    label="End"
+                    size="small"
+                    value={newSlot.endTime}
+                    onChange={e => setNewSlot({ ...newSlot, endTime: e.target.value })}
+                    InputLabelProps={{ shrink: true }}
+                    sx={{ ml: 1 }}
+                  />
+                </TableCell>
+                <TableCell>
+                  <TextField
+                    label="Max"
+                    type="number"
+                    size="small"
+                    value={newSlot.maxCapacity}
+                    onChange={e => setNewSlot({ ...newSlot, maxCapacity: e.target.value })}
+                    InputLabelProps={{ shrink: true }}
+                  />
+                </TableCell>
+                <TableCell align="right">
+                  <Button variant="contained" size="small" onClick={handleAdd}>
+                    Add
+                  </Button>
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <FeedbackSnackbar
+        open={snackbar.open}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+      />
+    </>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -31,7 +31,6 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs, { type TabItem } from '../../components/StyledTabs';
 import Page from '../../components/Page';
 import {
-  getAllSlots,
   addBlockedSlot,
   addRecurringBlockedSlot,
   removeBlockedSlot,
@@ -42,6 +41,7 @@ import {
   getBreaks,
   getRecurringBlockedSlots,
 } from '../../api/bookings';
+import { getAllSlots } from '../../api/slots';
 import { formatTime } from '../../utils/time';
 import type { Slot } from '../../types';
 import { formatLocaleDate, toDate, formatReginaDate } from '../../utils/date';

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -28,6 +28,7 @@ export interface Slot {
   id: string;
   startTime: string;
   endTime: string;
+  maxCapacity: number;
   available?: number;
   reason?: string;
   status?: 'blocked' | 'break';

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
+- Staff can manage pantry slots and capacities through the Admin → Pantry Settings page.
 
 ## Clone and initialize submodules
 


### PR DESCRIPTION
## Summary
- support creating, updating and deleting pantry slots with new staff-only endpoints
- expose slot CRUD operations in frontend with Pantry Settings admin page
- cover slot creation and capacity updates with backend tests

## Testing
- `npm test` *(backend: fails – bookingUtils, events, slots)*
- `npm test` *(frontend: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b092a2427c832d86ea49b3bc1656dc