### PR TITLE
refactor: import MUI icons individually

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -10,14 +10,12 @@ import {
   ListItemText,
   Chip,
 } from '@mui/material';
-import {
-  CalendarToday,
-  People,
-  WarningAmber,
-  Cancel as CancelIcon,
-  EventAvailable,
-  Announcement,
-} from '@mui/icons-material';
+import CalendarToday from '@mui/icons-material/CalendarToday';
+import People from '@mui/icons-material/People';
+import WarningAmber from '@mui/icons-material/WarningAmber';
+import CancelIcon from '@mui/icons-material/Cancel';
+import EventAvailable from '@mui/icons-material/EventAvailable';
+import Announcement from '@mui/icons-material/Announcement';
 import { getBookings, getSlotsRange } from '../../api/bookings';
 import type { Role } from '../../types';
 import { formatTime } from '../../utils/time';

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -21,7 +21,7 @@ import {
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
-import { AccessTime } from '@mui/icons-material';
+import AccessTime from '@mui/icons-material/AccessTime';
 import dayjs, { Dayjs } from 'dayjs';
 import { useQuery } from '@tanstack/react-query';
 import type { Slot, Holiday } from '../types';

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -8,7 +8,8 @@ import {
   Button,
   CircularProgress,
 } from '@mui/material';
-import { AccountCircle, Lock } from '@mui/icons-material';
+import AccountCircle from '@mui/icons-material/AccountCircle';
+import Lock from '@mui/icons-material/Lock';
 import type { Role, UserProfile } from '../../types';
 import { getUserProfile, changePassword, updateMyProfile } from '../../api/users';
 import { getVolunteerProfile } from '../../api/volunteers';

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -14,7 +14,9 @@ import {
   DialogContent,
   DialogActions,
 } from '@mui/material';
-import { EventAvailable, Announcement, History } from '@mui/icons-material';
+import EventAvailable from '@mui/icons-material/EventAvailable';
+import Announcement from '@mui/icons-material/Announcement';
+import History from '@mui/icons-material/History';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../../api/bookings';

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -23,7 +23,11 @@ import {
   ListItem,
   ListItemText,
 } from '@mui/material';
-import { DeleteOutline, Add, EventBusy, Restaurant, Block } from '@mui/icons-material';
+import DeleteOutline from '@mui/icons-material/DeleteOutline';
+import Add from '@mui/icons-material/Add';
+import EventBusy from '@mui/icons-material/EventBusy';
+import Restaurant from '@mui/icons-material/Restaurant';
+import Block from '@mui/icons-material/Block';
 import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import type { AlertColor } from '@mui/material';

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -18,7 +18,8 @@ import {
   Checkbox,
   Typography,
 } from '@mui/material';
-import { Edit, Delete } from '@mui/icons-material';
+import Edit from '@mui/icons-material/Edit';
+import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -15,7 +15,7 @@ import {
   Select,
   MenuItem,
 } from '@mui/material';
-import { Announcement } from '@mui/icons-material';
+import Announcement from '@mui/icons-material/Announcement';
 import { useNavigate } from 'react-router-dom';
 import {
   getMyVolunteerBookings,

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -17,7 +17,8 @@ import {
   Autocomplete,
   IconButton,
 } from '@mui/material';
-import { Edit, Delete } from '@mui/icons-material';
+import Edit from '@mui/icons-material/Edit';
+import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
@@ -17,7 +17,8 @@ import {
   Autocomplete,
   IconButton,
 } from '@mui/material';
-import { Edit, Delete } from '@mui/icons-material';
+import Edit from '@mui/icons-material/Edit';
+import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
@@ -16,7 +16,8 @@ import {
   TextField,
   IconButton,
 } from '@mui/material';
-import { Edit, Delete } from '@mui/icons-material';
+import Edit from '@mui/icons-material/Edit';
+import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
@@ -16,7 +16,8 @@ import {
   MenuItem,
   IconButton,
 } from '@mui/material';
-import { Edit, Delete } from '@mui/icons-material';
+import Edit from '@mui/icons-material/Edit';
+import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -18,13 +18,11 @@ import {
   Stack,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import {
-  Autorenew,
-  InfoOutlined,
-  TrendingUp,
-  WarningAmber,
-  Announcement,
-} from '@mui/icons-material';
+import Autorenew from '@mui/icons-material/Autorenew';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
+import TrendingUp from '@mui/icons-material/TrendingUp';
+import WarningAmber from '@mui/icons-material/WarningAmber';
+import Announcement from '@mui/icons-material/Announcement';
 import {
   ResponsiveContainer,
   LineChart,


### PR DESCRIPTION
## Summary
- refactor Dashboard and other components to import MUI icons from their individual paths for better tree-shaking
- adjust numerous pages to use per-icon `@mui/icons-material/IconName` imports

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden - ts-jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b09ac4fb7c832d9de55ca804565f2d