### PR TITLE
Add monthly volunteer stats to dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@
   lifetime volunteer hours, hours served in the current month, total completed shifts,
   and the current consecutive-week streak. It includes a `milestone` flag when total
   shifts reach 5, 10, or 25 so the frontend can display a celebration banner.
-  The response also includes `milestoneText`, `familiesServed`, and `poundsHandled`
-  so the dashboard can show appreciation messages.
+  The response also includes `milestoneText`, `familiesServed`, `poundsHandled`,
+  `monthFamiliesServed`, and `monthPoundsHandled` so the dashboard can show
+  appreciation messages.
 - Volunteer leaderboard available via `GET /volunteer-stats/leaderboard` returning
   `{ rank, percentile }` for the current volunteer without exposing names.
 - Group volunteer statistics via `GET /volunteer-stats/group` return total

--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -62,6 +62,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -72,6 +74,35 @@ beforeEach(() => {
 
     await waitFor(() => expect(getEvents).toHaveBeenCalled());
     expect(await screen.findByText(/Volunteer Event/)).toBeInTheDocument();
+  });
+
+  it('shows appreciation message with monthly stats', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      lifetimeHours: 0,
+      monthHours: 0,
+      totalShifts: 0,
+      currentStreak: 0,
+      milestone: null,
+      milestoneText: null,
+      familiesServed: 0,
+      poundsHandled: 0,
+      monthFamiliesServed: 3,
+      monthPoundsHandled: 50,
+    });
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(/You've helped serve 3 families and handle 50 lbs this month\./),
+    ).toBeInTheDocument();
   });
 
   it('hides slots already booked by volunteer', async () => {
@@ -115,6 +146,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -197,6 +230,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -241,6 +276,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -270,6 +307,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -295,6 +334,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 3, percentile: 75 });
 
@@ -323,6 +364,8 @@ beforeEach(() => {
       milestoneText: 'Congratulations on completing 5 shifts!',
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 1, percentile: 100 });
 
@@ -351,6 +394,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
     (getVolunteerGroupStats as jest.Mock).mockResolvedValue({
       totalHours: 10,
@@ -424,6 +469,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -413,6 +413,8 @@ export interface VolunteerStats {
   milestoneText: string | null;
   familiesServed: number;
   poundsHandled: number;
+  monthFamiliesServed: number;
+  monthPoundsHandled: number;
 }
 
 export interface VolunteerGroupStats {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -73,6 +73,8 @@ export default function VolunteerDashboard() {
         milestoneText: string | null;
         familiesServed: number;
         poundsHandled: number;
+        monthFamiliesServed: number;
+        monthPoundsHandled: number;
       }
     | undefined
   >(undefined);
@@ -125,10 +127,12 @@ export default function VolunteerDashboard() {
           milestoneText: data.milestoneText,
           familiesServed: data.familiesServed,
           poundsHandled: data.poundsHandled,
+          monthFamiliesServed: data.monthFamiliesServed,
+          monthPoundsHandled: data.monthPoundsHandled,
         });
         const msg =
           data.milestoneText ??
-          `${getNextEncouragement()} You've helped serve ${data.familiesServed} families and handle ${data.poundsHandled} lbs.`;
+          `${getNextEncouragement()} You've helped serve ${data.monthFamiliesServed} families and handle ${data.monthPoundsHandled} lbs this month.`;
         setSnackbarSeverity(data.milestoneText ? 'info' : 'success');
         setMessage(msg);
       })

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Individuals who use the food bank are referred to as clients throughout the appl
 
 - Run the relevant backend and frontend test suites (`npm test`) after making changes.
 - Update `AGENTS.md` with new repository instructions.
+
+## Volunteer Dashboard
+
+- The volunteer stats endpoint (`GET /volunteers/me/stats`) also returns
+  `monthFamiliesServed` and `monthPoundsHandled` for monthly appreciation
+  messages.
 - Reflect user-facing or setup changes in this `README.md`.
 
 ## Features


### PR DESCRIPTION
## Summary
- include monthFamiliesServed and monthPoundsHandled in VolunteerStats
- show monthly families served and pounds handled in volunteer dashboard message
- cover monthly stats in VolunteerDashboard tests and docs

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*


------
https://chatgpt.com/codex/tasks/task_e_68b13919b390832db849d4879ab9a584