### PR TITLE
Fix agency profile to show agency info and allow edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,9 @@ Volunteer management coordinates role-based staffing for the food bank.
 - A client may be linked to only one agency at a time; adding a client already
   associated with another agency returns a `409` with that agency's name.
   `clientId` refers to the public identifier (`clients.client_id`).
+- Agency users can view and update their own profile via `GET/PATCH /users/me`.
+  The response includes `firstName` (agency name), `email`, and `phone`
+  (contact info).
 
 ### Donors (`src/routes/donors.ts`)
 - `GET /donors?search=name` → `[ { id, name } ]`

--- a/MJ_FB_Backend/tests/agencyProfile.test.ts
+++ b/MJ_FB_Backend/tests/agencyProfile.test.ts
@@ -1,0 +1,71 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.user = { id: '1', type: 'agency', role: 'agency' };
+    next();
+  },
+  authorizeRoles: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../src/middleware/validate', () => ({
+  validate: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/users', usersRouter);
+
+afterEach(() => {
+  (pool.query as jest.Mock).mockReset();
+});
+
+describe('Agency profile routes', () => {
+  it('returns agency details', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 1, name: 'Agency', email: 'agency@example.com', contact_info: '123-4567' }],
+    });
+
+    const res = await request(app).get('/api/users/me');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: 1,
+      firstName: 'Agency',
+      lastName: '',
+      email: 'agency@example.com',
+      phone: '123-4567',
+      role: 'agency',
+    });
+  });
+
+  it('updates agency details', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 1, name: 'Agency', email: 'new@example.com', contact_info: 'info' }],
+    });
+
+    const res = await request(app)
+      .patch('/api/users/me')
+      .send({ email: 'new@example.com', phone: 'info' });
+
+    expect(res.status).toBe(200);
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE agencies'),
+      ['new@example.com', 'info', '1'],
+    );
+    expect(res.body).toEqual({
+      id: 1,
+      firstName: 'Agency',
+      lastName: '',
+      email: 'new@example.com',
+      phone: 'info',
+      role: 'agency',
+    });
+  });
+});

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -49,9 +49,10 @@ export default function Profile({ role }: { role: Role }) {
       })
       .catch(e => setError(e instanceof Error ? e.message : String(e)));
   }, [role]);
-
   const initials = profile
-    ? `${profile.firstName?.[0] ?? ''}${profile.lastName?.[0] ?? ''}`.toUpperCase()
+    ? profile.role === 'agency'
+      ? (profile.firstName ?? '').slice(0, 2).toUpperCase()
+      : `${profile.firstName?.[0] ?? ''}${profile.lastName?.[0] ?? ''}`.toUpperCase()
     : '';
   const phoneRegex = /^\+?[0-9\s-]{7,15}$/;
 
@@ -88,7 +89,7 @@ export default function Profile({ role }: { role: Role }) {
   async function handleEdit() {
     if (!profile) return;
     if (editing) {
-      if (phone && phoneError) {
+      if (profile.role !== 'agency' && phone && phoneError) {
         setToast({ open: true, message: 'Please enter a valid phone number.', severity: 'error' });
         return;
       }
@@ -174,22 +175,29 @@ export default function Profile({ role }: { role: Role }) {
                 InputLabelProps={{ shrink: true }}
               />
               <TextField
-                label="Phone"
-                type="tel"
+                label={profile.role === 'agency' ? 'Contact Info' : 'Phone'}
+                type={profile.role === 'agency' ? 'text' : 'tel'}
                 size="small"
                 value={phone}
                 onChange={e => {
-                  setPhone(e.target.value);
-                  if (e.target.value && !phoneRegex.test(e.target.value)) {
-                    setPhoneError('Use only numbers, spaces, or dashes.');
-                  } else {
-                    setPhoneError('');
+                  const val = e.target.value;
+                  setPhone(val);
+                  if (profile.role !== 'agency') {
+                    if (val && !phoneRegex.test(val)) {
+                      setPhoneError('Use only numbers, spaces, or dashes.');
+                    } else {
+                      setPhoneError('');
+                    }
                   }
                 }}
                 disabled={!editing}
                 InputLabelProps={{ shrink: true }}
-                error={!!phoneError}
-                helperText={phoneError || 'Format: 123-456-7890'}
+                error={profile.role === 'agency' ? false : !!phoneError}
+                helperText={
+                  profile.role === 'agency'
+                    ? undefined
+                    : phoneError || 'Format: 123-456-7890'
+                }
               />
               {profile.bookingsThisMonth !== undefined && (
                 <Typography>

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ control weight calculations:
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
 - Agencies can book appointments for their associated clients via the Agency → Book Appointment page, which lists existing clients and filters them client-side.
 - Agency navigation offers Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all behind an `AgencyGuard`.
+- Agency profile page shows the agency's name, email, and contact info with editable fields and password reset support.
 - Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list for managing associations.
 
 ## Deploying to Azure


### PR DESCRIPTION
## Summary
- show and update agency name, email, and contact info via `/users/me`
- adapt profile page to edit agency contact info and reset password
- document agency profile capability

## Testing
- `npm test` (backend) *(fails: jest not found; install forbidden)*
- `npm test` (frontend) *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b10ba07198832d8deea8514748808f