### PR TITLE
Allow agencies to reference themselves in client routes

### DIFF
--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -13,12 +13,14 @@ export async function addClientToAgency(
     if (!req.user || (req.user.role !== 'staff' && req.user.role !== 'agency')) {
       return res.status(403).json({ message: 'Forbidden' });
     }
-    const paramId = Number(req.params.id);
+    const requestedId = req.params.id;
+    const paramId =
+      requestedId === 'me' ? Number(req.user?.id) : Number(requestedId);
     const agencyId = req.user.role === 'agency' ? Number(req.user.id) : paramId;
     if (!agencyId || !req.body.clientId) {
       return res.status(400).json({ message: 'Missing fields' });
     }
-    if (req.user.role === 'agency' && agencyId !== paramId) {
+    if (req.user.role === 'agency' && requestedId !== 'me' && agencyId !== paramId) {
       return res.status(403).json({ message: 'Forbidden' });
     }
     await addAgencyClient(agencyId, Number(req.body.clientId));
@@ -37,13 +39,15 @@ export async function removeClientFromAgency(
     if (!req.user || (req.user.role !== 'staff' && req.user.role !== 'agency')) {
       return res.status(403).json({ message: 'Forbidden' });
     }
-    const paramId = Number(req.params.id);
+    const requestedId = req.params.id;
+    const paramId =
+      requestedId === 'me' ? Number(req.user?.id) : Number(requestedId);
     const agencyId = req.user.role === 'agency' ? Number(req.user.id) : paramId;
     const clientId = Number(req.params.clientId);
     if (!agencyId || !clientId) {
       return res.status(400).json({ message: 'Missing fields' });
     }
-    if (req.user.role === 'agency' && agencyId !== paramId) {
+    if (req.user.role === 'agency' && requestedId !== 'me' && agencyId !== paramId) {
       return res.status(403).json({ message: 'Forbidden' });
     }
     await removeAgencyClient(agencyId, clientId);


### PR DESCRIPTION
## Summary
- support `/agencies/me/clients` by using authenticated id when `id` param is `me`
- skip numeric comparison for agency self-references

## Testing
- `CI=true npx jest tests/volunteers.test.ts tests/authorization.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b0ba93944c832d8f0d03005496c9f4