### PR TITLE
Refine agency booking UI

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
@@ -22,5 +22,6 @@ describe('AgencyBookAppointment', () => {
     fireEvent.click(screen.getByText('Alice'));
 
     await screen.findByText(/BookingUI Alice 1/);
+    expect(screen.queryByRole('button', { name: 'Alice' })).toBeNull();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -75,4 +75,21 @@ describe('BookingUI visible slots', () => {
     });
     expect(getSlots).toHaveBeenCalledTimes(1);
   });
+
+  it('omits title when embedded', async () => {
+    (getSlots as jest.Mock).mockResolvedValue([]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+
+    const queryClient = new QueryClient();
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <BookingUI shopperName="Test" embedded />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText(/Booking for: Test/);
+    expect(screen.queryByText('Book Appointment')).toBeNull();
+  });
 });

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -66,12 +66,14 @@ export type BookingUIProps = {
   shopperName?: string;
   initialDate?: Dayjs;
   userId?: number;
+  embedded?: boolean;
 };
 
 export default function BookingUI({
   shopperName = 'John Shopper',
   initialDate = dayjs(),
   userId,
+  embedded = false,
 }: BookingUIProps) {
   const [date, setDate] = useState<Dayjs>(() => {
     let d = initialDate;
@@ -265,8 +267,7 @@ export default function BookingUI({
       ).format('h:mm a')}`
     : '';
 
-  return (
-    <Page title="Book Appointment">
+  const content = (
       <Container maxWidth="lg" sx={{ pb: 9 }}>
       <Toolbar />
       <Typography variant="h5" gutterBottom>
@@ -422,7 +423,9 @@ export default function BookingUI({
         severity="warning"
       />
     </Container>
-    </Page>
   );
+
+  if (embedded) return content;
+  return <Page title="Book Appointment">{content}</Page>;
 }
 

--- a/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
@@ -52,14 +52,28 @@ export default function AgencyBookAppointment() {
         fullWidth
         sx={{ mb: 2 }}
       />
-      <List>
-        {filtered.map(u => (
-          <ListItemButton key={u.id} onClick={() => setSelected(u)}>
-            <ListItemText primary={u.name} secondary={u.email} />
-          </ListItemButton>
-        ))}
-      </List>
-      {selected && <BookingUI shopperName={selected.name} userId={selected.id} />}
+      {(!selected || search) && (
+        <List>
+          {filtered.map(u => (
+            <ListItemButton
+              key={u.id}
+              onClick={() => {
+                setSelected(u);
+                setSearch('');
+              }}
+            >
+              <ListItemText primary={u.name} secondary={u.email} />
+            </ListItemButton>
+          ))}
+        </List>
+      )}
+      {selected && (
+        <BookingUI
+          shopperName={selected.name}
+          userId={selected.id}
+          embedded
+        />
+      )}
       <FeedbackSnackbar
         open={!!snackbar}
         onClose={() => setSnackbar('')}

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ control weight calculations:
 - Pantry Settings page lets staff configure one max booking capacity used for all pantry times.
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
-- Agencies can book appointments for their associated clients via the Agency → Book Appointment page, which lists existing clients and filters them client-side.
+- Agencies can book appointments for their associated clients via the Agency → Book Appointment page, which lists existing clients and filters them client-side. The page now hides the client list after a selection and uses a single “Book Appointment” heading for clarity.
 - Agency navigation offers Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all behind an `AgencyGuard`.
 - Agency profile page shows the agency's name, email, and contact info with editable fields and password reset support.
 - Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.


### PR DESCRIPTION
## Summary
- allow embedding BookingUI without its own heading
- hide selected client in agency booking list to avoid duplicate names
- document streamlined agency booking page

## Testing
- `npm test src/__tests__/App.test.tsx` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*
- `npm test src/__tests__/AgencyBookAppointment.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b11cac08e8832da407f33ac01d6c53