### PR TITLE
Handle auth refresh failures in API client

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/apiFetchRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/apiFetchRefresh.test.tsx
@@ -1,0 +1,37 @@
+import { apiFetch } from '../api/client';
+
+describe('apiFetch refresh handling', () => {
+  beforeEach(() => {
+    document.cookie = 'csrfToken=test';
+    localStorage.setItem('role', 'test');
+    Object.defineProperty(window, 'location', {
+      value: { assign: jest.fn(), pathname: '/' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects when refresh returns unexpected status', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+    await apiFetch('/test');
+    expect(window.location.assign).toHaveBeenCalledWith('/login');
+  });
+
+  it('redirects when refresh encounters network error', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockRejectedValueOnce(new Error('network'))
+      .mockRejectedValueOnce(new Error('network'));
+
+    await apiFetch('/test');
+    expect(window.location.assign).toHaveBeenCalledWith('/login');
+  });
+});

--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -65,20 +65,20 @@ export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {})
         refreshPromise = fetchWithRetry(
           `${API_BASE}/auth/refresh`,
           { method: 'POST', credentials: 'include' },
-          2,
+          1,
         );
       }
       const refreshRes = await refreshPromise;
       refreshPromise = null;
-      if (refreshRes.ok || refreshRes.status === 409) {
+      if ([200, 204, 409].includes(refreshRes.status)) {
         // 409 indicates another request already refreshed the tokens
         res = await fetchWithRetry(input, { credentials: 'include', ...init }, 1);
-      } else if (refreshRes.status === 401) {
+      } else {
         clearAuthAndRedirect();
       }
     } catch {
-      // network error during refresh; propagate original 401 without clearing auth
       refreshPromise = null;
+      clearAuthAndRedirect();
     }
   }
   return res;


### PR DESCRIPTION
## Summary
- Clear auth and redirect when refresh call fails with unexpected status or network error
- Add tests for refresh failure handling in apiFetch

## Testing
- `npm test` (fails: TS1343 import.meta not allowed, and other test errors)


------
https://chatgpt.com/codex/tasks/task_e_68b0b68466bc832d8ac80527854ab20c