### PR TITLE
Add volunteer stats endpoint and dashboard display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,8 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `DELETE /volunteer-bookings/recurring/:id?from=YYYY-MM-DD` → `{ message: 'Recurring bookings cancelled' }`
 - `PATCH /volunteer-bookings/:id/cancel` → `{ id, role_id, volunteer_id, date, status }`
 
+- `GET /volunteers/me/stats` aggregates completed volunteer shifts into lifetime and monthly hours, total shifts, current consecutive-week streak, and milestone flags (5, 10, 25 shifts).
+
 ### Agencies (`src/routes/agencies.ts`)
 - `GET /agencies/:id/clients` → `[ clientId ]`
 - `POST /agencies/add-client` `{ agencyId, clientId }` → `204` (404 if client not found)

--- a/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
@@ -7,6 +7,7 @@ import {
   searchVolunteers,
   createVolunteerShopperProfile,
   removeVolunteerShopperProfile,
+  getVolunteerStats,
 } from '../../controllers/volunteer/volunteerController';
 import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
 
@@ -15,6 +16,8 @@ const router = express.Router();
 router.post('/login', loginVolunteer);
 
 router.get('/me', authMiddleware, getVolunteerProfile);
+
+router.get('/me/stats', authMiddleware, getVolunteerStats);
 
 router.post(
   '/',

--- a/MJ_FB_Backend/tests/volunteerStats.test.ts
+++ b/MJ_FB_Backend/tests/volunteerStats.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import express from 'express';
+import volunteersRouter from '../src/routes/volunteer/volunteers';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: any, _res: express.Response, next: express.NextFunction) => {
+    req.user = { id: 1, role: 'volunteer' };
+    next();
+  },
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/volunteers', volunteersRouter);
+
+describe('GET /volunteers/me/stats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns volunteer stats with milestone', async () => {
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const day = today.getUTCDay();
+    const diff = (day + 6) % 7;
+    const thisMonday = new Date(today);
+    thisMonday.setUTCDate(thisMonday.getUTCDate() - diff);
+    const lastMonday = new Date(thisMonday);
+    lastMonday.setUTCDate(lastMonday.getUTCDate() - 7);
+
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ hours: 10, month_hours: 4, shifts: 5 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { week_start: thisMonday.toISOString().slice(0, 10) },
+          { week_start: lastMonday.toISOString().slice(0, 10) },
+        ],
+      });
+
+    const res = await request(app).get('/volunteers/me/stats');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      lifetimeHours: 10,
+      monthHours: 4,
+      totalShifts: 5,
+      currentStreak: 2,
+      milestone: 5,
+    });
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/FROM volunteer_bookings vb\s+JOIN volunteer_slots vs/);
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -6,6 +6,7 @@ import {
   getVolunteerRolesForVolunteer,
   requestVolunteerBooking,
   updateVolunteerBookingStatus,
+  getVolunteerStats,
 } from '../api/volunteers';
 import { getEvents } from '../api/events';
 
