### PR TITLE
feat: add time picker for volunteer role slots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - `api/` wraps server requests.
 - `utils/`, `types.ts`, and theming files manage helpers, typings, and Material UI themes.
 - Administrative pages enable staff to manage volunteer master roles and edit volunteer role slots.
+- Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page.
 
 ## Development Guidelines

--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -108,13 +108,21 @@ export default function VolunteerSettings() {
     }
   }
 
+  function toTimeInput(t: string) {
+    return t ? t.substring(0, 5) : '';
+  }
+
+  function toTimeValue(t: string) {
+    return t.length === 5 ? `${t}:00` : t;
+  }
+
   function openRoleDialog(init: Partial<typeof roleDialog>) {
     setRoleDialog({
       open: true,
       slotId: init.slotId,
       roleName: init.roleName || '',
-      startTime: init.startTime || '',
-      endTime: init.endTime || '',
+      startTime: init.startTime ? toTimeInput(init.startTime) : '',
+      endTime: init.endTime ? toTimeInput(init.endTime) : '',
       maxVolunteers: init.maxVolunteers?.toString() || '1',
       categoryId: init.categoryId,
       isWednesdaySlot: init.isWednesdaySlot || false,
@@ -127,12 +135,14 @@ export default function VolunteerSettings() {
         handleSnack('All fields are required', 'error');
         return;
       }
+      const startTime = toTimeValue(roleDialog.startTime);
+      const endTime = toTimeValue(roleDialog.endTime);
       const maxVolunteers = Number(roleDialog.maxVolunteers);
       if (roleDialog.slotId) {
         await updateVolunteerRole(roleDialog.slotId, {
           name: roleDialog.roleName,
-          startTime: roleDialog.startTime,
-          endTime: roleDialog.endTime,
+          startTime,
+          endTime,
           maxVolunteers,
           categoryId: roleDialog.categoryId,
           isWednesdaySlot: roleDialog.isWednesdaySlot,
@@ -141,8 +151,8 @@ export default function VolunteerSettings() {
       } else {
         await createVolunteerRole(
           roleDialog.roleName,
-          roleDialog.startTime,
-          roleDialog.endTime,
+          startTime,
+          endTime,
           maxVolunteers,
           roleDialog.categoryId,
           roleDialog.isWednesdaySlot,
@@ -332,18 +342,20 @@ export default function VolunteerSettings() {
           <TextField
             margin="dense"
             label="Start Time"
+            type="time"
             fullWidth
+            InputLabelProps={{ shrink: true }}
             value={roleDialog.startTime}
             onChange={e => setRoleDialog({ ...roleDialog, startTime: e.target.value })}
-            placeholder="09:00:00"
           />
           <TextField
             margin="dense"
             label="End Time"
+            type="time"
             fullWidth
+            InputLabelProps={{ shrink: true }}
             value={roleDialog.endTime}
             onChange={e => setRoleDialog({ ...roleDialog, endTime: e.target.value })}
-            placeholder="12:00:00"
           />
           <TextField
             margin="dense"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
 - Staff can manage booking slots and adjust a global "Max slots per time" value through the Admin → Pantry Settings page or `PUT /slots/capacity`.
 - Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots.
+- Volunteer role start and end times are selected via a native time picker and stored as `HH:MM:SS`.
 - Slot listing endpoint `/slots` returns an empty array and 200 status on holidays.
 
 ## Clone and initialize submodules


### PR DESCRIPTION
## Summary
- use native time picker for volunteer role start/end times
- convert time values to HH:MM:SS when saving
- document time picker behavior

## Testing
- `npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c594270c832da611554e94164a4e