### PR TITLE
feat: allow adding volunteer shifts by role id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 
 ### Volunteer Roles
 - `GET /volunteer-roles/mine?date=YYYY-MM-DD` → `[ { id, role_id, name, start_time, end_time, max_volunteers, category_id, category_name, is_wednesday_slot, booked, available, status, date } ]`
-- `POST /volunteer-roles` → `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active, category_name }`
+- `POST /volunteer-roles` accepts either `{ name, startTime, endTime, maxVolunteers, categoryId, isWednesdaySlot?, isActive? }` to create a new sub-role or `{ roleId, startTime, endTime, maxVolunteers, isWednesdaySlot?, isActive? }` to add a shift and returns `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active, category_name }`
 - `GET /volunteer-roles` → `[ { id, role_id, category_id, name, max_volunteers, category_name, shifts } ]`
 - `PUT /volunteer-roles/:id` → `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active, category_name }`
 - `PATCH /volunteer-roles/:id` → `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active }`

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -161,20 +161,31 @@ export async function deleteVolunteerMasterRole(id: number) {
   return handleResponse(res);
 }
 
-export async function createVolunteerRole(
-  name: string,
-  startTime: string,
-  endTime: string,
-  maxVolunteers: number,
-  categoryId: number,
-  isWednesdaySlot?: boolean,
-  isActive?: boolean,
-) {
+export async function createVolunteerRole({
+  name,
+  roleId,
+  startTime,
+  endTime,
+  maxVolunteers,
+  categoryId,
+  isWednesdaySlot,
+  isActive,
+}: {
+  name?: string;
+  roleId?: number;
+  startTime: string;
+  endTime: string;
+  maxVolunteers: number;
+  categoryId?: number;
+  isWednesdaySlot?: boolean;
+  isActive?: boolean;
+}) {
   const res = await apiFetch(`${API_BASE}/volunteer-roles`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       name,
+      roleId,
       startTime,
       endTime,
       maxVolunteers,

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page.
+- Shift creation supports supplying an existing `roleId` to add a shift to a sub-role without providing its name and category.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Walk-in bookings created via `/bookings/preapproved` are saved with status `approved` (the `preapproved` status has been removed).


### PR DESCRIPTION
## Summary
- support optional `roleId` when creating volunteer shifts and include `categoryId` in role lookup
- expose shift creation via `roleId` in frontend API and settings UI
- document updated volunteer role creation options

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Jest cannot parse import.meta and several suites fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c5adcb3c832dae54be2fdc1ef9ae