### PR TITLE
Move Add Sub-role button into sub-role header

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -439,6 +439,16 @@ export default function VolunteerSettings() {
                         </Button>
                       </Grid>
                       <Grid item>
+                        <Button
+                          size="small"
+                          variant="contained"
+                          startIcon={<AddIcon />}
+                          onClick={() => openSubRoleDialog(master.id)}
+                        >
+                          Add Sub-role
+                        </Button>
+                      </Grid>
+                      <Grid item>
                         <IconButton aria-label="delete" onClick={() => removeRole(role)}>
                           <DeleteIcon />
                         </IconButton>
@@ -486,14 +496,6 @@ export default function VolunteerSettings() {
                     </List>
                   </Box>
                 ))}
-                <Button
-                  size="small"
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={() => openSubRoleDialog(master.id)}
-                >
-                  Add Sub-role
-                </Button>
               </AccordionDetails>
             </Accordion>
           ))}


### PR DESCRIPTION
## Summary
- Shifted the Add Sub-role button into each sub-role row beside Add Shift and delete actions
- Removed redundant Add Sub-role button from the bottom of accordion sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0dcadfb0c832d96045b8d181b396e