### PR TITLE
feat: revamp volunteer search layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,5 +378,6 @@ Volunteer management coordinates role-based staffing for the food bank.
 - Volunteer and pantry schedules follow the same grid logic. The y‑axis lists shift times and the x‑axis lists sequential slot numbers up to each shift's `max_volunteers`. When a volunteer requests a shift, their booking occupies the first open slot. Pending requests highlight (e.g., yellow) and staff approve by clicking the cell, mirroring the shopping appointment schedule.
 - **BookingHistory** shows a volunteer's pending and upcoming bookings with Cancel and Reschedule options.
 - **CoordinatorDashboard** is the staff view using `VolunteerScheduleTable`. Staff see volunteer names for booked cells, approve/reject/reschedule pending requests, and cancel or reschedule approved bookings. Staff can also search volunteers, assign them to roles, and update trained areas.
+- The volunteer search page shows the selected volunteer's profile and role editor alongside their booking history in a two-column card layout.
 - These workflows rely on `volunteer_slots`, `volunteer_roles`, `volunteer_master_roles`, `volunteer_bookings`, `volunteers`, and `volunteer_trained_roles`. Training records in `volunteer_trained_roles` restrict which roles a volunteer can book.
 

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -125,12 +125,12 @@ describe('VolunteerManagement search reset', () => {
     );
 
     fireEvent.click(screen.getByText('Select Volunteer'));
-    expect(await screen.findByText(/Edit Roles for Test Vol/i)).toBeInTheDocument();
+    expect(await screen.findByLabelText(/shopper profile/i)).toBeInTheDocument();
 
     act(() => navigateFn('/volunteers/schedule'));
     act(() => navigateFn('/volunteers/search'));
 
-    expect(screen.queryByText(/Edit Roles for Test Vol/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/shopper profile/i)).not.toBeInTheDocument();
   });
 });
 
@@ -158,9 +158,10 @@ describe('VolunteerManagement role updates', () => {
     );
 
     fireEvent.click(screen.getByText('Select Volunteer'));
-    const checkbox = await screen.findByLabelText('Greeter');
-    fireEvent.click(checkbox);
-    fireEvent.click(screen.getByRole('button', { name: /save roles/i }));
+    const input = await screen.findByLabelText(/add role/i);
+    fireEvent.change(input, { target: { value: 'Greeter' } });
+    fireEvent.click(await screen.findByText('Greeter'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() =>
       expect(updateVolunteerTrainedAreas).toHaveBeenCalledWith(1, [5]),

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
+- Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
 - Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Volunteer Settings page's **Restore Original Roles & Shifts** button.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).


### PR DESCRIPTION
## Summary
- restyle volunteer search page with card-based two-column layout
- add role chips with autocomplete and inline save feedback
- document volunteer search card layout in guides

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0e8189bd4832d9d655d3ddf6762c5