### PR TITLE
Allow referencing existing volunteer roles when adding shifts

### DIFF
--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -162,26 +162,32 @@ export async function deleteVolunteerMasterRole(id: number) {
 }
 
 export async function createVolunteerRole(
-  name: string,
+  roleId: number | undefined,
+  name: string | undefined,
+  categoryId: number | undefined,
   startTime: string,
   endTime: string,
   maxVolunteers: number,
-  categoryId: number,
   isWednesdaySlot?: boolean,
   isActive?: boolean,
 ) {
+  const body: Record<string, unknown> = {
+    startTime,
+    endTime,
+    maxVolunteers,
+    isWednesdaySlot,
+    isActive,
+  };
+  if (roleId) {
+    body.roleId = roleId;
+  } else {
+    body.name = name;
+    body.categoryId = categoryId;
+  }
   const res = await apiFetch(`${API_BASE}/volunteer-roles`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      name,
-      startTime,
-      endTime,
-      maxVolunteers,
-      categoryId,
-      isWednesdaySlot,
-      isActive,
-    }),
+    body: JSON.stringify(body),
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -49,6 +49,7 @@ export default function VolunteerSettings() {
   const [roleDialog, setRoleDialog] = useState<{
     open: boolean;
     slotId?: number;
+    roleId?: number;
     roleName: string;
     startTime: string;
     endTime: string;
@@ -112,6 +113,7 @@ export default function VolunteerSettings() {
     setRoleDialog({
       open: true,
       slotId: init.slotId,
+      roleId: init.roleId,
       roleName: init.roleName || '',
       startTime: init.startTime || '',
       endTime: init.endTime || '',
@@ -123,7 +125,11 @@ export default function VolunteerSettings() {
 
   async function saveRole() {
     try {
-      if (!roleDialog.roleName || !roleDialog.startTime || !roleDialog.endTime || !roleDialog.categoryId) {
+      if (
+        !roleDialog.startTime ||
+        !roleDialog.endTime ||
+        (!roleDialog.roleId && (!roleDialog.roleName || !roleDialog.categoryId))
+      ) {
         handleSnack('All fields are required', 'error');
         return;
       }
@@ -139,15 +145,29 @@ export default function VolunteerSettings() {
         });
         handleSnack('Role updated');
       } else {
-        await createVolunteerRole(
-          roleDialog.roleName,
-          roleDialog.startTime,
-          roleDialog.endTime,
-          maxVolunteers,
-          roleDialog.categoryId,
-          roleDialog.isWednesdaySlot,
-          true,
-        );
+        if (roleDialog.roleId) {
+          await createVolunteerRole(
+            roleDialog.roleId,
+            undefined,
+            undefined,
+            roleDialog.startTime,
+            roleDialog.endTime,
+            maxVolunteers,
+            roleDialog.isWednesdaySlot,
+            true,
+          );
+        } else {
+          await createVolunteerRole(
+            undefined,
+            roleDialog.roleName,
+            roleDialog.categoryId,
+            roleDialog.startTime,
+            roleDialog.endTime,
+            maxVolunteers,
+            roleDialog.isWednesdaySlot,
+            true,
+          );
+        }
         handleSnack('Role created');
       }
       setRoleDialog({ open: false, roleName: '', startTime: '', endTime: '', maxVolunteers: '1', isWednesdaySlot: false });
@@ -222,7 +242,13 @@ export default function VolunteerSettings() {
                             size="small"
                             variant="outlined"
                             startIcon={<AddIcon />}
-                            onClick={() => openRoleDialog({ roleName: role.name, categoryId: master.id })}
+                            onClick={() =>
+                              openRoleDialog({
+                                roleId: role.id,
+                                roleName: role.name,
+                                categoryId: master.id,
+                              })
+                            }
                           >
                             Add Shift
                           </Button>


### PR DESCRIPTION
## Summary
- Support specifying `roleId` when creating volunteer roles on the backend and frontend API wrapper
- Update Volunteer Settings UI to add shifts to existing roles via `roleId`
- Continue to allow new roles with name and category when `roleId` is absent

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Jest cannot parse files using `import.meta` syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c5b4addc832da89c461204337a66