### PR TITLE
feat: split sub-role and shift dialogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - `api/` wraps server requests.
 - `utils/`, `types.ts`, and theming files manage helpers, typings, and Material UI themes.
 - Administrative pages enable staff to manage volunteer master roles and edit volunteer role slots.
+- The Volunteer Settings page uses separate dialogs: "Add Sub-role" collects the sub-role name with initial shift details, while "Add Shift" assumes the sub-role exists and omits an editable name field.
 - Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page.
 

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
@@ -135,6 +135,7 @@ describe('VolunteerSettings page', () => {
 
     fireEvent.click(await screen.findByText('Add Shift'));
     const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).queryByLabelText('Name')).toBeNull();
     fireEvent.change(within(dialog).getByLabelText('Start Time'), {
       target: { value: '13:00:00' },
     });

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
-- Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts.
+- Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Separate "Add Sub-role" and "Add Shift" dialogs streamline creating new sub-roles and shifts. Deleting a master role also removes its sub-roles and shifts.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Walk-in bookings created via `/bookings/preapproved` are saved with status `approved` (the `preapproved` status has been removed).
@@ -30,7 +30,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
 - Staff can set a single maximum booking capacity applied to all pantry time slots through the Admin → Pantry Settings page or `PUT /slots/capacity`.
-- Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots.
+- Administrative pages allow staff to manage volunteer master roles and edit volunteer role slots through dedicated dialogs.
 - `/volunteer-roles` now returns each role with `id` representing the role ID (the `role_id` field has been removed).
 - Creating volunteer role slots (`POST /volunteer-roles`) accepts either an existing `roleId` or a new `name` with `categoryId`.
 - Volunteer role start and end times are selected via a native time picker and stored as `HH:MM:SS`.


### PR DESCRIPTION
## Summary
- add dedicated "Add Sub-role" dialog to capture name and first shift
- update shift dialog to drop editable name field
- wire "Add Sub-role" and "Add Shift" buttons to their respective dialogs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cdb1b118832daa624e8e41c5d781