### PR TITLE
Add master role and slot typings with coverage tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - `components/` provide reusable UI elements; use `FeedbackSnackbar` for notifications. The dashboard UI lives in `components/dashboard`.
 - `api/` wraps server requests.
 - `utils/`, `types.ts`, and theming files manage helpers, typings, and Material UI themes.
+- Administrative pages enable staff to manage volunteer master roles and edit volunteer role slots.
 
 ## Development Guidelines
 

--- a/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerBooking from '../pages/volunteer-management/VolunteerBooking';
+import { getVolunteerRolesForVolunteer, requestVolunteerBooking } from '../api/volunteers';
+import { getHolidays } from '../api/bookings';
+
+jest.mock('../api/volunteers', () => ({
+  getVolunteerRolesForVolunteer: jest.fn(),
+  requestVolunteerBooking: jest.fn(),
+}));
+
+jest.mock('../api/bookings', () => ({
+  getHolidays: jest.fn(),
+}));
+
+describe('VolunteerBooking', () => {
+  it('requests a slot and shows confirmation', async () => {
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockImplementation(async (date: string) => [
+      {
+        id: 1,
+        role_id: 1,
+        name: 'Greeter',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        max_volunteers: 3,
+        booked: 0,
+        available: 3,
+        status: 'available',
+        date,
+        category_id: 1,
+        category_name: 'Front',
+        is_wednesday_slot: false,
+      },
+    ]);
+    (requestVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
+
+    const queryClient = new QueryClient();
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <VolunteerBooking />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    const slot = await screen.findByText(/9:00 AM/);
+    fireEvent.click(slot);
+    fireEvent.click(screen.getByRole('button', { name: /request shift/i }));
+
+    await waitFor(() =>
+      expect(requestVolunteerBooking).toHaveBeenCalledWith(1, expect.any(String)),
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Request submitted')).toBeInTheDocument(),
+    );
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -9,6 +9,8 @@ import {
   getVolunteerBookingHistory,
   createVolunteerShopperProfile,
   removeVolunteerShopperProfile,
+  updateVolunteerTrainedAreas,
+  createVolunteerBookingForVolunteer,
 } from '../api/volunteers';
 
 jest.mock('../api/volunteers', () => ({
@@ -17,6 +19,8 @@ jest.mock('../api/volunteers', () => ({
   getVolunteerBookingHistory: jest.fn(),
   createVolunteerShopperProfile: jest.fn(),
   removeVolunteerShopperProfile: jest.fn(),
+  updateVolunteerTrainedAreas: jest.fn(),
+  createVolunteerBookingForVolunteer: jest.fn(),
 }));
 
 let mockVolunteer: any = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
@@ -31,6 +35,8 @@ beforeEach(() => {
   (getVolunteerBookingHistory as jest.Mock).mockResolvedValue([]);
   (createVolunteerShopperProfile as jest.Mock).mockResolvedValue(undefined);
   (removeVolunteerShopperProfile as jest.Mock).mockResolvedValue(undefined);
+  (updateVolunteerTrainedAreas as jest.Mock).mockResolvedValue(undefined);
+  (createVolunteerBookingForVolunteer as jest.Mock).mockResolvedValue(undefined);
 });
 
 describe('VolunteerManagement shopper profile', () => {
@@ -125,6 +131,44 @@ describe('VolunteerManagement search reset', () => {
     act(() => navigateFn('/volunteers/search'));
 
     expect(screen.queryByText(/Edit Roles for Test Vol/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('VolunteerManagement role updates', () => {
+  it('saves trained roles for volunteer', async () => {
+    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+    (searchVolunteers as jest.Mock).mockResolvedValue([mockVolunteer]);
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      {
+        id: 5,
+        role_id: 5,
+        category_id: 1,
+        name: 'Greeter',
+        max_volunteers: 2,
+        category_name: 'Front',
+        shifts: [],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/volunteers/search']}>
+        <Routes>
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText('Select Volunteer'));
+    const checkbox = await screen.findByLabelText('Greeter');
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('button', { name: /save roles/i }));
+
+    await waitFor(() =>
+      expect(updateVolunteerTrainedAreas).toHaveBeenCalledWith(1, [5]),
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Roles updated')).toBeInTheDocument(),
+    );
   });
 });
 

--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
@@ -1,0 +1,46 @@
+import { apiFetch, handleResponse } from '../api/client';
+import {
+  createVolunteerBookingForVolunteer,
+  updateVolunteerTrainedAreas,
+  getVolunteerMasterRoles,
+} from '../api/volunteers';
+
+jest.mock('../api/client', () => ({
+  API_BASE: '/api',
+  apiFetch: jest.fn(),
+  handleResponse: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('volunteers api', () => {
+  beforeEach(() => {
+    (apiFetch as jest.Mock).mockResolvedValue(new Response(null));
+    jest.clearAllMocks();
+  });
+
+  it('creates volunteer booking for volunteer', async () => {
+    await createVolunteerBookingForVolunteer(5, 3, '2024-01-01');
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/volunteer-bookings/staff',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ volunteerId: 5, roleId: 3, date: '2024-01-01' }),
+      }),
+    );
+  });
+
+  it('updates volunteer trained areas', async () => {
+    await updateVolunteerTrainedAreas(2, [1, 3]);
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/volunteers/2/trained-areas',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ roleIds: [1, 3] }),
+      }),
+    );
+  });
+
+  it('fetches volunteer master roles', async () => {
+    await getVolunteerMasterRoles();
+    expect(apiFetch).toHaveBeenCalledWith('/api/volunteer-master-roles');
+  });
+});

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -164,3 +164,21 @@ export interface Shift {
   endTime: string;   // 'HH:MM:SS'
   maxVolunteers: number;
 }
+
+export interface VolunteerMasterRole {
+  id: number;
+  name: string;
+}
+
+export interface EditableSlot {
+  id: number;
+  role_id: number;
+  name: string;
+  start_time: string;
+  end_time: string;
+  max_volunteers: number;
+  category_id: number;
+  category_name: string;
+  is_wednesday_slot: boolean;
+  is_active: boolean;
+}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
+- Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots.
 
 ## Clone and initialize submodules
 


### PR DESCRIPTION
## Summary
- define VolunteerMasterRole and EditableSlot interfaces
- cover volunteer APIs and pages for slot requests and role updates
- document master role and slot management in README and AGENTS guidelines

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for ts-jest package)*

------
https://chatgpt.com/codex/tasks/task_e_68b092b0dea8832d85e89170d0f3d5fc