### PR TITLE
Remove hard-coded highlight from volunteer dashboard

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -33,6 +33,7 @@ beforeEach(() => {
     monthHoursGoal: 0,
     totalLbs: 0,
     weekLbs: 0,
+    monthFamilies: 0,
   });
   localStorage.clear();
 });
@@ -406,6 +407,7 @@ beforeEach(() => {
       monthHoursGoal: 8,
       totalLbs: 100,
       weekLbs: 25,
+      monthFamilies: 0,
     });
     const rand = jest.spyOn(Math, 'random').mockReturnValue(0);
 
@@ -424,8 +426,8 @@ beforeEach(() => {
     const gauge = screen.getByTestId('group-progress-gauge');
     expect(gauge.querySelector('svg')).toBeInTheDocument();
     expect(
-      screen.getByText('Canned Food Drive exceeded goals!'),
-    ).toBeInTheDocument();
+      screen.queryByText('Canned Food Drive exceeded goals!'),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText('We appreciate your dedication!'),
     ).toBeInTheDocument();
@@ -459,6 +461,7 @@ beforeEach(() => {
       monthHoursGoal: 10,
       totalLbs: 100,
       weekLbs: 25,
+      monthFamilies: 0,
     });
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
@@ -11,8 +11,6 @@ const QUOTES = [
   'Thanks for lending a helping hand!',
 ];
 
-const HIGHLIGHT_OF_MONTH = 'Canned Food Drive exceeded goals!';
-
 export default function VolunteerGroupStatsCard() {
   const [stats, setStats] = useState<VolunteerGroupStats>();
   const [quote, setQuote] = useState('');
@@ -33,9 +31,6 @@ export default function VolunteerGroupStatsCard() {
   return (
     <SectionCard title="Community Impact">
       <Stack spacing={2} alignItems="center">
-        {HIGHLIGHT_OF_MONTH && (
-          <Typography fontWeight="bold">{HIGHLIGHT_OF_MONTH}</Typography>
-        )}
         <Typography>{`Volunteers distributed ${stats.weekLbs} lbs this week`}</Typography>
         <Typography>{`Served ${stats.monthFamilies} families this month`}</Typography>
         <Box


### PR DESCRIPTION
## Summary
- remove hard-coded monthly highlight from volunteer group stats card
- update volunteer dashboard tests to expect dynamic content only

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*

------
https://chatgpt.com/codex/tasks/task_e_68b13c9211c8832da0769c3692923572