### PR TITLE
Add volunteer milestone stats and messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Agencies can retrieve holiday dates via `GET /holidays` to disable bookings on those days.
 - Milestone badge awards queue a thank-you card email and expose a downloadable card link via `/stats`.
 - Users see a random appreciation message on login.
+- Volunteer stats include families served, pounds handled, and a milestone message when thresholds are met.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -373,9 +373,22 @@ export async function getVolunteerStats(
        WHERE volunteer_id = $1 AND status = 'approved'`,
       [user.id],
     );
-    if (Number(heavyRes.rows[0].count) >= 10) badges.add('heavy-lifter');
+    const bookingCount = Number(heavyRes.rows[0].count);
+    if (bookingCount >= 10) badges.add('heavy-lifter');
 
-    res.json({ badges: Array.from(badges) });
+    const familiesServed = bookingCount;
+    const poundsHandled = bookingCount * 30;
+    let message: string | null = null;
+    if (bookingCount > 0 && bookingCount % 10 === 0) {
+      message = `You’ve helped serve ${familiesServed} families and handled ${poundsHandled} lbs of food!`;
+    }
+
+    res.json({
+      badges: Array.from(badges),
+      familiesServed,
+      poundsHandled,
+      message,
+    });
   } catch (error) {
     logger.error('Error fetching volunteer stats:', error);
     next(error);

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -183,11 +183,16 @@ describe('Volunteer badges', () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rows: [] }) // manual badges
       .mockResolvedValueOnce({ rowCount: 1 }) // early bird
-      .mockResolvedValueOnce({ rows: [{ count: '10' }] }); // heavy lifter
+      .mockResolvedValueOnce({ rows: [{ count: '20' }] }); // heavy lifter
 
     const res = await request(app).get('/volunteers/me/stats');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ badges: ['early-bird', 'heavy-lifter'] });
+    expect(res.body).toEqual({
+      badges: ['early-bird', 'heavy-lifter'],
+      familiesServed: 20,
+      poundsHandled: 600,
+      message: 'You’ve helped serve 20 families and handled 600 lbs of food!',
+    });
   });
 
   it('awards a badge', async () => {

--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -6,7 +6,7 @@ import {
   getVolunteerRolesForVolunteer,
   requestVolunteerBooking,
   updateVolunteerBookingStatus,
-  getVolunteerBadges,
+  getVolunteerStats,
 } from '../api/volunteers';
 import { getEvents } from '../api/events';
 
@@ -15,7 +15,7 @@ jest.mock('../api/volunteers', () => ({
   getVolunteerRolesForVolunteer: jest.fn(),
   requestVolunteerBooking: jest.fn(),
   updateVolunteerBookingStatus: jest.fn(),
-  getVolunteerBadges: jest.fn(),
+  getVolunteerStats: jest.fn(),
 }));
 
 jest.mock('../api/events', () => ({ getEvents: jest.fn() }));
@@ -37,7 +37,12 @@ describe('VolunteerDashboard', () => {
       upcoming: [],
       past: [],
     });
-    (getVolunteerBadges as jest.Mock).mockResolvedValue([]);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      familiesServed: 0,
+      poundsHandled: 0,
+      message: null,
+    });
 
     render(
       <MemoryRouter>
@@ -80,7 +85,12 @@ describe('VolunteerDashboard', () => {
       },
     ]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerBadges as jest.Mock).mockResolvedValue([]);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      familiesServed: 0,
+      poundsHandled: 0,
+      message: null,
+    });
 
     render(
       <MemoryRouter>
@@ -152,7 +162,12 @@ describe('VolunteerDashboard', () => {
     (requestVolunteerBooking as jest.Mock).mockRejectedValue(
       new Error('Already booked for this shift'),
     );
-    (getVolunteerBadges as jest.Mock).mockResolvedValue([]);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      familiesServed: 0,
+      poundsHandled: 0,
+      message: null,
+    });
 
     render(
       <MemoryRouter>
@@ -186,7 +201,12 @@ describe('VolunteerDashboard', () => {
     ]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerBadges as jest.Mock).mockResolvedValue([]);
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      familiesServed: 0,
+      poundsHandled: 0,
+      message: null,
+    });
 
     render(
       <MemoryRouter>
@@ -205,8 +225,12 @@ describe('VolunteerDashboard', () => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerBadges as jest.Mock).mockResolvedValue(['early-bird']);
-
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: ['early-bird'],
+      familiesServed: 0,
+      poundsHandled: 0,
+      message: null,
+    });
     render(
       <MemoryRouter>
         <VolunteerDashboard />
@@ -214,5 +238,25 @@ describe('VolunteerDashboard', () => {
     );
 
     expect(await screen.findByText('early-bird')).toBeInTheDocument();
+  });
+
+  it('shows appreciation message from stats', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      familiesServed: 5,
+      poundsHandled: 150,
+      message: 'Great job!',
+    });
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Great job!')).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -403,10 +403,22 @@ export async function removeVolunteerShopperProfile(
   await handleResponse(res);
 }
 
-export async function getVolunteerBadges(): Promise<string[]> {
+export interface VolunteerStats {
+  badges: string[];
+  familiesServed: number;
+  poundsHandled: number;
+  message: string | null;
+}
+
+export async function getVolunteerStats(): Promise<VolunteerStats> {
   const res = await apiFetch(`${API_BASE}/volunteers/me/stats`);
   const data = await handleResponse(res);
-  return data.badges ?? [];
+  return {
+    badges: data.badges ?? [],
+    familiesServed: data.familiesServed ?? 0,
+    poundsHandled: data.poundsHandled ?? 0,
+    message: data.message ?? null,
+  };
 }
 
 export async function awardVolunteerBadge(badgeCode: string): Promise<void> {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -22,7 +22,7 @@ import {
   getVolunteerRolesForVolunteer,
   requestVolunteerBooking,
   updateVolunteerBookingStatus,
-  getVolunteerBadges,
+  getVolunteerStats,
 } from '../../api/volunteers';
 import { getEvents, type EventGroups } from '../../api/events';
 import type { VolunteerBooking, VolunteerRole } from '../../types';
@@ -58,6 +58,13 @@ export default function VolunteerDashboard() {
   const [badges, setBadges] = useState<string[]>([]);
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
+  const encouragements = useMemo(
+    () =>
+      ['Thanks for helping today!', 'Your time makes a difference!', 'We appreciate your support!'].sort(
+        () => Math.random() - 0.5,
+      ),
+    [],
+  );
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -71,8 +78,13 @@ export default function VolunteerDashboard() {
   }, []);
 
   useEffect(() => {
-    getVolunteerBadges()
-      .then(setBadges)
+    getVolunteerStats()
+      .then(data => {
+        setBadges(data.badges);
+        const msg = data.message || encouragements[0];
+        setMessage(msg);
+        setSnackbarSeverity('info');
+      })
       .catch(() => setBadges([]));
   }, []);
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Users see a random appreciation message on each login with a link to download their card when available.
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.
 - Volunteer schedule prevents navigating to past dates and hides shifts that have already started.
-- Volunteer badges are calculated from activity and manually awardable. `GET /volunteers/me/stats` returns earned badges and the dashboard displays them.
+- Volunteer badges are calculated from activity and manually awardable. `GET /volunteers/me/stats` returns earned badges, contribution totals (families served and pounds handled), and an appreciation message when milestones are reached.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.
 - Approving a pending volunteer booking immediately removes it from the Pending list.


### PR DESCRIPTION
## Summary
- include families served, pounds handled, and milestone message in `getVolunteerStats`
- show appreciation message on VolunteerDashboard with randomized encouragements
- document volunteer stats milestone output

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm install` (backend) *(fails: 403 Forbidden for node-pg-migrate)*
- `npm test` (frontend) *(no results, ts-jest warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b12f0bfcac832d8872c226f95ed845