### PR TITLE
Allow agencies to manage bookings for their clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@
   Initially, the page shows only agency search; selecting an agency reveals a two-column layout with client search on the left and the agency's client list on the right.
 - Agencies can book appointments for their associated clients from the Agency → Book Appointment page, which loads clients once and filters client-side.
 - Agency navigation provides Dashboard, Book Appointment, and Booking History pages, all protected by `AgencyGuard`.
+- Agencies can view pantry slot availability and manage bookings—including creating, cancelling, and rescheduling—for their linked clients.
 
 ## Development Guidelines
 

--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -187,7 +187,14 @@ export async function cancelBooking(req: Request, res: Response, next: NextFunct
     if (!booking) return res.status(404).json({ message: 'Booking not found' });
 
     const requesterId = Number((requester as any).userId ?? requester.id);
-    if (requester.role !== 'staff' && booking.user_id !== requesterId) {
+    if (requester.role === 'agency') {
+      const associated = await isAgencyClient(requesterId, booking.user_id);
+      if (!associated) {
+        return res.status(403).json({
+          message: 'Client not associated with agency',
+        });
+      }
+    } else if (requester.role !== 'staff' && booking.user_id !== requesterId) {
       return res.status(403).json({ message: 'Forbidden' });
     }
 

--- a/MJ_FB_Backend/src/routes/slots.ts
+++ b/MJ_FB_Backend/src/routes/slots.ts
@@ -21,13 +21,13 @@ router.get(
 router.get(
   '/',
   authMiddleware,
-  authorizeRoles('shopper', 'delivery', 'staff'),
+  authorizeRoles('shopper', 'delivery', 'staff', 'agency'),
   listSlots,
 );
 router.get(
   '/range',
   authMiddleware,
-  authorizeRoles('shopper', 'delivery', 'staff'),
+  authorizeRoles('shopper', 'delivery', 'staff', 'agency'),
   listSlotsRange,
 );
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ control weight calculations:
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
 - Agencies can book appointments for their associated clients via the Agency → Book Appointment page, which lists existing clients and filters them client-side.
+- Agencies can view slot availability and cancel or reschedule bookings for their clients using the standard booking APIs.
 - Agency navigation offers Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all behind an `AgencyGuard`.
 - Agency profile page shows the agency's name, email, and contact info with editable fields and password reset support.
 - Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.


### PR DESCRIPTION
## Summary
- Allow agencies to query `/slots` and `/slots/range`
- Permit agencies to cancel client bookings when associated
- Document agency booking capabilities

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - node-pg-migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68b11c191b90832d80cced5bccb258aa