### PR TITLE
Ensure /slots/capacity is routed correctly

### DIFF
--- a/MJ_FB_Backend/src/routes/slots.ts
+++ b/MJ_FB_Backend/src/routes/slots.ts
@@ -32,13 +32,13 @@ router.get(
 );
 
 router.post('/', authMiddleware, authorizeRoles('staff'), createSlot);
-router.put('/:id', authMiddleware, authorizeRoles('staff'), updateSlot);
 router.put(
   '/capacity',
   authMiddleware,
   authorizeRoles('staff'),
   updateAllSlotCapacity,
 );
+router.put('/:id', authMiddleware, authorizeRoles('staff'), updateSlot);
 router.delete('/:id', authMiddleware, authorizeRoles('staff'), deleteSlot);
 
 export default router;

--- a/MJ_FB_Backend/tests/slotCrud.test.ts
+++ b/MJ_FB_Backend/tests/slotCrud.test.ts
@@ -81,3 +81,25 @@ describe('PUT /slots/:id', () => {
     expect(pool.query).not.toHaveBeenCalled();
   });
 });
+
+describe('PUT /slots/capacity', () => {
+  it('updates capacity for all slots', async () => {
+    const res = await request(app)
+      .put('/slots/capacity')
+      .send({ maxCapacity: 3 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Capacity updated' });
+    expect(pool.query).toHaveBeenCalledWith(
+      'UPDATE slots SET max_capacity = $1',
+      [3],
+    );
+  });
+
+  it('validates request body', async () => {
+    const res = await request(app)
+      .put('/slots/capacity')
+      .send({ maxCapacity: 0 });
+    expect(res.status).toBe(400);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Fix route precedence so `/slots/capacity` isn't treated as an ID
- Add tests for updating max capacity across all slots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0d7c8afe0832da6c907ce223e5854