### PR TITLE
Register ts-node for migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - `models/` and `db.ts` – PostgreSQL access.
 - `middleware/` – shared Express middleware (authentication, validation, etc.).
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
+- Run database migrations with `npm run migrate <direction>`; the script registers `ts-node` so TypeScript migration files run without precompiling.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -37,7 +37,7 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "test": "jest",
-    "migrate": "node-pg-migrate -m migrations -d \"postgres://$PG_USER:$PG_PASSWORD@$PG_HOST:$PG_PORT/$PG_DATABASE\""
+    "migrate": "node-pg-migrate -r ts-node/register -m migrations -d \"postgres://$PG_USER:$PG_PASSWORD@$PG_HOST:$PG_PORT/$PG_DATABASE\""
   },
   "keywords": [],
   "author": "",

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ npm run migrate up   # Run pending database migrations
 npm start   # or npm run dev
 ```
 
+Run migrations with `npm run migrate <direction>`. The script registers `ts-node` so TypeScript
+migration files execute without a separate build step. For example, `npm run migrate up` applies
+pending migrations.
+
 The latest migrations add support for agency logins (`agencies`, `agency_clients`),
 recurring volunteer bookings (`volunteer_recurring_bookings`) and email OTP verification
 (`client_email_verifications`). Run the migrate command after pulling updates so these


### PR DESCRIPTION
## Summary
- ensure node-pg-migrate registers ts-node when running migrations
- document how to run migrations in the root README
- note migration command in repository AGENTS guide

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0ebb390a4832d9349869aea3340b5