### PR TITLE
Use non-searchable dropdown for volunteer roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,5 +380,6 @@ Volunteer management coordinates role-based staffing for the food bank.
 - **BookingHistory** shows a volunteer's pending and upcoming bookings with Cancel and Reschedule options.
 - **CoordinatorDashboard** is the staff view using `VolunteerScheduleTable`. Staff see volunteer names for booked cells, approve/reject/reschedule pending requests, and cancel or reschedule approved bookings. Staff can also search volunteers, assign them to roles, and update trained areas.
 - The volunteer search page shows the selected volunteer's profile and role editor alongside their booking history in a two-column card layout.
+- Role selection in the volunteer search role editor uses a simple dropdown without search.
 - These workflows rely on `volunteer_slots`, `volunteer_roles`, `volunteer_master_roles`, `volunteer_bookings`, `volunteers`, and `volunteer_trained_roles`. Training records in `volunteer_trained_roles` restrict which roles a volunteer can book.
 

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -48,7 +48,6 @@ import {
   Grid,
   Stack,
   Chip,
-  Autocomplete,
 } from '@mui/material';
 import { lighten } from '@mui/material/styles';
 import Dashboard from '../../components/dashboard/Dashboard';
@@ -108,6 +107,7 @@ export default function VolunteerManagement() {
 
   const [selectedVolunteer, setSelectedVolunteer] = useState<VolunteerResult | null>(null);
   const [trainedEdit, setTrainedEdit] = useState<string[]>([]);
+  const [newTrainedRole, setNewTrainedRole] = useState('');
   const [editMsg, setEditMsg] = useState('');
   const [editSeverity, setEditSeverity] = useState<'success' | 'error'>('success');
   const [history, setHistory] = useState<VolunteerBookingDetail[]>([]);
@@ -213,14 +213,6 @@ export default function VolunteerManagement() {
     });
     return Array.from(groups.entries()).map(([category, roles]) => ({ category, roles }));
   }, [roles]);
-
-  const roleOptions = useMemo(
-    () =>
-      groupedRoles.flatMap(g =>
-        g.roles.map(r => ({ label: r.name, group: g.category })),
-      ),
-    [groupedRoles],
-  );
 
   const nameToSlotIds = useMemo(() => {
     const map = new Map<string, number[]>();
@@ -738,18 +730,30 @@ export default function VolunteerManagement() {
                         />
                       ))}
                     </Stack>
-                    <Autocomplete
-                      options={roleOptions}
-                      groupBy={option => option.group}
-                      getOptionLabel={option => option.label}
-                      onChange={(_e, v) => v && toggleTrained(v.label, true)}
-                      renderInput={params => (
-                        <TextField {...params} label="Add role" size="small" />
-                      )}
-                      value={null}
-                      sx={{ mb: 2 }}
-                      size="small"
-                    />
+                    <FormControl size="small" sx={{ mb: 2, minWidth: 200 }}>
+                      <InputLabel id="add-role-label">Add role</InputLabel>
+                      <Select
+                        labelId="add-role-label"
+                        value={newTrainedRole}
+                        label="Add role"
+                        onChange={e => {
+                          const val = e.target.value as string;
+                          toggleTrained(val, true);
+                          setNewTrainedRole('');
+                        }}
+                      >
+                        {groupedRoles.flatMap(g => [
+                          <ListSubheader key={`${g.category}-header`}>
+                            {g.category}
+                          </ListSubheader>,
+                          ...g.roles.map(r => (
+                            <MenuItem key={r.name} value={r.name}>
+                              {r.name}
+                            </MenuItem>
+                          )),
+                        ])}
+                      </Select>
+                    </FormControl>
                     <Button variant="contained" size="small" onClick={saveTrainedAreas}>
                       Save
                     </Button>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
+- Volunteer role assignment uses a simple dropdown without search capability.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
 - Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Volunteer Settings page's **Restore Original Roles & Shifts** button.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).


### PR DESCRIPTION
## Summary
- Replace Autocomplete with simple Select for assigning volunteer roles
- Document new role dropdown behavior in project README and AGENTS instructions

## Testing
- `npm test` *(fails: VolunteerSettings.test.tsx)`

------
https://chatgpt.com/codex/tasks/task_e_68b0f0ddba9c832dade0deb748b29217