### PR TITLE
feat: consolidate agency management into tabs

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -18,10 +18,9 @@ const UserHistory = React.lazy(() =>
 const ClientManagement = React.lazy(() =>
   import('./pages/staff/ClientManagement')
 );
-const AgencyClientManager = React.lazy(() =>
-  import('./pages/staff/AgencyClientManager')
+const AgencyManagement = React.lazy(() =>
+  import('./pages/staff/AgencyManagement')
 );
-const AddAgency = React.lazy(() => import('./pages/staff/AddAgency'));
 const BookingUI = React.lazy(() => import('./pages/BookingUI'));
 const PantrySchedule = React.lazy(() =>
   import('./pages/staff/PantrySchedule')
@@ -140,7 +139,6 @@ export default function App() {
       { label: 'Pantry Visits', to: '/pantry/visits' },
       { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Agency Management', to: '/pantry/agency-management' },
-      { label: 'Add Agency', to: '/pantry/add-agency' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
@@ -352,11 +350,8 @@ export default function App() {
               {showStaff && (
                 <Route
                   path="/pantry/agency-management"
-                  element={<AgencyClientManager />}
+                  element={<AgencyManagement />}
                 />
-              )}
-              {showStaff && (
-                <Route path="/pantry/add-agency" element={<AddAgency />} />
               )}
               {isStaff && <Route path="/events" element={<Events />} />}
               {showAdmin && <Route path="/admin/staff" element={<AdminStaffList />} />}

--- a/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import App from '../App';
+import { AuthProvider } from '../hooks/useAuth';
+
+describe('AgencyManagement', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+    localStorage.clear();
+  });
+
+  it('shows tabs for adding agencies and managing clients', async () => {
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test Staff');
+    localStorage.setItem('access', JSON.stringify(['pantry']));
+    window.history.pushState({}, '', '/pantry/agency-management');
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    );
+    expect(await screen.findByRole('tab', { name: /add agency/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /clients/i })).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -59,6 +59,19 @@ describe('App authentication persistence', () => {
     expect(window.location.pathname).toBe('/pantry');
   });
 
+  it('does not show Add Agency link for staff', () => {
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test Staff');
+    localStorage.setItem('access', JSON.stringify(['pantry']));
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>,
+    );
+    expect(screen.queryByRole('link', { name: /add agency/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /agency management/i })).toBeInTheDocument();
+  });
+
   it('redirects staff with only volunteer management access', () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');

--- a/MJ_FB_Frontend/src/pages/staff/AddAgency.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AddAgency.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { Grid, TextField, Button, Box } from '@mui/material';
-import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { createAgency } from '../../api/agencies';
 
@@ -32,7 +31,7 @@ export default function AddAgency() {
   };
 
   return (
-    <Page title="Add Agency">
+    <>
       <Grid container justifyContent="center" alignItems="center" spacing={2}>
         <Grid item xs={12} md={6} lg={4}>
           <Box component="form" onSubmit={handleSubmit}>
@@ -82,7 +81,7 @@ export default function AddAgency() {
         message={snackbar?.message || ''}
         severity={snackbar?.severity}
       />
-    </Page>
+    </>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -9,7 +9,6 @@ import {
   TextField,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import Page from '../../components/Page';
 import EntitySearch from '../../components/EntitySearch';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import {
@@ -90,7 +89,7 @@ export default function AgencyClientManager() {
   };
 
   return (
-    <Page title="Agency Management">
+    <>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
           <Typography variant="h5" gutterBottom>
@@ -133,7 +132,7 @@ export default function AgencyClientManager() {
         message={snackbar?.message || ''}
         severity={snackbar?.severity}
       />
-    </Page>
+    </>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/AgencyManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyManagement.tsx
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+import StyledTabs from '../../components/StyledTabs';
+import Page from '../../components/Page';
+import AddAgency from './AddAgency';
+import AgencyClientManager from './AgencyClientManager';
+
+export default function AgencyManagement() {
+  const [tab, setTab] = useState(0);
+  const tabs = [
+    { label: 'Add Agency', content: <AddAgency /> },
+    { label: 'Clients', content: <AgencyClientManager /> },
+  ];
+
+  return (
+    <Page title="Agency Management">
+      <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />
+    </Page>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ control weight calculations:
 - Pantry Settings page lets staff configure one max booking capacity used for all pantry times.
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
-- Staff can assign clients to agencies through the Harvest Pantry → Agency Management page.
+- Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- replace separate Add Agency page with tabbed Agency Management combining agency creation and client assignment
- streamline navigation by removing redundant Add Agency submenu
- cover new workflow with tests and docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0e6a0db4c832d88dc478b3eb51c3d