### PR TITLE
test: expand matchMedia mock in Navbar test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -40,28 +40,33 @@ describe('Navbar component', () => {
 
   it('moves greeting into hamburger menu on small screens', () => {
     const originalMatchMedia = window.matchMedia;
-    window.matchMedia = () => ({
-      matches: true,
-      addListener: () => {},
-      removeListener: () => {},
-    }) as any;
+    window.matchMedia = () =>
+      ({
+        matches: true,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }) as any;
 
-    render(
-      <MemoryRouter>
-        <Navbar
-          groups={[{ label: 'Home', links: [{ label: 'Home', to: '/' }] }]}
-          onLogout={() => {}}
-          name="Tester"
-        />
-      </MemoryRouter>
-    );
+    try {
+      render(
+        <MemoryRouter>
+          <Navbar
+            groups={[{ label: 'Home', links: [{ label: 'Home', to: '/' }] }]}
+            onLogout={() => {}}
+            name="Tester"
+          />
+        </MemoryRouter>
+      );
 
-    expect(screen.queryByText(/Hello, Tester/i)).toBeNull();
-    fireEvent.click(screen.getByLabelText(/open navigation menu/i));
-    expect(screen.getByText(/Hello, Tester/i)).toBeInTheDocument();
-    expect(screen.getByText(/Profile/i)).toBeInTheDocument();
-    expect(screen.getByText(/Logout/i)).toBeInTheDocument();
-
-    window.matchMedia = originalMatchMedia;
+      expect(screen.queryByText(/Hello, Tester/i)).toBeNull();
+      fireEvent.click(screen.getByLabelText(/open navigation menu/i));
+      expect(screen.getByText(/Hello, Tester/i)).toBeInTheDocument();
+      expect(screen.getByText(/Profile/i)).toBeInTheDocument();
+      expect(screen.getByText(/Logout/i)).toBeInTheDocument();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add addEventListener/removeEventListener to matchMedia mock in navbar test and ensure original function is restored

## Testing
- `npm test src/__tests__/Navbar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1267df95c832da2e7be0bd53efc84