### PR TITLE
Allow shift creation with existing volunteer role IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 
 ### Volunteer Roles
 - `GET /volunteer-roles/mine?date=YYYY-MM-DD` → `[ { id, role_id, name, start_time, end_time, max_volunteers, category_id, category_name, is_wednesday_slot, booked, available, status, date } ]`
-- `POST /volunteer-roles` (requires `roleId` or `name` + `categoryId`) → `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active, category_name }`
+- `POST /volunteer-roles` (requires `roleId` or `name` + `categoryId`; uses existing sub-role if the name and category match) → `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active, category_name }`
 - `GET /volunteer-roles` → `[ { id, role_id, category_id, name, max_volunteers, category_name, shifts } ]`
 - `PUT /volunteer-roles/:id` → `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active, category_name }`
 - `PATCH /volunteer-roles/:id` → `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active }`

--- a/MJ_FB_Backend/tests/volunteerRoles.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRoles.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
 describe('Volunteer roles routes', () => {
   it('creates a volunteer role', async () => {
     (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 1, category_id: 2 }] })
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -161,6 +161,11 @@ export async function deleteVolunteerMasterRole(id: number) {
   return handleResponse(res);
 }
 
+/**
+ * Create a volunteer role slot.
+ * Provide `roleId` to attach a shift to an existing sub-role; otherwise send
+ * `name` and `categoryId` to create or reuse a sub-role.
+ */
 export async function createVolunteerRole(
   roleId: number | undefined,
   name: string | undefined,

--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -161,7 +161,11 @@ export default function VolunteerSettings() {
 
   async function saveRole() {
     try {
-      if (!roleDialog.roleName || !roleDialog.startTime || !roleDialog.endTime) {
+      if (
+        !roleDialog.startTime ||
+        !roleDialog.endTime ||
+        (!roleDialog.roleId && !roleDialog.roleName)
+      ) {
         handleSnack('All fields are required', 'error');
         return;
       }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Staff can set a single maximum booking capacity applied to all pantry time slots through the Admin → Pantry Settings page or `PUT /slots/capacity`.
 - Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots.
 - `/volunteer-roles` now returns each role with `id` representing the role ID (the `role_id` field has been removed).
-- Creating volunteer role slots (`POST /volunteer-roles`) accepts either an existing `roleId` or a new `name` with `categoryId`.
+- Creating volunteer role slots (`POST /volunteer-roles`) accepts either an existing `roleId` or a new `name` with `categoryId`; if the name and category match an existing sub-role, it will be reused.
 - Volunteer role start and end times are selected via a native time picker and stored as `HH:MM:SS`.
 - Slot listing endpoint `/slots` returns an empty array and 200 status on holidays.
 


### PR DESCRIPTION
## Summary
- allow `POST /volunteer-roles` to reuse existing roles using `roleId` or name+category lookup
- enable frontend shift creation to send `roleId`
- document the updated volunteer role slot API

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b0cd2bc500832d99354bc8a1fd8ebe