### PR TITLE
Add volunteer stats endpoint and dashboard milestones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@
 - For changes in `MJ_FB_Backend`, run `npm test` from the `MJ_FB_Backend` directory.
 - For changes in `MJ_FB_Frontend`, run `npm test` from the `MJ_FB_Frontend` directory.
 
-- Volunteers can earn badges. Use `GET /volunteers/me/stats` to retrieve badges and
-  `POST /volunteers/me/badges` to manually award one.
+- Volunteers can earn badges. Use `GET /volunteers/me/stats` to retrieve badges,
+  lifetime and monthly volunteer hours, total shift counts, current streak, and
+  any milestone flag. Use `POST /volunteers/me/badges` to manually award a badge.
 
 - `GET /slots` returns an empty array with a 200 status on holidays.
 - Agencies can retrieve holiday dates via `GET /holidays` to disable bookings on those days.

--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -6,7 +6,7 @@ import {
   getVolunteerRolesForVolunteer,
   requestVolunteerBooking,
   updateVolunteerBookingStatus,
-  getVolunteerBadges,
+  getVolunteerStats,
 } from '../api/volunteers';
 import { getEvents } from '../api/events';
 
@@ -15,7 +15,7 @@ jest.mock('../api/volunteers', () => ({
   getVolunteerRolesForVolunteer: jest.fn(),
   requestVolunteerBooking: jest.fn(),
   updateVolunteerBookingStatus: jest.fn(),
-  getVolunteerBadges: jest.fn(),
+  getVolunteerStats: jest.fn(),
 }));
 
 jest.mock('../api/events', () => ({ getEvents: jest.fn() }));
@@ -37,7 +37,13 @@ describe('VolunteerDashboard', () => {
       upcoming: [],
       past: [],
     });
-    (getVolunteerBadges as jest.Mock).mockResolvedValue([]);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      lifetimeHours: 0,
+      monthHours: 0,
+      totalShifts: 0,
+      currentStreak: 0,
+    });
 
     render(
       <MemoryRouter>
@@ -80,7 +86,13 @@ describe('VolunteerDashboard', () => {
       },
     ]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerBadges as jest.Mock).mockResolvedValue([]);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      lifetimeHours: 0,
+      monthHours: 0,
+      totalShifts: 0,
+      currentStreak: 0,
+    });
 
     render(
       <MemoryRouter>
@@ -152,7 +164,13 @@ describe('VolunteerDashboard', () => {
     (requestVolunteerBooking as jest.Mock).mockRejectedValue(
       new Error('Already booked for this shift'),
     );
-    (getVolunteerBadges as jest.Mock).mockResolvedValue([]);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      lifetimeHours: 0,
+      monthHours: 0,
+      totalShifts: 0,
+      currentStreak: 0,
+    });
 
     render(
       <MemoryRouter>
@@ -186,7 +204,13 @@ describe('VolunteerDashboard', () => {
     ]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerBadges as jest.Mock).mockResolvedValue([]);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      lifetimeHours: 0,
+      monthHours: 0,
+      totalShifts: 0,
+      currentStreak: 0,
+    });
 
     render(
       <MemoryRouter>
@@ -205,7 +229,13 @@ describe('VolunteerDashboard', () => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerBadges as jest.Mock).mockResolvedValue(['early-bird']);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: ['early-bird'],
+      lifetimeHours: 0,
+      monthHours: 0,
+      totalShifts: 0,
+      currentStreak: 0,
+    });
 
     render(
       <MemoryRouter>
@@ -214,5 +244,29 @@ describe('VolunteerDashboard', () => {
     );
 
     expect(await screen.findByText('early-bird')).toBeInTheDocument();
+  });
+
+  it('shows milestone banner when milestone returned', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      lifetimeHours: 10,
+      monthHours: 4,
+      totalShifts: 5,
+      currentStreak: 1,
+      milestone: 5,
+    });
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(/completed 5 shifts/i),
+    ).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -403,12 +403,6 @@ export async function removeVolunteerShopperProfile(
   await handleResponse(res);
 }
 
-export async function getVolunteerBadges(): Promise<string[]> {
-  const res = await apiFetch(`${API_BASE}/volunteers/me/stats`);
-  const data = await handleResponse(res);
-  return data.badges ?? [];
-}
-
 export async function awardVolunteerBadge(badgeCode: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/volunteers/me/badges`, {
     method: 'POST',
@@ -416,4 +410,18 @@ export async function awardVolunteerBadge(badgeCode: string): Promise<void> {
     body: JSON.stringify({ badgeCode }),
   });
   await handleResponse(res);
+}
+
+export interface VolunteerStats {
+  badges: string[];
+  lifetimeHours: number;
+  monthHours: number;
+  totalShifts: number;
+  currentStreak: number;
+  milestone?: number;
+}
+
+export async function getVolunteerStats(): Promise<VolunteerStats> {
+  const res = await apiFetch(`${API_BASE}/volunteers/me/stats`);
+  return handleResponse(res);
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Users see a random appreciation message on each login with a link to download their card when available.
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.
 - Volunteer schedule prevents navigating to past dates and hides shifts that have already started.
-- Volunteer badges are calculated from activity and manually awardable. `GET /volunteers/me/stats` returns earned badges and the dashboard displays them.
+- Volunteer badges and stats are calculated from activity. `GET /volunteers/me/stats`
+  returns earned badges, lifetime and monthly hours, total shifts, current streak,
+  and any milestone flag; the dashboard displays these metrics.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.
 - Approving a pending volunteer booking immediately removes it from the Pending list.


### PR DESCRIPTION
## Summary
- extend volunteer stats API to return hours, shifts, streak, and milestones
- expose getVolunteerStats in API wrapper
- show volunteer stats and milestone banner on dashboard

## Testing
- `npm test` *(MJ_FB_Backend)* - failed: jest not found / dependency install blocked
- `npm test` *(MJ_FB_Frontend)* - failed: VolunteerManagement and VolunteerSettings tests


------
https://chatgpt.com/codex/tasks/task_e_68b12eb7ef04832da08171e7fb644ae7