### PR TITLE
fix: stabilize month range across time zones

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingUtils.ts
+++ b/MJ_FB_Backend/src/utils/bookingUtils.ts
@@ -6,13 +6,16 @@ export type Queryable = Pool | PoolClient;
 
 export function getMonthRange(date: Date | string): { start: string; end: string } | false {
   try {
-    const d = typeof date === 'string' ? new Date(date) : date;
-    const start = new Date(d.getFullYear(), d.getMonth(), 1);
-    const end = new Date(d.getFullYear(), d.getMonth() + 1, 0);
-    return {
-      start: formatReginaDate(start),
-      end: formatReginaDate(end),
-    };
+    const reginaStr = formatReginaDate(date);
+    const [yearStr, monthStr] = reginaStr.split('-');
+    const year = Number(yearStr);
+    const month = Number(monthStr); // 1-based month
+
+    const start = `${yearStr}-${monthStr}-01`;
+    const endDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+    const end = `${yearStr}-${monthStr}-${String(endDay).padStart(2, '0')}`;
+
+    return { start, end };
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- compute month start/end using Regina-local date strings to avoid time zone drift

## Testing
- `npm test` *(fails: slots.test.ts, events.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0abbc0504832d88c187a604fa7165