### PR TITLE
Add volunteer role reset endpoint and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `POST /volunteer-master-roles` → `{ id, name }`
 - `PUT /volunteer-master-roles/:id` → `{ id, name }`
 - `DELETE /volunteer-master-roles/:id` → `{ message: 'Master role deleted' }` (removes associated `volunteer_roles` and `volunteer_slots`)
+- `POST /volunteer-roles/restore` → `{ message: 'Volunteer roles restored' }` (staff only; resets roles, shifts, and training links)
 
 ### Volunteer Bookings
 - `POST /volunteer-bookings` → `{ id, role_id, volunteer_id, date, status, reschedule_token, status_color }`

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -330,3 +330,96 @@ export async function listVolunteerRolesForVolunteer(
     next(error);
   }
 }
+
+export async function restoreDefaultVolunteerRoles(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    await client.query(
+      'CREATE TEMP TABLE tmp_trained AS SELECT volunteer_id, role_id FROM volunteer_trained_roles',
+    );
+
+    await client.query(
+      'TRUNCATE volunteer_slots, volunteer_roles, volunteer_master_roles RESTART IDENTITY CASCADE',
+    );
+
+    await client.query(`
+      INSERT INTO volunteer_master_roles (id, name) VALUES
+        (1, 'Pantry'),
+        (2, 'Warehouse'),
+        (3, 'Gardening'),
+        (4, 'Administration'),
+        (5, 'Special Events')
+      ON CONFLICT DO NOTHING;
+      SELECT setval('volunteer_master_roles_id_seq', (SELECT COALESCE(MAX(id), 0) FROM volunteer_master_roles));
+    `);
+
+    await client.query(`
+      INSERT INTO volunteer_roles (id, name, category_id) VALUES
+        (1, 'Food Sorter', 2),
+        (2, 'Production Worker', 2),
+        (3, 'Driver Assistant', 2),
+        (4, 'Loading Dock Personnel', 2),
+        (5, 'General Cleaning & Maintenance', 2),
+        (6, 'Reception', 1),
+        (7, 'Greeter / Pantry Assistant', 1),
+        (8, 'Stock Person', 1),
+        (9, 'Gardening Assistant', 3),
+        (10, 'Event Organizer', 5),
+        (11, 'Event Resource Specialist', 5),
+        (12, 'Volunteer Marketing Associate', 4),
+        (13, 'Client Resource Associate', 4),
+        (14, 'Assistant Volunteer Coordinator', 4),
+        (15, 'Volunteer Office Administrator', 4)
+      ON CONFLICT (id) DO NOTHING;
+      SELECT setval('volunteer_roles_id_seq', (SELECT COALESCE(MAX(id), 0) FROM volunteer_roles));
+    `);
+
+    await client.query(`
+      INSERT INTO volunteer_slots (role_id, start_time, end_time, max_volunteers, is_wednesday_slot) VALUES
+        (1, '09:00:00', '12:00:00', 3, false),
+        (2, '09:00:00', '12:00:00', 3, false),
+        (3, '09:00:00', '12:00:00', 1, false),
+        (4, '09:00:00', '12:00:00', 1, false),
+        (5, '08:00:00', '11:00:00', 1, false),
+        (6, '09:00:00', '12:00:00', 1, false),
+        (6, '12:30:00', '15:30:00', 1, false),
+        (6, '15:30:00', '18:30:00', 1, true),
+        (7, '09:00:00', '12:00:00', 3, false),
+        (7, '12:30:00', '15:30:00', 3, false),
+        (7, '15:30:00', '18:30:00', 3, true),
+        (7, '16:30:00', '19:30:00', 3, true),
+        (8, '08:00:00', '11:00:00', 1, false),
+        (8, '12:00:00', '15:00:00', 1, false),
+        (9, '13:00:00', '16:00:00', 2, false),
+        (10, '09:00:00', '17:00:00', 5, false),
+        (11, '09:00:00', '17:00:00', 5, false),
+        (12, '08:00:00', '16:00:00', 1, false),
+        (13, '08:00:00', '16:00:00', 1, false),
+        (14, '08:00:00', '16:00:00', 1, false),
+        (15, '08:00:00', '16:00:00', 1, false)
+      ON CONFLICT (role_id, start_time, end_time) DO NOTHING;
+    `);
+
+    await client.query(`
+      INSERT INTO volunteer_trained_roles (volunteer_id, role_id, category_id)
+      SELECT t.volunteer_id, t.role_id, vr.category_id
+      FROM tmp_trained t
+      JOIN volunteer_roles vr ON vr.id = t.role_id;
+    `);
+
+    await client.query('COMMIT');
+    res.json({ message: 'Volunteer roles restored' });
+  } catch (error) {
+    await client.query('ROLLBACK');
+    logger.error('Error restoring volunteer roles:', error);
+    next(error);
+  } finally {
+    client.release();
+  }
+}

