### PR TITLE
Show client IDs in pantry schedule slots

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PantrySchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantrySchedule.test.tsx
@@ -61,10 +61,10 @@ describe('PantrySchedule status colors', () => {
       </ThemeProvider>
     );
 
-    const submitted = await screen.findByText('Sub');
-    const approved = screen.getByText('App');
-    const noShow = screen.getByText('No');
-    const visited = screen.getByText('Vis');
+    const submitted = await screen.findByText('Sub (1)');
+    const approved = screen.getByText('App (2)');
+    const noShow = screen.getByText('No (3)');
+    const visited = screen.getByText('Vis (4)');
 
     expect(getComputedStyle(submitted).backgroundColor).toBe(hexToRgb(theme.palette.warning.light));
     expect(getComputedStyle(approved).backgroundColor).toBe('rgb(228, 241, 228)');

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -196,7 +196,9 @@ export default function PantrySchedule({
       cells: Array.from({ length: 4 }).map((_, i) => {
         const booking = slotBookings[i];
         return {
-          content: booking ? booking.user_name : '',
+          content: booking
+            ? `${booking.user_name} (${booking.client_id})`
+            : '',
           backgroundColor: booking
             ? statusColors[booking.status]
             : undefined,

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ control weight calculations:
 - Admin staff creation page provides a link back to the staff list for easier navigation.
 - Admin navigation includes Pantry Settings and Volunteer Settings pages.
 - Pantry schedule cells use color coding: yellow for submitted, rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, and rgb(111,146,113) for visited.
+- Filled pantry schedule slots display the client's ID in parentheses next to their name.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- Display client ID in parentheses beside names for filled pantry schedule slots
- Update pantry schedule tests to account for client ID
- Document client ID display in README

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - rollup-plugin-visualizer)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a2ace084832daf4b598fe18a6b56