### PR TITLE
Fix loadData hook in VolunteerSettings

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -81,11 +81,7 @@ export default function VolunteerSettings() {
     return map;
   }, [roles]);
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  async function loadData(newId?: number) {
+  const loadData = useCallback(async (newId?: number) => {
     try {
       const [master, roleData] = await Promise.all([
         getVolunteerMasterRoles(),


### PR DESCRIPTION
## Summary
- convert `loadData` in VolunteerSettings to a `useCallback` hook and remove stray `useEffect`

## Testing
- `npm test` *(fails: 19 failed, 15 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b134ce74d8832daacbc00c0f1c52b8