### PR TITLE
Fix database creation query parameter type for Postgres

### DIFF
--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -17,7 +17,7 @@ export async function setupDatabase() {
   const dbExists = await adminClient.query('SELECT 1 FROM pg_database WHERE datname = $1', [dbName]);
   if ((dbExists.rowCount ?? 0) === 0) {
     const createDbQuery = await adminClient.query(
-      "SELECT format('CREATE DATABASE %I', $1) AS query",
+      "SELECT format('CREATE DATABASE %I', $1::text) AS query",
       [dbName],
     );
     await adminClient.query(createDbQuery.rows[0].query);


### PR DESCRIPTION
## Summary
- Cast database name parameter as text when building CREATE DATABASE query

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f64f339c832d98488b326d86dcd4