@@ -14,11 +15,20 @@ jest.mock('../api/volunteers', () => ({
   getVolunteerRolesForVolunteer: jest.fn(),
   requestVolunteerBooking: jest.fn(),
   updateVolunteerBookingStatus: jest.fn(),
+  getVolunteerStats: jest.fn(),
 }));
 
 jest.mock('../api/events', () => ({ getEvents: jest.fn() }));
 
 describe('VolunteerDashboard', () => {
+  beforeEach(() => {
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      lifetimeHours: 0,
+      monthHours: 0,
+      totalShifts: 0,
+      currentStreak: 0,
+    });
+  });
   it('shows events in News & Events section', async () => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
@@ -158,5 +168,26 @@ describe('VolunteerDashboard', () => {
     expect(screen.queryByText(/No upcoming shifts/)).not.toBeInTheDocument();
 
     jest.useRealTimers();
+  });
+
+  it('shows milestone banner when milestone returned', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      lifetimeHours: 5,
+      monthHours: 5,
+      totalShifts: 5,
+      currentStreak: 1,
+      milestone: 5,
+    });
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/5 shifts/)).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
@@ -3,6 +3,7 @@ import {
   createVolunteerBookingForVolunteer,
   updateVolunteerTrainedAreas,
   getVolunteerMasterRoles,
+  getVolunteerStats,
 } from '../api/volunteers';
 
 jest.mock('../api/client', () => ({
@@ -42,5 +43,10 @@ describe('volunteers api', () => {
   it('fetches volunteer master roles', async () => {
     await getVolunteerMasterRoles();
     expect(apiFetch).toHaveBeenCalledWith('/api/volunteer-master-roles');
+  });
+
+  it('fetches volunteer stats', async () => {
+    await getVolunteerStats();
+    expect(apiFetch).toHaveBeenCalledWith('/api/volunteers/me/stats');
   });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -6,6 +6,7 @@ import type {
   Shift,
   VolunteerBooking,
   UserProfile,
+  VolunteerStats,
 } from '../types';
 import type { LoginResponse } from './users';
 
@@ -35,6 +36,11 @@ export async function loginVolunteer(
 
 export async function getVolunteerProfile(): Promise<UserProfile> {
   const res = await apiFetch(`${API_BASE}/volunteers/me`);
+  return handleResponse(res);
+}
+
+export async function getVolunteerStats(): Promise<VolunteerStats> {
+  const res = await apiFetch(`${API_BASE}/volunteers/me/stats`);
   return handleResponse(res);
 }
 

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -22,9 +22,10 @@ import {
   getVolunteerRolesForVolunteer,
   requestVolunteerBooking,
   updateVolunteerBookingStatus,
+  getVolunteerStats,
 } from '../../api/volunteers';
 import { getEvents, type EventGroups } from '../../api/events';
-import type { VolunteerBooking, VolunteerRole } from '../../types';
+import type { VolunteerBooking, VolunteerRole, VolunteerStats } from '../../types';
 import {
   formatTime,
   formatReginaDate,
@@ -57,6 +58,7 @@ export default function VolunteerDashboard() {
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
   const navigate = useNavigate();
+  const [stats, setStats] = useState<VolunteerStats | null>(null);
 
   useEffect(() => {
     getMyVolunteerBookings()
@@ -66,6 +68,10 @@ export default function VolunteerDashboard() {
 
   useEffect(() => {
     getEvents().then(setEvents).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    getVolunteerStats().then(setStats).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -174,6 +180,35 @@ export default function VolunteerDashboard() {
   return (
     <Page title="Volunteer Dashboard">
       <Grid container spacing={2}>
+        {stats?.milestone && (
+          <Grid size={{ xs: 12 }}>
+            <SectionCard>
+              <Typography>{`🎉 You reached ${stats.milestone} shifts!`}</Typography>
+            </SectionCard>
+          </Grid>
+        )}
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <SectionCard title="My Stats">
+            <Stack spacing={1}>
+              <Typography>
+                {`Lifetime hours: ${stats ? stats.lifetimeHours : 0}`}
+              </Typography>
+              <Typography>
+                {`This month: ${stats ? stats.monthHours : 0} hours`}
+              </Typography>
+              <Typography>
+                {`Total shifts: ${stats ? stats.totalShifts : 0}`}
+              </Typography>
+              <Typography>
+                {`Current streak: ${stats ? stats.currentStreak : 0} week${
+                  stats && stats.currentStreak === 1 ? '' : 's'
+                }`}
+              </Typography>
+            </Stack>
+          </SectionCard>
+        </Grid>
+
         <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard title="My Next Shift">
             {nextShift ? (

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -137,6 +137,14 @@ export interface VolunteerBookingDetail {
   recurring_id?: number;
 }
 
+export interface VolunteerStats {
+  lifetimeHours: number;
+  monthHours: number;
+  totalShifts: number;
+  currentStreak: number;
+  milestone?: number | null;
+}
+
 export interface UserProfile {
   id: number;
   firstName: string;

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.
+- Volunteer dashboard now shows lifetime and monthly volunteer hours, total shifts, and current streak via `GET /volunteers/me/stats`, displaying milestone banners at 5, 10, and 25 shifts.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.
 - Approving a pending volunteer booking immediately removes it from the Pending list.


### PR DESCRIPTION
## Summary
- add GET /volunteers/me/stats with streak and milestone logic
- expose getVolunteerStats in API wrapper and show stats on volunteer dashboard
- include tests and docs for volunteer stats feature

## Testing
- `npm test` (backend) *(fails: jest not found; install 403)*
- `npm test` (frontend) *(fails: multiple test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b12cb38a34832da2cfb25055922d4a