### PR TITLE
Move Add Sub-role button in VolunteerSettings

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -417,6 +417,16 @@ export default function VolunteerSettings() {
                 </Stack>
               </AccordionSummary>
               <AccordionDetails sx={{ borderTop: 1, borderColor: 'divider' }}>
+                <Box mb={2}>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => openSubRoleDialog(master.id)}
+                  >
+                    Add Sub-role
+                  </Button>
+                </Box>
                 {roles.filter(r => r.category_id === master.id).map(role => (
                   <Box key={role.id} mb={2}>
                     <Grid container alignItems="center" spacing={1}>
@@ -439,16 +449,6 @@ export default function VolunteerSettings() {
                           }
                         >
                           Add Shift
-                        </Button>
-                      </Grid>
-                      <Grid item>
-                        <Button
-                          size="small"
-                          variant="contained"
-                          startIcon={<AddIcon />}
-                          onClick={() => openSubRoleDialog(master.id)}
-                        >
-                          Add Sub-role
                         </Button>
                       </Grid>
                       <Grid item>


### PR DESCRIPTION
## Summary
- show "Add Sub-role" once at the top of each master role accordion
- remove per-sub-role "Add Sub-role" buttons

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0e38a67d0832d939472e4ac85e683