### PR TITLE
feat: add rollup visualizer and build chunking

### DIFF
--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -45,6 +45,7 @@
     "jest-environment-jsdom": "^30.0.5",
     "postcss": "^8.5.6",
     "react-calendar": "^6.0.0",
+    "rollup-plugin-visualizer": "^5.12.0",
     "ts-jest": "^30.0.0",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.40.0",

--- a/MJ_FB_Frontend/vite.config.ts
+++ b/MJ_FB_Frontend/vite.config.ts
@@ -2,16 +2,44 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: true,
-    port: 5173,
-    strictPort: true,
-    hmr: {
-      protocol: 'ws',
-      host: 'localhost',
+export default defineConfig(async ({ mode }) => {
+  const plugins = [react()]
+  if (mode === 'production') {
+    try {
+      const { visualizer } = await import('rollup-plugin-visualizer')
+      plugins.push(
+        visualizer({ filename: 'stats.html', open: false })
+      )
+    } catch (err) {
+      console.warn('rollup-plugin-visualizer is not installed', err)
+    }
+  }
+
+  return {
+    plugins,
+    server: {
+      host: true,
       port: 5173,
+      strictPort: true,
+      hmr: {
+        protocol: 'ws',
+        host: 'localhost',
+        port: 5173,
+      },
     },
-  },
+    build: {
+      target: 'es2020',
+      sourcemap: false,
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            react: ['react', 'react-dom'],
+            mui: ['@mui/material', '@mui/icons-material'],
+            router: ['react-router-dom'],
+            recharts: ['recharts'],
+          },
+        },
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- add rollup-plugin-visualizer to production build
- split major libraries into dedicated Rollup chunks and target ES2020

## Testing
- `npm test` (fails: sh: 1: jest: not found)
- `npm run build` (fails: Cannot find module 'react' or its type declarations and other missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68b09c073d70832d8c1ab42a16e6254e