### PR TITLE
Consolidate volunteer stats into single dashboard card

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -292,6 +292,40 @@ beforeEach(() => {
     expect(await screen.findByText('early-bird')).toBeInTheDocument();
   });
 
+  it('shows volunteer stats in a single card', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerStats as jest.Mock).mockResolvedValue({
+      badges: [],
+      lifetimeHours: 10,
+      monthHours: 5,
+      totalShifts: 3,
+      currentStreak: 2,
+      milestone: null,
+      milestoneText: null,
+      familiesServed: 0,
+      poundsHandled: 0,
+      monthFamiliesServed: 0,
+      monthPoundsHandled: 0,
+    });
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Lifetime Hours')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('Hours This Month')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('Total Shifts')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Current Streak')).toBeInTheDocument();
+    expect(screen.getByText('2 weeks')).toBeInTheDocument();
+  });
+
   it('shows leaderboard percentile', async () => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -437,42 +437,57 @@ export default function VolunteerDashboard() {
           </Grid>
         )}
 
-        {stats && stats.totalShifts > 0 && (
-          <>
-            <Grid size={{ xs: 6, md: 3 }}>
-              <SectionCard title="Lifetime Hours">
-                <Typography>{stats.lifetimeHours}</Typography>
-              </SectionCard>
-            </Grid>
-            <Grid size={{ xs: 6, md: 3 }}>
-              <SectionCard title="Hours This Month">
-                <Typography>{stats.monthHours}</Typography>
-              </SectionCard>
-            </Grid>
-            <Grid size={{ xs: 6, md: 3 }}>
-              <SectionCard title="Total Shifts">
-                <Typography>{stats.totalShifts}</Typography>
-              </SectionCard>
-            </Grid>
-            <Grid size={{ xs: 6, md: 3 }}>
-              <SectionCard title="Current Streak">
-                <Typography>{stats.currentStreak} week{stats.currentStreak === 1 ? '' : 's'}</Typography>
-              </SectionCard>
-            </Grid>
-          </>
-        )}
-
         <Grid size={{ xs: 12, md: 6 }}>
-          <SectionCard title="Badges">
-            {badges.length > 0 ? (
-              <Stack direction="row" spacing={1} flexWrap="wrap">
-                {badges.map(b => (
-                  <Chip key={b} label={b} />
-                ))}
-              </Stack>
-            ) : (
-              <Typography>No badges earned yet</Typography>
-            )}
+          <SectionCard title="My Stats">
+            <Stack spacing={2}>
+              {badges.length > 0 ? (
+                <Stack direction="row" spacing={1} flexWrap="wrap">
+                  {badges.map(b => (
+                    <Chip key={b} label={b} />
+                  ))}
+                </Stack>
+              ) : (
+                <Typography>No badges earned yet</Typography>
+              )}
+              {stats && stats.totalShifts > 0 && (
+                <Grid container spacing={2}>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack>
+                      <Typography variant="body2" color="text.secondary">
+                        Lifetime Hours
+                      </Typography>
+                      <Typography variant="h6">{stats.lifetimeHours}</Typography>
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack>
+                      <Typography variant="body2" color="text.secondary">
+                        Hours This Month
+                      </Typography>
+                      <Typography variant="h6">{stats.monthHours}</Typography>
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack>
+                      <Typography variant="body2" color="text.secondary">
+                        Total Shifts
+                      </Typography>
+                      <Typography variant="h6">{stats.totalShifts}</Typography>
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack>
+                      <Typography variant="body2" color="text.secondary">
+                        Current Streak
+                      </Typography>
+                      <Typography variant="h6">
+                        {stats.currentStreak} week{stats.currentStreak === 1 ? '' : 's'}
+                      </Typography>
+                    </Stack>
+                  </Grid>
+                </Grid>
+              )}
+            </Stack>
           </SectionCard>
         </Grid>
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
   appreciation quotes.
 - Volunteer dashboard includes a contribution trend chart showing monthly shift
   counts.
+- Volunteer dashboard groups badges, lifetime hours, this month's hours, total shifts, and current streak into a single stats card.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.
 - Approving a pending volunteer booking immediately removes it from the Pending list.


### PR DESCRIPTION
## Summary
- Combine badges, lifetime hours, month hours, total shifts, and streak into one "My Stats" card on volunteer dashboard
- Add test coverage ensuring stats display together
- Document new dashboard layout in README

## Testing
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b13e08089c832d824f040e43541ee9