### PR TITLE
feat: enhance volunteer appreciation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@
   lifetime volunteer hours, hours served in the current month, total completed shifts,
   and the current consecutive-week streak. It includes a `milestone` flag when total
   shifts reach 5, 10, or 25 so the frontend can display a celebration banner.
+  The response also includes `milestoneText`, `familiesServed`, and `poundsHandled`
+  so the dashboard can show appreciation messages.
 - Volunteer leaderboard available via `GET /volunteer-stats/leaderboard` returning
   `{ rank, percentile }` for the current volunteer without exposing names.
 
@@ -22,6 +24,7 @@
 - Agencies can retrieve holiday dates via `GET /holidays` to disable bookings on those days.
 - Milestone badge awards queue a thank-you card email and expose a downloadable card link via `/stats`.
 - Users see a random appreciation message on login.
+- The volunteer dashboard rotates encouragement messages when no milestone is reached.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -430,6 +430,17 @@ export async function getVolunteerStats(
 
     const milestone = [25, 10, 5].find(m => m === totalShifts) ?? null;
 
+    const contribRes = await pool.query<{ families_served: string; pounds_handled: string }>(
+      `SELECT COUNT(*) AS families_served,
+              COALESCE(SUM(weight_with_cart - weight_without_cart), 0) AS pounds_handled
+         FROM client_visits`,
+    );
+    const familiesServed = Number(contribRes.rows[0]?.families_served ?? 0);
+    const poundsHandled = Number(contribRes.rows[0]?.pounds_handled ?? 0);
+    const milestoneText = milestone
+      ? `Congratulations on completing ${milestone} shifts!`
+      : null;
+
     res.json({
       badges: Array.from(badges),
       lifetimeHours,
@@ -437,6 +448,9 @@ export async function getVolunteerStats(
       totalShifts,
       currentStreak: streak,
       milestone,
+       milestoneText,
+       familiesServed,
+       poundsHandled,
     });
   } catch (error) {
     logger.error('Error fetching volunteer stats:', error);

--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -23,9 +23,10 @@ jest.mock('../api/volunteers', () => ({
 jest.mock('../api/events', () => ({ getEvents: jest.fn() }));
 
 describe('VolunteerDashboard', () => {
-  beforeEach(() => {
-    (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 1, percentile: 100 });
-  });
+beforeEach(() => {
+  (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 1, percentile: 100 });
+  localStorage.clear();
+});
   it('shows events in News & Events section', async () => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
@@ -49,6 +50,9 @@ describe('VolunteerDashboard', () => {
       totalShifts: 0,
       currentStreak: 0,
       milestone: null,
+      milestoneText: null,
+      familiesServed: 0,
+      poundsHandled: 0,
     });
 
     render(
@@ -99,6 +103,9 @@ describe('VolunteerDashboard', () => {
       totalShifts: 0,
       currentStreak: 0,
       milestone: null,
+      milestoneText: null,
+      familiesServed: 0,
+      poundsHandled: 0,
     });
 
     render(
@@ -178,6 +185,9 @@ describe('VolunteerDashboard', () => {
       totalShifts: 0,
       currentStreak: 0,
       milestone: null,
+      milestoneText: null,
+      familiesServed: 0,
+      poundsHandled: 0,
     });
 
     render(
@@ -219,6 +229,9 @@ describe('VolunteerDashboard', () => {
       totalShifts: 0,
       currentStreak: 0,
       milestone: null,
+      milestoneText: null,
+      familiesServed: 0,
+      poundsHandled: 0,
     });
 
     render(
@@ -245,6 +258,9 @@ describe('VolunteerDashboard', () => {
       totalShifts: 0,
       currentStreak: 0,
       milestone: null,
+      milestoneText: null,
+      familiesServed: 0,
+      poundsHandled: 0,
     });
 
     render(
@@ -267,6 +283,9 @@ describe('VolunteerDashboard', () => {
       totalShifts: 0,
       currentStreak: 0,
       milestone: null,
+      milestoneText: null,
+      familiesServed: 0,
+      poundsHandled: 0,
     });
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 3, percentile: 75 });
 
@@ -292,6 +311,9 @@ describe('VolunteerDashboard', () => {
       totalShifts: 5,
       currentStreak: 1,
       milestone: 5,
+      milestoneText: 'Congratulations on completing 5 shifts!',
+      familiesServed: 0,
+      poundsHandled: 0,
     });
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 1, percentile: 100 });
 

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -410,6 +410,9 @@ export interface VolunteerStats {
   totalShifts: number;
   currentStreak: number;
   milestone: number | null;
+  milestoneText: string | null;
+  familiesServed: number;
+  poundsHandled: number;
 }
 
 export async function getVolunteerStats(): Promise<VolunteerStats> {

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -136,6 +136,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       localStorage.setItem('access', JSON.stringify(u.access || []));
       if (u.id) localStorage.setItem('id', String(u.id));
       else localStorage.removeItem('id');
+      localStorage.removeItem('encouragementOrder');
+      localStorage.removeItem('encouragementIndex');
       setSessionMessage(getRandomAppreciation());
       try {
         const statsRes = await apiFetch(`${API_BASE}/stats`);

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -40,6 +40,7 @@ import type { AlertColor } from '@mui/material';
 import SectionCard from '../../components/dashboard/SectionCard';
 import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
+import { getNextEncouragement } from '../../utils/appreciationMessages';
 
 function formatDateLabel(dateStr: string) {
   const d = toDate(dateStr);
@@ -64,6 +65,9 @@ export default function VolunteerDashboard() {
         totalShifts: number;
         currentStreak: number;
         milestone: number | null;
+        milestoneText: string | null;
+        familiesServed: number;
+        poundsHandled: number;
       }
     | undefined
   >(undefined);
@@ -92,7 +96,15 @@ export default function VolunteerDashboard() {
           totalShifts: data.totalShifts,
           currentStreak: data.currentStreak,
           milestone: data.milestone,
+          milestoneText: data.milestoneText,
+          familiesServed: data.familiesServed,
+          poundsHandled: data.poundsHandled,
         });
+        const msg =
+          data.milestoneText ??
+          `${getNextEncouragement()} You've helped serve ${data.familiesServed} families and handle ${data.poundsHandled} lbs.`;
+        setSnackbarSeverity(data.milestoneText ? 'info' : 'success');
+        setMessage(msg);
       })
       .catch(() => {
         setBadges([]);
@@ -375,9 +387,7 @@ export default function VolunteerDashboard() {
         {stats?.milestone && (
           <Grid size={{ xs: 12 }}>
             <SectionCard title="Milestone">
-              <Typography>
-                Congratulations on completing {stats.milestone} shifts!
-              </Typography>
+              <Typography>{stats.milestoneText}</Typography>
             </SectionCard>
           </Grid>
         )}

--- a/MJ_FB_Frontend/src/utils/appreciationMessages.ts
+++ b/MJ_FB_Frontend/src/utils/appreciationMessages.ts
@@ -4,7 +4,32 @@ export const APPRECIATION_MESSAGES = [
   'We appreciate your commitment!',
 ];
 
+export const ENCOURAGEMENT_MESSAGES = [
+  'Keep up the great work!',
+  "You're making a difference!",
+  'Your dedication matters!',
+];
+
 export function getRandomAppreciation(): string {
   const idx = Math.floor(Math.random() * APPRECIATION_MESSAGES.length);
   return APPRECIATION_MESSAGES[idx];
+}
+
+export function getNextEncouragement(): string {
+  let order = localStorage.getItem('encouragementOrder');
+  if (!order) {
+    const shuffled = [...ENCOURAGEMENT_MESSAGES];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    order = JSON.stringify(shuffled);
+    localStorage.setItem('encouragementOrder', order);
+    localStorage.setItem('encouragementIndex', '0');
+  }
+  const messages: string[] = JSON.parse(order);
+  const idx = Number(localStorage.getItem('encouragementIndex') ?? '0');
+  const msg = messages[idx % messages.length];
+  localStorage.setItem('encouragementIndex', String((idx + 1) % messages.length));
+  return msg;
 }

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Volunteer role management and scheduling restricted to trained areas.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Users see a random appreciation message on each login with a link to download their card when available.
+- Volunteers also see rotating encouragement messages on the dashboard when no milestone is reached.
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.
 - Volunteer schedule prevents navigating to past dates and hides shifts that have already started.
 - Volunteer badges are calculated from activity and manually awardable. `GET /volunteers/me/stats` returns earned badges along with lifetime hours, this month's hours, total completed shifts, and current streak. The endpoint also flags milestones at 5, 10, and 25 shifts so the dashboard can show a celebration banner.
+- The stats endpoint now provides a milestone message and contribution totals (`familiesServed` and `poundsHandled`) so the dashboard can display appreciation.
 - Volunteer leaderboard endpoint `GET /volunteer-stats/leaderboard` returns your rank and percentile.
   The volunteer dashboard shows “You're in the top X%!” based on this data.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.


### PR DESCRIPTION
## Summary
- add milestone text and contribution totals to volunteer stats
- rotate encouragement messages and show snackbar/banner on dashboard
- clear encouragement rotation on login

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm test` (frontend) *(fails: 20 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b131a9d490832d8df7583bc8fc91b4