### PR TITLE
Include walk-in visits in booking history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
+- `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
 
 ### Frontend (`MJ_FB_Frontend`)

--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -533,8 +533,14 @@ export async function getBookingHistory(req: Request, res: Response, next: NextF
 
     const status = (req.query.status as string)?.toLowerCase();
     const past = req.query.past === 'true';
+    const includeVisits = req.query.includeVisits === 'true';
 
-    const rows = await repoFetchBookingHistory(userId, past, status);
+    const rows = await repoFetchBookingHistory(
+      userId,
+      past,
+      status,
+      includeVisits,
+    );
     res.json(rows);
   } catch (error) {
     logger.error('Error fetching booking history:', error);

--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -125,6 +125,7 @@ export async function fetchBookingHistory(
   userId: number,
   past: boolean,
   status: string | undefined,
+  includeVisits = false,
   client: Queryable = pool,
 ) {
   const params: any[] = [userId];
@@ -145,7 +146,30 @@ export async function fetchBookingHistory(
        ORDER BY b.created_at DESC`,
     params,
   );
-  return res.rows;
+  let rows = res.rows;
+  if (includeVisits && (!status || status === 'visited')) {
+    const visitWhere = [
+      'c.id = $1',
+      "v.date >= CURRENT_DATE - INTERVAL '6 months'",
+    ];
+    if (past) {
+      visitWhere.push('v.date < CURRENT_DATE');
+    }
+    const visitRes = await client.query(
+      `SELECT v.id, 'visited' AS status, v.date, NULL AS slot_id, NULL AS reason, NULL AS start_time, NULL AS end_time, v.date AS created_at, false AS is_staff_booking, NULL AS reschedule_token
+         FROM client_visits v
+         INNER JOIN clients c ON c.client_id = v.client_id
+         WHERE ${visitWhere.join(' AND ')}
+         ORDER BY v.date DESC`,
+      [userId],
+    );
+    rows = rows.concat(visitRes.rows);
+    rows.sort(
+      (a: any, b: any) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
+  }
+  return rows;
 }
 
   export async function insertWalkinUser(

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -48,6 +48,7 @@ router.get(
 );
 
 // Booking history for user or staff lookup
+// Optional query params: status, past=true, userId (staff/agency), includeVisits=true
 router.get('/history', authMiddleware, getBookingHistory);
 
 // Staff approve/reject booking

--- a/MJ_FB_Backend/tests/bookingHistoryVisits.test.ts
+++ b/MJ_FB_Backend/tests/bookingHistoryVisits.test.ts
@@ -1,0 +1,52 @@
+import pool from '../src/db';
+import { fetchBookingHistory } from '../src/models/bookingRepository';
+
+jest.mock('../src/db');
+
+describe('fetchBookingHistory includeVisits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns walk-in visits when includeVisits flag is true', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            status: 'approved',
+            date: '2024-01-01',
+            slot_id: 1,
+            reason: null,
+            start_time: '09:00:00',
+            end_time: '10:00:00',
+            created_at: '2024-01-01',
+            is_staff_booking: false,
+            reschedule_token: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 2,
+            status: 'visited',
+            date: '2024-01-02',
+            slot_id: null,
+            reason: null,
+            start_time: null,
+            end_time: null,
+            created_at: '2024-01-02',
+            is_staff_booking: false,
+            reschedule_token: null,
+          },
+        ],
+      });
+
+    const rows = await fetchBookingHistory(1, false, undefined, true);
+    expect(rows).toHaveLength(2);
+    const statuses = rows.map(r => r.status).sort();
+    expect(statuses).toEqual(['approved', 'visited']);
+  });
+});
+

