### PR TITLE
feat: add volunteer stats gauge

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -74,6 +74,7 @@ beforeEach(() => {
     expect(await screen.findByText(/Volunteer Event/)).toBeInTheDocument();
   });
 
+
   it('hides slots already booked by volunteer', async () => {
     const today = new Date().toISOString().split('T')[0];
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
@@ -337,48 +338,47 @@ beforeEach(() => {
     ).toBeInTheDocument();
   });
 
-  it('shows group stats card with progress and quote', async () => {
-    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
-    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
-    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-    });
-    (getVolunteerGroupStats as jest.Mock).mockResolvedValue({
-      totalHours: 10,
-      monthHours: 4,
-      monthHoursGoal: 8,
-      totalLbs: 100,
-      weekLbs: 25,
-    });
-    const rand = jest.spyOn(Math, 'random').mockReturnValue(0);
+    it('shows group stats card with progress and quote', async () => {
+      (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+      (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+      (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+      (getVolunteerStats as jest.Mock).mockResolvedValue({
+        badges: [],
+        lifetimeHours: 0,
+        monthHours: 0,
+        totalShifts: 0,
+        currentStreak: 0,
+        milestone: null,
+        milestoneText: null,
+        familiesServed: 0,
+        poundsHandled: 0,
+      });
+      (getVolunteerGroupStats as jest.Mock).mockResolvedValue({
+        totalHours: 10,
+        monthHours: 4,
+        monthHoursGoal: 8,
+        totalLbs: 100,
+        weekLbs: 25,
+      });
+      const rand = jest.spyOn(Math, 'random').mockReturnValue(0);
 
-    render(
-      <MemoryRouter>
-        <VolunteerDashboard />
-      </MemoryRouter>,
-    );
+      render(
+        <MemoryRouter>
+          <VolunteerDashboard />
+        </MemoryRouter>,
+      );
 
-    expect(
-      await screen.findByText(/Volunteers distributed 25 lbs this week/),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Hours This Month: 4 \/ 8/),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('Canned Food Drive exceeded goals!'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('We appreciate your dedication!'),
-    ).toBeInTheDocument();
-    rand.mockRestore();
-  });
+      expect(
+        await screen.findByText(/Volunteers distributed 25 lbs this week/),
+      ).toBeInTheDocument();
+      expect(await screen.findByTestId('group-stats-gauge')).toBeInTheDocument();
+      expect(screen.getByText('4 / 8 hrs')).toBeInTheDocument();
+      expect(
+        screen.getByText('Canned Food Drive exceeded goals!'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('We appreciate your dedication!'),
+      ).toBeInTheDocument();
+      rand.mockRestore();
+    });
 });

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Box, LinearProgress, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { RadialBarChart, RadialBar, PolarAngleAxis } from 'recharts';
 import SectionCard from './SectionCard';
 import { getVolunteerGroupStats, type VolunteerGroupStats } from '../../api/volunteers';
 
@@ -14,6 +16,7 @@ const HIGHLIGHT_OF_MONTH = 'Canned Food Drive exceeded goals!';
 export default function VolunteerGroupStatsCard() {
   const [stats, setStats] = useState<VolunteerGroupStats>();
   const [quote, setQuote] = useState('');
+  const theme = useTheme();
 
   useEffect(() => {
     getVolunteerGroupStats().then(setStats).catch(() => {});
@@ -28,16 +31,38 @@ export default function VolunteerGroupStatsCard() {
 
   return (
     <SectionCard title="Community Impact">
-      <Stack spacing={2}>
+      <Stack spacing={2} alignItems="center">
         {HIGHLIGHT_OF_MONTH && (
           <Typography fontWeight="bold">{HIGHLIGHT_OF_MONTH}</Typography>
         )}
         <Typography>{`Volunteers distributed ${stats.weekLbs} lbs this week`}</Typography>
-        <Box>
-          <Typography variant="body2" mb={1}>{`Hours This Month: ${stats.monthHours} / ${stats.monthHoursGoal}`}</Typography>
-          <LinearProgress variant="determinate" value={progress} />
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          data-testid="group-stats-gauge"
+        >
+          <RadialBarChart
+            width={120}
+            height={120}
+            innerRadius={60}
+            outerRadius={80}
+            data={[{ value: progress }]}
+            startAngle={90}
+            endAngle={450}
+          >
+            <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+            <RadialBar
+              dataKey="value"
+              clockWise
+              background
+              cornerRadius={10}
+              fill={theme.palette.primary.main}
+            />
+          </RadialBarChart>
+          <Typography variant="body2" mt={1}>{`${stats.monthHours} / ${stats.monthHoursGoal} hrs`}</Typography>
         </Box>
-        {quote && <Typography variant="body2">{quote}</Typography>}
+        {quote && <Typography variant="body2" align="center">{quote}</Typography>}
       </Stack>
     </SectionCard>
   );

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -234,9 +234,6 @@ export default function VolunteerDashboard() {
   return (
     <Page title="Volunteer Dashboard">
       <Grid container spacing={2}>
-        <Grid size={{ xs: 12 }}>
-          <VolunteerGroupStatsCard />
-        </Grid>
         {leaderboard && (
           <Grid size={{ xs: 12 }}>
             <SectionCard title="Volunteer Leaderboard">
@@ -383,10 +380,14 @@ export default function VolunteerDashboard() {
         </Grid>
 
         <Grid size={{ xs: 12, md: 6 }}>
+          <VolunteerGroupStatsCard />
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
           <SectionCard title="News & Events" icon={<Announcement color="primary" />}>
             <EventList events={[...events.today, ...events.upcoming]} limit={5} />
           </SectionCard>
-      </Grid>
+        </Grid>
 
         {stats?.milestone && (
           <Grid size={{ xs: 12 }}>


### PR DESCRIPTION
## Summary
- replace linear volunteer progress bar with radial gauge and numeric hours
- reposition group stats card near quick actions
- test that gauge renders with group stats

## Testing
- `npm test src/__tests__/VolunteerDashboard.test.tsx -t "group stats card"` *(fails: Unable to find Greeter; milestone banner)*

------
https://chatgpt.com/codex/tasks/task_e_68b1358e39d0832da8152a3c6b813a52