### PR TITLE
fix: align holiday form field heights

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -274,7 +274,7 @@ export default function ManageAvailability() {
                   label="Date"
                   value={holidayDate}
                   onChange={setHolidayDate}
-                  slotProps={{ textField: { fullWidth: true } }}
+                  slotProps={{ textField: { fullWidth: true, size: 'medium' } }}
                 />
               </Grid>
               <Grid item xs={12} sm={6}>
@@ -283,6 +283,7 @@ export default function ManageAvailability() {
                   value={holidayReason}
                   onChange={(e) => setHolidayReason(e.target.value)}
                   fullWidth
+                  size="medium"
                 />
               </Grid>
               <Grid item xs={12} sm={2}>


### PR DESCRIPTION
## Summary
- match holiday Date and Reason field heights using medium-sized inputs

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden when fetching ts-jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b099330180832da4616a26497ad4d6