### PR TITLE
Show loading indicator for agency booking slots

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
@@ -1,20 +1,50 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { useEffect } from 'react';
 import AgencyBookAppointment from '../pages/agency/AgencyBookAppointment';
 
 jest.mock('../api/agencies', () => ({
   getMyAgencyClients: jest.fn(),
 }));
 
-jest.mock('../pages/BookingUI', () => ({ shopperName, userId }: any) => (
-  <div>BookingUI {shopperName} {userId}</div>
-));
+const mockBookingUI = jest.fn();
+jest.mock('../pages/BookingUI', () => (props: any) => mockBookingUI(props));
 
 describe('AgencyBookAppointment', () => {
+  afterEach(() => {
+    mockBookingUI.mockReset();
+  });
+
+  it('shows loading indicator while BookingUI loads', async () => {
+    const { getMyAgencyClients } = require('../api/agencies');
+    (getMyAgencyClients as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'Alice', email: 'a@example.com' },
+    ]);
+    mockBookingUI.mockImplementation(({ shopperName, userId }: any) => (
+      <div>BookingUI {shopperName} {userId}</div>
+    ));
+
+    render(<AgencyBookAppointment />);
+
+    fireEvent.change(screen.getByLabelText(/Search Clients/i), {
+      target: { value: 'Alice' },
+    });
+    await screen.findByText('Alice');
+    fireEvent.click(screen.getByText('Alice'));
+
+    expect(await screen.findByText(/Loading availability/i)).toBeInTheDocument();
+  });
+
   it('renders BookingUI when a client is selected', async () => {
     const { getMyAgencyClients } = require('../api/agencies');
     (getMyAgencyClients as jest.Mock).mockResolvedValue([
       { id: 1, name: 'Alice', email: 'a@example.com' },
     ]);
+    mockBookingUI.mockImplementation(({ shopperName, userId, onLoadingChange }: any) => {
+      useEffect(() => {
+        onLoadingChange(false);
+      }, [onLoadingChange]);
+      return <div>BookingUI {shopperName} {userId}</div>;
+    });
 
     render(<AgencyBookAppointment />);
 
@@ -25,6 +55,6 @@ describe('AgencyBookAppointment', () => {
     fireEvent.click(screen.getByText('Alice'));
 
     await screen.findByText(/BookingUI Alice 1/);
-    expect(screen.queryByRole('button', { name: 'Alice' })).toBeNull();
+    expect(screen.queryByText(/Loading availability/i)).toBeNull();
   });
 });

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -67,6 +67,7 @@ export type BookingUIProps = {
   initialDate?: Dayjs;
   userId?: number;
   embedded?: boolean;
+  onLoadingChange?: (loading: boolean) => void;
 };
 
 export default function BookingUI({
@@ -74,6 +75,7 @@ export default function BookingUI({
   initialDate = dayjs(),
   userId,
   embedded = false,
+  onLoadingChange,
 }: BookingUIProps) {
   const [date, setDate] = useState<Dayjs>(() => {
     let d = initialDate;
@@ -137,6 +139,10 @@ export default function BookingUI({
   const [morningSlots, setMorningSlots] = useState<Slot[]>([]);
   const [afternoonSlots, setAfternoonSlots] = useState<Slot[]>([]);
   const [slotsReady, setSlotsReady] = useState(false);
+  const loading = isLoading || !holidaysReady || !slotsReady;
+  useEffect(() => {
+    onLoadingChange?.(loading);
+  }, [loading, onLoadingChange]);
   useEffect(() => {
     setSlotsReady(false);
     const handle = scheduleIdle(() => {

--- a/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from 'react';
-import { TextField, List, ListItemButton, ListItemText } from '@mui/material';
+import {
+  TextField,
+  List,
+  ListItemButton,
+  ListItemText,
+  Box,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
 import BookingUI from '../BookingUI';
 import { getMyAgencyClients } from '../../api/agencies';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -16,6 +24,7 @@ export default function AgencyBookAppointment() {
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<AgencyClient | null>(null);
   const [snackbar, setSnackbar] = useState('');
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     getMyAgencyClients()
@@ -61,6 +70,7 @@ export default function AgencyBookAppointment() {
               key={u.id}
               onClick={() => {
                 setSelected(u);
+                setLoading(true);
                 setSearch('');
               }}
             >
@@ -70,11 +80,29 @@ export default function AgencyBookAppointment() {
         </List>
       )}
       {selected && (
-        <BookingUI
-          shopperName={selected.name}
-          userId={selected.id}
-          embedded
-        />
+        <>
+          {loading && (
+            <Box
+              sx={{
+                minHeight: 200,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <CircularProgress size={24} />
+              <Typography sx={{ ml: 2 }}>Loading availability...</Typography>
+            </Box>
+          )}
+          <Box sx={{ display: loading ? 'none' : 'block' }}>
+            <BookingUI
+              shopperName={selected.name}
+              userId={selected.id}
+              embedded
+              onLoadingChange={setLoading}
+            />
+          </Box>
+        </>
       )}
       <FeedbackSnackbar
         open={!!snackbar}


### PR DESCRIPTION
## Summary
- expose onLoadingChange from BookingUI to surface slot-fetching status
- display loading spinner and copy in AgencyBookAppointment while availability loads
- add tests covering loading indicator behaviour

## Testing
- `npm test -- --runInBand` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b124bb9508832d88529b1c3d3bb21c