### PR TITLE
Allow specifying roleId when creating volunteer shift

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -41,8 +41,8 @@ export async function addVolunteerRole(
     let resolvedRoleId: number = roleId as number;
     if (typeof resolvedRoleId !== 'number') {
       const existing = await pool.query(
-        'SELECT id, category_id FROM volunteer_roles WHERE name=$1 LIMIT 1',
-        [name]
+        'SELECT id, category_id FROM volunteer_roles WHERE name=$1 AND category_id=$2 LIMIT 1',
+        [name, categoryId]
       );
       if ((existing.rowCount ?? 0) > 0) {
         resolvedRoleId = existing.rows[0].id;

--- a/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
@@ -83,5 +83,10 @@ describe('addVolunteerRole validation', () => {
     expect(res.status).toBe(201);
     expect(res.body.role_id).toBe(10);
     expect(res.body.name).toBe('New');
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      'SELECT id, category_id FROM volunteer_roles WHERE name=$1 AND category_id=$2 LIMIT 1',
+      ['New', 3]
+    );
   });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -161,19 +161,30 @@ export async function deleteVolunteerMasterRole(id: number) {
   return handleResponse(res);
 }
 
-export async function createVolunteerRole(
-  name: string,
-  startTime: string,
-  endTime: string,
-  maxVolunteers: number,
-  categoryId: number,
-  isWednesdaySlot?: boolean,
-  isActive?: boolean,
-) {
+export async function createVolunteerRole({
+  roleId,
+  name,
+  startTime,
+  endTime,
+  maxVolunteers,
+  categoryId,
+  isWednesdaySlot,
+  isActive,
+}: {
+  roleId?: number;
+  name?: string;
+  startTime: string;
+  endTime: string;
+  maxVolunteers: number;
+  categoryId?: number;
+  isWednesdaySlot?: boolean;
+  isActive?: boolean;
+}) {
   const res = await apiFetch(`${API_BASE}/volunteer-roles`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
+      roleId,
       name,
       startTime,
       endTime,

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
@@ -115,15 +115,50 @@ describe('VolunteerSettings page', () => {
     fireEvent.click(within(dialog).getByText('Save'));
 
     await waitFor(() =>
-      expect(createVolunteerRole).toHaveBeenCalledWith(
-        'Sorter',
-        '09:00:00',
-        '12:00:00',
-        2,
-        1,
-        false,
-        true
-      )
+      expect(createVolunteerRole).toHaveBeenCalledWith({
+        name: 'Sorter',
+        startTime: '09:00:00',
+        endTime: '12:00:00',
+        maxVolunteers: 2,
+        categoryId: 1,
+        isWednesdaySlot: false,
+        isActive: true,
+      })
+    );
+  });
+
+  it('handles adding shift for existing role', async () => {
+    (createVolunteerRole as jest.Mock).mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <VolunteerSettings />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByText('Add Shift'));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText('Start Time'), {
+      target: { value: '09:00:00' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('End Time'), {
+      target: { value: '12:00:00' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Max Volunteers'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(within(dialog).getByText('Save'));
+
+    await waitFor(() =>
+      expect(createVolunteerRole).toHaveBeenCalledWith({
+        roleId: 1,
+        startTime: '09:00:00',
+        endTime: '12:00:00',
+        maxVolunteers: 2,
+        categoryId: 1,
+        isWednesdaySlot: false,
+        isActive: true,
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary
- include `categoryId` when checking for existing volunteer roles to avoid cross-category name collisions
- allow POST /volunteer-roles to accept `roleId` and skip name lookup; update frontend API and Volunteer Settings page accordingly
- add tests for roleId-driven shift creation

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0cb7c6dfc832db9c7b7eda914da61