### PR TITLE
test: restore global fetch after tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
 
+const originalFetch = (global as any).fetch;
+
 jest.mock('../pages/volunteer-management/VolunteerManagement', () => () => (
   <div>VolunteerManagement</div>
 ));
@@ -25,6 +27,14 @@ describe('App authentication persistence', () => {
     });
     localStorage.clear();
     window.history.pushState({}, '', '/');
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      (global as any).fetch = originalFetch;
+    } else {
+      delete (global as any).fetch;
+    }
   });
 
   it('shows login when not authenticated', () => {


### PR DESCRIPTION
## Summary
- ensure App tests restore global `fetch` after each run

## Testing
- `npm test` *(fails: Jest encountered unexpected tokens and failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b12683ec28832d8e0b14ebf6694921