### PR TITLE
Handle refresh failures on auth refresh

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthProvider } from '../hooks/useAuth';
+
+const realFetch = global.fetch;
+
+describe('AuthProvider refresh handling', () => {
+  beforeEach(() => {
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test');
+    (global as any).fetch = jest.fn().mockRejectedValue(new Error('network'));
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('clears auth and shows message when refresh fails', async () => {
+    render(
+      <AuthProvider>
+        <div />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(localStorage.getItem('role')).toBeNull());
+    expect(await screen.findByText('Session expired')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- retry /auth/refresh and clear auth on repeated failure
- notify user when session expires
- add test verifying refresh failure handling

## Testing
- `npm test src/__tests__/useAuthRefresh.test.tsx`
- `npm test` *(fails: 17 failed, 9 passed, 26 total)*


------
https://chatgpt.com/codex/tasks/task_e_68b0b8556e2c832db4dc62101b4f6f7a