### PR TITLE
feat(agency): add status-filtered client history with lazy load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
+- Agency Client History page fetches bookings for all of an agency's clients with status filtering and lazy-loaded pagination.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
 - `PUT /slots/capacity` updates the `max_capacity` for all slots.
 

--- a/MJ_FB_Frontend/src/__tests__/ClientHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientHistory.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ClientHistory from '../pages/agency/ClientHistory';
+import { getBookingHistory } from '../api/bookings';
+import { getMyAgencyClients } from '../api/agencies';
+
+jest.mock('../api/bookings', () => ({
+  getBookingHistory: jest.fn(),
+}));
+
+jest.mock('../api/agencies', () => ({
+  getMyAgencyClients: jest.fn(),
+}));
+
+beforeEach(() => {
+  (window as any).IntersectionObserver = jest.fn(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+});
+
+describe('ClientHistory', () => {
+  it('appends bookings when loading more', async () => {
+    (getMyAgencyClients as jest.Mock).mockResolvedValue([{ id: 1, name: 'Alice' }]);
+    (getBookingHistory as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          status: 'approved',
+          date: '2024-01-01',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          created_at: '2024-01-01',
+          slot_id: 1,
+          is_staff_booking: false,
+          reschedule_token: 't',
+          client_id: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 2,
+          status: 'approved',
+          date: '2024-01-02',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          created_at: '2024-01-02',
+          slot_id: 1,
+          is_staff_booking: false,
+          reschedule_token: 't',
+          client_id: 1,
+        },
+      ]);
+
+    render(<ClientHistory />);
+
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+    expect(getBookingHistory).toHaveBeenCalledWith({
+      clientIds: [1],
+      status: 'approved',
+      limit: 10,
+      offset: 0,
+    });
+
+    fireEvent.click(await screen.findByText('Load more'));
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalledTimes(2));
+    expect(getBookingHistory).toHaveBeenLastCalledWith({
+      clientIds: [1],
+      status: 'approved',
+      limit: 10,
+      offset: 1,
+    });
+
+    expect(screen.getAllByText('approved')).toHaveLength(2);
+  });
+
+  it('filters bookings by status', async () => {
+    (getMyAgencyClients as jest.Mock).mockResolvedValue([{ id: 1, name: 'Alice' }]);
+    (getBookingHistory as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          status: 'approved',
+          date: '2024-01-01',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          created_at: '2024-01-01',
+          slot_id: 1,
+          is_staff_booking: false,
+          reschedule_token: 't',
+          client_id: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 2,
+          status: 'visited',
+          date: '2024-01-02',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          created_at: '2024-01-02',
+          slot_id: 1,
+          is_staff_booking: false,
+          reschedule_token: 't',
+          client_id: 1,
+        },
+      ]);
+
+    render(<ClientHistory />);
+
+    expect(await screen.findByText('approved')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Status') as HTMLInputElement, {
+      target: { value: 'visited' },
+    });
+
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalledTimes(2));
+    expect(getBookingHistory).toHaveBeenLastCalledWith({
+      clientIds: [1],
+      status: 'visited',
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(screen.getByText('visited')).toBeInTheDocument();
+    expect(screen.queryByText('approved')).not.toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -128,6 +128,9 @@ export async function getBookingHistory(
     past?: boolean;
     userId?: number;
     includeVisits?: boolean;
+    clientIds?: number[];
+    limit?: number;
+    offset?: number;
   } = {},
 ) {
   const params = new URLSearchParams();
@@ -135,6 +138,10 @@ export async function getBookingHistory(
   if (opts.past) params.append('past', 'true');
   if (opts.userId) params.append('userId', String(opts.userId));
   if (opts.includeVisits) params.append('includeVisits', 'true');
+  if (opts.clientIds && opts.clientIds.length)
+    params.append('clientIds', opts.clientIds.join(','));
+  if (opts.limit) params.append('limit', String(opts.limit));
+  if (opts.offset) params.append('offset', String(opts.offset));
   const res = await apiFetch(
     `${API_BASE}/bookings/history?${params.toString()}`,
   );

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Adding a client visit automatically updates any approved booking for that client on the same date to `visited`.
 - The Manage Booking dialog now displays the client's name, a link to their profile, and their visit count for the current month to assist staff decisions.
 - Client booking history tables can filter bookings by `visited` and `no_show` statuses.
+- Agencies can view booking histories for all their clients with status filters and lazy-loaded pagination.
 - Booking requests are automatically approved or rejected; the pending approval workflow has been removed.
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts).


### PR DESCRIPTION
## Summary
- show agency client booking history without search; include client names
- fetch booking history by client IDs with status filter and lazy-load pagination
- test client history paging and status filtering

## Testing
- `npm test` *(fails: Jest cannot parse import.meta in src/api/client.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1072ad2e8832d8457aa973789aed9