### PR TITLE
Use public client ID for agency associations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `POST /agencies` `{ name, email, password, contactInfo? }` → `{ id }` (staff only)
 - A client may be linked to only one agency at a time; adding a client already
   associated with another agency returns a `409` with that agency's name.
+  `clientId` refers to the public identifier (`clients.client_id`).
 
 ### Donors (`src/routes/donors.ts`)
 - `GET /donors?search=name` → `[ { id, name } ]`

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -75,20 +75,21 @@ export async function addClientToAgency(
     const paramId =
       requestedId === 'me' ? Number(req.user?.id) : Number(requestedId);
     const agencyId = req.user.role === 'agency' ? Number(req.user.id) : paramId;
-    if (!agencyId || !req.body.clientId) {
+    const clientId = Number(req.body.clientId);
+    if (!agencyId || !clientId) {
       return res.status(400).json({ message: 'Missing fields' });
     }
     if (req.user.role === 'agency' && requestedId !== 'me' && agencyId !== paramId) {
       return res.status(403).json({ message: 'Forbidden' });
     }
-    const existing = await getAgencyForClient(Number(req.body.clientId));
+    const existing = await getAgencyForClient(clientId);
     if (existing) {
       return res.status(409).json({
         message: `Client already associated with ${existing.name}`,
         agencyName: existing.name,
       });
     }
-    await addAgencyClient(agencyId, Number(req.body.clientId));
+    await addAgencyClient(agencyId, clientId);
     res.status(204).send();
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/src/migrations/1720000001000_agency_clients_client_id_ref.ts
+++ b/MJ_FB_Backend/src/migrations/1720000001000_agency_clients_client_id_ref.ts
@@ -1,0 +1,25 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_fkey');
+  pgm.alterColumn('agency_clients', 'client_id', { type: 'bigint' });
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_fkey', {
+    foreignKeys: {
+      columns: 'client_id',
+      references: 'clients(client_id)',
+      onDelete: 'CASCADE',
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_fkey');
+  pgm.alterColumn('agency_clients', 'client_id', { type: 'integer' });
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_fkey', {
+    foreignKeys: {
+      columns: 'client_id',
+      references: 'clients(id)',
+      onDelete: 'CASCADE',
+    },
+  });
+}

--- a/MJ_FB_Backend/src/models/agency.ts
+++ b/MJ_FB_Backend/src/models/agency.ts
@@ -39,9 +39,9 @@ export async function getAgencyClients(
   agencyId: number,
 ): Promise<AgencyClientSummary[]> {
   const res = await pool.query(
-    `SELECT c.client_id, c.first_name, c.last_name, c.email
+    `SELECT ac.client_id, c.first_name, c.last_name, c.email
      FROM agency_clients ac
-     INNER JOIN clients c ON c.client_id = ac.client_id
+     INNER JOIN clients c USING (client_id)
      WHERE ac.agency_id = $1`,
     [agencyId],
   );

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -123,7 +123,7 @@ CREATE TABLE IF NOT EXISTS agencies (
 
 CREATE TABLE IF NOT EXISTS agency_clients (
     agency_id integer NOT NULL REFERENCES public.agencies(id) ON DELETE CASCADE,
-    client_id integer NOT NULL UNIQUE REFERENCES public.clients(id) ON DELETE CASCADE,
+    client_id bigint NOT NULL UNIQUE REFERENCES public.clients(client_id) ON DELETE CASCADE,
     UNIQUE (agency_id, client_id)
 );
 

--- a/README.md
+++ b/README.md
@@ -111,15 +111,18 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
    # As staff assigning client 42 to agency 1
    curl -X POST http://localhost:4000/agencies/1/clients \
      -H "Authorization: Bearer <token>" \
-     -H "Content-Type: application/json" \
-     -d '{"clientId":42}'
-
-   # As the agency itself
-   curl -X POST http://localhost:4000/agencies/me/clients \
-     -H "Authorization: Bearer <agency-token>" \
     -H "Content-Type: application/json" \
     -d '{"clientId":42}'
+
+    # As the agency itself
+    curl -X POST http://localhost:4000/agencies/me/clients \
+      -H "Authorization: Bearer <agency-token>" \
+     -H "Content-Type: application/json" \
+     -d '{"clientId":42}'
   ```
+
+   In these examples, `clientId` is the public identifier from the `clients`
+   table (`clients.client_id`).
 
    A client may be linked to only one agency at a time. If the client is
    already associated with another agency, the request returns a `409 Conflict`


### PR DESCRIPTION
## Summary
- reference `clients.client_id` in `agency_clients`
- add migration and adjust queries to use the public client identifier
- document that agency client endpoints expect the `client_id`

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b109a9a43c832d9189d900227f021d