### PR TITLE
Reference agency clients by external client ID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,9 +298,9 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `PATCH /volunteer-bookings/:id/cancel` → `{ id, role_id, volunteer_id, date, status }`
 
 ### Agencies (`src/routes/agencies.ts`)
-- `GET /agencies/:id/clients` → `[ clientId ]`
-- `POST /agencies/:id/clients` `{ clientId }` → `204`
-- `DELETE /agencies/:id/clients/:clientId` → `204`
+- `GET /agencies/:id/clients` → `[ clientId ]` (each `clientId` is the client's `client_id`)
+- `POST /agencies/:id/clients` `{ clientId }` → `204` (use the client's `client_id`)
+- `DELETE /agencies/:id/clients/:clientId` → `204` (clientId is the client's `client_id`)
 - `POST /agencies` `{ name, email, password, contactInfo? }` → `{ id }` (staff only)
 - A client may be linked to only one agency at a time; adding a client already
   associated with another agency returns a `409` with that agency's name.

--- a/MJ_FB_Backend/src/migrations/1720000001001_agency_clients_client_id_bigint.ts
+++ b/MJ_FB_Backend/src/migrations/1720000001001_agency_clients_client_id_bigint.ts
@@ -1,0 +1,25 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_fkey');
+  pgm.alterColumn('agency_clients', 'client_id', { type: 'bigint' });
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_fkey', {
+    foreignKeys: {
+      columns: 'client_id',
+      references: 'clients(client_id)',
+      onDelete: 'CASCADE',
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_fkey');
+  pgm.alterColumn('agency_clients', 'client_id', { type: 'integer' });
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_fkey', {
+    foreignKeys: {
+      columns: 'client_id',
+      references: 'clients(id)',
+      onDelete: 'CASCADE',
+    },
+  });
+}

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -123,7 +123,7 @@ CREATE TABLE IF NOT EXISTS agencies (
 
 CREATE TABLE IF NOT EXISTS agency_clients (
     agency_id integer NOT NULL REFERENCES public.agencies(id) ON DELETE CASCADE,
-    client_id integer NOT NULL UNIQUE REFERENCES public.clients(id) ON DELETE CASCADE,
+    client_id bigint NOT NULL UNIQUE REFERENCES public.clients(client_id) ON DELETE CASCADE,
     UNIQUE (agency_id, client_id)
 );
 

--- a/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
@@ -7,7 +7,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { useAuth } from '../../hooks/useAuth';
 import Page from '../../components/Page';
 
-interface User { id: number; name: string; email: string; }
+interface User { id: number; name: string; email: string; client_id: number; }
 
 export default function ClientBookings() {
   const { id: agencyId } = useAuth();
@@ -32,7 +32,7 @@ export default function ClientBookings() {
   async function choose(user: User) {
     if (!agencyId) return;
     try {
-      await addAgencyClient(agencyId, user.id);
+      await addAgencyClient(agencyId, user.client_id);
       setSelected(user);
       setSnackbar('Client added');
     } catch (err: any) {

--- a/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
@@ -39,7 +39,7 @@ export default function ClientList() {
       const data = await getMyAgencyClients();
       const mapped = Array.isArray(data)
         ? data.map((c: any) => ({
-            id: c.id ?? c.client_id,
+            id: c.client_id,
             name:
               c.name ??
               c.client_name ??

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -40,7 +40,7 @@ export default function AgencyClientManager() {
       const data = await getAgencyClients(id);
       const mapped = Array.isArray(data)
         ? data.map((c: any) => ({
-            id: c.id ?? c.client_id,
+            id: c.client_id,
             name:
               c.name ??
               c.client_name ??
@@ -68,7 +68,7 @@ export default function AgencyClientManager() {
       return;
     }
     try {
-      await addAgencyClient(agency.id, user.id);
+      await addAgencyClient(agency.id, user.client_id);
       setSnackbar({ message: 'Client added', severity: 'success' });
       load(agency.id);
     } catch (err: any) {

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
    ```
 
 2. **Assign clients to the agency** – authenticate as staff or the
-   agency and call the API:
+   agency and call the API (use the client's `client_id` for `clientId`):
 
    ```bash
    # As staff assigning client 42 to agency 1


### PR DESCRIPTION
## Summary
- store agency client links using `clients.client_id`
- update frontend agency management to send client IDs
- clarify docs on agency client endpoints

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm test` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b105c46164832db64ab6df53fa6cc5