### PR TITLE
Enable gzip compression and asset caching

### DIFF
--- a/MJ_FB_Frontend/nginx.conf
+++ b/MJ_FB_Frontend/nginx.conf
@@ -12,7 +12,13 @@ server {
 
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
+  gzip on;
+  gzip_types text/css application/javascript application/json;
+
   root /usr/share/nginx/html;
+  location ~* \.(js|css|woff2|png|svg)$ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
   location / {
     try_files $uri $uri/ /index.html;
   }


### PR DESCRIPTION
## Summary
- enable gzip compression for served content
- add immutable long-term caching headers for JS, CSS, fonts, and images

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci` *(fails: 403 Forbidden fetching ts-jest)*
- `apt-get update` *(fails: repository 403, preventing Nginx install)*
- `nginx -s reload` *(command not found)*
- `curl -I http://localhost` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b09ad1dee0832d97d2255580f6de05