### PR TITLE
Persist holidays via API in Manage Availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Volunteer role start and end times are selected via a native time picker and stored as `HH:MM:SS`.
 - Listing volunteer roles (`GET /volunteer-roles`) accepts `includeInactive=true` to return inactive shifts.
 - Slot listing endpoint `/slots` returns an empty array and 200 status on holidays. Each slot includes an `overbooked` flag when approved bookings exceed `max_capacity`, and the `available` count never goes below zero.
+- Staff can add or remove holidays from the Manage Availability page, which persists changes to the backend.
 
 ## Clone and initialize submodules
 


### PR DESCRIPTION
## Summary
- Load holidays from backend in Manage Availability
- Send API requests when adding or removing holidays
- Document holiday management in README

## Testing
- `npm test` (fails: SyntaxError Cannot use 'import.meta' outside a module)


------
https://chatgpt.com/codex/tasks/task_e_68b12630f340832d8f6207c06c3abbe0