### PR TITLE
Fix client visit recording and show client info in booking dialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ManageBookingDialog from '../components/ManageBookingDialog';
+import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('../api/bookings', () => ({
   getSlots: jest.fn(),
@@ -41,12 +42,14 @@ describe('ManageBookingDialog', () => {
     (markBookingVisited as jest.Mock).mockResolvedValue({});
 
     render(
-      <ManageBookingDialog
-        open
-        booking={{ id: 1, client_id: 5, date: '2024-02-01', reschedule_token: '', user_name: 'Client' }}
-        onClose={onClose}
-        onUpdated={onUpdated}
-      />
+      <MemoryRouter>
+        <ManageBookingDialog
+          open
+          booking={{ id: 1, client_id: 5, user_id: 1, bookings_this_month: 2, date: '2024-02-01', reschedule_token: '', user_name: 'Client' }}
+          onClose={onClose}
+          onUpdated={onUpdated}
+        />
+      </MemoryRouter>
     );
 
     fireEvent.change(screen.getByLabelText(/status/i), { target: { value: 'visited' } });
@@ -72,6 +75,23 @@ describe('ManageBookingDialog', () => {
     );
     await waitFor(() => expect(markBookingVisited).toHaveBeenCalledWith(1));
     expect(onUpdated).toHaveBeenCalledWith('Visit recorded', 'success');
+  });
+  it('shows client info', () => {
+    render(
+      <MemoryRouter>
+        <ManageBookingDialog
+          open
+          booking={{ id: 1, client_id: 5, user_id: 1, bookings_this_month: 3, date: '2024-02-01', reschedule_token: '', user_name: 'Client' }}
+          onClose={() => {}}
+          onUpdated={() => {}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Client: Client')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: '5' });
+    expect(link).toHaveAttribute('href', '/pantry/client-management?tab=history&id=1&name=Client&clientId=5');
+    expect(screen.getByText('Visits this month: 3')).toBeInTheDocument();
   });
 });
 

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -8,7 +8,10 @@ import {
   TextField,
   MenuItem,
   Stack,
+  Typography,
+  Link as MuiLink,
 } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
 import FeedbackSnackbar from './FeedbackSnackbar';
@@ -23,7 +26,9 @@ interface Booking {
   id: number;
   reschedule_token: string;
   client_id: number;
+  user_id: number;
   user_name: string;
+  bookings_this_month: number;
   date: string;
 }
 
@@ -123,7 +128,7 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
           }
           await createClientVisit({
             date: booking.date,
-            clientId: booking.client_id,
+            clientId: Number(booking.client_id),
             anonymous: false,
             weightWithCart: Number(weightWithCart),
             weightWithoutCart: Number(weightWithoutCart),
@@ -150,6 +155,19 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
       <DialogTitle>Manage Booking</DialogTitle>
       <DialogContent sx={{ pt: 2 }}>
         <Stack spacing={2}>
+          <Stack spacing={0.5}>
+            <Typography>Client: {booking.user_name}</Typography>
+            <Typography>
+              Client ID:{' '}
+              <MuiLink
+                component={RouterLink}
+                to={`/pantry/client-management?tab=history&id=${booking.user_id}&name=${encodeURIComponent(booking.user_name)}&clientId=${booking.client_id}`}
+              >
+                {booking.client_id}
+              </MuiLink>
+            </Typography>
+            <Typography>Visits this month: {booking.bookings_this_month}</Typography>
+          </Stack>
           <TextField
             select
             label="Status"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Staff can record visits directly from a booking in the pantry schedule. Selecting **Visited** in the booking dialog captures cart weights and creates the visit record before marking the booking visited.
+- The Manage Booking dialog now displays the client's name, a link to their profile, and their visit count for the current month to assist staff decisions.
 - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts).
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).


### PR DESCRIPTION
## Summary
- Display client name, profile link, and monthly visit count in Manage Booking dialog
- Ensure client ID is numeric when recording a visit
- Cover new UI and behavior with tests and document in README

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b093ebb290832da555b05e7341604d