### PR TITLE
Use composite primary key for agency_clients

### DIFF
--- a/MJ_FB_Backend/src/migrations/1720000002000_agency_clients_primary_key.ts
+++ b/MJ_FB_Backend/src/migrations/1720000002000_agency_clients_primary_key.ts
@@ -1,0 +1,15 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_agency_id_client_id_key');
+  pgm.addConstraint('agency_clients', 'agency_clients_pkey', {
+    primaryKey: ['agency_id', 'client_id'],
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('agency_clients', 'agency_clients_pkey');
+  pgm.addConstraint('agency_clients', 'agency_clients_agency_id_client_id_key', {
+    unique: ['agency_id', 'client_id'],
+  });
+}

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -124,7 +124,7 @@ CREATE TABLE IF NOT EXISTS agencies (
 CREATE TABLE IF NOT EXISTS agency_clients (
     agency_id integer NOT NULL REFERENCES public.agencies(id) ON DELETE CASCADE,
     client_id bigint NOT NULL UNIQUE REFERENCES public.clients(client_id) ON DELETE CASCADE,
-    UNIQUE (agency_id, client_id)
+    PRIMARY KEY (agency_id, client_id)
 );
 
 CREATE TABLE IF NOT EXISTS client_email_verifications (


### PR DESCRIPTION
## Summary
- Replace UNIQUE constraint on `agency_clients` `(agency_id, client_id)` with a composite primary key
- Adjust setup script to create `agency_clients` with this composite primary key

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden for node-pg-migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68b1102f25e0832dafd8d8286507cbc7