### PR TITLE
Ensure holiday removals call API

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -167,7 +167,7 @@ export default function ManageAvailability() {
 
   const handleRemoveHoliday = async (date: string) => {
     try {
-      await removeHoliday(date);
+      await removeHoliday(formatReginaDate(date));
       setHolidays(prev => prev.filter(h => h.date !== date));
       showSnackbar('Holiday removed', 'success');
     } catch {

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailability.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailability.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ManageAvailability from '../ManageAvailability';
+import { removeHoliday } from '../../../api/bookings';
+
+jest.mock('../../../api/bookings', () => ({
+  getAllSlots: jest.fn().mockResolvedValue([]),
+  getBreaks: jest.fn().mockResolvedValue([]),
+  getRecurringBlockedSlots: jest.fn().mockResolvedValue([]),
+  getBlockedSlots: jest.fn().mockResolvedValue([]),
+  getHolidays: jest.fn().mockResolvedValue([
+    { date: '2024-01-01', reason: 'Holiday' },
+  ]),
+  addHoliday: jest.fn(),
+  removeHoliday: jest.fn(),
+  addBlockedSlot: jest.fn(),
+  addRecurringBlockedSlot: jest.fn(),
+  removeBlockedSlot: jest.fn(),
+  removeRecurringBlockedSlot: jest.fn(),
+  addBreak: jest.fn(),
+  removeBreak: jest.fn(),
+}));
+
+describe('ManageAvailability', () => {
+  it('calls API when removing a holiday', async () => {
+    render(<ManageAvailability />);
+
+    const removeBtn = await screen.findByLabelText('remove');
+    fireEvent.click(removeBtn);
+
+    await waitFor(() => {
+      expect(removeHoliday).toHaveBeenCalledWith('2024-01-01');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Format holiday date before issuing delete request so API is invoked reliably
- Test that removing a holiday triggers the backend call

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module; VolunteerDashboard test failing, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b128816abc832d99f1c1d5624ac404