### PR TITLE
Expand newly created master role accordion

### DIFF
--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -4,3 +4,4 @@ import { TextEncoder, TextDecoder } from 'util';
 // Polyfill TextEncoder/Decoder for testing environment
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder as any;
+(Element.prototype as any).scrollIntoView = jest.fn();

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
@@ -57,12 +57,17 @@ describe('VolunteerSettings page', () => {
     const subButtons = screen.getAllByText('Add Sub-role');
     expect(subButtons).toHaveLength(1);
 
-    const buttons = screen.getAllByRole('button');
-    expect(buttons[buttons.length - 1]).toHaveTextContent('Add Master Role');
+    expect(screen.getByRole('button', { name: 'Add Master Role' })).toBeInTheDocument();
   });
 
   it('handles master role dialog flow', async () => {
     (createVolunteerMasterRole as jest.Mock).mockResolvedValue({ id: 2, name: 'Drivers' });
+    (getVolunteerMasterRoles as jest.Mock)
+      .mockResolvedValueOnce([{ id: 1, name: 'Food Prep' }])
+      .mockResolvedValueOnce([
+        { id: 1, name: 'Food Prep' },
+        { id: 2, name: 'Drivers' },
+      ]);
 
     render(
       <MemoryRouter>
@@ -79,6 +84,9 @@ describe('VolunteerSettings page', () => {
 
     await waitFor(() => expect(createVolunteerMasterRole).toHaveBeenCalledWith('Drivers'));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+    const summary = await screen.findByRole('button', { name: 'Drivers' });
+    expect(summary).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('handles sub-role dialog flow', async () => {


### PR DESCRIPTION
## Summary
- Open newly created volunteer master role accordion and scroll it into view
- Polyfill scrollIntoView for tests and update unit tests accordingly

## Testing
- `cd MJ_FB_Frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c8d53aa8832d9adb07ed0b1952bc