### PR TITLE
feat: show monthly volunteer impact

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -62,6 +62,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -115,6 +117,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -197,6 +201,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -241,6 +247,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -270,6 +278,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(
@@ -295,6 +305,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 3, percentile: 75 });
 
@@ -323,6 +335,8 @@ beforeEach(() => {
       milestoneText: 'Congratulations on completing 5 shifts!',
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 1, percentile: 100 });
 
@@ -334,6 +348,38 @@ beforeEach(() => {
 
     expect(
       await screen.findByText(/Congratulations on completing 5 shifts!/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows appreciation message with monthly totals', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      lifetimeHours: 10,
+      monthHours: 5,
+      totalShifts: 2,
+      currentStreak: 1,
+      milestone: null,
+      milestoneText: null,
+      familiesServed: 20,
+      poundsHandled: 200,
+      monthFamiliesServed: 3,
+      monthPoundsHandled: 30,
+    });
+    (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 1, percentile: 100 });
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(
+        /This month you've helped serve 3 families and handle 30 lbs/,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -351,6 +397,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
     (getVolunteerGroupStats as jest.Mock).mockResolvedValue({
       totalHours: 10,
@@ -424,6 +472,8 @@ beforeEach(() => {
       milestoneText: null,
       familiesServed: 0,
       poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
     });
 
     render(

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -413,6 +413,8 @@ export interface VolunteerStats {
   milestoneText: string | null;
   familiesServed: number;
   poundsHandled: number;
+  monthFamiliesServed: number;
+  monthPoundsHandled: number;
 }
 
 export interface VolunteerGroupStats {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -73,6 +73,8 @@ export default function VolunteerDashboard() {
         milestoneText: string | null;
         familiesServed: number;
         poundsHandled: number;
+        monthFamiliesServed: number;
+        monthPoundsHandled: number;
       }
     | undefined
   >(undefined);
@@ -125,11 +127,13 @@ export default function VolunteerDashboard() {
           milestoneText: data.milestoneText,
           familiesServed: data.familiesServed,
           poundsHandled: data.poundsHandled,
+          monthFamiliesServed: data.monthFamiliesServed,
+          monthPoundsHandled: data.monthPoundsHandled,
         });
         if (data.totalShifts > 0) {
           const msg =
             data.milestoneText ??
-            `${getNextEncouragement()} You've helped serve ${data.familiesServed} families and handle ${data.poundsHandled} lbs.`;
+            `${getNextEncouragement()} This month you've helped serve ${data.monthFamiliesServed} families and handle ${data.monthPoundsHandled} lbs.`;
           setSnackbarSeverity(data.milestoneText ? 'info' : 'success');
           setMessage(msg);
         } else {


### PR DESCRIPTION
## Summary
- include monthFamiliesServed and monthPoundsHandled in VolunteerStats
- reference monthly contributions in dashboard appreciation message
- extend dashboard tests to cover monthly metrics

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b13a4c2cd8832db4861a593c90df8b