### PR TITLE
Add agency client management page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - `api/` wraps server requests.
 - `utils/`, `types.ts`, and theming files manage helpers, typings, and Material UI themes.
 - Administrative pages enable staff to manage volunteer master roles and edit volunteer role slots.
+- Staff can assign clients to agencies from the Harvest Pantry → Agency Management page.
 
 ## Development Guidelines
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -18,6 +18,9 @@ const UserHistory = React.lazy(() =>
 const ClientManagement = React.lazy(() =>
   import('./pages/staff/ClientManagement')
 );
+const AgencyClientManager = React.lazy(() =>
+  import('./pages/staff/AgencyClientManager')
+);
 const BookingUI = React.lazy(() => import('./pages/BookingUI'));
 const PantrySchedule = React.lazy(() =>
   import('./pages/staff/PantrySchedule')
@@ -135,6 +138,7 @@ export default function App() {
       { label: 'Pantry Schedule', to: '/pantry/schedule' },
       { label: 'Pantry Visits', to: '/pantry/visits' },
       { label: 'Client Management', to: '/pantry/client-management' },
+      { label: 'Agency Management', to: '/pantry/agency-management' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
@@ -341,6 +345,12 @@ export default function App() {
                 <Route
                   path="/pantry/client-management"
                   element={<ClientManagement />}
+                />
+              )}
+              {showStaff && (
+                <Route
+                  path="/pantry/agency-management"
+                  element={<AgencyClientManager />}
                 />
               )}
               {isStaff && <Route path="/events" element={<Events />} />}

--- a/MJ_FB_Frontend/src/api/agencies.ts
+++ b/MJ_FB_Frontend/src/api/agencies.ts
@@ -1,8 +1,12 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
 
-export async function getMyAgencyClients() {
-  const res = await apiFetch(`${API_BASE}/agencies/me/clients`);
+export async function getAgencyClients(agencyId: number | 'me') {
+  const res = await apiFetch(`${API_BASE}/agencies/${agencyId}/clients`);
   return handleResponse(res);
+}
+
+export async function getMyAgencyClients() {
+  return getAgencyClients('me');
 }
 
 export async function addAgencyClient(

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+import {
+  Grid,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  TextField,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import Page from '../../components/Page';
+import EntitySearch from '../../components/EntitySearch';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import {
+  addAgencyClient,
+  removeAgencyClient,
+  getAgencyClients,
+} from '../../api/agencies';
+
+interface AgencyClient {
+  id: number;
+  name: string;
+  email?: string;
+}
+
+export default function AgencyClientManager() {
+  const [agencyId, setAgencyId] = useState('');
+  const [clients, setClients] = useState<AgencyClient[]>([]);
+  const [snackbar, setSnackbar] = useState<
+    { message: string; severity: 'success' | 'error' } | null
+  >(null);
+
+  const load = async (id: number) => {
+    try {
+      const data = await getAgencyClients(id);
+      const mapped = Array.isArray(data)
+        ? data.map((c: any) => ({
+            id: c.id ?? c.client_id,
+            name:
+              c.name ??
+              c.client_name ??
+              `${c.first_name ?? ''} ${c.last_name ?? ''}`.trim(),
+            email: c.email,
+          }))
+        : [];
+      setClients(mapped);
+    } catch {
+      setClients([]);
+    }
+  };
+
+  useEffect(() => {
+    const id = Number(agencyId);
+    if (!id) {
+      setClients([]);
+      return;
+    }
+    load(id);
+  }, [agencyId]);
+
+  const handleAdd = async (user: any) => {
+    const id = Number(agencyId);
+    if (!id) return;
+    try {
+      await addAgencyClient(id, user.id);
+      setSnackbar({ message: 'Client added', severity: 'success' });
+      load(id);
+    } catch (err: any) {
+      setSnackbar({
+        message: err.message || 'Failed to add client',
+        severity: 'error',
+      });
+    }
+  };
+
+  const handleRemove = async (id: number) => {
+    const agency = Number(agencyId);
+    if (!agency) return;
+    try {
+      await removeAgencyClient(agency, id);
+      setSnackbar({ message: 'Client removed', severity: 'success' });
+      load(agency);
+    } catch (err: any) {
+      setSnackbar({
+        message: err.message || 'Failed to remove client',
+        severity: 'error',
+      });
+    }
+  };
+
+  return (
+    <Page title="Agency Management">
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <Typography variant="h5" gutterBottom>
+            Clients
+          </Typography>
+          <List dense>
+            {clients.map(c => (
+              <ListItem
+                key={c.id}
+                secondaryAction={
+                  <IconButton edge="end" aria-label="remove" onClick={() => handleRemove(c.id)}>
+                    <DeleteIcon />
+                  </IconButton>
+                }
+              >
+                <ListItemText primary={c.name} secondary={`ID: ${c.id}`} />
+              </ListItem>
+            ))}
+            {clients.length === 0 && <Typography>No clients assigned.</Typography>}
+          </List>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Typography variant="h5" gutterBottom>
+            Add Client
+          </Typography>
+          <TextField
+            label="Agency ID"
+            value={agencyId}
+            onChange={e => setAgencyId(e.target.value)}
+            size="small"
+            fullWidth
+            sx={{ mb: 2 }}
+          />
+          <EntitySearch type="user" onSelect={handleAdd} placeholder="Search clients" />
+        </Grid>
+      </Grid>
+      <FeedbackSnackbar
+        open={!!snackbar}
+        onClose={() => setSnackbar(null)}
+        message={snackbar?.message || ''}
+        severity={snackbar?.severity}
+      />
+    </Page>
+  );
+}
+

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ control weight calculations:
 - Admin navigation includes Pantry Settings and Volunteer Settings pages.
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, and rgb(111,146,113) for visited.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
+- Staff can assign clients to agencies through the Harvest Pantry → Agency Management page.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- add AgencyClientManager page for staff to manage agency-client links
- expose generic getAgencyClients API helper
- wire Agency Management into pantry navigation

## Testing
- `CI=true npx jest --runInBand --forceExit` *(fails: Unable to find an element with the text: Volunteer Needed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ba954934832da63e55747639722b