### PR TITLE
Prevent multiple agency links for a client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,8 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `POST /agencies/:id/clients` `{ clientId }` → `204`
 - `DELETE /agencies/:id/clients/:clientId` → `204`
 - `POST /agencies` `{ name, email, password, contactInfo? }` → `{ id }` (staff only)
+- A client may be linked to only one agency at a time; adding a client already
+  associated with another agency returns a `409` with that agency's name.
 
 ### Donors (`src/routes/donors.ts`)
 - `GET /donors?search=name` → `[ { id, name } ]`

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -5,6 +5,7 @@ import {
   getAgencyClients as fetchAgencyClients,
   createAgency as insertAgency,
   getAgencyByEmail,
+  getAgencyForClient,
   searchAgencies as findAgencies,
 } from '../models/agency';
 import bcrypt from 'bcrypt';
@@ -79,6 +80,13 @@ export async function addClientToAgency(
     }
     if (req.user.role === 'agency' && requestedId !== 'me' && agencyId !== paramId) {
       return res.status(403).json({ message: 'Forbidden' });
+    }
+    const existing = await getAgencyForClient(Number(req.body.clientId));
+    if (existing) {
+      return res.status(409).json({
+        message: `Client already associated with ${existing.name}`,
+        agencyName: existing.name,
+      });
     }
     await addAgencyClient(agencyId, Number(req.body.clientId));
     res.status(204).send();

--- a/MJ_FB_Backend/src/migrations/1720000000000_unique_client_agency.ts
+++ b/MJ_FB_Backend/src/migrations/1720000000000_unique_client_agency.ts
@@ -1,0 +1,11 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_unique', {
+    unique: ['client_id'],
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_unique');
+}

--- a/MJ_FB_Backend/src/models/agency.ts
+++ b/MJ_FB_Backend/src/models/agency.ts
@@ -59,6 +59,19 @@ export async function isAgencyClient(
   return (res.rowCount ?? 0) > 0;
 }
 
+export async function getAgencyForClient(
+  clientId: number,
+): Promise<AgencySummary | undefined> {
+  const res = await pool.query(
+    `SELECT a.id, a.name
+     FROM agency_clients ac
+     INNER JOIN agencies a ON a.id = ac.agency_id
+     WHERE ac.client_id = $1`,
+    [clientId],
+  );
+  return res.rows[0] as AgencySummary | undefined;
+}
+
 export async function addAgencyClient(
   agencyId: number,
   clientId: number,

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -123,7 +123,7 @@ CREATE TABLE IF NOT EXISTS agencies (
 
 CREATE TABLE IF NOT EXISTS agency_clients (
     agency_id integer NOT NULL REFERENCES public.agencies(id) ON DELETE CASCADE,
-    client_id integer NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+    client_id integer NOT NULL UNIQUE REFERENCES public.clients(id) ON DELETE CASCADE,
     UNIQUE (agency_id, client_id)
 );
 

--- a/MJ_FB_Backend/tests/agencyClientUnique.test.ts
+++ b/MJ_FB_Backend/tests/agencyClientUnique.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import express from 'express';
+import agenciesRoutes from '../src/routes/agencies';
+import { getAgencyForClient, addAgencyClient } from '../src/models/agency';
+
+jest.mock('../src/models/agency', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/models/agency'),
+  getAgencyForClient: jest.fn(),
+  addAgencyClient: jest.fn(),
+}));
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: '1', role: 'staff' };
+    next();
+  },
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/agencies', agenciesRoutes);
+app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  res.status(err.status || 500).json({ message: err.message, agencyName: err.agencyName });
+});
+
+describe('POST /agencies/:id/clients', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects when client already associated with another agency', async () => {
+    (getAgencyForClient as jest.Mock).mockResolvedValue({ id: 2, name: 'Existing Agency' });
+
+    const res = await request(app)
+      .post('/agencies/1/clients')
+      .send({ clientId: 5 });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      message: 'Client already associated with Existing Agency',
+      agencyName: 'Existing Agency',
+    });
+    expect(addAgencyClient).not.toHaveBeenCalled();
+  });
+});

