### PR TITLE
Add slot management endpoints and admin UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
+- Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
 
 ### Frontend (`MJ_FB_Frontend`)
 - React app built with Vite.

--- a/MJ_FB_Backend/src/routes/slots.ts
+++ b/MJ_FB_Backend/src/routes/slots.ts
@@ -1,5 +1,12 @@
 import express from 'express';
-import { listSlots, listAllSlots, listSlotsRange } from '../controllers/slotController';
+import {
+  listSlots,
+  listAllSlots,
+  listSlotsRange,
+  createSlot,
+  updateSlot,
+  deleteSlot,
+} from '../controllers/slotController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 
 const router = express.Router();
@@ -22,5 +29,9 @@ router.get(
   authorizeRoles('shopper', 'delivery', 'staff'),
   listSlotsRange,
 );
+
+router.post('/', authMiddleware, authorizeRoles('staff'), createSlot);
+router.put('/:id', authMiddleware, authorizeRoles('staff'), updateSlot);
+router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteSlot);
 
 export default router;

--- a/MJ_FB_Backend/src/schemas/slotSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/slotSchemas.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const slotSchema = z.object({
+  startTime: z.string().min(1),
+  endTime: z.string().min(1),
+  maxCapacity: z.coerce.number().int().positive(),
+});
+
+export const slotIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+export type SlotInput = z.infer<typeof slotSchema>;
+export type SlotIdParams = z.infer<typeof slotIdParamSchema>;

--- a/MJ_FB_Backend/tests/slotCrud.test.ts
+++ b/MJ_FB_Backend/tests/slotCrud.test.ts
@@ -1,0 +1,83 @@
+import request from 'supertest';
+import express from 'express';
+import slotsRouter from '../src/routes/slots';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/slots', slotsRouter);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /slots', () => {
+  it('creates a slot', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        { id: 1, start_time: '09:00:00', end_time: '09:30:00', max_capacity: 5 },
+      ],
+    });
+    const res = await request(app)
+      .post('/slots')
+      .send({ startTime: '09:00:00', endTime: '09:30:00', maxCapacity: 5 });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      id: '1',
+      startTime: '09:00:00',
+      endTime: '09:30:00',
+      maxCapacity: 5,
+    });
+    expect(pool.query).toHaveBeenCalledWith(
+      'INSERT INTO slots (start_time, end_time, max_capacity) VALUES ($1,$2,$3) RETURNING id, start_time, end_time, max_capacity',
+      ['09:00:00', '09:30:00', 5],
+    );
+  });
+
+  it('validates request body', async () => {
+    const res = await request(app)
+      .post('/slots')
+      .send({ startTime: '', endTime: '', maxCapacity: 0 });
+    expect(res.status).toBe(400);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});
+
+describe('PUT /slots/:id', () => {
+  it('updates slot capacity', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [
+        { id: 2, start_time: '10:00:00', end_time: '10:30:00', max_capacity: 8 },
+      ],
+    });
+    const res = await request(app)
+      .put('/slots/2')
+      .send({ startTime: '10:00:00', endTime: '10:30:00', maxCapacity: 8 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: '2',
+      startTime: '10:00:00',
+      endTime: '10:30:00',
+      maxCapacity: 8,
+    });
+    expect(pool.query).toHaveBeenCalledWith(
+      'UPDATE slots SET start_time = $1, end_time = $2, max_capacity = $3 WHERE id = $4 RETURNING id, start_time, end_time, max_capacity',
+      ['10:00:00', '10:30:00', 8, 2],
+    );
+  });
+
+  it('returns 400 for invalid id', async () => {
+    const res = await request(app)
+      .put('/slots/abc')
+      .send({ startTime: '10:00:00', endTime: '10:30:00', maxCapacity: 8 });
+    expect(res.status).toBe(400);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});