--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UserHistory from '../pages/staff/client-management/UserHistory';
+import { getBookingHistory, cancelBooking } from '../api/bookings';
+import { getUserByClientId, updateUserInfo } from '../api/users';
+
+jest.mock('../api/bookings', () => ({
+  getBookingHistory: jest.fn(),
+  cancelBooking: jest.fn(),
+}));
+
+jest.mock('../api/users', () => ({
+  getUserByClientId: jest.fn(),
+  updateUserInfo: jest.fn(),
+}));
+
+describe('UserHistory', () => {
+  it('renders bookings and walk-in visits', async () => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'approved',
+        date: '2024-01-01',
+        start_time: '09:00:00',
+        end_time: '10:00:00',
+        created_at: '2024-01-01',
+        slot_id: 1,
+        is_staff_booking: false,
+        reschedule_token: 't',
+      },
+      {
+        id: 2,
+        status: 'visited',
+        date: '2024-01-02',
+        start_time: null,
+        end_time: null,
+        created_at: '2024-01-02',
+        slot_id: null,
+        is_staff_booking: false,
+        reschedule_token: null,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
+    expect(getBookingHistory).toHaveBeenCalledWith({ includeVisits: true });
+    expect(await screen.findByText('approved')).toBeInTheDocument();
+    expect(await screen.findByText('visited')).toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -95,12 +95,18 @@ export async function getBookings(
 }
 
 export async function getBookingHistory(
-  opts: { status?: string; past?: boolean; userId?: number } = {},
+  opts: {
+    status?: string;
+    past?: boolean;
+    userId?: number;
+    includeVisits?: boolean;
+  } = {},
 ) {
   const params = new URLSearchParams();
   if (opts.status) params.append('status', opts.status);
   if (opts.past) params.append('past', 'true');
   if (opts.userId) params.append('userId', String(opts.userId));
+  if (opts.includeVisits) params.append('includeVisits', 'true');
   const res = await apiFetch(
     `${API_BASE}/bookings/history?${params.toString()}`,
   );

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -57,8 +57,14 @@ export default function ClientHistory() {
 
   const loadBookings = useCallback(() => {
     if (!selected) return Promise.resolve();
-    const opts: { status?: string; past?: boolean; userId?: number } = {
+    const opts: {
+      status?: string;
+      past?: boolean;
+      userId?: number;
+      includeVisits?: boolean;
+    } = {
       userId: selected.id,
+      includeVisits: true,
     };
     if (filter === 'past') opts.past = true;
     else if (filter !== 'all') opts.status = filter;

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -84,7 +84,7 @@ export default function ClientDashboard() {
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
 
   useEffect(() => {
-    getBookingHistory()
+    getBookingHistory({ includeVisits: true })
       .then(setBookings)
       .catch(() => {});
   }, []);
@@ -307,20 +307,23 @@ export default function ClientDashboard() {
         <Grid size={12}>
           <SectionCard title="Recent Bookings" icon={<History color="primary" />}>
             <List>
-              {history.slice(0, 3).map(b => (
-                <ListItem
-                  key={b.id}
-                  secondaryAction={
-                    <Chip label={b.status} color={statusColor(b.status)} />
-                  }
-                >
-                  <ListItemText
-                    primary={`${formatDate(b.date)} ${formatTime(
-                      b.start_time || '',
-                    )}`}
-                  />
-                </ListItem>
-              ))}
+              {history.slice(0, 3).map(b => {
+                const time = b.start_time ? formatTime(b.start_time) : '';
+                return (
+                  <ListItem
+                    key={b.id}
+                    secondaryAction={
+                      <Chip label={b.status} color={statusColor(b.status)} />
+                    }
+                  >
+                    <ListItemText
+                      primary={
+                        time ? `${formatDate(b.date)} ${time}` : formatDate(b.date)
+                      }
+                    />
+                  </ListItem>
+                );
+              })}
             </List>
           </SectionCard>
         </Grid>

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -85,7 +85,12 @@ export default function UserHistory({
 
   const loadBookings = useCallback(() => {
     if (!selected) return Promise.resolve();
-    const opts: { status?: string; past?: boolean; userId?: number } = {};
+    const opts: {
+      status?: string;
+      past?: boolean;
+      userId?: number;
+      includeVisits?: boolean;
+    } = { includeVisits: true };
     if (!initialUser) opts.userId = selected.id;
     if (filter === 'past') opts.past = true;
     else if (filter !== 'all') opts.status = filter;

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Staff can record visits directly from a booking in the pantry schedule. Selecting **Visited** in the booking dialog captures cart weights and creates the visit record before marking the booking visited.
 - The Manage Booking dialog now displays the client's name, a link to their profile, and their visit count for the current month to assist staff decisions.
 - Client booking history tables can filter bookings by `visited` and `no_show` statuses.
+- Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts).
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).


### PR DESCRIPTION
## Summary
- allow `/bookings/history` to include walk-in visits from `client_visits` via `includeVisits` flag
- surface new `includeVisits` query on backend and frontend booking history calls
- render visit records in client history views and add tests

## Testing
- `npm test` (backend) *(fails: bookingUtils, events, slots tests)*
- `npm test tests/bookingHistoryVisits.test.ts` (backend)
- `npm test` (frontend, fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68b0a7f44e4c832dae55fb995cef5d59