### PR TITLE
Clarify bookings_status_check rollback constraints

### DIFF
--- a/MJ_FB_Backend/migrations/20241015130000_add_visited_status_to_bookings.ts
+++ b/MJ_FB_Backend/migrations/20241015130000_add_visited_status_to_bookings.ts
@@ -8,6 +8,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Revert to state before the 'visited' status was introduced
+  // Previously allowed statuses: approved, rejected, cancelled, no_show, expired
   pgm.dropConstraint('bookings', 'bookings_status_check');
   pgm.addConstraint('bookings', 'bookings_status_check', {
     check: "status = ANY (ARRAY['approved','rejected','cancelled','no_show','expired'])",

--- a/MJ_FB_Backend/migrations/20241020160000_allow_visited_and_no_show_in_bookings.ts
+++ b/MJ_FB_Backend/migrations/20241020160000_allow_visited_and_no_show_in_bookings.ts
@@ -8,8 +8,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Restore constraint from previous migration which already allowed
+  // 'no_show' and 'visited'
+  // Previously: status = ANY (ARRAY['approved','rejected','cancelled','no_show','expired','visited'])
   pgm.dropConstraint('bookings', 'bookings_status_check');
   pgm.addConstraint('bookings', 'bookings_status_check', {
-    check: "status IN ('approved','rejected','cancelled','expired')",
+    check: "status = ANY (ARRAY['approved','rejected','cancelled','no_show','expired','visited'])",
   });
 }

--- a/MJ_FB_Backend/migrations/20241120120000_add_no_show_to_bookings.ts
+++ b/MJ_FB_Backend/migrations/20241120120000_add_no_show_to_bookings.ts
@@ -8,8 +8,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Revert to constraint before this migration; previous state already
+  // allowed both 'no_show' and 'visited'
+  // Previously: status IN ('approved','rejected','cancelled','no_show','expired','visited')
   pgm.dropConstraint('bookings', 'bookings_status_check');
   pgm.addConstraint('bookings', 'bookings_status_check', {
-    check: "status IN ('approved','rejected','cancelled','expired','visited')",
+    check: "status IN ('approved','rejected','cancelled','no_show','expired','visited')",
   });
 }

--- a/MJ_FB_Backend/migrations/20241201120000_add_visited_to_bookings.ts
+++ b/MJ_FB_Backend/migrations/20241201120000_add_visited_to_bookings.ts
@@ -8,8 +8,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Revert to constraint prior to this migration; previous state included
+  // 'visited' alongside other statuses
+  // Previously: status IN ('approved','rejected','cancelled','no_show','expired','visited')
   pgm.dropConstraint('bookings', 'bookings_status_check');
   pgm.addConstraint('bookings', 'bookings_status_check', {
-    check: "status IN ('approved','rejected','cancelled','no_show','expired')",
+    check: "status IN ('approved','rejected','cancelled','no_show','expired','visited')",
   });
 }


### PR DESCRIPTION
## Summary
- document previous bookings_status_check states in down migrations
- ensure each down() restores the constraint from the prior migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0ebb2889c832d9a78f05eae823fc5