### PR TITLE
feat: add agency clients endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,11 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `DELETE /volunteer-bookings/recurring/:id?from=YYYY-MM-DD` → `{ message: 'Recurring bookings cancelled' }`
 - `PATCH /volunteer-bookings/:id/cancel` → `{ id, role_id, volunteer_id, date, status }`
 
+### Agencies (`src/routes/agencies.ts`)
+- `GET /agencies/:id/clients` → `[ clientId ]`
+- `POST /agencies/:id/clients` `{ clientId }` → `204`
+- `DELETE /agencies/:id/clients/:clientId` → `204`
+
 ### Donors (`src/routes/donors.ts`)
 - `GET /donors?search=name` → `[ { id, name } ]`
 - `POST /donors` `{ name }` → `{ id, name }`

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import {
   addAgencyClient,
   removeAgencyClient,
+  getAgencyClients as fetchAgencyClients,
 } from '../models/agency';
 
 export async function addClientToAgency(
@@ -48,6 +49,30 @@ export async function removeClientFromAgency(
     }
     await removeAgencyClient(agencyId, clientId);
     res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getAgencyClients(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    if (!req.user || (req.user.role !== 'staff' && req.user.role !== 'agency')) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    const paramId = Number(req.params.id);
+    const agencyId = req.user.role === 'agency' ? Number(req.user.id) : paramId;
+    if (!agencyId) {
+      return res.status(400).json({ message: 'Missing fields' });
+    }
+    if (req.user.role === 'agency' && agencyId !== paramId) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    const clients = await fetchAgencyClients(agencyId);
+    res.json(clients);
   } catch (err) {
     next(err);
   }

--- a/MJ_FB_Backend/src/models/agency.ts
+++ b/MJ_FB_Backend/src/models/agency.ts
@@ -13,12 +13,24 @@ export async function getAgencyByEmail(email: string): Promise<Agency | undefine
   return res.rows[0] as Agency | undefined;
 }
 
-export async function getAgencyClients(agencyId: number): Promise<number[]> {
+export interface AgencyClientSummary {
+  client_id: number;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+}
+
+export async function getAgencyClients(
+  agencyId: number,
+): Promise<AgencyClientSummary[]> {
   const res = await pool.query(
-    'SELECT client_id FROM agency_clients WHERE agency_id = $1',
+    `SELECT c.client_id, c.first_name, c.last_name, c.email
+     FROM agency_clients ac
+     INNER JOIN clients c ON c.client_id = ac.client_id
+     WHERE ac.agency_id = $1`,
     [agencyId],
   );
-  return res.rows.map(r => r.client_id as number);
+  return res.rows as AgencyClientSummary[];
 }
 
 export async function isAgencyClient(

--- a/MJ_FB_Backend/src/routes/agencies.ts
+++ b/MJ_FB_Backend/src/routes/agencies.ts
@@ -3,9 +3,17 @@ import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import {
   addClientToAgency,
   removeClientFromAgency,
+  getAgencyClients,
 } from '../controllers/agencyController';
 
 const router = Router();
+
+router.get(
+  '/:id/clients',
+  authMiddleware,
+  authorizeRoles('staff', 'agency'),
+  getAgencyClients,
+);
 
 router.post(
   '/:id/clients',

--- a/MJ_FB_Frontend/src/api/agencies.ts
+++ b/MJ_FB_Frontend/src/api/agencies.ts
@@ -1,7 +1,9 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
 
 export async function getMyAgencyClients() {
-  const res = await apiFetch(`${API_BASE}/agencies/me/clients`);
+  const res = await apiFetch(`${API_BASE}/agencies/me/clients`, {
+    method: 'GET',
+  });
   return handleResponse(res);
 }
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,15 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
    # As the agency itself
    curl -X POST http://localhost:4000/agencies/me/clients \
      -H "Authorization: Bearer <agency-token>" \
-     -H "Content-Type: application/json" \
-     -d '{"clientId":42}'
-   ```
+    -H "Content-Type: application/json" \
+    -d '{"clientId":42}'
+  ```
 
    Remove a client with
    `DELETE /agencies/:id/clients/:clientId` (use `me` for the authenticated agency).
+
+   List clients for an agency with
+   `GET /agencies/:id/clients` (use `me` for the authenticated agency).
 
 ### Password Requirements
 


### PR DESCRIPTION
## Summary
- add GET /agencies/:id/clients route
- support fetching agency client details on backend
- wire frontend API to new endpoint and document usage

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: mediaQueryList.addEventListener is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ba937a10832d9210b786ac5736da