### PR TITLE
Global slot capacity configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
+- `PUT /slots/capacity` updates the `max_capacity` for all slots.
 
 ### Frontend (`MJ_FB_Frontend`)
 - React app built with Vite.

--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -3,7 +3,7 @@ import pool from '../db';
 import { Slot } from '../models/slot';
 import logger from '../utils/logger';
 import { formatReginaDate, reginaStartOfDayISO } from '../utils/dateUtils';
-import { slotSchema, slotIdParamSchema } from '../schemas/slotSchemas';
+import { slotSchema, slotIdParamSchema, slotCapacitySchema } from '../schemas/slotSchemas';
 
 const REGINA_TZ = 'America/Regina';
 
@@ -284,6 +284,25 @@ export async function updateSlot(req: Request, res: Response, next: NextFunction
     });
   } catch (error) {
     logger.error('Error updating slot:', error);
+    next(error);
+  }
+}
+
+export async function updateAllSlotCapacity(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const parsed = slotCapacitySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ errors: parsed.error.issues });
+  }
+  const { maxCapacity } = parsed.data;
+  try {
+    await pool.query('UPDATE slots SET max_capacity = $1', [maxCapacity]);
+    res.json({ message: 'Capacity updated' });
+  } catch (error) {
+    logger.error('Error updating slot capacity:', error);
     next(error);
   }
 }

--- a/MJ_FB_Backend/src/routes/slots.ts
+++ b/MJ_FB_Backend/src/routes/slots.ts
@@ -5,6 +5,7 @@ import {
   listSlotsRange,
   createSlot,
   updateSlot,
+  updateAllSlotCapacity,
   deleteSlot,
 } from '../controllers/slotController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
@@ -32,6 +33,12 @@ router.get(
 
 router.post('/', authMiddleware, authorizeRoles('staff'), createSlot);
 router.put('/:id', authMiddleware, authorizeRoles('staff'), updateSlot);
+router.put(
+  '/capacity',
+  authMiddleware,
+  authorizeRoles('staff'),
+  updateAllSlotCapacity,
+);
 router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteSlot);
 
 export default router;

--- a/MJ_FB_Backend/src/schemas/slotSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/slotSchemas.ts
@@ -10,5 +10,10 @@ export const slotIdParamSchema = z.object({
   id: z.coerce.number().int().positive(),
 });
 
+export const slotCapacitySchema = z.object({
+  maxCapacity: z.coerce.number().int().positive(),
+});
+
 export type SlotInput = z.infer<typeof slotSchema>;
 export type SlotIdParams = z.infer<typeof slotIdParamSchema>;
