### PR TITLE
Use radial gauge for volunteer group progress

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -371,8 +371,10 @@ beforeEach(() => {
       await screen.findByText(/Volunteers distributed 25 lbs this week/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Hours This Month: 4 \/ 8/),
+      screen.getByText(/4 \/ 8 hrs/),
     ).toBeInTheDocument();
+    const gauge = screen.getByTestId('group-progress-gauge');
+    expect(gauge.querySelector('svg')).toBeInTheDocument();
     expect(
       screen.getByText('Canned Food Drive exceeded goals!'),
     ).toBeInTheDocument();
@@ -434,8 +436,7 @@ beforeEach(() => {
     const contribution = screen.getByTestId('contribution-chart');
     expect(contribution.querySelector('svg')).toBeInTheDocument();
 
-    const communityTitle = await screen.findByText('Community Impact');
-    const communityCard = communityTitle.closest('div')?.parentElement?.parentElement;
-    expect(communityCard?.querySelector('svg')).toBeInTheDocument();
+    const gauge = await screen.findByTestId('group-progress-gauge');
+    expect(gauge.querySelector('svg')).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Box, LinearProgress, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { RadialBarChart, RadialBar, PolarAngleAxis } from 'recharts';
 import SectionCard from './SectionCard';
 import { getVolunteerGroupStats, type VolunteerGroupStats } from '../../api/volunteers';
 
@@ -14,6 +16,7 @@ const HIGHLIGHT_OF_MONTH = 'Canned Food Drive exceeded goals!';
 export default function VolunteerGroupStatsCard() {
   const [stats, setStats] = useState<VolunteerGroupStats>();
   const [quote, setQuote] = useState('');
+  const theme = useTheme();
 
   useEffect(() => {
     getVolunteerGroupStats().then(setStats).catch(() => {});
@@ -25,17 +28,42 @@ export default function VolunteerGroupStatsCard() {
   const progress = stats.monthHoursGoal
     ? Math.min(100, (stats.monthHours / stats.monthHoursGoal) * 100)
     : 0;
+  const chartData = [{ value: progress }];
 
   return (
     <SectionCard title="Community Impact">
-      <Stack spacing={2}>
+      <Stack spacing={2} alignItems="center">
         {HIGHLIGHT_OF_MONTH && (
           <Typography fontWeight="bold">{HIGHLIGHT_OF_MONTH}</Typography>
         )}
         <Typography>{`Volunteers distributed ${stats.weekLbs} lbs this week`}</Typography>
-        <Box>
-          <Typography variant="body2" mb={1}>{`Hours This Month: ${stats.monthHours} / ${stats.monthHoursGoal}`}</Typography>
-          <LinearProgress variant="determinate" value={progress} />
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          data-testid="group-progress-gauge"
+        >
+          <RadialBarChart
+            width={120}
+            height={120}
+            cx={60}
+            cy={60}
+            innerRadius={40}
+            outerRadius={60}
+            startAngle={90}
+            endAngle={450}
+            data={chartData}
+          >
+            <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+            <RadialBar
+              dataKey="value"
+              cornerRadius={5}
+              background
+              clockWise
+              fill={theme.palette.primary.main}
+            />
+          </RadialBarChart>
+          <Typography variant="body2" mt={-2}>{`${stats.monthHours} / ${stats.monthHoursGoal} hrs`}</Typography>
         </Box>
         {quote && <Typography variant="body2">{quote}</Typography>}
       </Stack>

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -259,9 +259,6 @@ export default function VolunteerDashboard() {
   return (
     <Page title="Volunteer Dashboard">
       <Grid container spacing={2}>
-        <Grid size={{ xs: 12 }}>
-          <VolunteerGroupStatsCard />
-        </Grid>
         {leaderboard && (
           <Grid size={{ xs: 12 }}>
             <SectionCard title="Volunteer Leaderboard">
@@ -412,6 +409,10 @@ export default function VolunteerDashboard() {
               </Button>
             </Stack>
           </SectionCard>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <VolunteerGroupStatsCard />
         </Grid>
 
         <Grid size={{ xs: 12, md: 6 }}>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Group volunteer stats endpoint `GET /volunteer-stats/group` aggregates total hours
   and weekly pounds handled, returning current-month hours alongside a configurable
   goal for dashboard progress.
-- Volunteer dashboard now highlights weekly pounds distributed, a progress bar
+- Volunteer dashboard now highlights weekly pounds distributed, a progress gauge
   toward the monthly hours goal, a highlight of the month, and rotating
   appreciation quotes.
 - Volunteer dashboard includes a contribution trend chart showing monthly shift


### PR DESCRIPTION
## Summary
- Replace linear progress bar with radial gauge chart for group stats
- Reposition group stats card below Quick Actions for a compact layout
- Note progress gauge in README and add tests for new chart

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b137b95bd0832daff3b2d7bd16c770