### PR TITLE
Switch contribution chart to line graph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
 - Milestone badge awards queue a thank-you card email and expose a downloadable card link via `/stats`.
 - Users see a random appreciation message on login.
 - The volunteer dashboard rotates encouragement messages when no milestone is reached.
-- The volunteer dashboard shows a monthly contribution chart of shift counts.
+- The volunteer dashboard shows a monthly contribution line chart of shift counts.
 
 ## Project Layout
 

--- a/MJ_FB_Frontend/src/components/dashboard/PersonalContributionChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/PersonalContributionChart.tsx
@@ -1,8 +1,8 @@
 import { useTheme } from '@mui/material/styles';
 import {
   ResponsiveContainer,
-  BarChart,
-  Bar,
+  LineChart,
+  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -22,13 +22,13 @@ export default function PersonalContributionChart({ data }: PersonalContribution
   const theme = useTheme();
   return (
     <ResponsiveContainer width="100%" height={300} data-testid="contribution-chart">
-      <BarChart data={data}>
+      <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="month" />
         <YAxis allowDecimals={false} />
         <Tooltip />
-        <Bar dataKey="count" name="Shifts" fill={theme.palette.primary.main} />
-      </BarChart>
+        <Line type="monotone" dataKey="count" name="Shifts" stroke={theme.palette.primary.main} />
+      </LineChart>
     </ResponsiveContainer>
   );
 }

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Volunteer dashboard now highlights weekly pounds distributed, a progress gauge
   toward the monthly hours goal, a highlight of the month, and rotating
   appreciation quotes.
-- Volunteer dashboard includes a contribution trend chart showing monthly shift
-  counts.
+- Volunteer dashboard includes a line chart showing monthly shift counts to illustrate the contribution trend.
 - Volunteer dashboard groups badges, lifetime hours, this month's hours, total shifts, and current streak into a single stats card.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.


### PR DESCRIPTION
## Summary
- replace volunteer contribution bar chart with line chart for smoother trend visualization
- note the line chart in AGENTS and README

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module, ResizeObserver is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b13fb6bfe0832dbf88da5b3b829671