### PR TITLE
Allow volunteer shift creation with explicit roleId

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -41,8 +41,8 @@ export async function addVolunteerRole(
     let resolvedRoleId: number = roleId as number;
     if (typeof resolvedRoleId !== 'number') {
       const existing = await pool.query(
-        'SELECT id, category_id FROM volunteer_roles WHERE name=$1 LIMIT 1',
-        [name]
+        'SELECT id FROM volunteer_roles WHERE name=$1 AND category_id=$2 LIMIT 1',
+        [name, categoryId]
       );
       if ((existing.rowCount ?? 0) > 0) {
         resolvedRoleId = existing.rows[0].id;

--- a/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
@@ -83,5 +83,10 @@ describe('addVolunteerRole validation', () => {
     expect(res.status).toBe(201);
     expect(res.body.role_id).toBe(10);
     expect(res.body.name).toBe('New');
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      'SELECT id FROM volunteer_roles WHERE name=$1 AND category_id=$2 LIMIT 1',
+      ['New', 3]
+    );
   });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -161,19 +161,30 @@ export async function deleteVolunteerMasterRole(id: number) {
   return handleResponse(res);
 }
 
-export async function createVolunteerRole(
-  name: string,
-  startTime: string,
-  endTime: string,
-  maxVolunteers: number,
-  categoryId: number,
-  isWednesdaySlot?: boolean,
-  isActive?: boolean,
-) {
+export async function createVolunteerRole({
+  roleId,
+  name,
+  startTime,
+  endTime,
+  maxVolunteers,
+  categoryId,
+  isWednesdaySlot,
+  isActive,
+}: {
+  roleId?: number;
+  name?: string;
+  startTime: string;
+  endTime: string;
+  maxVolunteers: number;
+  categoryId?: number;
+  isWednesdaySlot?: boolean;
+  isActive?: boolean;
+}) {
   const res = await apiFetch(`${API_BASE}/volunteer-roles`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
+      roleId,
       name,
       startTime,
       endTime,

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
@@ -56,9 +56,7 @@ describe('VolunteerSettings page', () => {
 
     const subButtons = screen.getAllByText('Add Sub-role');
     expect(subButtons).toHaveLength(1);
-
-    const buttons = screen.getAllByRole('button');
-    expect(buttons[buttons.length - 1]).toHaveTextContent('Add Master Role');
+    expect(screen.getByText('Add Master Role')).toBeInTheDocument();
   });
 
   it('handles master role dialog flow', async () => {
@@ -107,15 +105,46 @@ describe('VolunteerSettings page', () => {
     fireEvent.click(within(dialog).getByText('Save'));
 
     await waitFor(() =>
-      expect(createVolunteerRole).toHaveBeenCalledWith(
-        'Sorter',
-        '09:00:00',
-        '12:00:00',
-        2,
-        1,
-        false,
-        true
-      )
+      expect(createVolunteerRole).toHaveBeenCalledWith({
+        name: 'Sorter',
+        startTime: '09:00:00',
+        endTime: '12:00:00',
+        maxVolunteers: 2,
+        categoryId: 1,
+        isWednesdaySlot: false,
+        isActive: true,
+      })
+    );
+  });
+
+  it('handles shift dialog flow', async () => {
+    (createVolunteerRole as jest.Mock).mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <VolunteerSettings />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByText('Add Shift'));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText('Start Time'), {
+      target: { value: '09:00:00' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('End Time'), {
+      target: { value: '12:00:00' },
+    });
+    fireEvent.click(within(dialog).getByText('Save'));
+
+    await waitFor(() =>
+      expect(createVolunteerRole).toHaveBeenCalledWith({
+        roleId: 1,
+        startTime: '09:00:00',
+        endTime: '12:00:00',
+        maxVolunteers: 1,
+        isWednesdaySlot: false,
+        isActive: true,
+      })
     );
   });
 });

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots.
 - `/volunteer-roles` now returns each role with `id` representing the role ID (the `role_id` field has been removed).
 - Creating volunteer role slots (`POST /volunteer-roles`) accepts either an existing `roleId` or a new `name` with `categoryId`.
+- Role name lookups during slot creation are scoped by `categoryId`, allowing the same sub-role name under different master roles.
 - Volunteer role start and end times are selected via a native time picker and stored as `HH:MM:SS`.
 - Slot listing endpoint `/slots` returns an empty array and 200 status on holidays.
 


### PR DESCRIPTION
## Summary
- ensure volunteer role lookup includes category id to avoid name conflicts
- allow shift creation with explicit roleId
- support sending roleId from Volunteer Settings UI

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b0c89916e4832da375db565d637e6a