### PR TITLE
Allow agencies to access holidays API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - For changes in `MJ_FB_Frontend`, run `npm test` from the `MJ_FB_Frontend` directory.
 
 - `GET /slots` returns an empty array with a 200 status on holidays.
+- Agencies can retrieve holiday dates via `GET /holidays` to disable bookings on those days.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/src/routes/holidays.ts
+++ b/MJ_FB_Backend/src/routes/holidays.ts
@@ -9,7 +9,7 @@ const router = express.Router();
 router.get(
   '/',
   authMiddleware,
-  authorizeRoles('staff', 'volunteer', 'user'),
+  authorizeRoles('staff', 'volunteer', 'user', 'agency'),
   async (_, res) => {
     const result = await pool.query('SELECT date, reason FROM holidays ORDER BY date');
     res.json(

--- a/MJ_FB_Backend/tests/holidaysAccess.test.ts
+++ b/MJ_FB_Backend/tests/holidaysAccess.test.ts
@@ -79,4 +79,29 @@ describe('GET /holidays', () => {
     expect(res.status).toBe(200);
       expect(res.body).toEqual([{ date: '2024-12-24', reason: 'Christmas' }]);
     });
+
+  it('allows agencies to fetch holidays', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'agency', type: 'agency' });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            id: 1,
+            name: 'Test Agency',
+            email: 'agency@example.com',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ date: new Date('2024-12-25'), reason: 'Christmas' }],
+      });
+
+    const res = await request(app)
+      .get('/holidays')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ date: '2024-12-24', reason: 'Christmas' }]);
+  });
   });

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Volunteer role start and end times are selected via a native time picker and stored as `HH:MM:SS`.
 - Listing volunteer roles (`GET /volunteer-roles`) accepts `includeInactive=true` to return inactive shifts.
 - Slot listing endpoint `/slots` returns an empty array and 200 status on holidays. Each slot includes an `overbooked` flag when approved bookings exceed `max_capacity`, and the `available` count never goes below zero.
+- Holiday listings via `GET /holidays` are available to agencies so booking interfaces can disable those dates.
 
 ## Clone and initialize submodules
 


### PR DESCRIPTION
## Summary
- permit agencies to fetch holiday listings from backend
- test agency access to holiday endpoint
- document holiday access for agencies

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for node-pg-migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68b1253b309c832db7c00b04776eb444