--- a/MJ_FB_Frontend/jest.config.cjs
+++ b/MJ_FB_Frontend/jest.config.cjs
@@ -1,7 +1,10 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  testMatch: ['<rootDir>/src/pages/admin/__tests__/**/*.test.tsx'],
+  testMatch: [
+    '<rootDir>/src/pages/admin/__tests__/**/*.test.tsx',
+    '<rootDir>/src/__tests__/**/*.test.tsx',
+  ],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',

--- a/MJ_FB_Frontend/src/__tests__/AgencyClientManager.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyClientManager.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AgencyClientManager from '../pages/staff/AgencyClientManager';
+
+jest.mock('../api/agencies', () => ({
+  addAgencyClient: jest.fn(),
+  removeAgencyClient: jest.fn(),
+  getAgencyClients: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../components/EntitySearch', () =>
+  function MockEntitySearch({ type, onSelect, renderResult }: any) {
+    if (type === 'agency') {
+      return <button onClick={() => onSelect({ id: 1, name: 'Agency A' })}>select agency</button>;
+    }
+    const user = { id: 2, name: 'Client C', client_id: 2 };
+    return <div>{renderResult(user, () => onSelect(user))}</div>;
+  },
+);
+
+describe('AgencyClientManager', () => {
+  it('shows modal when client already associated with another agency', async () => {
+    const { addAgencyClient } = require('../api/agencies');
+    (addAgencyClient as jest.Mock).mockRejectedValue({
+      message: 'Client already associated with Other Agency',
+      details: { agencyName: 'Other Agency' },
+    });
+
+    render(<AgencyClientManager />);
+    fireEvent.click(screen.getByText('select agency'));
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /This client is already associated with Other Agency/i,
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -7,6 +7,10 @@ import {
   ListItemText,
   IconButton,
   Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EntitySearch from '../../components/EntitySearch';
@@ -29,6 +33,7 @@ export default function AgencyClientManager() {
   const [snackbar, setSnackbar] = useState<
     { message: string; severity: 'success' | 'error' } | null
   >(null);
+  const [conflictAgency, setConflictAgency] = useState<string | null>(null);
 
   const load = async (id: number) => {
     try {
@@ -67,10 +72,14 @@ export default function AgencyClientManager() {
       setSnackbar({ message: 'Client added', severity: 'success' });
       load(agency.id);
     } catch (err: any) {
-      setSnackbar({
-        message: err.message || 'Failed to add client',
-        severity: 'error',
-      });
+      if (err.details?.agencyName) {
+        setConflictAgency(err.details.agencyName as string);
+      } else {
+        setSnackbar({
+          message: err.message || 'Failed to add client',
+          severity: 'error',
+        });
+      }
     }
   };
 
@@ -164,6 +173,18 @@ export default function AgencyClientManager() {
         message={snackbar?.message || ''}
         severity={snackbar?.severity}
       />
+      <Dialog open={!!conflictAgency} onClose={() => setConflictAgency(null)}>
+        <DialogTitle>Client Already Associated</DialogTitle>
+        <DialogContent>
+          <Typography>
+            This client is already associated with {conflictAgency}. Remove them
+            from there and add again.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConflictAgency(null)}>OK</Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
     -d '{"clientId":42}'
   ```
 
+   A client may be linked to only one agency at a time. If the client is
+   already associated with another agency, the request returns a `409 Conflict`
+   response containing that agency's name.
+
    Remove a client with
    `DELETE /agencies/:id/clients/:clientId` (use `me` for the authenticated agency).
 


### PR DESCRIPTION
## Summary
- Block linking a client to a second agency and return the existing agency name
- Enforce unique client-to-agency constraint in the database
- Show a modal when attempting to add a client already tied to another agency

## Testing
- `npm test` (backend)
- `npm test` *(fails: VolunteerSettings.test.tsx)*
- `npm test src/__tests__/AgencyClientManager.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0fd8880b4832da692a0f60347a47c