### PR TITLE
feat: separate sub-role and shift dialogs

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -47,7 +47,16 @@ export default function VolunteerSettings() {
   const [snack, setSnack] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({ open: false, message: '', severity: 'success' });
 
   const [masterDialog, setMasterDialog] = useState<{ open: boolean; id?: number; name: string }>({ open: false, name: '' });
-  const [roleDialog, setRoleDialog] = useState<{
+  const [subRoleDialog, setSubRoleDialog] = useState<{
+    open: boolean;
+    roleName: string;
+    startTime: string;
+    endTime: string;
+    maxVolunteers: string;
+    categoryId?: number;
+    isWednesdaySlot: boolean;
+  }>({ open: false, roleName: '', startTime: '', endTime: '', maxVolunteers: '1', isWednesdaySlot: false });
+  const [shiftDialog, setShiftDialog] = useState<{
     open: boolean;
     slotId?: number;
     roleName: string;
@@ -135,54 +144,99 @@ export default function VolunteerSettings() {
     return t.length === 5 ? `${t}:00` : t;
   }
 
-  function openRoleDialog(
+  function openSubRoleDialog(categoryId: number) {
+    setSubRoleDialog({
+      open: true,
+      roleName: '',
+      startTime: '',
+      endTime: '',
+      maxVolunteers: '1',
+      categoryId,
+      isWednesdaySlot: false,
+    });
+  }
+
+  function openShiftDialog(
     categoryId: number,
-    init: Partial<Omit<typeof roleDialog, 'categoryId' | 'open'>> = {},
+    init: {
+      roleName: string;
+      slotId?: number;
+      startTime?: string;
+      endTime?: string;
+      maxVolunteers?: string | number;
+      isWednesdaySlot?: boolean;
+    },
   ) {
-    setRoleDialog({
+    setShiftDialog({
       open: true,
       slotId: init.slotId,
-      roleName: init.roleName || '',
+      roleName: init.roleName,
       startTime: init.startTime ? toTimeInput(init.startTime) : '',
       endTime: init.endTime ? toTimeInput(init.endTime) : '',
-      maxVolunteers: init.maxVolunteers?.toString() || '1',
+      maxVolunteers: typeof init.maxVolunteers === 'number' ? init.maxVolunteers.toString() : init.maxVolunteers || '1',
       categoryId,
       isWednesdaySlot: init.isWednesdaySlot || false,
     });
   }
 
-  async function saveRole() {
+  async function saveSubRole() {
     try {
-      if (!roleDialog.roleName || !roleDialog.startTime || !roleDialog.endTime) {
+      if (!subRoleDialog.roleName || !subRoleDialog.startTime || !subRoleDialog.endTime) {
         handleSnack('All fields are required', 'error');
         return;
       }
-      const startTime = toTimeValue(roleDialog.startTime);
-      const endTime = toTimeValue(roleDialog.endTime);
-      const maxVolunteers = Number(roleDialog.maxVolunteers);
-      if (roleDialog.slotId) {
-        await updateVolunteerRole(roleDialog.slotId, {
-          name: roleDialog.roleName,
+      const startTime = toTimeValue(subRoleDialog.startTime);
+      const endTime = toTimeValue(subRoleDialog.endTime);
+      const maxVolunteers = Number(subRoleDialog.maxVolunteers);
+      await createVolunteerRole(
+        subRoleDialog.roleName,
+        startTime,
+        endTime,
+        maxVolunteers,
+        subRoleDialog.categoryId!,
+        subRoleDialog.isWednesdaySlot,
+        true,
+      );
+      handleSnack('Role created');
+      setSubRoleDialog({ open: false, roleName: '', startTime: '', endTime: '', maxVolunteers: '1', isWednesdaySlot: false });
+      loadData();
+    } catch (e) {
+      handleSnack('Failed to save role', 'error');
+    }
+  }
+
+  async function saveShift() {
+    try {
+      if (!shiftDialog.roleName || !shiftDialog.startTime || !shiftDialog.endTime) {
+        handleSnack('All fields are required', 'error');
+        return;
+      }
+      const startTime = toTimeValue(shiftDialog.startTime);
+      const endTime = toTimeValue(shiftDialog.endTime);
+      const maxVolunteers = Number(shiftDialog.maxVolunteers);
+      if (shiftDialog.slotId) {
+        await updateVolunteerRole(shiftDialog.slotId, {
+          name: shiftDialog.roleName,
           startTime,
           endTime,
           maxVolunteers,
-          categoryId: roleDialog.categoryId!,
-          isWednesdaySlot: roleDialog.isWednesdaySlot,
+          categoryId: shiftDialog.categoryId!,
+          isWednesdaySlot: shiftDialog.isWednesdaySlot,
         });
         handleSnack('Role updated');
       } else {
         await createVolunteerRole(
-          roleDialog.roleName,
+          shiftDialog.roleName,
           startTime,
           endTime,
           maxVolunteers,
-          roleDialog.categoryId!,
-          roleDialog.isWednesdaySlot,
+          shiftDialog.categoryId!,
+          shiftDialog.isWednesdaySlot,
           true,
         );
         handleSnack('Role created');
       }
-      setRoleDialog({ open: false, roleName: '', startTime: '', endTime: '', maxVolunteers: '1', isWednesdaySlot: false });
+      setShiftDialog({ open: false, roleName: '', startTime: '', endTime: '', maxVolunteers: '1', isWednesdaySlot: false });
       loadData();
     } catch (e) {
       handleSnack('Failed to save role', 'error');
@@ -279,7 +333,12 @@ export default function VolunteerSettings() {
                             size="small"
                             variant="outlined"
                             startIcon={<AddIcon />}
-                            onClick={() => openRoleDialog(master.id, { roleName: role.name })}
+                            onClick={() =>
+                              openShiftDialog(master.id, {
+                                roleName: role.name,
+                                maxVolunteers: role.max_volunteers.toString(),
+                              })
+                            }
                           >
                             Add Shift
                           </Button>
@@ -304,7 +363,7 @@ export default function VolunteerSettings() {
                                 <IconButton
                                   aria-label="edit"
                                   onClick={() =>
-                                    openRoleDialog(master.id, {
+                                    openShiftDialog(master.id, {
                                       slotId: shift.id,
                                       roleName: role.name,
                                       startTime: shift.start_time,
@@ -335,7 +394,7 @@ export default function VolunteerSettings() {
                     size="small"
                     variant="contained"
                     startIcon={<AddIcon />}
-                    onClick={() => openRoleDialog(master.id)}
+                    onClick={() => openSubRoleDialog(master.id)}
                   >
                     Add Sub-role
                   </Button>
@@ -368,15 +427,15 @@ export default function VolunteerSettings() {
         </DialogActions>
       </Dialog>
 
-      <Dialog open={roleDialog.open} onClose={() => setRoleDialog({ ...roleDialog, open: false })} fullWidth>
-        <DialogTitle>{roleDialog.slotId ? 'Edit Role' : 'Add Role'}</DialogTitle>
+      <Dialog open={subRoleDialog.open} onClose={() => setSubRoleDialog({ ...subRoleDialog, open: false })} fullWidth>
+        <DialogTitle>Add Sub-role</DialogTitle>
         <DialogContent>
           <TextField
             margin="dense"
             label="Name"
             fullWidth
-            value={roleDialog.roleName}
-            onChange={e => setRoleDialog({ ...roleDialog, roleName: e.target.value })}
+            value={subRoleDialog.roleName}
+            onChange={e => setSubRoleDialog({ ...subRoleDialog, roleName: e.target.value })}
           />
           <TextField
             margin="dense"
@@ -384,8 +443,8 @@ export default function VolunteerSettings() {
             type="time"
             fullWidth
             InputLabelProps={{ shrink: true }}
-            value={roleDialog.startTime}
-            onChange={e => setRoleDialog({ ...roleDialog, startTime: e.target.value })}
+            value={subRoleDialog.startTime}
+            onChange={e => setSubRoleDialog({ ...subRoleDialog, startTime: e.target.value })}
           />
           <TextField
             margin="dense"
@@ -393,23 +452,70 @@ export default function VolunteerSettings() {
             type="time"
             fullWidth
             InputLabelProps={{ shrink: true }}
-            value={roleDialog.endTime}
-            onChange={e => setRoleDialog({ ...roleDialog, endTime: e.target.value })}
+            value={subRoleDialog.endTime}
+            onChange={e => setSubRoleDialog({ ...subRoleDialog, endTime: e.target.value })}
           />
           <TextField
             margin="dense"
             label="Max Volunteers"
             fullWidth
             type="number"
-            value={roleDialog.maxVolunteers}
-            onChange={e => setRoleDialog({ ...roleDialog, maxVolunteers: e.target.value })}
+            value={subRoleDialog.maxVolunteers}
+            onChange={e => setSubRoleDialog({ ...subRoleDialog, maxVolunteers: e.target.value })}
           />
         </DialogContent>
         <DialogActions>
-          <Button size="small" onClick={() => setRoleDialog({ ...roleDialog, open: false })}>
+          <Button size="small" onClick={() => setSubRoleDialog({ ...subRoleDialog, open: false })}>
             Cancel
           </Button>
-          <Button size="small" variant="contained" onClick={saveRole}>
+          <Button size="small" variant="contained" onClick={saveSubRole}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={shiftDialog.open} onClose={() => setShiftDialog({ ...shiftDialog, open: false })} fullWidth>
+        <DialogTitle>{shiftDialog.slotId ? 'Edit Shift' : 'Add Shift'}</DialogTitle>
+        <DialogContent>
+          <TextField
+            margin="dense"
+            label="Role"
+            fullWidth
+            value={shiftDialog.roleName}
+            InputProps={{ readOnly: true }}
+          />
+          <TextField
+            margin="dense"
+            label="Start Time"
+            type="time"
+            fullWidth
+            InputLabelProps={{ shrink: true }}
+            value={shiftDialog.startTime}
+            onChange={e => setShiftDialog({ ...shiftDialog, startTime: e.target.value })}
+          />
+          <TextField
+            margin="dense"
+            label="End Time"
+            type="time"
+            fullWidth
+            InputLabelProps={{ shrink: true }}
+            value={shiftDialog.endTime}
+            onChange={e => setShiftDialog({ ...shiftDialog, endTime: e.target.value })}
+          />
+          <TextField
+            margin="dense"
+            label="Max Volunteers"
+            fullWidth
+            type="number"
+            value={shiftDialog.maxVolunteers}
+            onChange={e => setShiftDialog({ ...shiftDialog, maxVolunteers: e.target.value })}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button size="small" onClick={() => setShiftDialog({ ...shiftDialog, open: false })}>
+            Cancel
+          </Button>
+          <Button size="small" variant="contained" onClick={saveShift}>
             Save
           </Button>
         </DialogActions>

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
@@ -126,4 +126,42 @@ describe('VolunteerSettings page', () => {
       )
     );
   });
+
+  it('opens shift dialog with read-only role field', async () => {
+    (createVolunteerRole as jest.Mock).mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <VolunteerSettings />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByText('Add Shift'));
+    const dialog = await screen.findByRole('dialog');
+    const nameField = within(dialog).getByLabelText('Role');
+    expect(nameField).toHaveAttribute('readonly');
+
+    fireEvent.change(within(dialog).getByLabelText('Start Time'), {
+      target: { value: '13:00:00' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('End Time'), {
+      target: { value: '15:00:00' },
+    });
+    fireEvent.change(within(dialog).getByLabelText('Max Volunteers'), {
+      target: { value: '3' },
+    });
+    fireEvent.click(within(dialog).getByText('Save'));
+
+    await waitFor(() =>
+      expect(createVolunteerRole).toHaveBeenCalledWith(
+        'Packing',
+        '13:00:00',
+        '15:00:00',
+        3,
+        1,
+        false,
+        true,
+      ),
+    );
+  });
 });

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts.
+- Volunteer Settings now provides a dedicated dialog for adding sub-roles and a separate shift dialog with the sub-role name read-only.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Walk-in bookings created via `/bookings/preapproved` are saved with status `approved` (the `preapproved` status has been removed).


### PR DESCRIPTION
## Summary
- add dedicated Add Sub-role dialog with initial shift fields
- keep existing shift dialog for adding/editing shifts with read-only role name
- update tests for new dialogs and note in README

## Testing
- `cd MJ_FB_Frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cbea5a94832daba3685b3a746e8b