### PR TITLE
Automatically set volunteer role category

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - `api/` wraps server requests.
 - `utils/`, `types.ts`, and theming files manage helpers, typings, and Material UI themes.
 - Administrative pages enable staff to manage volunteer master roles and edit volunteer role slots.
+- Volunteer role dialogs automatically populate Category IDs based on the selected master role; the Category ID field has been removed.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page.
 
 ## Development Guidelines

--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -40,22 +40,31 @@ import type { VolunteerRoleWithShifts } from '../../types';
 
 type MasterRole = { id: number; name: string };
 
+interface RoleDialogState {
+  open: boolean;
+  slotId?: number;
+  roleName: string;
+  startTime: string;
+  endTime: string;
+  maxVolunteers: string;
+  categoryId?: number;
+  isWednesdaySlot: boolean;
+}
+
 export default function VolunteerSettings() {
   const [masterRoles, setMasterRoles] = useState<MasterRole[]>([]);
   const [roles, setRoles] = useState<VolunteerRoleWithShifts[]>([]);
   const [snack, setSnack] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({ open: false, message: '', severity: 'success' });
 
   const [masterDialog, setMasterDialog] = useState<{ open: boolean; id?: number; name: string }>({ open: false, name: '' });
-  const [roleDialog, setRoleDialog] = useState<{
-    open: boolean;
-    slotId?: number;
-    roleName: string;
-    startTime: string;
-    endTime: string;
-    maxVolunteers: string;
-    categoryId?: number;
-    isWednesdaySlot: boolean;
-  }>({ open: false, roleName: '', startTime: '', endTime: '', maxVolunteers: '1', isWednesdaySlot: false });
+  const [roleDialog, setRoleDialog] = useState<RoleDialogState>({
+    open: false,
+    roleName: '',
+    startTime: '',
+    endTime: '',
+    maxVolunteers: '1',
+    isWednesdaySlot: false,
+  });
 
   useEffect(() => {
     loadData();
@@ -108,22 +117,22 @@ export default function VolunteerSettings() {
     }
   }
 
-  function openRoleDialog(init: Partial<typeof roleDialog>) {
+  function openRoleDialog(categoryId: number, init?: Partial<RoleDialogState>) {
     setRoleDialog({
       open: true,
-      slotId: init.slotId,
-      roleName: init.roleName || '',
-      startTime: init.startTime || '',
-      endTime: init.endTime || '',
-      maxVolunteers: init.maxVolunteers?.toString() || '1',
-      categoryId: init.categoryId,
-      isWednesdaySlot: init.isWednesdaySlot || false,
+      slotId: init?.slotId,
+      roleName: init?.roleName || '',
+      startTime: init?.startTime || '',
+      endTime: init?.endTime || '',
+      maxVolunteers: init?.maxVolunteers || '1',
+      categoryId,
+      isWednesdaySlot: init?.isWednesdaySlot || false,
     });
   }
 
   async function saveRole() {
     try {
-      if (!roleDialog.roleName || !roleDialog.startTime || !roleDialog.endTime || !roleDialog.categoryId) {
+      if (!roleDialog.roleName || !roleDialog.startTime || !roleDialog.endTime) {
         handleSnack('All fields are required', 'error');
         return;
       }
@@ -134,7 +143,7 @@ export default function VolunteerSettings() {
           startTime: roleDialog.startTime,
           endTime: roleDialog.endTime,
           maxVolunteers,
-          categoryId: roleDialog.categoryId,
+          categoryId: roleDialog.categoryId!,
           isWednesdaySlot: roleDialog.isWednesdaySlot,
         });
         handleSnack('Role updated');
@@ -144,7 +153,7 @@ export default function VolunteerSettings() {
           roleDialog.startTime,
           roleDialog.endTime,
           maxVolunteers,
-          roleDialog.categoryId,
+          roleDialog.categoryId!,
           roleDialog.isWednesdaySlot,
           true,
         );
@@ -222,7 +231,7 @@ export default function VolunteerSettings() {
                             size="small"
                             variant="outlined"
                             startIcon={<AddIcon />}
-                            onClick={() => openRoleDialog({ roleName: role.name, categoryId: master.id })}
+                            onClick={() => openRoleDialog(master.id, { roleName: role.name })}
                           >
                             Add Shift
                           </Button>
@@ -245,13 +254,12 @@ export default function VolunteerSettings() {
                               <IconButton
                                 aria-label="edit"
                                 onClick={() =>
-                                  openRoleDialog({
+                                  openRoleDialog(master.id, {
                                     slotId: shift.id,
                                     roleName: role.name,
                                     startTime: shift.start_time,
                                     endTime: shift.end_time,
                                     maxVolunteers: role.max_volunteers.toString(),
-                                    categoryId: master.id,
                                     isWednesdaySlot: shift.is_wednesday_slot,
                                   })
                                 }
@@ -276,7 +284,7 @@ export default function VolunteerSettings() {
                     size="small"
                     variant="contained"
                     startIcon={<AddIcon />}
-                    onClick={() => openRoleDialog({ categoryId: master.id })}
+                    onClick={() => openRoleDialog(master.id)}
                   >
                     Add Sub-role
                   </Button>
@@ -352,14 +360,6 @@ export default function VolunteerSettings() {
             type="number"
             value={roleDialog.maxVolunteers}
             onChange={e => setRoleDialog({ ...roleDialog, maxVolunteers: e.target.value })}
-          />
-          <TextField
-            margin="dense"
-            label="Category ID"
-            fullWidth
-            type="number"
-            value={roleDialog.categoryId ?? ''}
-            onChange={e => setRoleDialog({ ...roleDialog, categoryId: Number(e.target.value) })}
           />
         </DialogContent>
         <DialogActions>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page.
+- Category IDs for volunteer roles are assigned automatically based on the selected master role; the dialog no longer prompts for manual entry.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Walk-in bookings created via `/bookings/preapproved` are saved with status `approved` (the `preapproved` status has been removed).


### PR DESCRIPTION
## Summary
- Automatically populate role `categoryId` when opening the Volunteer Settings dialog
- Remove manual `Category ID` input and simplify role save validation
- Document automatic category assignment in README and AGENTS guidelines

## Testing
- `npm test` (fails: Jest encountered an unexpected token and other configuration issues)


------
https://chatgpt.com/codex/tasks/task_e_68b0c588de70832dbfed89fb7bb52433