### PR TITLE
Switch agency client assignment to payload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 
 ### Agencies (`src/routes/agencies.ts`)
 - `GET /agencies/:id/clients` → `[ clientId ]`
-- `POST /agencies/:id/clients` `{ clientId }` → `204` (404 if client not found)
+- `POST /agencies/add-client` `{ agencyId, clientId }` → `204` (404 if client not found)
 - `DELETE /agencies/:id/clients/:clientId` → `204`
 - `POST /agencies` `{ name, email, password, contactInfo? }` → `{ id }` (staff only)
 - A client may be linked to only one agency at a time; adding a client already

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -72,25 +72,27 @@ export async function addClientToAgency(
     if (!req.user || (req.user.role !== 'staff' && req.user.role !== 'agency')) {
       return res.status(403).json({ message: 'Forbidden' });
     }
-    const requestedId = req.params.id;
-    const paramId =
-      requestedId === 'me' ? Number(req.user?.id) : Number(requestedId);
-    const agencyId = req.user.role === 'agency' ? Number(req.user.id) : paramId;
+    const requestedAgencyId = req.body.agencyId;
+    const bodyId =
+      requestedAgencyId === 'me'
+        ? Number(req.user?.id)
+        : Number(requestedAgencyId);
+    const agencyId = req.user.role === 'agency' ? Number(req.user.id) : bodyId;
     const clientId = Number(req.body.clientId);
-    if (!agencyId || !clientId) {
+    if (!bodyId || !clientId) {
       return res.status(400).json({ message: 'Missing fields' });
     }
-      if (req.user.role === 'agency' && requestedId !== 'me' && agencyId !== paramId) {
-        return res.status(403).json({ message: 'Forbidden' });
-      }
-      if (!(await clientExists(clientId))) {
-        return res.status(404).json({ message: 'Client not found' });
-      }
-      const existing = await getAgencyForClient(clientId);
-      if (existing) {
-        return res.status(409).json({
-          message: `Client already associated with ${existing.name}`,
-          agencyName: existing.name,
+    if (req.user.role === 'agency' && agencyId !== bodyId) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    if (!(await clientExists(clientId))) {
+      return res.status(404).json({ message: 'Client not found' });
+    }
+    const existing = await getAgencyForClient(clientId);
+    if (existing) {
+      return res.status(409).json({
+        message: `Client already associated with ${existing.name}`,
+        agencyName: existing.name,
       });
     }
     await addAgencyClient(agencyId, clientId);

--- a/MJ_FB_Backend/src/routes/agencies.ts
+++ b/MJ_FB_Backend/src/routes/agencies.ts
@@ -21,7 +21,7 @@ router.get(
 );
 
 router.post(
-  '/:id/clients',
+  '/add-client',
   authMiddleware,
   authorizeRoles('staff', 'agency'),
   addClientToAgency,

--- a/MJ_FB_Backend/tests/agencyClientUnique.test.ts
+++ b/MJ_FB_Backend/tests/agencyClientUnique.test.ts
@@ -34,7 +34,7 @@ app.use((err: any, _req: express.Request, res: express.Response, _next: express.
   res.status(err.status || 500).json({ message: err.message, agencyName: err.agencyName });
 });
 
-describe('POST /agencies/:id/clients', () => {
+describe('POST /agencies/add-client', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -44,8 +44,8 @@ describe('POST /agencies/:id/clients', () => {
     (getAgencyForClient as jest.Mock).mockResolvedValue({ id: 2, name: 'Existing Agency' });
 
     const res = await request(app)
-      .post('/agencies/1/clients')
-      .send({ clientId: 5 });
+      .post('/agencies/add-client')
+      .send({ agencyId: 1, clientId: 5 });
 
     expect(res.status).toBe(409);
     expect(res.body).toEqual({
@@ -59,8 +59,8 @@ describe('POST /agencies/:id/clients', () => {
     (clientExists as jest.Mock).mockResolvedValue(false);
 
     const res = await request(app)
-      .post('/agencies/1/clients')
-      .send({ clientId: 999 });
+      .post('/agencies/add-client')
+      .send({ agencyId: 1, clientId: 999 });
 
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ message: 'Client not found' });

--- a/MJ_FB_Frontend/src/api/agencies.ts
+++ b/MJ_FB_Frontend/src/api/agencies.ts
@@ -23,10 +23,10 @@ export async function addAgencyClient(
   clientId: number,
 ): Promise<void> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  const res = await apiFetch(`${API_BASE}/agencies/${agencyId}/clients`, {
+  const res = await apiFetch(`${API_BASE}/agencies/add-client`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ clientId }),
+    body: JSON.stringify({ agencyId, clientId }),
   });
   await handleResponse(res);
 }

--- a/README.md
+++ b/README.md
@@ -108,17 +108,17 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
    agency and call the API:
 
    ```bash
-   # As staff assigning client 42 to agency 1
-   curl -X POST http://localhost:4000/agencies/1/clients \
-     -H "Authorization: Bearer <token>" \
-    -H "Content-Type: application/json" \
-    -d '{"clientId":42}'
+  # As staff assigning client 42 to agency 1
+  curl -X POST http://localhost:4000/agencies/add-client \
+    -H "Authorization: Bearer <token>" \
+   -H "Content-Type: application/json" \
+   -d '{"agencyId":1,"clientId":42}'
 
-    # As the agency itself
-    curl -X POST http://localhost:4000/agencies/me/clients \
-      -H "Authorization: Bearer <agency-token>" \
-     -H "Content-Type: application/json" \
-     -d '{"clientId":42}'
+   # As the agency itself
+   curl -X POST http://localhost:4000/agencies/add-client \
+     -H "Authorization: Bearer <agency-token>" \
+    -H "Content-Type: application/json" \
+    -d '{"agencyId":1,"clientId":42}'
   ```
 
    In these examples, `clientId` is the public identifier from the `clients`


### PR DESCRIPTION
## Summary
- accept agency and client IDs in request body when linking clients to agencies
- update frontend API helper to post to `/agencies/add-client`
- document new add-client endpoint

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm install` (backend) *(fails: 403 Forbidden - node-pg-migrate)*
- `npm test` (frontend) *(fails: Test Suites: 20 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b117a4b8f8832db6a8a9c73356824f