### PR TITLE
Ensure volunteer booking appears in pending list

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
@@ -34,7 +34,13 @@ describe('VolunteerBooking', () => {
         is_wednesday_slot: false,
       },
     ]);
-    (requestVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
+    (requestVolunteerBooking as jest.Mock).mockResolvedValue({
+      id: 1,
+      role_id: 1,
+      volunteer_id: 1,
+      date: '2024-01-01',
+      status: 'pending',
+    });
 
     const queryClient = new QueryClient();
     render(

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -65,7 +65,7 @@ export async function getVolunteerRolesForVolunteer(
 export async function requestVolunteerBooking(
   roleId: number,
   date: string
-): Promise<void> {
+): Promise<VolunteerBooking> {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings`, {
     method: 'POST',
     headers: {
@@ -73,7 +73,8 @@ export async function requestVolunteerBooking(
     },
     body: JSON.stringify({ roleId, date }),
   });
-  await handleResponse(res);
+  const data = await handleResponse(res);
+  return normalizeVolunteerBooking(data);
 }
 
 export async function createRecurringVolunteerBooking(

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -123,7 +123,7 @@ export default function VolunteerDashboard() {
       s =>
         !activeBookings.some(
           b =>
-            b.role_id === s.role_id &&
+            b.role_id === s.id &&
             b.date === s.date &&
             b.start_time === s.start_time &&
             b.end_time === s.end_time,
@@ -142,11 +142,19 @@ export default function VolunteerDashboard() {
 
   async function request(role: VolunteerRole) {
     try {
-      await requestVolunteerBooking(role.id, role.date);
+      const booking = await requestVolunteerBooking(role.id, role.date);
       setSnackbarSeverity('success');
       setMessage('Request submitted');
-      const data = await getMyVolunteerBookings();
-      setBookings(data);
+      setBookings(prev => [
+        ...prev,
+        {
+          ...booking,
+          role_name: role.name,
+          start_time: role.start_time,
+          end_time: role.end_time,
+          category_name: role.category_name,
+        },
+      ]);
     } catch (e: unknown) {
       setSnackbarSeverity('error');
       if (typeof e === 'object' && e && 'message' in e) {


### PR DESCRIPTION
## Summary
- return new booking from volunteer booking request API
- refresh dashboard state immediately after requesting a shift
- adjust tests for updated API

## Testing
- `CI=true npx jest src/__tests__/VolunteerBooking.test.tsx --runTestsByPath` *(fails: Can not find the date and time pickers localization context)*

------
https://chatgpt.com/codex/tasks/task_e_68b12bd16868832d9a71c7bc11bbe0df