### PR TITLE
feat: allow staff to create agencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
+- Staff can create agencies via `POST /agencies` and assign clients with `POST /agencies/:id/clients`.
 
 ### Frontend (`MJ_FB_Frontend`)
 - React app built with Vite.

--- a/MJ_FB_Backend/src/models/agency.ts
+++ b/MJ_FB_Backend/src/models/agency.ts
@@ -8,6 +8,21 @@ export interface Agency {
   contact_info: string | null;
 }
 
+export async function createAgency(
+  name: string,
+  email: string,
+  password: string,
+  contactInfo?: string,
+): Promise<Agency> {
+  const res = await pool.query(
+    `INSERT INTO agencies (name, email, password, contact_info)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [name, email, password, contactInfo ?? null],
+  );
+  return res.rows[0] as Agency;
+}
+
 export async function getAgencyByEmail(email: string): Promise<Agency | undefined> {
   const res = await pool.query('SELECT * FROM agencies WHERE email = $1', [email]);
   return res.rows[0] as Agency | undefined;

--- a/MJ_FB_Backend/src/routes/agencies.ts
+++ b/MJ_FB_Backend/src/routes/agencies.ts
@@ -3,9 +3,17 @@ import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import {
   addClientToAgency,
   removeClientFromAgency,
+  createAgency,
 } from '../controllers/agencyController';
 
 const router = Router();
+
+router.post(
+  '/',
+  authMiddleware,
+  authorizeRoles('staff'),
+  createAgency,
+);
 
 router.post(
   '/:id/clients',

--- a/MJ_FB_Backend/tests/agencyCreation.test.ts
+++ b/MJ_FB_Backend/tests/agencyCreation.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import express from 'express';
+import agenciesRoutes from '../src/routes/agencies';
+import pool from '../src/db';
+import bcrypt from 'bcrypt';
+
+let role = 'staff';
+jest.mock('../src/db');
+jest.mock('bcrypt');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.user = { id: '1', role };
+    next();
+  },
+  authorizeRoles: (...allowed: string[]) => (req: any, res: any, next: any) => {
+    if (!req.user || !allowed.includes(req.user.role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/agencies', agenciesRoutes);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /agencies', () => {
+  it('creates agency when staff', async () => {
+    role = 'staff';
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [
+        { id: 1, name: 'A', email: 'a@b.com', password: 'hashed', contact_info: null },
+      ],
+    });
+    const res = await request(app)
+      .post('/agencies')
+      .send({ name: 'A', email: 'a@b.com', password: 'Password1!' });
+    expect(res.status).toBe(201);
+    expect(pool.query).toHaveBeenCalled();
+  });
+
+  it('rejects non-staff', async () => {
+    role = 'agency';
+    const res = await request(app)
+      .post('/agencies')
+      .send({ name: 'A', email: 'a@b.com', password: 'Password1!' });
+    expect(res.status).toBe(403);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -81,6 +81,7 @@ const VolunteerSettings = React.lazy(() =>
 );
 const Events = React.lazy(() => import('./pages/events/Events'));
 const PantryVisits = React.lazy(() => import('./pages/staff/PantryVisits'));
+const AddAgency = React.lazy(() => import('./pages/staff/AddAgency'));
 const AgencyLogin = React.lazy(() => import('./pages/agency/Login'));
 const AgencyClientBookings = React.lazy(() =>
   import('./pages/agency/ClientBookings')
@@ -135,6 +136,7 @@ export default function App() {
       { label: 'Pantry Schedule', to: '/pantry/schedule' },
       { label: 'Pantry Visits', to: '/pantry/visits' },
       { label: 'Client Management', to: '/pantry/client-management' },
+      { label: 'Add Agency', to: '/pantry/add-agency' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
@@ -265,6 +267,9 @@ export default function App() {
               )}
               {showStaff && (
                 <Route path="/pantry/visits" element={<PantryVisits />} />
+              )}
+              {showStaff && (
+                <Route path="/pantry/add-agency" element={<AddAgency />} />
               )}
               {showWarehouse && (
                 <Route path="/warehouse-management" element={<WarehouseDashboard />} />

--- a/MJ_FB_Frontend/src/__tests__/AddAgency.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AddAgency.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { theme } from '../theme';
+import AddAgency from '../pages/staff/AddAgency';
+import * as agenciesApi from '../api/agencies';
+
+jest.mock('../api/agencies');
+
+describe('AddAgency page', () => {
+  it('submits agency data', async () => {
+    (agenciesApi.createAgency as jest.Mock).mockResolvedValue({});
+    render(
+      <ThemeProvider theme={theme}>
+        <AddAgency />
+      </ThemeProvider>
+    );
+    fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'Passw0rd!' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create Agency/i }));
+    await waitFor(() => expect(agenciesApi.createAgency).toHaveBeenCalled());
+  });
+});

--- a/MJ_FB_Frontend/src/api/agencies.ts
+++ b/MJ_FB_Frontend/src/api/agencies.ts
@@ -5,6 +5,22 @@ export async function getMyAgencyClients() {
   return handleResponse(res);
 }
 
+export interface CreateAgencyData {
+  name: string;
+  email: string;
+  password: string;
+  contactInfo?: string;
+}
+
+export async function createAgency(data: CreateAgencyData) {
+  const res = await apiFetch(`${API_BASE}/agencies`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
 export async function addAgencyClient(
   agencyId: number | 'me',
   clientId: number,

--- a/MJ_FB_Frontend/src/pages/staff/AddAgency.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AddAgency.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { createAgency } from '../../api/agencies';
+import Page from '../../components/Page';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { Box, Button, Stack, TextField } from '@mui/material';
+
+export default function AddAgency() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [contactInfo, setContactInfo] = useState('');
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+
+  async function submit() {
+    if (!name || !email || !password) {
+      setError('Name, email and password required');
+      return;
+    }
+    try {
+      await createAgency({
+        name,
+        email,
+        password,
+        contactInfo: contactInfo || undefined,
+      });
+      setSuccess('Agency created');
+      setName('');
+      setEmail('');
+      setPassword('');
+      setContactInfo('');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <Page title="Add Agency">
+      <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
+        <Box maxWidth={400} width="100%" mt={4}>
+          <Stack spacing={2}>
+            <TextField label="Name" value={name} onChange={e => setName(e.target.value)} />
+            <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} />
+            <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+            <TextField
+              label="Contact Info (optional)"
+              value={contactInfo}
+              onChange={e => setContactInfo(e.target.value)}
+            />
+            <Button variant="contained" color="primary" size="small" onClick={submit}>
+              Create Agency
+            </Button>
+          </Stack>
+          <FeedbackSnackbar
+            open={!!error}
+            onClose={() => setError('')}
+            message={error}
+            severity="error"
+          />
+          <FeedbackSnackbar
+            open={!!success}
+            onClose={() => setSuccess('')}
+            message={success}
+            severity="success"
+          />
+        </Box>
+      </Box>
+    </Page>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts).
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).
+- Staff can create agencies via `POST /agencies` or the staff Add Agency page and assign clients to them.
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
 - Staff can manage booking slots and adjust slot capacities through the Admin → Pantry Settings page.
@@ -82,7 +83,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 
 ### Agency setup
 
-1. **Create an agency** – hash a password and insert a row into the
+1. **Create an agency** – staff can create agencies via `POST /agencies` or the Add Agency page. To seed manually, hash a password and insert a row into the
    `agencies` table. For example:
 
    ```bash


### PR DESCRIPTION
## Summary
- allow staff to create agencies via POST /agencies
- add staff UI for creating agencies
- document agency creation in README and AGENTS

## Testing
- `npm test` (backend)
- `npm test` (frontend, failed: ReferenceError: Response is not defined)

------
https://chatgpt.com/codex/tasks/task_e_68b0ba943350832da2e177498a705f3c