### PR TITLE
Log migrations to console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - `models/` and `db.ts` – PostgreSQL access.
 - `middleware/` – shared Express middleware (authentication, validation, etc.).
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
-- The database schema is managed via TypeScript migrations in `src/migrations` using `npm run migrate`.
+- The database schema is managed via TypeScript migrations in `src/migrations` using `npm run migrate`. The command logs each migration's success or failure to the console.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -37,7 +37,7 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "test": "jest",
-    "migrate": "node-pg-migrate up -m src/migrations --tsconfig tsconfig.json",
+    "migrate": "ts-node src/runMigrations.ts",
     "migration:create": "node-pg-migrate create -m src/migrations -j ts"
   },
   "keywords": [],

--- a/MJ_FB_Backend/src/runMigrations.ts
+++ b/MJ_FB_Backend/src/runMigrations.ts
@@ -1,0 +1,31 @@
+import pgMigrate from 'node-pg-migrate';
+import config from './config';
+import logger from './utils/logger';
+
+async function runMigrations() {
+  try {
+    const migrations = await pgMigrate({
+      databaseUrl: {
+        host: config.pgHost,
+        port: config.pgPort,
+        database: config.pgDatabase,
+        user: config.pgUser,
+        password: config.pgPassword,
+      },
+      dir: 'src/migrations',
+      direction: 'up',
+      migrationsTable: 'pgmigrations',
+      tsconfig: 'tsconfig.json',
+      logger: {
+        log: msg => logger.info(msg),
+        error: msg => logger.error(msg),
+      },
+    });
+    logger.info(`Migrations applied: ${migrations.join(', ') || 'none'}`);
+  } catch (error) {
+    logger.error(`Migration failed: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+runMigrations();

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm install
 npm start   # or npm run dev
 ```
 
-The database schema is managed via TypeScript migrations in `src/migrations`; run `npm run migrate` to apply them.
+The database schema is managed via TypeScript migrations in `src/migrations`; run `npm run migrate` to apply them. The command logs each executed migration or any failures to the console so you can track what ran.
 
 ### Environment variables
 


### PR DESCRIPTION
## Summary
- log migration success/failure to console via dedicated script
- document migration logging and update migrate command

## Testing
- `npm test` (fails: jest: not found)
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/node-pg-migrate)

------
https://chatgpt.com/codex/tasks/task_e_68b11210c890832db74f75aaa75e3c64