### PR TITLE
feat: reveal client search after selecting agency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 - Deleting sub-roles and shifts prompts confirmation dialogs to prevent accidental removal.
 - Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations.
+  Initially, the page shows only agency search; selecting an agency reveals a two-column layout with client search on the left and the agency's client list on the right.
 
 ## Development Guidelines
 

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -88,6 +88,26 @@ export default function AgencyClientManager() {
       });
     }
   };
+  if (!agency) {
+    return (
+      <>
+        <Typography variant="h5" gutterBottom>
+          Select Agency
+        </Typography>
+        <EntitySearch
+          type="agency"
+          placeholder="Search agencies"
+          onSelect={ag => setAgency({ id: ag.id, name: ag.name })}
+        />
+        <FeedbackSnackbar
+          open={!!snackbar}
+          onClose={() => setSnackbar(null)}
+          message={snackbar?.message || ''}
+          severity={snackbar?.severity}
+        />
+      </>
+    );
+  }
 
   return (
     <>
@@ -126,36 +146,28 @@ export default function AgencyClientManager() {
             placeholder="Search agencies"
             onSelect={ag => setAgency({ id: ag.id, name: ag.name })}
           />
-          {agency ? (
-            <>
-              <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
-                Clients for {agency.name}
-              </Typography>
-              <List dense>
-                {clients.map(c => (
-                  <ListItem
-                    key={c.id}
-                    secondaryAction={
-                      <IconButton
-                        edge="end"
-                        aria-label="remove"
-                        onClick={() => handleRemove(c.id)}
-                      >
-                        <DeleteIcon />
-                      </IconButton>
-                    }
+          <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
+            Clients for {agency.name}
+          </Typography>
+          <List dense>
+            {clients.map(c => (
+              <ListItem
+                key={c.id}
+                secondaryAction={
+                  <IconButton
+                    edge="end"
+                    aria-label="remove"
+                    onClick={() => handleRemove(c.id)}
                   >
-                    <ListItemText primary={c.name} secondary={`ID: ${c.id}`} />
-                  </ListItem>
-                ))}
-                {clients.length === 0 && (
-                  <Typography>No clients assigned.</Typography>
-                )}
-              </List>
-            </>
-          ) : (
-            <Typography sx={{ mt: 2 }}>Select an agency to view clients.</Typography>
-          )}
+                    <DeleteIcon />
+                  </IconButton>
+                }
+              >
+                <ListItemText primary={c.name} secondary={`ID: ${c.id}`} />
+              </ListItem>
+            ))}
+            {clients.length === 0 && <Typography>No clients assigned.</Typography>}
+          </List>
         </Grid>
       </Grid>
       <FeedbackSnackbar

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/AgencyClientManager.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/AgencyClientManager.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AgencyClientManager from '../AgencyClientManager';
+
+jest.mock('../../../components/EntitySearch', () => (props: any) => (
+  <button onClick={() => props.onSelect({ id: 1, name: 'Test Agency' })}>
+    {props.type === 'agency' ? 'Select Agency' : 'Select Client'}
+  </button>
+));
+
+jest.mock('../../../api/agencies', () => ({
+  addAgencyClient: jest.fn(),
+  removeAgencyClient: jest.fn(),
+  getAgencyClients: jest.fn().mockResolvedValue([]),
+}));
+
+describe('AgencyClientManager', () => {
+  it('shows agency search before selection then shows client search', async () => {
+    render(<AgencyClientManager />);
+
+    expect(screen.getByText('Select Agency')).toBeInTheDocument();
+    expect(screen.queryByText('Select Client')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Select Agency'));
+
+    expect(await screen.findByText('Select Client')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Clients for Test Agency'),
+    ).toBeInTheDocument();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ control weight calculations:
 - Pantry Settings page lets staff configure one max booking capacity used for all pantry times.
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
-- Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab lets staff search for an agency, view its clients, and manage client associations.
+- Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list for managing associations.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- show only agency search in Add Client to Agency tab until an agency is selected
- display client search and agency client list side by side after selection
- add tests for agency/client association workflow

## Testing
- `npm test` (fails: VolunteerSettings.test.tsx)`

------
https://chatgpt.com/codex/tasks/task_e_68b0fe79329c832d8df711836fa07fdb