### PR TITLE
feat: remove agency client and schedule links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations.
   Initially, the page shows only agency search; selecting an agency reveals a two-column layout with client search on the left and the agency's client list on the right.
 - Agencies can book appointments for their associated clients from the Agency → Book Appointment page, which loads clients once and filters client-side.
-- Agency navigation provides Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all protected by `AgencyGuard`.
+- Agency navigation provides Dashboard, Book Appointment, and Booking History pages, all protected by `AgencyGuard`.
 
 ## Development Guidelines
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -25,13 +25,9 @@ const BookingUI = React.lazy(() => import('./pages/BookingUI'));
 const PantrySchedule = React.lazy(() =>
   import('./pages/staff/PantrySchedule')
 );
-const AgencySchedule = React.lazy(() =>
-  import('./pages/agency/AgencySchedule')
-);
 const AgencyDashboard = React.lazy(() =>
   import('./pages/agency/AgencyDashboard')
 );
-const ClientList = React.lazy(() => import('./pages/agency/ClientList'));
 const ClientHistory = React.lazy(() =>
   import('./pages/agency/ClientHistory')
 );
@@ -187,8 +183,6 @@ export default function App() {
         { label: 'Dashboard', to: '/' },
         { label: 'Book Appointment', to: '/agency/book' },
         { label: 'Booking History', to: '/agency/history' },
-        { label: 'Clients', to: '/agency/clients' },
-        { label: 'Schedule', to: '/agency/schedule' },
       ],
     });
   } else if (role === 'shopper') {
@@ -388,26 +382,10 @@ export default function App() {
                 {role === 'agency' && (
                   <>
                     <Route
-                      path="/agency/schedule"
-                      element={
-                        <AgencyGuard>
-                          <AgencySchedule />
-                        </AgencyGuard>
-                      }
-                    />
-                    <Route
                       path="/agency/book"
                       element={
                         <AgencyGuard>
                           <AgencyBookAppointment />
-                        </AgencyGuard>
-                      }
-                    />
-                    <Route
-                      path="/agency/clients"
-                      element={
-                        <AgencyGuard>
-                          <ClientList />
                         </AgencyGuard>
                       }
                     />

--- a/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
@@ -7,8 +7,6 @@ jest.mock('../api/users', () => ({
   loginAgency: jest.fn(),
 }));
 
-jest.mock('../pages/agency/AgencySchedule', () => () => <div>AgencySchedule</div>);
-jest.mock('../pages/agency/ClientList', () => () => <div>AgencyClientList</div>);
 jest.mock('../pages/agency/AgencyBookAppointment', () => () => <div>AgencyBookAppointment</div>);
 jest.mock('../pages/agency/ClientHistory', () => () => <div>AgencyClientHistory</div>);
 
@@ -46,17 +44,19 @@ describe('Agency UI access', () => {
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
 
     await waitFor(() =>
-      expect(screen.getByRole('link', { name: /schedule/i })).toBeInTheDocument()
+      expect(
+        screen.getByRole('link', { name: /book appointment/i })
+      ).toBeInTheDocument()
     );
-    expect(screen.getByRole('link', { name: /clients/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /book appointment/i })).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /booking history/i })
     ).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /schedule/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /clients/i })).not.toBeInTheDocument();
   });
 
   it('redirects unauthenticated users away from agency routes', async () => {
-    window.history.pushState({}, '', '/agency/schedule');
+    window.history.pushState({}, '', '/agency/book');
     render(
       <AuthProvider>
         <App />

--- a/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
@@ -200,7 +200,7 @@ export default function AgencyDashboard() {
                         size="small"
                         variant="contained"
                         sx={{ textTransform: 'none' }}
-                        onClick={() => navigate('/agency/schedule')}
+                        onClick={() => navigate('/agency/book')}
                       >
                         Book
                       </Button>
@@ -244,7 +244,7 @@ export default function AgencyDashboard() {
                 size="small"
                 variant="contained"
                 sx={{ textTransform: 'none' }}
-                onClick={() => navigate('/agency/schedule')}
+                onClick={() => navigate('/agency/book')}
               >
                 Book Appointment
               </Button>

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ control weight calculations:
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
 - Agencies can book appointments for their associated clients via the Agency → Book Appointment page, which lists existing clients and filters them client-side.
-- Agency navigation offers Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all behind an `AgencyGuard`.
+- Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.
 - Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list for managing associations.
 
 ## Deploying to Azure


### PR DESCRIPTION
## Summary
- hide Clients and Schedule links for agency users
- drop agency routes for client list and schedule pages
- redirect dashboard actions to the booking page

## Testing
- `npm test` *(fails: Test Suites: 20 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b10b693514832d98b5daed896f1233