### PR TITLE
Add volunteer group stats endpoint and dashboard display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@
   so the dashboard can show appreciation messages.
 - Volunteer leaderboard available via `GET /volunteer-stats/leaderboard` returning
   `{ rank, percentile }` for the current volunteer without exposing names.
+- Group volunteer statistics via `GET /volunteer-stats/group` return total
+  volunteer hours and food pounds handled along with current-month hours and a
+  configurable goal for dashboard progress.
 
 - `GET /slots` returns an empty array with a 200 status on holidays.
 - Agencies can retrieve holiday dates via `GET /holidays` to disable bookings on those days.

--- a/MJ_FB_Backend/src/routes/volunteerStats.ts
+++ b/MJ_FB_Backend/src/routes/volunteerStats.ts
@@ -1,9 +1,13 @@
 import express from 'express';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
-import { getVolunteerLeaderboard } from '../controllers/volunteer/volunteerStatsController';
+import {
+  getVolunteerLeaderboard,
+  getVolunteerGroupStats,
+} from '../controllers/volunteer/volunteerStatsController';
 
 const router = express.Router();
 
 router.get('/leaderboard', authMiddleware, authorizeRoles('volunteer'), getVolunteerLeaderboard);
+router.get('/group', authMiddleware, authorizeRoles('volunteer'), getVolunteerGroupStats);
 
 export default router;

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -496,7 +496,8 @@ ON CONFLICT (role_id, start_time, end_time) DO NOTHING;
     `INSERT INTO app_config (key, value) VALUES
       ('cart_tare','0'),
       ('bread_weight_multiplier','10'),
-      ('cans_weight_multiplier','20')
+      ('cans_weight_multiplier','20'),
+      ('volunteer_monthly_hours_goal','80')
     ON CONFLICT (key) DO NOTHING;`
   );
 

--- a/MJ_FB_Backend/tests/volunteerGroupStats.test.ts
+++ b/MJ_FB_Backend/tests/volunteerGroupStats.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import express from 'express';
+import volunteerStatsRouter from '../src/routes/volunteerStats';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (req as any).user = { id: 1, role: 'volunteer' };
+  next();
+});
+app.use('/volunteer-stats', volunteerStatsRouter);
+
+describe('Volunteer group stats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns aggregated hours and weight', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          total_hours: '100',
+          month_hours: '40',
+          month_goal: '80',
+          total_lbs: '2000',
+          week_lbs: '500',
+        },
+      ],
+    });
+    const res = await request(app).get('/volunteer-stats/group');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalHours: 100,
+      monthHours: 40,
+      monthHoursGoal: 80,
+      totalLbs: 2000,
+      weekLbs: 500,
+    });
+    const query = (pool.query as jest.Mock).mock.calls[0][0];
+    expect(query).toContain('volunteer_bookings');
+    expect(query).toContain('client_visits');
+    expect(query).toContain('app_config');
+  });
+});

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -415,6 +415,14 @@ export interface VolunteerStats {
   poundsHandled: number;
 }
 
+export interface VolunteerGroupStats {
+  totalHours: number;
+  monthHours: number;
+  monthHoursGoal: number;
+  totalLbs: number;
+  weekLbs: number;
+}
+
 export async function getVolunteerStats(): Promise<VolunteerStats> {
   const res = await apiFetch(`${API_BASE}/volunteers/me/stats`);
   return handleResponse(res);
@@ -427,6 +435,11 @@ export async function getVolunteerBadges(): Promise<string[]> {
 
 export async function getVolunteerLeaderboard(): Promise<{ rank: number; percentile: number }> {
   const res = await apiFetch(`${API_BASE}/volunteer-stats/leaderboard`);
+  return handleResponse(res);
+}
+
+export async function getVolunteerGroupStats(): Promise<VolunteerGroupStats> {
+  const res = await apiFetch(`${API_BASE}/volunteer-stats/group`);
   return handleResponse(res);
 }
 

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { Box, LinearProgress, Stack, Typography } from '@mui/material';
+import SectionCard from './SectionCard';
+import { getVolunteerGroupStats, type VolunteerGroupStats } from '../../api/volunteers';
+
+const QUOTES = [
+  'We appreciate your dedication!',
+  'Your service makes a difference!',
+  'Thanks for lending a helping hand!',
+];
+
+const HIGHLIGHT_OF_MONTH = 'Canned Food Drive exceeded goals!';
+
+export default function VolunteerGroupStatsCard() {
+  const [stats, setStats] = useState<VolunteerGroupStats>();
+  const [quote, setQuote] = useState('');
+
+  useEffect(() => {
+    getVolunteerGroupStats().then(setStats).catch(() => {});
+    setQuote(QUOTES[Math.floor(Math.random() * QUOTES.length)]);
+  }, []);
+
+  if (!stats) return null;
+
+  const progress = stats.monthHoursGoal
+    ? Math.min(100, (stats.monthHours / stats.monthHoursGoal) * 100)
+    : 0;
+
+  return (
+    <SectionCard title="Community Impact">
+      <Stack spacing={2}>
+        {HIGHLIGHT_OF_MONTH && (
+          <Typography fontWeight="bold">{HIGHLIGHT_OF_MONTH}</Typography>
+        )}
+        <Typography>{`Volunteers distributed ${stats.weekLbs} lbs this week`}</Typography>
+        <Box>
+          <Typography variant="body2" mb={1}>{`Hours This Month: ${stats.monthHours} / ${stats.monthHoursGoal}`}</Typography>
+          <LinearProgress variant="determinate" value={progress} />
+        </Box>
+        {quote && <Typography variant="body2">{quote}</Typography>}
+      </Stack>
+    </SectionCard>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -41,6 +41,7 @@ import SectionCard from '../../components/dashboard/SectionCard';
 import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 import { getNextEncouragement } from '../../utils/appreciationMessages';
+import VolunteerGroupStatsCard from '../../components/dashboard/VolunteerGroupStatsCard';
 
 function formatDateLabel(dateStr: string) {
   const d = toDate(dateStr);
@@ -233,6 +234,9 @@ export default function VolunteerDashboard() {
   return (
     <Page title="Volunteer Dashboard">
       <Grid container spacing={2}>
+        <Grid size={{ xs: 12 }}>
+          <VolunteerGroupStatsCard />
+        </Grid>
         {leaderboard && (
           <Grid size={{ xs: 12 }}>
             <SectionCard title="Volunteer Leaderboard">

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - The stats endpoint now provides a milestone message and contribution totals (`familiesServed` and `poundsHandled`) so the dashboard can display appreciation.
 - Volunteer leaderboard endpoint `GET /volunteer-stats/leaderboard` returns your rank and percentile.
   The volunteer dashboard shows “You're in the top X%!” based on this data.
+- Group volunteer stats endpoint `GET /volunteer-stats/group` aggregates total hours
+  and weekly pounds handled, returning current-month hours alongside a configurable
+  goal for dashboard progress.
+- Volunteer dashboard now highlights weekly pounds distributed, a progress bar
+  toward the monthly hours goal, a highlight of the month, and rotating
+  appreciation quotes.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.
 - Approving a pending volunteer booking immediately removes it from the Pending list.


### PR DESCRIPTION
## Summary
- expose `GET /volunteer-stats/group` for aggregated volunteer hours and pounds handled with a monthly goal
- seed default `volunteer_monthly_hours_goal` app config
- show weekly pounds and monthly hours progress with highlight and appreciation quote on Volunteer Dashboard

## Testing
- `npm test` *(MJ_FB_Backend, fails: jest: not found)*
- `npm test` *(MJ_FB_Frontend, fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b13369b048832d9036fc4f5c6f1021