### PR TITLE
Refresh volunteer pending list after booking

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -46,7 +46,15 @@ beforeEach(() => {
   ]);
   (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
   (getHolidays as jest.Mock).mockResolvedValue([]);
-  (requestVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
+  (requestVolunteerBooking as jest.Mock).mockResolvedValue({
+    id: 1,
+    status: 'pending',
+    role_id: 1,
+    date: '2024-01-01',
+    start_time: '09:00:00',
+    end_time: '10:00:00',
+    role_name: 'Test Role',
+  });
   (createRecurringVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
   (cancelVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
   (cancelRecurringVolunteerBooking as jest.Mock).mockResolvedValue(undefined);

--- a/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
@@ -34,7 +34,15 @@ describe('VolunteerBooking', () => {
         is_wednesday_slot: false,
       },
     ]);
-    (requestVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
+    (requestVolunteerBooking as jest.Mock).mockResolvedValue({
+      id: 1,
+      status: 'pending',
+      role_id: 1,
+      date: '2024-01-01',
+      start_time: '09:00:00',
+      end_time: '12:00:00',
+      role_name: 'Greeter',
+    });
 
     const queryClient = new QueryClient();
     render(

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -65,7 +65,7 @@ export async function getVolunteerRolesForVolunteer(
 export async function requestVolunteerBooking(
   roleId: number,
   date: string
-): Promise<void> {
+): Promise<VolunteerBooking> {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings`, {
     method: 'POST',
     headers: {
@@ -73,7 +73,8 @@ export async function requestVolunteerBooking(
     },
     body: JSON.stringify({ roleId, date }),
   });
-  await handleResponse(res);
+  const data = await handleResponse(res);
+  return normalizeVolunteerBooking(data);
 }
 
 export async function createRecurringVolunteerBooking(

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -125,11 +125,18 @@ export default function VolunteerDashboard() {
 
   async function request(role: VolunteerRole) {
     try {
-      await requestVolunteerBooking(role.id, role.date);
+      const newBooking = await requestVolunteerBooking(role.id, role.date);
       setSnackbarSeverity('success');
       setMessage('Request submitted');
-      const data = await getMyVolunteerBookings();
-      setBookings(data);
+      setBookings(prev => [
+        ...prev,
+        {
+          ...newBooking,
+          role_name: role.name,
+          start_time: role.start_time,
+          end_time: role.end_time,
+        },
+      ]);
     } catch {
       setSnackbarSeverity('error');
       setMessage('Failed to request shift');


### PR DESCRIPTION
## Summary
- return the created booking from `requestVolunteerBooking`
- append new booking to volunteer dashboard state so pending list updates
- update tests for new booking return value

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b129baf35c832d913a153eb4f45c06