### PR TITLE
Use PATCH endpoint for volunteer booking cancel

### DIFF
--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -102,9 +102,15 @@ export async function createRecurringVolunteerBooking(
 export async function cancelVolunteerBooking(
   bookingId: number,
 ): Promise<void> {
-  const res = await apiFetch(`${API_BASE}/volunteer-bookings/${bookingId}`, {
-    method: 'DELETE',
-  });
+  const res = await apiFetch(
+    `${API_BASE}/volunteer-bookings/${bookingId}/cancel`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
   await handleResponse(res);
 }
 


### PR DESCRIPTION
## Summary
- update volunteer booking cancellation to use PATCH /volunteer-bookings/{id}/cancel

## Testing
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b0d287ba00832da418cddc72d71778