### PR TITLE
fix: allow agencies to retrieve their own clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,8 @@ Volunteer management coordinates role-based staffing for the food bank.
 - A client may be linked to only one agency at a time; adding a client already
   associated with another agency returns a `409` with that agency's name.
   `clientId` refers to the public identifier (`clients.client_id`).
+  Authenticated agency users may substitute `me` for `:id` in the above client
+  routes (e.g. `GET /agencies/me/clients`).
 
 ### Donors (`src/routes/donors.ts`)
 - `GET /donors?search=name` → `[ { id, name } ]`

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -132,12 +132,17 @@ export async function getAgencyClients(
     if (!req.user || (req.user.role !== 'staff' && req.user.role !== 'agency')) {
       return res.status(403).json({ message: 'Forbidden' });
     }
-    const paramId = Number(req.params.id);
+    const requestedId = req.params.id;
+    const paramId = requestedId === 'me' ? Number(req.user?.id) : Number(requestedId);
     const agencyId = req.user.role === 'agency' ? Number(req.user.id) : paramId;
     if (!agencyId) {
       return res.status(400).json({ message: 'Missing fields' });
     }
-    if (req.user.role === 'agency' && agencyId !== paramId) {
+    if (
+      req.user.role === 'agency' &&
+      requestedId !== 'me' &&
+      agencyId !== paramId
+    ) {
       return res.status(403).json({ message: 'Forbidden' });
     }
     const clients = await fetchAgencyClients(agencyId);

--- a/MJ_FB_Backend/tests/agencyClientsMe.test.ts
+++ b/MJ_FB_Backend/tests/agencyClientsMe.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import express from 'express';
+import agenciesRoutes from '../src/routes/agencies';
+import { getAgencyClients } from '../src/models/agency';
+
+jest.mock('../src/models/agency', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/models/agency'),
+  getAgencyClients: jest.fn(),
+}));
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: '1', role: 'agency' };
+    next();
+  },
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/agencies', agenciesRoutes);
+app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  res.status(err.status || 500).json({ message: err.message });
+});
+
+describe('GET /agencies/me/clients', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns clients for authenticated agency', async () => {
+    (getAgencyClients as jest.Mock).mockResolvedValue([
+      { client_id: 5, first_name: 'John', last_name: 'Doe', email: null },
+    ]);
+
+    const res = await request(app).get('/agencies/me/clients');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { client_id: 5, first_name: 'John', last_name: 'Doe', email: null },
+    ]);
+    expect(getAgencyClients).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- handle `me` parameter in `GET /agencies/:id/clients`
- cover agency self-client retrieval with a new test
- document ability to use `me` for agency client routes

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b10b280288832d8d34d1e1d55dbc6e