### PR TITLE
Display volunteer dashboard charts side by side

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -276,11 +276,20 @@ export default function VolunteerDashboard() {
             </SectionCard>
           </Grid>
         )}
-        {contributionData.length > 0 && (
+        {contributionData.length > 0 ? (
+          <>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <SectionCard title="My Contribution Trend">
+                <PersonalContributionChart data={contributionData} />
+              </SectionCard>
+            </Grid>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <VolunteerGroupStatsCard />
+            </Grid>
+          </>
+        ) : (
           <Grid size={{ xs: 12 }}>
-            <SectionCard title="My Contribution Trend">
-              <PersonalContributionChart data={contributionData} />
-            </SectionCard>
+            <VolunteerGroupStatsCard />
           </Grid>
         )}
         <Grid size={{ xs: 12, md: 6 }}>
@@ -417,10 +426,6 @@ export default function VolunteerDashboard() {
               </Button>
             </Stack>
           </SectionCard>
-        </Grid>
-
-        <Grid size={{ xs: 12, md: 6 }}>
-          <VolunteerGroupStatsCard />
         </Grid>
 
         <Grid size={{ xs: 12, md: 6 }}>


### PR DESCRIPTION
## Summary
- Lay out personal contribution and community impact charts in a shared row
- Remove duplicated community impact card later in the dashboard

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b13e23a6b4832d9de75b1e4d4de809