+export type SlotCapacityInput = z.infer<typeof slotCapacitySchema>;

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -17,6 +17,8 @@ interface SlotResponse {
   available: number;
   reason?: string;
   status?: string;
+  max_capacity?: number;
+  maxCapacity?: number;
 }
 
 interface SlotsByDateResponse {
@@ -36,6 +38,7 @@ const mapSlot = (s: SlotResponse): Slot => ({
   startTime: s.startTime ?? s.start_time ?? '',
   endTime: s.endTime ?? s.end_time ?? '',
   available: s.available,
+  maxCapacity: s.maxCapacity ?? s.max_capacity,
   reason: s.reason,
   status: s.status,
 });

--- a/MJ_FB_Frontend/src/api/slots.ts
+++ b/MJ_FB_Frontend/src/api/slots.ts
@@ -31,6 +31,15 @@ export async function updateSlot(
   return handleResponse(res);
 }
 
+export async function updateSlotCapacity(newCapacity: number) {
+  const res = await apiFetch(`${API_BASE}/slots/capacity`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ maxCapacity: newCapacity }),
+  });
+  return handleResponse(res);
+}
+
 export async function deleteSlot(id: number | string) {
   const res = await apiFetch(`${API_BASE}/slots/${id}`, {
     method: 'DELETE',

--- a/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
@@ -11,12 +11,13 @@ import {
 import type { AlertColor } from '@mui/material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import { getAllSlots, updateSlot } from '../../api/slots';
+import { getAllSlots, updateSlotCapacity } from '../../api/slots';
 import type { Slot } from '../../types';
 import { formatTime } from '../../utils/time';
 
 export default function PantrySettings() {
   const [slots, setSlots] = useState<Slot[]>([]);
+  const [capacity, setCapacity] = useState<number>(0);
   const [snackbar, setSnackbar] = useState<
     { message: string; severity: AlertColor } | null
   >(null);
@@ -25,6 +26,7 @@ export default function PantrySettings() {
     try {
       const data = await getAllSlots();
       setSlots(data);
+      if (data.length > 0) setCapacity(data[0].maxCapacity ?? 0);
     } catch {
       setSnackbar({ message: 'Failed to load slots', severity: 'error' });
     }
@@ -34,24 +36,14 @@ export default function PantrySettings() {
     load();
   }, []);
 
-  const handleChange = (id: string, value: string) => {
-    setSlots(prev =>
-      prev.map(s => (s.id === id ? { ...s, maxCapacity: Number(value) } : s)),
-    );
-  };
-
-  const handleSave = async (slot: Slot) => {
+  const handleSave = async () => {
     try {
-      await updateSlot(slot.id, {
-        startTime: slot.startTime,
-        endTime: slot.endTime,
-        maxCapacity: Number(slot.maxCapacity) || 0,
-      });
-      setSnackbar({ message: 'Slot updated', severity: 'success' });
+      await updateSlotCapacity(Number(capacity) || 0);
+      setSnackbar({ message: 'Capacity updated', severity: 'success' });
       load();
     } catch (err: any) {
       setSnackbar({
-        message: err.message || 'Failed to update slot',
+        message: err.message || 'Failed to update capacity',
         severity: 'error',
       });
     }
@@ -60,27 +52,33 @@ export default function PantrySettings() {
   return (
     <Page title="Pantry Settings">
       <Grid container spacing={2} p={2}>
+        <Grid item xs={12}>
+          <Card>
+            <CardHeader title="Max slots per time" />
+            <CardContent>
+              <TextField
+                label="Max slots per time"
+                type="number"
+                size="small"
+                value={capacity}
+                onChange={e => setCapacity(Number(e.target.value))}
+              />
+              <Button
+                size="small"
+                sx={{ ml: 2 }}
+                variant="contained"
+                onClick={handleSave}
+              >
+                Save
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
+
         {slots.map(slot => (
           <Grid item xs={12} md={6} key={slot.id}>
             <Card>
               <CardHeader title={`${formatTime(slot.startTime)} - ${formatTime(slot.endTime)}`} />
-              <CardContent>
-                <TextField
-                  label="Max Capacity"
-                  type="number"
-                  size="small"
-                  value={slot.maxCapacity ?? ''}
-                  onChange={e => handleChange(slot.id, e.target.value)}
-                />
-                <Button
-                  size="small"
-                  sx={{ ml: 2 }}
-                  variant="contained"
-                  onClick={() => handleSave(slot)}
-                >
-                  Save
-                </Button>
-              </CardContent>
             </Card>
           </Grid>
         ))}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
-- Staff can manage booking slots and adjust slot capacities through the Admin → Pantry Settings page.
+- Staff can manage booking slots and adjust a global "Max slots per time" value through the Admin → Pantry Settings page or `PUT /slots/capacity`.
 - Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots.
 - Slot listing endpoint `/slots` returns an empty array and 200 status on holidays.
 


### PR DESCRIPTION
## Summary
- allow staff to update all slot capacities through new `PUT /slots/capacity`
- expose `updateSlotCapacity` in frontend API and simplify Pantry Settings UI
- include maxCapacity in `/slots` responses for schedule and booking logic

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: SyntaxError: Cannot use 'import.meta' outside a module)


------
https://chatgpt.com/codex/tasks/task_e_68b0c3411bb0832d8beaabff7cd6976e