### PR TITLE
Remove approved pending volunteer bookings immediately

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,6 +393,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 - Volunteer and pantry schedules follow the same grid logic. The y‑axis lists shift times and the x‑axis lists sequential slot numbers up to each shift's `max_volunteers`. When a volunteer requests a shift, their booking occupies the first open slot. Pending requests highlight (e.g., yellow) and staff approve by clicking the cell, mirroring the shopping appointment schedule.
 - **BookingHistory** shows a volunteer's pending and upcoming bookings with Cancel and Reschedule options.
 - **CoordinatorDashboard** is the staff view using `VolunteerScheduleTable`. Staff see volunteer names for booked cells, approve/reject/reschedule pending requests, and cancel or reschedule approved bookings. Staff can also search volunteers, assign them to roles, and update trained areas.
+- Approving a pending volunteer booking removes it from the Pending page immediately.
 - The volunteer search page shows the selected volunteer's profile and role editor alongside their booking history in a two-column card layout.
 - Role selection in the volunteer search role editor uses a simple dropdown without search.
 - These workflows rely on `volunteer_slots`, `volunteer_roles`, `volunteer_master_roles`, `volunteer_bookings`, `volunteers`, and `volunteer_trained_roles`. Training records in `volunteer_trained_roles` restrict which roles a volunteer can book.

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -320,6 +320,9 @@ export default function VolunteerManagement() {
   ) {
     try {
       await updateVolunteerBookingStatus(id, status, reason);
+      if (tab === 'pending') {
+        setPending(prev => prev.filter(b => b.id !== id));
+      }
       if (selectedRole) {
         const ids = nameToSlotIds.get(selectedRole) || [];
         const data = await Promise.all(

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Volunteer role management and scheduling restricted to trained areas.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.
+- Approving a pending volunteer booking immediately removes it from the Pending list.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
 - Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Volunteer Settings page's **Restore Original Roles & Shifts** button.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).


### PR DESCRIPTION
## Summary
- Remove approved or rejected volunteer requests from pending list as soon as status updates
- Test pending approval flow to ensure items disappear immediately
- Document immediate removal of approved volunteer requests

## Testing
- `npm test src/__tests__/VolunteerManagement.test.tsx -t "pending approvals"`
- `npm test` *(fails: BookingUI.test.tsx, VolunteerBooking.test.tsx, RecurringBookings.test.tsx, ClientSignup.test.tsx, Page.test.tsx, RescheduleDialog.test.tsx, VolunteerDashboard.test.tsx, App.test.tsx, AgencyManagement.test.tsx, AgencyAccess.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b129f40e38832dae564e9141512001