### PR TITLE
Include category in volunteer role lookup

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -40,13 +40,21 @@ export async function addVolunteerRole(
   try {
     let resolvedRoleId: number = roleId as number;
     if (typeof resolvedRoleId !== 'number') {
-      const roleRes = await pool.query(
-        `INSERT INTO volunteer_roles (name, category_id)
-         VALUES ($1,$2)
-         RETURNING id, category_id`,
-        [name, categoryId]
+      const existing = await pool.query(
+        `SELECT id FROM volunteer_roles WHERE name=$1 AND category_id=$2`,
+        [name, categoryId],
       );
-      resolvedRoleId = roleRes.rows[0].id;
+      if ((existing.rowCount ?? 0) > 0) {
+        resolvedRoleId = existing.rows[0].id;
+      } else {
+        const roleRes = await pool.query(
+          `INSERT INTO volunteer_roles (name, category_id)
+           VALUES ($1,$2)
+           RETURNING id`,
+          [name, categoryId],
+        );
+        resolvedRoleId = roleRes.rows[0].id;
+      }
     }
     const overlap = await pool.query(
       `SELECT 1 FROM volunteer_slots

--- a/MJ_FB_Backend/tests/volunteerRoles.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRoles.test.ts
@@ -22,7 +22,8 @@ afterEach(() => {
 describe('Volunteer roles routes', () => {
   it('creates a volunteer role', async () => {
     (pool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ id: 1, category_id: 2 }] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({
         rows: [

--- a/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
@@ -57,7 +57,8 @@ describe('addVolunteerRole validation', () => {
 
   it('creates slot with new role name and categoryId', async () => {
     (pool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ id: 10, category_id: 3 }] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 10 }] })
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({
         rows: [


### PR DESCRIPTION
## Summary
- check existing volunteer roles by name and category when creating shifts
- reuse provided roleId to skip name lookup
- adjust volunteer role tests for new lookup logic

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ced852c0832db43fba8eff8163d4