### PR TITLE
Link agency clients by external client ID

### DIFF
--- a/MJ_FB_Backend/src/migrations/1720000000001_agency_clients_use_client_client_id.ts
+++ b/MJ_FB_Backend/src/migrations/1720000000001_agency_clients_use_client_client_id.ts
@@ -1,0 +1,27 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Ensure client_id stores the external client identifier.
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_fkey');
+  pgm.alterColumn('agency_clients', 'client_id', { type: 'bigint' });
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_fkey', {
+    foreignKeys: {
+      columns: 'client_id',
+      references: 'clients(client_id)',
+      onDelete: 'CASCADE',
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_client_id_fkey');
+  pgm.alterColumn('agency_clients', 'client_id', { type: 'integer' });
+  pgm.addConstraint('agency_clients', 'agency_clients_client_id_fkey', {
+    foreignKeys: {
+      columns: 'client_id',
+      references: 'clients(id)',
+      onDelete: 'CASCADE',
+    },
+  });
+}
+

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -123,7 +123,7 @@ CREATE TABLE IF NOT EXISTS agencies (
 
 CREATE TABLE IF NOT EXISTS agency_clients (
     agency_id integer NOT NULL REFERENCES public.agencies(id) ON DELETE CASCADE,
-    client_id integer NOT NULL UNIQUE REFERENCES public.clients(id) ON DELETE CASCADE,
+    client_id bigint NOT NULL UNIQUE REFERENCES public.clients(client_id) ON DELETE CASCADE,
     UNIQUE (agency_id, client_id)
 );
 

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -73,7 +73,8 @@ export default function AgencyClientManager() {
       return;
     }
     try {
-      await addAgencyClient(agency.id, user.id);
+      const clientId = user.client_id ?? user.id;
+      await addAgencyClient(agency.id, clientId);
       setSnackbar({ message: 'Client added', severity: 'success' });
       load(agency.id);
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- Reference `clients.client_id` in `agency_clients` table
- Add migration to update foreign key and column type
- Send client_id when adding an agency client from staff UI

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm install` (backend) *(fails: 403 Forbidden on node-pg-migrate)*
- `npm test` (frontend) *(hangs with ts-jest warnings, no results)*

------
https://chatgpt.com/codex/tasks/task_e_68b1098f28fc832da30c7f4882f1345c