### PR TITLE
Fix timezone parsing for volunteer next shift

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -45,4 +45,35 @@ describe('VolunteerDashboard', () => {
     await waitFor(() => expect(getEvents).toHaveBeenCalled());
     expect(screen.getByText(/Volunteer Event/)).toBeInTheDocument();
   });
+
+  it('shows upcoming approved shift in My Next Shift', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-02-06T18:00:00Z'));
+
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'approved',
+        role_id: 1,
+        date: '2024-02-06',
+        start_time: '17:00:00',
+        end_time: '18:00:00',
+        role_name: 'Greeter',
+      },
+    ]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getMyVolunteerBookings).toHaveBeenCalled());
+    expect(await screen.findByText(/Greeter/)).toBeInTheDocument();
+    expect(screen.queryByText(/No upcoming shifts/)).not.toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
 });

--- a/MJ_FB_Frontend/src/utils/date.ts
+++ b/MJ_FB_Frontend/src/utils/date.ts
@@ -11,7 +11,7 @@ export const REGINA_TIMEZONE = 'America/Regina';
 dayjs.tz.setDefault(REGINA_TIMEZONE);
 
 export function toDayjs(input?: ConfigType) {
-  return dayjs(input).tz();
+  return dayjs.tz(input);
 }
 
 export function toDate(input?: ConfigType) {


### PR DESCRIPTION
## Summary
- ensure date parsing uses Regina timezone for volunteer bookings
- add test confirming upcoming approved shift appears on dashboard

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*
- `npx jest src/__tests__/VolunteerDashboard.test.tsx -t "upcoming approved shift"`


------
https://chatgpt.com/codex/tasks/task_e_68b12a225718832dafabb5cf5bd256af