### PR TITLE
Hide zeroed volunteer stats when none exist

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -126,11 +126,15 @@ export default function VolunteerDashboard() {
           familiesServed: data.familiesServed,
           poundsHandled: data.poundsHandled,
         });
-        const msg =
-          data.milestoneText ??
-          `${getNextEncouragement()} You've helped serve ${data.familiesServed} families and handle ${data.poundsHandled} lbs.`;
-        setSnackbarSeverity(data.milestoneText ? 'info' : 'success');
-        setMessage(msg);
+        if (data.totalShifts > 0) {
+          const msg =
+            data.milestoneText ??
+            `${getNextEncouragement()} You've helped serve ${data.familiesServed} families and handle ${data.poundsHandled} lbs.`;
+          setSnackbarSeverity(data.milestoneText ? 'info' : 'success');
+          setMessage(msg);
+        } else {
+          setMessage('');
+        }
       })
       .catch(() => {
         setBadges([]);
@@ -428,7 +432,7 @@ export default function VolunteerDashboard() {
           </Grid>
         )}
 
-        {stats && (
+        {stats && stats.totalShifts > 0 && (
           <>
             <Grid size={{ xs: 6, md: 3 }}>
               <SectionCard title="Lifetime Hours">


### PR DESCRIPTION
## Summary
- Avoid showing appreciation messages with zero counts for volunteers who haven't completed shifts
- Skip volunteer stats cards when the volunteer has no shift history

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b138b816c0832d9316de7b8189c877