### PR TITLE
refactor: simplify volunteer role id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,6 @@ Volunteer management coordinates role-based staffing for the food bank.
 [
   {
     "id": <role_id>,
-    "role_id": <role_id>,
     "category_id": <category_id>,
     "name": "<role name>",
     "max_volunteers": 3,
@@ -340,6 +339,8 @@ Volunteer management coordinates role-based staffing for the food bank.
   ...
 ]
 ```
+
+`id` represents the role ID; each shift object uses its own `id` for the slot identifier.
 
 `GET /volunteer-roles/mine?date=YYYY-MM-DD` returns each slot the logged-in volunteer is trained for:
 

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -95,7 +95,7 @@ export async function listVolunteerRoles(
 ) {
   try {
     const result = await pool.query(
-        `SELECT vr.id AS role_id, vr.category_id, vr.name,
+        `SELECT vr.id, vr.category_id, vr.name,
                 MAX(vs.max_volunteers) AS max_volunteers,
                 vmr.name AS category_name,
                 json_agg(
@@ -117,8 +117,7 @@ export async function listVolunteerRoles(
     );
     res.json(
       result.rows.map(row => ({
-        id: row.role_id,
-        role_id: row.role_id,
+        id: row.id,
         category_id: row.category_id,
         name: row.name,
         max_volunteers: row.max_volunteers,

--- a/MJ_FB_Backend/tests/volunteerRolesActive.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesActive.test.ts
@@ -44,7 +44,7 @@ describe('Volunteer roles activation', () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({
       rows: [
         {
-          role_id: 1,
+          id: 1,
           category_id: 1,
           name: 'Role',
           max_volunteers: 1,
@@ -66,7 +66,6 @@ describe('Volunteer roles activation', () => {
     expect(res.body).toEqual([
       {
         id: 1,
-        role_id: 1,
         category_id: 1,
         name: 'Role',
         max_volunteers: 1,

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -141,7 +141,6 @@ describe('VolunteerManagement role updates', () => {
     (getVolunteerRoles as jest.Mock).mockResolvedValue([
       {
         id: 5,
-        role_id: 5,
         category_id: 1,
         name: 'Greeter',
         max_volunteers: 2,

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -91,7 +91,6 @@ export interface VolunteerRoleShift {
 
 export interface VolunteerRoleWithShifts {
   id: number;
-  role_id: number;
   category_id: number;
   name: string;
   max_volunteers: number;

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
 - Staff can manage booking slots and adjust a global "Max slots per time" value through the Admin → Pantry Settings page or `PUT /slots/capacity`.
 - Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots.
+- `/volunteer-roles` now returns each role with `id` representing the role ID (the `role_id` field has been removed).
 - Slot listing endpoint `/slots` returns an empty array and 200 status on holidays.
 
 ## Clone and initialize submodules


### PR DESCRIPTION
## Summary
- drop redundant `role_id` from volunteer role listings so `id` is the role identifier
- propagate role id change through frontend types and tests
- update Slot API docs to describe new shape

## Testing
- `npx jest --runInBand --watchAll=false` *(frontend: 19 failed, 7 passed)*
- `CI=true npm test` *(backend: 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c5eb2790832d9ec494d3f00289c1