### PR TITLE
Move volunteer leaderboard into My Stats card

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import VolunteerDashboard from '../pages/volunteer-management/VolunteerDashboard';
 import {
@@ -287,7 +287,7 @@ beforeEach(() => {
     expect(screen.getByText('2 weeks')).toBeInTheDocument();
   });
 
-  it('shows leaderboard percentile', async () => {
+  it('shows leaderboard percentile in My Stats card', async () => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
@@ -300,8 +300,11 @@ beforeEach(() => {
       </MemoryRouter>,
     );
 
+    const myStatsHeader = await screen.findByText('My Stats');
+    const card = myStatsHeader.closest('.MuiCard-root');
+    expect(card).not.toBeNull();
     expect(
-      await screen.findByText("You're in the top 75%!")
+      within(card as HTMLElement).getByText("You're in the top 75%!")
     ).toBeInTheDocument();
   });
 

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -243,15 +243,6 @@ export default function VolunteerDashboard() {
   return (
     <Page title="Volunteer Dashboard">
       <Grid container spacing={2}>
-        {leaderboard && (
-          <Grid size={{ xs: 12 }}>
-            <SectionCard title="Volunteer Leaderboard">
-              <Typography variant="h6">
-                {`You're in the top ${Math.round(leaderboard.percentile)}%!`}
-              </Typography>
-            </SectionCard>
-          </Grid>
-        )}
         {contributionData.length > 0 ? (
           <>
             <Grid size={{ xs: 12, md: 6 }}>
@@ -467,6 +458,11 @@ export default function VolunteerDashboard() {
                     </Stack>
                   </Grid>
                 </Grid>
+              )}
+              {leaderboard && (
+                <Typography variant="h6">
+                  {`You're in the top ${Math.round(leaderboard.percentile)}%!`}
+                </Typography>
               )}
             </Stack>
           </SectionCard>


### PR DESCRIPTION
## Summary
- Move volunteer leaderboard message into the My Stats section on the Volunteer Dashboard
- Update dashboard tests to expect leaderboard within My Stats card

## Testing
- `npm test` (fails: SyntaxError: Cannot use 'import.meta' outside a module, ResizeObserver is not defined, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b13f8c9f00832d8364d70d10ecc215