### PR TITLE
fix(frontend): use supported ts-jest version

### DIFF
--- a/MJ_FB_Frontend/package-lock.json
+++ b/MJ_FB_Frontend/package-lock.json
@@ -41,7 +41,7 @@
         "jest-environment-jsdom": "^30.0.5",
         "postcss": "^8.5.6",
         "react-calendar": "^6.0.0",
-        "ts-jest": "^29.4.1",
+        "ts-jest": "^29.2.5",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.40.0",
         "vite": "^7.1.3"

--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -45,7 +45,7 @@
     "jest-environment-jsdom": "^30.0.5",
     "postcss": "^8.5.6",
     "react-calendar": "^6.0.0",
-    "ts-jest": "^30.0.0",
+    "ts-jest": "^29.2.5",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.40.0",
     "vite": "^7.1.3"


### PR DESCRIPTION
## Summary
- pin `ts-jest` to an available 29.x release so install no longer fails

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/write-excel-file)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09c9d66fc832da11e7c219832bd28