--- a/MJ_FB_Frontend/src/api/slots.ts
+++ b/MJ_FB_Frontend/src/api/slots.ts
@@ -1,0 +1,39 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+import type { Slot } from '../types';
+
+export async function getAllSlots(): Promise<Slot[]> {
+  const res = await apiFetch(`${API_BASE}/slots/all`);
+  return handleResponse(res);
+}
+
+export async function createSlot(data: {
+  startTime: string;
+  endTime: string;
+  maxCapacity: number;
+}) {
+  const res = await apiFetch(`${API_BASE}/slots`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
+export async function updateSlot(
+  id: number | string,
+  data: { startTime: string; endTime: string; maxCapacity: number },
+) {
+  const res = await apiFetch(`${API_BASE}/slots/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
+export async function deleteSlot(id: number | string) {
+  const res = await apiFetch(`${API_BASE}/slots/${id}`, {
+    method: 'DELETE',
+  });
+  return handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
@@ -1,11 +1,100 @@
-import { Box } from '@mui/material';
+import { useEffect, useState } from 'react';
+import {
+  Grid,
+  Card,
+  CardHeader,
+  CardContent,
+  TextField,
+  Button,
+  Typography,
+} from '@mui/material';
+import type { AlertColor } from '@mui/material';
 import Page from '../../components/Page';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { getAllSlots, updateSlot } from '../../api/slots';
+import type { Slot } from '../../types';
 
 export default function PantrySettings() {
+  const [slots, setSlots] = useState<Slot[]>([]);
+  const [snackbar, setSnackbar] = useState<
+    { message: string; severity: AlertColor } | null
+  >(null);
+
+  async function load() {
+    try {
+      const data = await getAllSlots();
+      setSlots(data);
+    } catch {
+      setSnackbar({ message: 'Failed to load slots', severity: 'error' });
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleChange = (id: string, value: string) => {
+    setSlots(prev =>
+      prev.map(s => (s.id === id ? { ...s, maxCapacity: Number(value) } : s)),
+    );
+  };
+
+  const handleSave = async (slot: Slot) => {
+    try {
+      await updateSlot(slot.id, {
+        startTime: slot.startTime,
+        endTime: slot.endTime,
+        maxCapacity: Number(slot.maxCapacity) || 0,
+      });
+      setSnackbar({ message: 'Slot updated', severity: 'success' });
+      load();
+    } catch (err: any) {
+      setSnackbar({
+        message: err.message || 'Failed to update slot',
+        severity: 'error',
+      });
+    }
+  };
+
   return (
     <Page title="Pantry Settings">
-      <Box p={2}></Box>
+      <Grid container spacing={2} p={2}>
+        {slots.map(slot => (
+          <Grid item xs={12} md={6} key={slot.id}>
+            <Card>
+              <CardHeader title={`${slot.startTime} - ${slot.endTime}`} />
+              <CardContent>
+                <TextField
+                  label="Max Capacity"
+                  type="number"
+                  size="small"
+                  value={slot.maxCapacity ?? ''}
+                  onChange={e => handleChange(slot.id, e.target.value)}
+                />
+                <Button
+                  size="small"
+                  sx={{ ml: 2 }}
+                  variant="contained"
+                  onClick={() => handleSave(slot)}
+                >
+                  Save
+                </Button>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+        {slots.length === 0 && (
+          <Grid item xs={12}>
+            <Typography>No slots found.</Typography>
+          </Grid>
+        )}
+      </Grid>
+      <FeedbackSnackbar
+        open={!!snackbar}
+        onClose={() => setSnackbar(null)}
+        message={snackbar?.message || ''}
+        severity={snackbar?.severity}
+      />
     </Page>
   );
 }
-

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -28,6 +28,7 @@ export interface Slot {
   id: string;
   startTime: string;
   endTime: string;
+  maxCapacity?: number;
   available?: number;
   reason?: string;
   status?: 'blocked' | 'break';

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
+- Staff can manage booking slots and adjust slot capacities through the Admin → Pantry Settings page.
 
 ## Clone and initialize submodules
 


### PR DESCRIPTION
## Summary
- add create, update, and delete slot handlers with validation
- expose staff-only slot management routes
- add slot CRUD tests and frontend API + admin page for editing slot capacity

## Testing
- `npm test` (backend) *(fails: slots.test.ts, bookingUtils.test.ts, events.test.ts)*
- `npm test` (frontend) *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b094628fa8832d8dc26342e4196959