### PR TITLE
Hide agency client list until search on booking page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@
 - Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations.
   Initially, the page shows only agency search; selecting an agency reveals a two-column layout with client search on the left and the agency's client list on the right.
-- Agencies can book appointments for their associated clients from the Agency → Book Appointment page, which loads clients once and filters client-side.
+- Agencies can book appointments for their associated clients from the Agency → Book Appointment page. Clients load once and display only after entering a search term, with filtering performed client-side to avoid long lists.
 - Agency navigation provides Dashboard, Book Appointment, and Booking History pages, all protected by `AgencyGuard`.
 - Agencies can view pantry slot availability and manage bookings—including creating, cancelling, and rescheduling—for their linked clients.
 

--- a/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
@@ -18,6 +18,9 @@ describe('AgencyBookAppointment', () => {
 
     render(<AgencyBookAppointment />);
 
+    fireEvent.change(screen.getByLabelText(/Search Clients/i), {
+      target: { value: 'Alice' },
+    });
     await screen.findByText('Alice');
     fireEvent.click(screen.getByText('Alice'));
 

--- a/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
@@ -35,13 +35,15 @@ export default function AgencyBookAppointment() {
       .catch(() => setSnackbar('Failed to load clients'));
   }, []);
 
-  const filtered = clients.filter(c => {
-    const term = search.toLowerCase();
-    return (
-      c.name.toLowerCase().includes(term) ||
-      (c.email ? c.email.toLowerCase().includes(term) : false)
-    );
-  });
+  const filtered = search
+    ? clients.filter(c => {
+        const term = search.toLowerCase();
+        return (
+          c.name.toLowerCase().includes(term) ||
+          (c.email ? c.email.toLowerCase().includes(term) : false)
+        );
+      })
+    : [];
 
   return (
     <Page title="Book Appointment">
@@ -52,7 +54,7 @@ export default function AgencyBookAppointment() {
         fullWidth
         sx={{ mb: 2 }}
       />
-      {(!selected || search) && (
+      {search && (
         <List>
           {filtered.map(u => (
             <ListItemButton

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ control weight calculations:
 - Pantry Settings page lets staff configure one max booking capacity used for all pantry times.
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses next to their name.
-- Agencies can book appointments for their associated clients via the Agency → Book Appointment page, which lists existing clients and filters them client-side. The page now hides the client list after a selection and uses a single “Book Appointment” heading for clarity.
+- Agencies can book appointments for their associated clients via the Agency → Book Appointment page. Clients load once and appear only after entering a search term, avoiding long lists. The page hides the client list after a selection and uses a single “Book Appointment” heading for clarity.
 - Agencies can view slot availability and cancel or reschedule bookings for their clients using the standard booking APIs.
 - Agency navigation offers Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all behind an `AgencyGuard`.
 - Agency profile page shows the agency's name, email, and contact info with editable fields and password reset support.


### PR DESCRIPTION
## Summary
- Only show client search results on agency Book Appointment page after entering text
- Update agency booking test, docs, and guidelines for search-only behavior

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module; TypeError: mediaQueryList.addEventListener is not a function, etc.)*
- `npm test -- src/__tests__/AgencyBookAppointment.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b11f63bd9c832d9a0813c37a1f8fb2