### PR TITLE
chore: configure TypeScript migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - `models/` and `db.ts` – PostgreSQL access.
 - `middleware/` – shared Express middleware (authentication, validation, etc.).
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
-- The database schema is initialized via `src/setupDatabase.ts`; migrations are no longer used.
+- The database schema is managed via TypeScript migrations in `src/migrations` using `npm run migrate`.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.

--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -1,6 +1,8 @@
 # Project Overview
+
 Frontend: https://github.com/Amrutha-A-J/MJ_FB_Frontend
 Backend: https://github.com/Amrutha-A-J/MJ_FB_Backend
+Run `npm run migrate` to apply TypeScript database migrations from `src/migrations`.
 
 
 ## Environment Variables

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -26,7 +26,8 @@
     "supertest": "^7.1.4",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "node-pg-migrate": "^7.9.1"
   },
   "overrides": {
     "test-exclude": "^7.0.1"
@@ -35,7 +36,9 @@
     "dev": "ts-node src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "test": "jest"
+    "test": "jest",
+    "migrate": "node-pg-migrate up -m src/migrations --tsconfig tsconfig.json",
+    "migration:create": "node-pg-migrate create -m src/migrations -j ts"
   },
   "keywords": [],
   "author": "",

--- a/MJ_FB_Backend/tsconfig.json
+++ b/MJ_FB_Backend/tsconfig.json
@@ -9,8 +9,13 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "ts-node": {
     "files": true
-  }
+  },
+  "exclude": [
+    "src/migrations"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm install
 npm start   # or npm run dev
 ```
 
-The database schema is initialized automatically on startup via `src/setupDatabase.ts`; no separate migration step is required.
+The database schema is managed via TypeScript migrations in `src/migrations`; run `npm run migrate` to apply them.
 
 ### Environment variables
 


### PR DESCRIPTION
## Summary
- add node-pg-migrate with scripts for TypeScript migrations
- exclude migration files from TypeScript build
- document new migration workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0f820dd88832d8913248cd45983eb