### PR TITLE
feat: validate volunteer settings fields inline

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSettings.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerSettings from '../pages/admin/VolunteerSettings';
+import {
+  getVolunteerMasterRoles,
+  getVolunteerRoles,
+  createVolunteerRole,
+} from '../api/volunteers';
+
+jest.mock('../api/volunteers', () => ({
+  getVolunteerMasterRoles: jest.fn(),
+  getVolunteerRoles: jest.fn(),
+  createVolunteerRole: jest.fn(),
+  createVolunteerMasterRole: jest.fn(),
+  updateVolunteerMasterRole: jest.fn(),
+  deleteVolunteerMasterRole: jest.fn(),
+  updateVolunteerRole: jest.fn(),
+  toggleVolunteerRole: jest.fn(),
+  deleteVolunteerRole: jest.fn(),
+}));
+
+describe('VolunteerSettings', () => {
+  it('shows inline errors for required fields', async () => {
+    (getVolunteerMasterRoles as jest.Mock).mockResolvedValue([{ id: 1, name: 'Pantry' }]);
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
+    const queryClient = new QueryClient();
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <VolunteerSettings />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    const addSubRole = await screen.findByRole('button', { name: /add sub-role/i });
+    fireEvent.click(addSubRole);
+    fireEvent.change(screen.getByLabelText(/max volunteers/i), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    expect(createVolunteerRole).not.toHaveBeenCalled();
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    expect(screen.getByText('Start time is required')).toBeInTheDocument();
+    expect(screen.getByText('End time is required')).toBeInTheDocument();
+    expect(screen.getByText('Max volunteers is required')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -56,6 +56,12 @@ export default function VolunteerSettings() {
     categoryId?: number;
     isWednesdaySlot: boolean;
   }>({ open: false, roleName: '', startTime: '', endTime: '', maxVolunteers: '1', isWednesdaySlot: false });
+  const [roleErrors, setRoleErrors] = useState<{
+    roleName?: string;
+    startTime?: string;
+    endTime?: string;
+    maxVolunteers?: string;
+  }>({});
 
   useEffect(() => {
     loadData();
@@ -119,12 +125,18 @@ export default function VolunteerSettings() {
       categoryId: init.categoryId,
       isWednesdaySlot: init.isWednesdaySlot || false,
     });
+    setRoleErrors({});
   }
 
   async function saveRole() {
     try {
-      if (!roleDialog.roleName || !roleDialog.startTime || !roleDialog.endTime || !roleDialog.categoryId) {
-        handleSnack('All fields are required', 'error');
+      const errors: typeof roleErrors = {};
+      if (!roleDialog.roleName.trim()) errors.roleName = 'Name is required';
+      if (!roleDialog.startTime.trim()) errors.startTime = 'Start time is required';
+      if (!roleDialog.endTime.trim()) errors.endTime = 'End time is required';
+      if (!roleDialog.maxVolunteers.trim()) errors.maxVolunteers = 'Max volunteers is required';
+      if (Object.keys(errors).length > 0) {
+        setRoleErrors(errors);
         return;
       }
       const maxVolunteers = Number(roleDialog.maxVolunteers);
@@ -151,6 +163,7 @@ export default function VolunteerSettings() {
         handleSnack('Role created');
       }
       setRoleDialog({ open: false, roleName: '', startTime: '', endTime: '', maxVolunteers: '1', isWednesdaySlot: false });
+      setRoleErrors({});
       loadData();
     } catch (e) {
       handleSnack('Failed to save role', 'error');
@@ -327,23 +340,38 @@ export default function VolunteerSettings() {
             label="Name"
             fullWidth
             value={roleDialog.roleName}
-            onChange={e => setRoleDialog({ ...roleDialog, roleName: e.target.value })}
+            onChange={e => {
+              setRoleDialog({ ...roleDialog, roleName: e.target.value });
+              if (roleErrors.roleName) setRoleErrors({ ...roleErrors, roleName: undefined });
+            }}
+            error={!!roleErrors.roleName}
+            helperText={roleErrors.roleName}
           />
           <TextField
             margin="dense"
             label="Start Time"
             fullWidth
             value={roleDialog.startTime}
-            onChange={e => setRoleDialog({ ...roleDialog, startTime: e.target.value })}
+            onChange={e => {
+              setRoleDialog({ ...roleDialog, startTime: e.target.value });
+              if (roleErrors.startTime) setRoleErrors({ ...roleErrors, startTime: undefined });
+            }}
             placeholder="09:00:00"
+            error={!!roleErrors.startTime}
+            helperText={roleErrors.startTime}
           />
           <TextField
             margin="dense"
             label="End Time"
             fullWidth
             value={roleDialog.endTime}
-            onChange={e => setRoleDialog({ ...roleDialog, endTime: e.target.value })}
+            onChange={e => {
+              setRoleDialog({ ...roleDialog, endTime: e.target.value });
+              if (roleErrors.endTime) setRoleErrors({ ...roleErrors, endTime: undefined });
+            }}
             placeholder="12:00:00"
+            error={!!roleErrors.endTime}
+            helperText={roleErrors.endTime}
           />
           <TextField
             margin="dense"
@@ -351,7 +379,12 @@ export default function VolunteerSettings() {
             fullWidth
             type="number"
             value={roleDialog.maxVolunteers}
-            onChange={e => setRoleDialog({ ...roleDialog, maxVolunteers: e.target.value })}
+            onChange={e => {
+              setRoleDialog({ ...roleDialog, maxVolunteers: e.target.value });
+              if (roleErrors.maxVolunteers) setRoleErrors({ ...roleErrors, maxVolunteers: undefined });
+            }}
+            error={!!roleErrors.maxVolunteers}
+            helperText={roleErrors.maxVolunteers}
           />
           <TextField
             margin="dense"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page.
+- Volunteer Settings forms validate required fields inline and only show snackbar messages for API errors.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Walk-in bookings created via `/bookings/preapproved` are saved with status `approved` (the `preapproved` status has been removed).


### PR DESCRIPTION
## Summary
- add inline TextField validation to volunteer role dialog
- document volunteer settings inline validation behavior
- cover volunteer settings form validation with tests

## Testing
- `npm test src/__tests__/VolunteerSettings.test.tsx`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c5e5d970832dad4955fc65bbc3f0