### PR TITLE
feat: expand agency navigation and guard routes

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -181,9 +181,11 @@ export default function App() {
     navGroups.push({
       label: 'Agency',
       links: [
-        { label: 'Schedule', to: '/agency/schedule' },
+        { label: 'Dashboard', to: '/' },
+        { label: 'Book Appointment', to: '/agency/book' },
+        { label: 'Booking History', to: '/agency/history' },
         { label: 'Clients', to: '/agency/clients' },
-        { label: 'Client History', to: '/agency/history' },
+        { label: 'Schedule', to: '/agency/schedule' },
       ],
     });
   } else if (role === 'shopper') {
@@ -309,12 +311,6 @@ export default function App() {
                   element={<Exports />}
                 />
               )}
-              {role === 'agency' && (
-                <Route
-                  path="/agency/clients"
-                  element={<AgencyClientBookings />}
-                />
-              )}
               {role === 'shopper' && (
                 <Route path="/book-appointment" element={<BookingUI shopperName={name || undefined} />} />
               )}
@@ -391,6 +387,14 @@ export default function App() {
                     element={
                       <AgencyGuard>
                         <AgencySchedule />
+                      </AgencyGuard>
+                    }
+                  />
+                  <Route
+                    path="/agency/book"
+                    element={
+                      <AgencyGuard>
+                        <AgencyClientBookings />
                       </AgencyGuard>
                     }
                   />

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ control weight calculations:
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
 - Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list for managing associations.
+- Agency users have a dedicated navigation menu with links to Dashboard, Book Appointment, Booking History, Clients, and Schedule.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- add dashboard, booking, history, client, and schedule links for agency nav
- secure agency booking routes with `AgencyGuard`
- document agency navigation options

## Testing
- `CI=true npm test -- src/__tests__/App.test.tsx` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b107312248832d9c54976c4d911f91