### PR TITLE
chore: remove unused read-excel-file

### DIFF
--- a/MJ_FB_Backend/package-lock.json
+++ b/MJ_FB_Backend/package-lock.json
@@ -30,7 +30,6 @@
         "@types/supertest": "^6.0.3",
         "jest": "^30.0.5",
         "node-pg-migrate": "^7.0.0",
-        "read-excel-file": "^5.8.3",
         "supertest": "^7.1.4",
         "ts-jest": "^29.4.1",
         "ts-node": "^10.9.2",
@@ -1765,16 +1764,6 @@
         "win32"
       ]
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2156,13 +2145,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -2876,16 +2858,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3196,13 +3168,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fflate": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
-      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/file-saver": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
@@ -3343,21 +3308,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
@@ -4524,19 +4474,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -5619,18 +5556,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/read-excel-file": {
-      "version": "5.8.8",
-      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-5.8.8.tgz",
-      "integrity": "sha512-Jb3g7wYe3NU7k52q5xs16swqsl47xIxc/CvHuJy49Elzp6+G6bg56Lds4s57FayosuCYm+TTU0ROpMMuM7WE0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.2",
-        "fflate": "^0.7.3",
-        "unzipper": "^0.12.2"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -6506,16 +6431,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -6558,20 +6473,6 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
-      }
-    },
-    "node_modules/unzipper": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "~3.7.2",
-        "duplexer2": "~0.1.4",
-        "fs-extra": "^11.2.0",
-        "graceful-fs": "^4.2.2",
-        "node-int64": "^0.4.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mj_fb_backend",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "dist/server.js",
   "dependencies": {
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
@@ -25,7 +25,6 @@
     "jest": "^30.0.5",
     "supertest": "^7.1.4",
     "ts-jest": "^29.4.1",
-    "read-excel-file": "^5.8.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
     "node-pg-migrate": "^7.0.0"

--- a/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
@@ -2,9 +2,10 @@ import request from 'supertest';
 import express from 'express';
 import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';
 import pool from '../src/db';
-import readXlsxFile from 'read-excel-file/node';
+import writeXlsxFile from 'write-excel-file/node';
 
 jest.mock('../src/db');
+jest.mock('write-excel-file/node', () => jest.fn().mockResolvedValue(Buffer.from('test')));
 
 const app = express();
 app.use('/warehouse-overall', warehouseOverallRoutes);
@@ -17,6 +18,9 @@ describe('GET /warehouse-overall/export', () => {
         { month: 2, donations: 5, surplus: 3, pigPound: 0, outgoingDonations: 1 },
       ],
     });
+
+    const buffer = Buffer.from('test');
+    (writeXlsxFile as jest.Mock).mockResolvedValueOnce(buffer);
 
     const res = await request(app)
       .get('/warehouse-overall/export?year=2024')
@@ -31,9 +35,11 @@ describe('GET /warehouse-overall/export', () => {
     expect(res.headers['content-type']).toBe(
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
+    expect(res.body).toEqual(buffer);
 
-    const rows = await readXlsxFile(res.body);
-    expect(rows[0]).toEqual([
+    const rows = (writeXlsxFile as jest.Mock).mock.calls[0][0];
+    const values = rows.map((row: any[]) => row.map(cell => cell.value));
+    expect(values[0]).toEqual([
       'Month',
       'Donations',
       'Surplus',
@@ -41,9 +47,9 @@ describe('GET /warehouse-overall/export', () => {
       'Outgoing Donations',
       'Total',
     ]);
-    expect(rows[1]).toEqual(['January', 10, 2, 1, 0, 13]);
-    expect(rows[2]).toEqual(['February', 5, 3, 0, 1, 9]);
-    expect(rows[3]).toEqual(['March', 0, 0, 0, 0, 0]);
-    expect(rows[13]).toEqual(['Total', 15, 5, 1, 1, 22]);
+    expect(values[1]).toEqual(['January', 10, 2, 1, 0, 13]);
+    expect(values[2]).toEqual(['February', 5, 3, 0, 1, 9]);
+    expect(values[3]).toEqual(['March', 0, 0, 0, 0, 0]);
+    expect(values[13]).toEqual(['Total', 15, 5, 1, 1, 22]);
   });
 });


### PR DESCRIPTION
## Summary
- point backend package to compiled server entry and drop unused read-excel-file
- mock spreadsheet export in tests instead of parsing generated file

## Testing
- `npm install`
- `npm test` *(fails: slots.test.ts, events.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b650f060832d95c52f98ef1d0225