### PR TITLE
Add migration for visited booking status

### DIFF
--- a/MJ_FB_Backend/migrations/20241201120000_add_visited_to_bookings.ts
+++ b/MJ_FB_Backend/migrations/20241201120000_add_visited_to_bookings.ts
@@ -1,0 +1,15 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('bookings', 'bookings_status_check');
+  pgm.addConstraint('bookings', 'bookings_status_check', {
+    check: "status IN ('approved','rejected','cancelled','no_show','expired','visited')",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('bookings', 'bookings_status_check');
+  pgm.addConstraint('bookings', 'bookings_status_check', {
+    check: "status IN ('approved','rejected','cancelled','no_show','expired')",
+  });
+}

--- a/MJ_FB_Backend/tests/bookingsStatusConstraint.test.ts
+++ b/MJ_FB_Backend/tests/bookingsStatusConstraint.test.ts
@@ -1,8 +1,8 @@
 import MigrationBuilder from 'node-pg-migrate/dist/migrationBuilder';
-import { up } from '../migrations/20241120120000_add_no_show_to_bookings';
+import { up } from '../migrations/20241201120000_add_visited_to_bookings';
 
 describe('bookings status constraint migration', () => {
-  it('includes no_show in allowed statuses', async () => {
+  it('includes visited in allowed statuses', async () => {
     const pgm = new (MigrationBuilder as any)({ log: () => {} });
     await up(pgm);
     const sql = pgm.getSql();


### PR DESCRIPTION
## Summary
- add migration to allow `visited` status in bookings check constraint
- update status constraint test to exercise new migration

## Testing
- `cd MJ_FB_Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0e7d24ad0832dad03a2fa184690a2