### PR TITLE
refactor: extend express request type with user

### DIFF
--- a/MJ_FB_Backend/src/types/express.d.ts
+++ b/MJ_FB_Backend/src/types/express.d.ts
@@ -2,8 +2,7 @@ import type { AuthUser } from './AuthUser';
 
 declare global {
   namespace Express {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface Request {
+    interface Request extends Express.Request {
       user?: AuthUser;
     }
   }


### PR DESCRIPTION
## Summary
- extend Express Request interface to include optional `user` while inheriting from original Request

## Testing
- `CI=true npm test` *(fails: 2 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b64a170c832d823849083a173854