### PR TITLE
Mark booking visited when recording client visit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
+- Creating a client visit will automatically mark the client's approved booking on that date as visited.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
 

--- a/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
@@ -1,0 +1,129 @@
+import request from 'supertest';
+import express from 'express';
+import clientVisitsRouter from '../src/routes/clientVisits';
+import bookingsRouter from '../src/routes/bookings';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: 99, role: 'staff', access: ['pantry'] };
+    next();
+  },
+  authorizeAccess: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  optionalAuthMiddleware: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/client-visits', clientVisitsRouter);
+app.use('/bookings', bookingsRouter);
+app.use(
+  (
+    err: any,
+    _req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+  ) => {
+    res.status(err.status || 500).json({ message: err.message });
+  },
+);
+
+describe('client visit booking integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates booking to visited and avoids duplicate history record', async () => {
+    (pool.query as jest.Mock)
+      // insert visit
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 7,
+            date: '2024-01-02',
+            clientId: 123,
+            weightWithCart: 10,
+            weightWithoutCart: 8,
+            petItem: 0,
+            anonymous: false,
+          },
+        ],
+        rowCount: 1,
+      })
+      // select client name
+      .mockResolvedValueOnce({
+        rows: [{ first_name: 'Ann', last_name: 'Client' }],
+        rowCount: 1,
+      })
+      // refresh visit count
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      // find existing booking
+      .mockResolvedValueOnce({ rows: [{ id: 55 }], rowCount: 1 })
+      // update booking status
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      // booking history query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 55,
+            status: 'visited',
+            date: '2024-01-02',
+            slot_id: 1,
+            reason: null,
+            start_time: '09:00:00',
+            end_time: '09:30:00',
+            created_at: '2024-01-02',
+            is_staff_booking: false,
+            reschedule_token: null,
+          },
+        ],
+        rowCount: 1,
+      })
+      // visits query should return empty because booking exists
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const visitRes = await request(app)
+      .post('/client-visits')
+      .send({
+        date: '2024-01-02',
+        clientId: 123,
+        weightWithCart: 10,
+        weightWithoutCart: 8,
+        petItem: 0,
+        anonymous: false,
+      });
+    expect(visitRes.status).toBe(201);
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE bookings SET status'),
+      ['visited', 55],
+    );
+
+    const historyRes = await request(app)
+      .get('/bookings/history?userId=1&includeVisits=true');
+
+    expect(historyRes.status).toBe(200);
+    expect(historyRes.body).toHaveLength(1);
+    expect(historyRes.body[0].status).toBe('visited');
+  });
+});
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Walk-in bookings created via `/bookings/preapproved` are saved with status `approved` (the `preapproved` status has been removed).
 - Staff can record visits directly from a booking in the pantry schedule. Selecting **Visited** in the booking dialog captures cart weights and creates the visit record before marking the booking visited.
+- Adding a client visit automatically updates any approved booking for that client on the same date to `visited`.
 - The Manage Booking dialog now displays the client's name, a link to their profile, and their visit count for the current month to assist staff decisions.
 - Client booking history tables can filter bookings by `visited` and `no_show` statuses.
 - Booking requests are automatically approved or rejected; the pending approval workflow has been removed.


### PR DESCRIPTION
## Summary
- auto-update associated approved booking to `visited` after inserting a client visit
- document automatic visit booking update
- add integration test covering booking update and history deduplication

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c381bfb0832dac169c971131e759