### PR TITLE
Cast volunteer leaderboard percentiles to numeric

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerStatsController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerStatsController.ts
@@ -26,7 +26,7 @@ export async function getVolunteerLeaderboard(
          FROM volunteer_counts
        )
        SELECT rank,
-              ROUND((1.0 - (rank - 1)::float / total_volunteers) * 100, 2) AS percentile
+              ROUND((1 - (rank - 1)::numeric / total_volunteers::numeric) * 100, 2) AS percentile
        FROM ranked
        WHERE id = $1`,
       [user.id],

--- a/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
+++ b/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
@@ -28,6 +28,8 @@ describe('Volunteer leaderboard', () => {
     const res = await request(app).get('/volunteer-stats/leaderboard');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ rank: 5, percentile: 80 });
-    expect((pool.query as jest.Mock).mock.calls[0][0]).toContain('volunteer_counts');
+    const query = (pool.query as jest.Mock).mock.calls[0][0];
+    expect(query).toContain('volunteer_counts');
+    expect(query).toContain('::numeric');
   });
 });


### PR DESCRIPTION
## Summary
- ensure volunteer leaderboard percentile uses numeric math to avoid PostgreSQL round() errors
- extend unit test to verify query includes numeric casting

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden fetching node-pg-migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68b131487fec832d85faac9cb4f41dc7