### PR TITLE
Fetch holidays immediately in BookingUI

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -97,10 +97,7 @@ export default function BookingUI({
   });
   const [holidaysReady, setHolidaysReady] = useState(false);
   useEffect(() => {
-    const handle = scheduleIdle(() => {
-      refetchHolidays().finally(() => setHolidaysReady(true));
-    });
-    return () => cancelIdle(handle);
+    refetchHolidays().finally(() => setHolidaysReady(true));
   }, [refetchHolidays]);
   const holidaySet = useMemo(() => new Set(holidays.map(h => h.date)), [holidays]);
   const isDisabled = (d: Dayjs) =>


### PR DESCRIPTION
## Summary
- refetch holidays on mount without idle scheduling so calendar shows sooner

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b124b41290832db4c051c838e54add