--- a/MJ_FB_Backend/src/routes/volunteer/volunteerRoles.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteerRoles.ts
@@ -6,6 +6,7 @@ import {
   deleteVolunteerRole,
   listVolunteerRolesForVolunteer,
   updateVolunteerRoleStatus,
+  restoreDefaultVolunteerRoles,
 } from '../../controllers/volunteer/volunteerRoleController';
 import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
 
@@ -19,5 +20,6 @@ router.get('/', listVolunteerRoles);
 router.put('/:id', updateVolunteerRole);
 router.patch('/:id', updateVolunteerRoleStatus);
 router.delete('/:id', deleteVolunteerRole);
+router.post('/restore', restoreDefaultVolunteerRoles);
 
 export default router;

--- a/MJ_FB_Backend/tests/volunteerRolesRestore.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesRestore.test.ts
@@ -1,0 +1,152 @@
+import request from 'supertest';
+import express from 'express';
+
+const DEFAULT_MASTER_ROLES = [
+  { id: 1, name: 'Pantry' },
+  { id: 2, name: 'Warehouse' },
+  { id: 3, name: 'Gardening' },
+  { id: 4, name: 'Administration' },
+  { id: 5, name: 'Special Events' },
+];
+
+const DEFAULT_ROLES = [
+  { id: 1, name: 'Food Sorter', category_id: 2 },
+  { id: 2, name: 'Production Worker', category_id: 2 },
+  { id: 3, name: 'Driver Assistant', category_id: 2 },
+  { id: 4, name: 'Loading Dock Personnel', category_id: 2 },
+  { id: 5, name: 'General Cleaning & Maintenance', category_id: 2 },
+  { id: 6, name: 'Reception', category_id: 1 },
+  { id: 7, name: 'Greeter / Pantry Assistant', category_id: 1 },
+  { id: 8, name: 'Stock Person', category_id: 1 },
+  { id: 9, name: 'Gardening Assistant', category_id: 3 },
+  { id: 10, name: 'Event Organizer', category_id: 5 },
+  { id: 11, name: 'Event Resource Specialist', category_id: 5 },
+  { id: 12, name: 'Volunteer Marketing Associate', category_id: 4 },
+  { id: 13, name: 'Client Resource Associate', category_id: 4 },
+  { id: 14, name: 'Assistant Volunteer Coordinator', category_id: 4 },
+  { id: 15, name: 'Volunteer Office Administrator', category_id: 4 },
+];
+
+const DEFAULT_SLOTS = [
+  { role_id: 1, start_time: '09:00:00', end_time: '12:00:00', max_volunteers: 3, is_wednesday_slot: false },
+  { role_id: 2, start_time: '09:00:00', end_time: '12:00:00', max_volunteers: 3, is_wednesday_slot: false },
+  { role_id: 3, start_time: '09:00:00', end_time: '12:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 4, start_time: '09:00:00', end_time: '12:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 5, start_time: '08:00:00', end_time: '11:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 6, start_time: '09:00:00', end_time: '12:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 6, start_time: '12:30:00', end_time: '15:30:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 6, start_time: '15:30:00', end_time: '18:30:00', max_volunteers: 1, is_wednesday_slot: true },
+  { role_id: 7, start_time: '09:00:00', end_time: '12:00:00', max_volunteers: 3, is_wednesday_slot: false },
+  { role_id: 7, start_time: '12:30:00', end_time: '15:30:00', max_volunteers: 3, is_wednesday_slot: false },
+  { role_id: 7, start_time: '15:30:00', end_time: '18:30:00', max_volunteers: 3, is_wednesday_slot: true },
+  { role_id: 7, start_time: '16:30:00', end_time: '19:30:00', max_volunteers: 3, is_wednesday_slot: true },
+  { role_id: 8, start_time: '08:00:00', end_time: '11:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 8, start_time: '12:00:00', end_time: '15:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 9, start_time: '13:00:00', end_time: '16:00:00', max_volunteers: 2, is_wednesday_slot: false },
+  { role_id: 10, start_time: '09:00:00', end_time: '17:00:00', max_volunteers: 5, is_wednesday_slot: false },
+  { role_id: 11, start_time: '09:00:00', end_time: '17:00:00', max_volunteers: 5, is_wednesday_slot: false },
+  { role_id: 12, start_time: '08:00:00', end_time: '16:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 13, start_time: '08:00:00', end_time: '16:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 14, start_time: '08:00:00', end_time: '16:00:00', max_volunteers: 1, is_wednesday_slot: false },
+  { role_id: 15, start_time: '08:00:00', end_time: '16:00:00', max_volunteers: 1, is_wednesday_slot: false },
+];
+
+let masterRoles: any[] = [];
+let roles: any[] = [];
+let slots: any[] = [];
+let trained: any[] = [];
+let tempTrained: any[] = [];
+
+const mockQuery = jest.fn(async (sql: string) => {
+  if (sql.startsWith('BEGIN') || sql.startsWith('COMMIT') || sql.startsWith('ROLLBACK')) {
+    return { rows: [], rowCount: 0 };
+  }
+  if (sql.startsWith('CREATE TEMP TABLE')) {
+    tempTrained = trained.map(t => ({ ...t }));
+    return { rows: [], rowCount: tempTrained.length };
+  }
+  if (sql.includes('TRUNCATE volunteer_slots')) {
+    masterRoles = [];
+    roles = [];
+    slots = [];
+    return { rows: [], rowCount: 0 };
+  }
+  if (sql.includes('INSERT INTO volunteer_master_roles')) {
+    masterRoles = DEFAULT_MASTER_ROLES.map(r => ({ ...r }));
+    return { rows: [], rowCount: masterRoles.length };
+  }
+  if (sql.includes("SELECT setval('volunteer_master_roles_id_seq'")) {
+    return { rows: [], rowCount: 0 };
+  }
+  if (sql.includes('INSERT INTO volunteer_roles')) {
+    roles = DEFAULT_ROLES.map(r => ({ ...r }));
+    return { rows: [], rowCount: roles.length };
+  }
+  if (sql.includes("SELECT setval('volunteer_roles_id_seq'")) {
+    return { rows: [], rowCount: 0 };
+  }
+  if (sql.includes('INSERT INTO volunteer_slots')) {
+    slots = DEFAULT_SLOTS.map((s, idx) => ({ slot_id: idx + 1, ...s }));
+    return { rows: [], rowCount: slots.length };
+  }
+  if (sql.includes('INSERT INTO volunteer_trained_roles')) {
+    trained = tempTrained
+      .filter(t => roles.find(r => r.id === t.role_id))
+      .map(t => ({
+        volunteer_id: t.volunteer_id,
+        role_id: t.role_id,
+        category_id: roles.find(r => r.id === t.role_id)!.category_id,
+      }));
+    return { rows: [], rowCount: trained.length };
+  }
+  return { rows: [], rowCount: 0 };
+});
+
+const mockConnect = jest.fn(async () => ({ query: mockQuery, release: jest.fn() }));
+
+jest.mock('../src/db', () => ({
+  __esModule: true,
+  default: { query: (sql: string) => mockQuery(sql), connect: mockConnect },
+}));
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const volunteerRolesRouter = require('../src/routes/volunteer/volunteerRoles').default;
+
+const app = express();
+app.use(express.json());
+app.use('/volunteer-roles', volunteerRolesRouter);
+
+describe('POST /volunteer-roles/restore', () => {
+  beforeEach(() => {
+    masterRoles = [{ id: 1, name: 'Old' }, { id: 99, name: 'Temp' }];
+    roles = [
+      { id: 1, name: 'Old Role', category_id: 1 },
+      { id: 200, name: 'Extra', category_id: 99 },
+    ];
+    slots = [
+      { slot_id: 1, role_id: 1, start_time: '00:00:00', end_time: '01:00:00', max_volunteers: 1, is_wednesday_slot: false },
+    ];
+    trained = [
+      { volunteer_id: 5, role_id: 1, category_id: 1 },
+      { volunteer_id: 5, role_id: 200, category_id: 99 },
+    ];
+    tempTrained = [];
+    mockQuery.mockClear();
+  });
+
+  it('restores defaults and preserves training for existing roles', async () => {
+    const res = await request(app).post('/volunteer-roles/restore');
+    expect(res.status).toBe(200);
+    expect(masterRoles).toEqual(DEFAULT_MASTER_ROLES);
+    expect(roles).toEqual(DEFAULT_ROLES);
+    expect(slots).toHaveLength(DEFAULT_SLOTS.length);
+    expect(trained).toEqual([
+      { volunteer_id: 5, role_id: 1, category_id: 2 },
+    ]);
+  });
+});
+

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -146,6 +146,13 @@ export async function getVolunteerMasterRoles() {
   return handleResponse(res);
 }
 
+export async function restoreVolunteerRoles() {
+  const res = await apiFetch(`${API_BASE}/volunteer-roles/restore`, {
+    method: 'POST',
+  });
+  await handleResponse(res);
+}
+
 export async function createVolunteerMasterRole(name: string) {
   const res = await apiFetch(`${API_BASE}/volunteer-master-roles`, {
     method: 'POST',

--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -35,6 +35,7 @@ import {
   updateVolunteerRole,
   toggleVolunteerRole,
   deleteVolunteerRole,
+  restoreVolunteerRoles,
 } from '../../api/volunteers';
 import { formatTime } from '../../utils/time';
 import type { VolunteerRoleWithShifts } from '../../types';
@@ -84,6 +85,7 @@ export default function VolunteerSettings() {
   const [roleToDelete, setRoleToDelete] = useState<VolunteerRoleWithShifts | null>(null);
   const [shiftToDelete, setShiftToDelete] = useState<number | null>(null);
   const [expanded, setExpanded] = useState<number | false>(false);
+  const [restoreDialog, setRestoreDialog] = useState(false);
 
   useEffect(() => {
     loadData();
@@ -114,6 +116,18 @@ export default function VolunteerSettings() {
 
   function openMasterDialog(role?: MasterRole) {
     setMasterDialog({ open: true, id: role?.id, name: role?.name || '' });
+  }
+
+  async function handleRestoreRoles() {
+    try {
+      await restoreVolunteerRoles();
+      handleSnack('Roles restored');
+      setRestoreDialog(false);
+      loadData();
+    } catch (e) {
+      handleSnack('Failed to restore roles', 'error');
+      setRestoreDialog(false);
+    }
   }
 
   async function saveMasterRole() {
@@ -343,14 +357,23 @@ export default function VolunteerSettings() {
     <Page title="Volunteer Settings">
       <Box p={2}>
         <Box mb={2}>
-          <Button
-            size="small"
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={() => openMasterDialog()}
-          >
-            Add Master Role
-          </Button>
+          <Stack direction="row" spacing={1}>
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => openMasterDialog()}
+            >
+              Add Master Role
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => setRestoreDialog(true)}
+            >
+              Restore Original Roles & Shifts
+            </Button>
+          </Stack>
         </Box>
         <Box>
           {masterRoles.map(master => (
@@ -677,6 +700,23 @@ export default function VolunteerSettings() {
           </Button>
           <Button size="small" color="error" variant="contained" onClick={confirmRemoveMasterRole}>
             Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={restoreDialog} onClose={() => setRestoreDialog(false)}>
+        <DialogTitle>Restore roles?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            All current roles and shifts will be replaced with the defaults. Continue?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button size="small" onClick={() => setRestoreDialog(false)}>
+            Cancel
+          </Button>
+          <Button size="small" variant="contained" onClick={handleRestoreRoles}>
+            Restore
           </Button>
         </DialogActions>
       </Dialog>

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
@@ -8,6 +8,7 @@ jest.mock('../../../api/volunteers', () => ({
   createVolunteerMasterRole: jest.fn(),
   createVolunteerRole: jest.fn(),
   deleteVolunteerRole: jest.fn(),
+  restoreVolunteerRoles: jest.fn(),
 }));
 
 const {
@@ -16,6 +17,7 @@ const {
   createVolunteerMasterRole,
   createVolunteerRole,
   deleteVolunteerRole,
+  restoreVolunteerRoles,
 } = jest.requireMock('../../../api/volunteers');
 
 describe('VolunteerSettings page', () => {
@@ -209,6 +211,23 @@ describe('VolunteerSettings page', () => {
 
     expect(await screen.findByText('Slot times overlap existing slots'))
       .toBeInTheDocument();
+  });
+
+  it('restores roles and reloads data', async () => {
+    (restoreVolunteerRoles as jest.Mock).mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <VolunteerSettings />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByText('Restore Original Roles & Shifts'));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByText('Restore'));
+
+    await waitFor(() => expect(restoreVolunteerRoles).toHaveBeenCalled());
+    await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalledTimes(2));
   });
 
   it('confirms before deleting shift', async () => {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
+- Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Volunteer Settings page's **Restore Original Roles & Shifts** button.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Walk-in bookings created via `/bookings/preapproved` are saved with status `approved` (the `preapproved` status has been removed).


### PR DESCRIPTION
## Summary
- add controller and route to restore default volunteer roles and shifts
- provide frontend button and API helper for staff to trigger restoration
- cover restoration with backend and frontend tests

## Testing
- `npm test` in `MJ_FB_Backend`
- `npm test` in `MJ_FB_Frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b0d75a5ea0832d88aa320275733c84