### PR TITLE
feat: refine volunteer stats typing and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@
   lifetime volunteer hours, hours served in the current month, total completed shifts,
   and the current consecutive-week streak. It includes a `milestone` flag when total
   shifts reach 5, 10, or 25 so the frontend can display a celebration banner.
-  The response also includes `milestoneText`, `familiesServed`, and `poundsHandled`
+  The response also includes `milestoneText`, `familiesServed`, `poundsHandled`,
+  and current-month totals `monthFamiliesServed` and `monthPoundsHandled`
   so the dashboard can show appreciation messages.
 - Volunteer leaderboard available via `GET /volunteer-stats/leaderboard` returning
   `{ rank, percentile }` for the current volunteer without exposing names.

--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -9,6 +9,7 @@ import {
   getVolunteerStats,
   getVolunteerLeaderboard,
   getVolunteerGroupStats,
+  type VolunteerStats,
 } from '../api/volunteers';
 import { getEvents } from '../api/events';
 
@@ -23,6 +24,24 @@ jest.mock('../api/volunteers', () => ({
 }));
 
 jest.mock('../api/events', () => ({ getEvents: jest.fn() }));
+
+const baseStats: VolunteerStats = {
+  badges: [],
+  lifetimeHours: 0,
+  monthHours: 0,
+  totalShifts: 0,
+  currentStreak: 0,
+  milestone: null,
+  milestoneText: null,
+  familiesServed: 0,
+  poundsHandled: 0,
+  monthFamiliesServed: 0,
+  monthPoundsHandled: 0,
+};
+
+function makeStats(overrides: Partial<VolunteerStats> = {}): VolunteerStats {
+  return { ...baseStats, ...overrides };
+}
 
 describe('VolunteerDashboard', () => {
 beforeEach(() => {
@@ -52,19 +71,7 @@ beforeEach(() => {
       upcoming: [],
       past: [],
     });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
 
     render(
       <MemoryRouter>
@@ -107,19 +114,7 @@ beforeEach(() => {
       },
     ]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
 
     render(
       <MemoryRouter>
@@ -191,19 +186,7 @@ beforeEach(() => {
     (requestVolunteerBooking as jest.Mock).mockRejectedValue(
       new Error('Already booked for this shift'),
     );
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
 
     render(
       <MemoryRouter>
@@ -237,19 +220,7 @@ beforeEach(() => {
     ]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
 
     render(
       <MemoryRouter>
@@ -268,19 +239,9 @@ beforeEach(() => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: ['early-bird'],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(
+      makeStats({ badges: ['early-bird'] }),
+    );
 
     render(
       <MemoryRouter>
@@ -295,19 +256,7 @@ beforeEach(() => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 3, percentile: 75 });
 
     render(
@@ -325,19 +274,16 @@ beforeEach(() => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 10,
-      monthHours: 5,
-      totalShifts: 5,
-      currentStreak: 1,
-      milestone: 5,
-      milestoneText: 'Congratulations on completing 5 shifts!',
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(
+      makeStats({
+        lifetimeHours: 10,
+        monthHours: 5,
+        totalShifts: 5,
+        currentStreak: 1,
+        milestone: 5,
+        milestoneText: 'Congratulations on completing 5 shifts!',
+      }),
+    );
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 1, percentile: 100 });
 
     render(
@@ -355,19 +301,18 @@ beforeEach(() => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 10,
-      monthHours: 5,
-      totalShifts: 2,
-      currentStreak: 1,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 20,
-      poundsHandled: 200,
-      monthFamiliesServed: 3,
-      monthPoundsHandled: 30,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(
+      makeStats({
+        lifetimeHours: 10,
+        monthHours: 5,
+        totalShifts: 2,
+        currentStreak: 1,
+        familiesServed: 20,
+        poundsHandled: 200,
+        monthFamiliesServed: 3,
+        monthPoundsHandled: 30,
+      }),
+    );
     (getVolunteerLeaderboard as jest.Mock).mockResolvedValue({ rank: 1, percentile: 100 });
 
     render(
@@ -387,19 +332,7 @@ beforeEach(() => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
     (getVolunteerGroupStats as jest.Mock).mockResolvedValue({
       totalHours: 10,
       monthHours: 4,
@@ -462,19 +395,7 @@ beforeEach(() => {
     });
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerStats as jest.Mock).mockResolvedValue({
-      badges: [],
-      lifetimeHours: 0,
-      monthHours: 0,
-      totalShifts: 0,
-      currentStreak: 0,
-      milestone: null,
-      milestoneText: null,
-      familiesServed: 0,
-      poundsHandled: 0,
-      monthFamiliesServed: 0,
-      monthPoundsHandled: 0,
-    });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
 
     render(
       <MemoryRouter>

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -413,7 +413,9 @@ export interface VolunteerStats {
   milestoneText: string | null;
   familiesServed: number;
   poundsHandled: number;
+  /** Families served in the current month */
   monthFamiliesServed: number;
+  /** Pounds handled in the current month */
   monthPoundsHandled: number;
 }
 

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -24,6 +24,7 @@ import {
   updateVolunteerBookingStatus,
   getVolunteerStats,
   getVolunteerLeaderboard,
+  type VolunteerStats,
 } from '../../api/volunteers';
 import { getEvents, type EventGroups } from '../../api/events';
 import type { VolunteerBooking, VolunteerRole } from '../../types';
@@ -63,21 +64,7 @@ export default function VolunteerDashboard() {
   const [roleFilter, setRoleFilter] = useState<string>('');
   const [events, setEvents] = useState<EventGroups>({ today: [], upcoming: [], past: [] });
   const [badges, setBadges] = useState<string[]>([]);
-  const [stats, setStats] = useState<
-    | {
-        lifetimeHours: number;
-        monthHours: number;
-        totalShifts: number;
-        currentStreak: number;
-        milestone: number | null;
-        milestoneText: string | null;
-        familiesServed: number;
-        poundsHandled: number;
-        monthFamiliesServed: number;
-        monthPoundsHandled: number;
-      }
-    | undefined
-  >(undefined);
+  const [stats, setStats] = useState<VolunteerStats>();
   const [leaderboard, setLeaderboard] = useState<{ rank: number; percentile: number }>();
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
@@ -118,18 +105,7 @@ export default function VolunteerDashboard() {
     getVolunteerStats()
       .then(data => {
         setBadges(data.badges ?? []);
-        setStats({
-          lifetimeHours: data.lifetimeHours,
-          monthHours: data.monthHours,
-          totalShifts: data.totalShifts,
-          currentStreak: data.currentStreak,
-          milestone: data.milestone,
-          milestoneText: data.milestoneText,
-          familiesServed: data.familiesServed,
-          poundsHandled: data.poundsHandled,
-          monthFamiliesServed: data.monthFamiliesServed,
-          monthPoundsHandled: data.monthPoundsHandled,
-        });
+        setStats(data);
         if (data.totalShifts > 0) {
           const msg =
             data.milestoneText ??


### PR DESCRIPTION
## Summary
- document monthly volunteer stat fields in API typings
- centralize VolunteerStats usage in dashboard and appreciation messaging
- simplify volunteer dashboard tests with reusable stats mocks

## Testing
- `npm test` *(fails: jest not found; dependency installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b13c8ab334832dad9430c57e6f49be