### PR TITLE
Reference client numbers in agency-client links

### DIFF
--- a/MJ_FB_Backend/src/migrations/1730000000000_agency_clients_clientid_fk.ts
+++ b/MJ_FB_Backend/src/migrations/1730000000000_agency_clients_clientid_fk.ts
@@ -1,0 +1,25 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_fkey');
+  pgm.alterColumn('agency_clients', 'client_id', { type: 'bigint' });
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_fkey', {
+    foreignKeys: {
+      columns: 'client_id',
+      references: 'clients(client_id)',
+      onDelete: 'CASCADE',
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_fkey');
+  pgm.alterColumn('agency_clients', 'client_id', { type: 'integer' });
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_fkey', {
+    foreignKeys: {
+      columns: 'client_id',
+      references: 'clients(id)',
+      onDelete: 'CASCADE',
+    },
+  });
+}

--- a/MJ_FB_Backend/src/models/agency.ts
+++ b/MJ_FB_Backend/src/models/agency.ts
@@ -39,7 +39,7 @@ export async function getAgencyClients(
   agencyId: number,
 ): Promise<AgencyClientSummary[]> {
   const res = await pool.query(
-    `SELECT c.client_id, c.first_name, c.last_name, c.email
+    `SELECT c.client_id AS client_id, c.first_name, c.last_name, c.email
      FROM agency_clients ac
      INNER JOIN clients c ON c.client_id = ac.client_id
      WHERE ac.agency_id = $1`,

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -123,7 +123,7 @@ CREATE TABLE IF NOT EXISTS agencies (
 
 CREATE TABLE IF NOT EXISTS agency_clients (
     agency_id integer NOT NULL REFERENCES public.agencies(id) ON DELETE CASCADE,
-    client_id integer NOT NULL UNIQUE REFERENCES public.clients(id) ON DELETE CASCADE,
+    client_id bigint NOT NULL UNIQUE REFERENCES public.clients(client_id) ON DELETE CASCADE,
     UNIQUE (agency_id, client_id)
 );
 

--- a/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientBookings.tsx
@@ -7,7 +7,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { useAuth } from '../../hooks/useAuth';
 import Page from '../../components/Page';
 
-interface User { id: number; name: string; email: string; }
+interface User { id: number; client_id: number; name: string; email: string; }
 
 export default function ClientBookings() {
   const { id: agencyId } = useAuth();
@@ -32,7 +32,7 @@ export default function ClientBookings() {
   async function choose(user: User) {
     if (!agencyId) return;
     try {
-      await addAgencyClient(agencyId, user.id);
+      await addAgencyClient(agencyId, user.client_id);
       setSelected(user);
       setSnackbar('Client added');
     } catch (err: any) {

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -73,7 +73,7 @@ export default function AgencyClientManager() {
       return;
     }
     try {
-      await addAgencyClient(agency.id, user.id);
+      await addAgencyClient(agency.id, user.client_id);
       setSnackbar({ message: 'Client added', severity: 'success' });
       load(agency.id);
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- Ensure agency-client join table references clients by their `client_id`
- Add migration to switch agency client foreign key to client number
- Pass client numbers in agency client assignment flows on frontend

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm install` (backend) *(fails: 403 Forbidden)*
- `npm test` (frontend) *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b107dfdd1c832da57d198e95ce5910