### PR TITLE
feat: add agency booking navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations.
   Initially, the page shows only agency search; selecting an agency reveals a two-column layout with client search on the left and the agency's client list on the right.
 - Agencies can book appointments for their associated clients from the Agency → Book Appointment page, which loads clients once and filters client-side.
+- Agency navigation provides Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all protected by `AgencyGuard`.
 
 ## Development Guidelines
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -185,10 +185,10 @@ export default function App() {
       label: 'Agency',
       links: [
         { label: 'Dashboard', to: '/' },
-        { label: 'Schedule', to: '/agency/schedule' },
-        { label: 'Clients', to: '/agency/clients' },
-        { label: 'Client History', to: '/agency/history' },
         { label: 'Book Appointment', to: '/agency/book' },
+        { label: 'Booking History', to: '/agency/history' },
+        { label: 'Clients', to: '/agency/clients' },
+        { label: 'Schedule', to: '/agency/schedule' },
       ],
     });
   } else if (role === 'shopper') {

--- a/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
@@ -10,6 +10,7 @@ jest.mock('../api/users', () => ({
 jest.mock('../pages/agency/AgencySchedule', () => () => <div>AgencySchedule</div>);
 jest.mock('../pages/agency/ClientList', () => () => <div>AgencyClientList</div>);
 jest.mock('../pages/agency/AgencyBookAppointment', () => () => <div>AgencyBookAppointment</div>);
+jest.mock('../pages/agency/ClientHistory', () => () => <div>AgencyClientHistory</div>);
 
 describe('Agency UI access', () => {
   beforeEach(() => {
@@ -49,6 +50,9 @@ describe('Agency UI access', () => {
     );
     expect(screen.getByRole('link', { name: /clients/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /book appointment/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /booking history/i })
+    ).toBeInTheDocument();
   });
 
   it('redirects unauthenticated users away from agency routes', async () => {

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ control weight calculations:
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
 - Agencies can book appointments for their associated clients via the Agency → Book Appointment page, which lists existing clients and filters them client-side.
+- Agency navigation offers Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all behind an `AgencyGuard`.
 - Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list for managing associations.
 
 ## Deploying to Azure


### PR DESCRIPTION
## Summary
- add agency nav links for booking, history, clients, and schedule
- document agency navigation and guard usage
- test agency login shows booking history link

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b109054e98832d963efbc8fdd353fe