### PR TITLE
Use formatted times in Volunteer Settings

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -35,6 +35,7 @@ import {
   toggleVolunteerRole,
   deleteVolunteerRole,
 } from '../../api/volunteers';
+import { formatTime } from '../../utils/time';
 import type { VolunteerRoleWithShifts } from '../../types';
 
 type MasterRole = { id: number; name: string };
@@ -263,7 +264,7 @@ export default function VolunteerSettings() {
                             </Stack>
                           }>
                             <ListItemText
-                              primary={`${shift.start_time} - ${shift.end_time}`}
+                              primary={`${formatTime(shift.start_time)} - ${formatTime(shift.end_time)}`}
                               secondary={`Max volunteers: ${role.max_volunteers}`}
                             />
                           </ListItem>


### PR DESCRIPTION
## Summary
- format shift times using `formatTime` in Volunteer Settings

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c0ec55e0832d861eec0edf3c7349