### PR TITLE
feat: append master role state

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -103,7 +103,13 @@ export default function VolunteerSettings() {
         const created = await createVolunteerMasterRole(masterDialog.name);
         handleSnack('Master role created');
         setMasterDialog({ open: false, name: '' });
-        await loadData(created.id);
+        setMasterRoles(prev => [...prev, created]);
+        setExpanded(created.id);
+        setTimeout(() => {
+          document.getElementById(`master-role-${created.id}`)?.scrollIntoView({
+            behavior: 'smooth',
+          });
+        }, 100);
       }
     } catch (e) {
       handleSnack('Failed to save master role', 'error');

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
@@ -18,6 +18,7 @@ const {
 
 describe('VolunteerSettings page', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     (getVolunteerMasterRoles as jest.Mock).mockResolvedValue([
       { id: 1, name: 'Food Prep' },
     ]);
@@ -62,12 +63,6 @@ describe('VolunteerSettings page', () => {
 
   it('handles master role dialog flow', async () => {
     (createVolunteerMasterRole as jest.Mock).mockResolvedValue({ id: 2, name: 'Drivers' });
-    (getVolunteerMasterRoles as jest.Mock)
-      .mockResolvedValueOnce([{ id: 1, name: 'Food Prep' }])
-      .mockResolvedValueOnce([
-        { id: 1, name: 'Food Prep' },
-        { id: 2, name: 'Drivers' },
-      ]);
 
     render(
       <MemoryRouter>
@@ -84,6 +79,7 @@ describe('VolunteerSettings page', () => {
 
     await waitFor(() => expect(createVolunteerMasterRole).toHaveBeenCalledWith('Drivers'));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(getVolunteerMasterRoles).toHaveBeenCalledTimes(1);
 
     const summary = await screen.findByRole('button', { name: 'Drivers' });
     expect(summary).toHaveAttribute('aria-expanded', 'true');


### PR DESCRIPTION
## Summary
- append new volunteer master role to state and open its accordion
- adjust tests for improved flow without reloading data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cbf4285c832d9b2ddb5ac5f20864