### PR TITLE
Handle invalid date inputs

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/date.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/date.test.tsx
@@ -1,4 +1,4 @@
-import { formatReginaDate, formatReginaDateTime, reginaStartOfDay } from '../utils/date';
+import { formatReginaDate, formatReginaDateTime, reginaStartOfDay, toDate } from '../utils/date';
 
 describe('date utils', () => {
   const sample = '2024-01-15T12:34:56Z';
@@ -14,5 +14,10 @@ describe('date utils', () => {
   test('reginaStartOfDay', () => {
     const start = reginaStartOfDay(sample);
     expect(start.format('YYYY-MM-DD HH:mm:ss')).toBe('2024-01-15 00:00:00');
+  });
+
+  test('handles invalid input', () => {
+    const d = toDate('invalid');
+    expect(isNaN(d.getTime())).toBe(true);
   });
 });

--- a/MJ_FB_Frontend/src/utils/date.ts
+++ b/MJ_FB_Frontend/src/utils/date.ts
@@ -11,7 +11,11 @@ export const REGINA_TIMEZONE = 'America/Regina';
 dayjs.tz.setDefault(REGINA_TIMEZONE);
 
 export function toDayjs(input?: ConfigType) {
-  return dayjs.tz(input);
+  if (input === undefined || input === null || input === '') {
+    return dayjs();
+  }
+  const parsed = dayjs(input);
+  return parsed.isValid() ? parsed.tz(REGINA_TIMEZONE) : dayjs(NaN);
 }
 
 export function toDate(input?: ConfigType) {


### PR DESCRIPTION
## Summary
- guard against invalid date strings in date utility
- add test to ensure invalid inputs yield Invalid Date

## Testing
- `npm test` *(fails: see logs for VolunteerDashboard, App, BookingUI, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b12fb66694832dac771b95cc738f11