### PR TITLE
fix: use import.meta env for API base

### DIFF
--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 const API_BASE =
-  process.env.VITE_API_BASE ||
+  import.meta.env.VITE_API_BASE ||
   (globalThis as any).VITE_API_BASE ||
   'http://localhost:4000';
 


### PR DESCRIPTION
## Summary
- avoid `process is not defined` by using `import.meta.env` for API base config

## Testing
- `npm test -- --watchAll=false` (MJ_FB_Frontend)

------
https://chatgpt.com/codex/tasks/task_e_68b0bb4dab1c832dbee480ea03e67ed9