### PR TITLE
feat: add global pantry capacity setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
+ - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes. Use `PUT /slots/max-capacity` to set the pantry-wide booking capacity for all slots.
 
 ### Frontend (`MJ_FB_Frontend`)
 - React app built with Vite.
@@ -34,6 +35,7 @@
 - `utils/`, `types.ts`, and theming files manage helpers, typings, and Material UI themes.
 - Administrative pages enable staff to manage volunteer master roles and edit volunteer role slots.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page.
+- Admin → Pantry Settings allows setting a single pantry-wide booking capacity.
 
 ## Development Guidelines
 

--- a/MJ_FB_Backend/src/routes/slots.ts
+++ b/MJ_FB_Backend/src/routes/slots.ts
@@ -5,6 +5,7 @@ import {
   listSlotsRange,
   createSlot,
   updateSlot,
+  updateAllSlotCapacity,
   deleteSlot,
 } from '../controllers/slotController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
@@ -31,6 +32,12 @@ router.get(
 );
 
 router.post('/', authMiddleware, authorizeRoles('staff'), createSlot);
+router.put(
+  '/max-capacity',
+  authMiddleware,
+  authorizeRoles('staff'),
+  updateAllSlotCapacity,
+);
 router.put('/:id', authMiddleware, authorizeRoles('staff'), updateSlot);
 router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteSlot);
 

--- a/MJ_FB_Backend/src/schemas/slotSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/slotSchemas.ts
@@ -10,5 +10,11 @@ export const slotIdParamSchema = z.object({
   id: z.coerce.number().int().positive(),
 });
 
+export const slotCapacitySchema = z.object({
+  maxCapacity: z.coerce.number().int().nonnegative(),
+});
+
 export type SlotInput = z.infer<typeof slotSchema>;
 export type SlotIdParams = z.infer<typeof slotIdParamSchema>;
+export type SlotCapacityInput = z.infer<typeof slotCapacitySchema>;
+

--- a/MJ_FB_Frontend/src/api/slots.ts
+++ b/MJ_FB_Frontend/src/api/slots.ts
@@ -37,3 +37,12 @@ export async function deleteSlot(id: number | string) {
   });
   return handleResponse(res);
 }
+
+export async function updateAllSlotsCapacity(maxCapacity: number) {
+  const res = await apiFetch(`${API_BASE}/slots/max-capacity`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ maxCapacity }),
+  });
+  return handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
@@ -6,17 +6,14 @@ import {
   CardContent,
   TextField,
   Button,
-  Typography,
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import { getAllSlots, updateSlot } from '../../api/slots';
-import type { Slot } from '../../types';
-import { formatTime } from '../../utils/time';
+import { getAllSlots, updateAllSlotsCapacity } from '../../api/slots';
 
 export default function PantrySettings() {
-  const [slots, setSlots] = useState<Slot[]>([]);
+  const [capacity, setCapacity] = useState<number | ''>('');
   const [snackbar, setSnackbar] = useState<
     { message: string; severity: AlertColor } | null
   >(null);
@@ -24,7 +21,7 @@ export default function PantrySettings() {
   async function load() {
     try {
       const data = await getAllSlots();
-      setSlots(data);
+      setCapacity(data[0]?.maxCapacity ?? '');
     } catch {
       setSnackbar({ message: 'Failed to load slots', severity: 'error' });
     }
@@ -34,24 +31,14 @@ export default function PantrySettings() {
     load();
   }, []);
 
-  const handleChange = (id: string, value: string) => {
-    setSlots(prev =>
-      prev.map(s => (s.id === id ? { ...s, maxCapacity: Number(value) } : s)),
-    );
-  };
-
-  const handleSave = async (slot: Slot) => {
+  const handleSave = async () => {
     try {
-      await updateSlot(slot.id, {
-        startTime: slot.startTime,
-        endTime: slot.endTime,
-        maxCapacity: Number(slot.maxCapacity) || 0,
-      });
-      setSnackbar({ message: 'Slot updated', severity: 'success' });
+      await updateAllSlotsCapacity(Number(capacity) || 0);
+      setSnackbar({ message: 'Pantry capacity updated', severity: 'success' });
       load();
     } catch (err: any) {
       setSnackbar({
-        message: err.message || 'Failed to update slot',
+        message: err.message || 'Failed to update capacity',
         severity: 'error',
       });
     }
@@ -60,35 +47,28 @@ export default function PantrySettings() {
   return (
     <Page title="Pantry Settings">
       <Grid container spacing={2} p={2}>
-        {slots.map(slot => (
-          <Grid item xs={12} md={6} key={slot.id}>
-            <Card>
-              <CardHeader title={`${formatTime(slot.startTime)} - ${formatTime(slot.endTime)}`} />
-              <CardContent>
-                <TextField
-                  label="Max Capacity"
-                  type="number"
-                  size="small"
-                  value={slot.maxCapacity ?? ''}
-                  onChange={e => handleChange(slot.id, e.target.value)}
-                />
-                <Button
-                  size="small"
-                  sx={{ ml: 2 }}
-                  variant="contained"
-                  onClick={() => handleSave(slot)}
-                >
-                  Save
-                </Button>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
-        {slots.length === 0 && (
-          <Grid item xs={12}>
-            <Typography>No slots found.</Typography>
-          </Grid>
-        )}
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardHeader title="Pantry Booking Capacity" />
+            <CardContent>
+              <TextField
+                label="Max Capacity"
+                type="number"
+                size="small"
+                value={capacity}
+                onChange={e => setCapacity(e.target.value === '' ? '' : Number(e.target.value))}
+              />
+              <Button
+                size="small"
+                sx={{ ml: 2 }}
+                variant="contained"
+                onClick={handleSave}
+              >
+                Save
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
       </Grid>
       <FeedbackSnackbar
         open={!!snackbar}
@@ -99,3 +79,4 @@ export default function PantrySettings() {
     </Page>
   );
 }
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
-- Staff can manage booking slots and adjust slot capacities through the Admin → Pantry Settings page.
+- Staff can set a single pantry-wide booking capacity through the Admin → Pantry Settings page.
 - Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots.
 - Slot listing endpoint `/slots` returns an empty array and 200 status on holidays.
 


### PR DESCRIPTION
## Summary
- allow staff to update pantry-wide slot capacity via PUT /slots/max-capacity
- show a single max capacity field on the Admin → Pantry Settings page
- document global pantry booking capacity in project docs

## Testing
- ✅ `npm test` (backend)
- ⚠️ `npm test` (frontend) *(SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c4fa42c0832d8a4af5a222cf3787