### PR TITLE
Ensure holiday removals trigger backend API calls

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailability.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailability.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ManageAvailability from '../ManageAvailability';
+
+jest.mock('../../../api/bookings', () => ({
+  getAllSlots: jest.fn().mockResolvedValue([]),
+  getBreaks: jest.fn().mockResolvedValue([]),
+  getRecurringBlockedSlots: jest.fn().mockResolvedValue([]),
+  getBlockedSlots: jest.fn().mockResolvedValue([]),
+  getHolidays: jest.fn().mockResolvedValue([{ date: '2024-01-01', reason: 'New Year' }]),
+  removeHoliday: jest.fn().mockResolvedValue(undefined),
+  addHoliday: jest.fn(),
+}));
+
+describe('ManageAvailability', () => {
+  it('calls API when removing holiday', async () => {
+    const user = userEvent.setup();
+    render(<ManageAvailability />);
+
+    const removeButton = await screen.findByLabelText('remove');
+    await user.click(removeButton);
+
+    await waitFor(() =>
+      expect(require('../../../api/bookings').removeHoliday).toHaveBeenCalledWith(
+        '2024-01-01',
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- load holidays from API in Manage Availability
- call add/remove holiday endpoints to persist changes
- add test confirming holiday removal hits API

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b126c725c8832da76c7779e92779eb