### PR TITLE
Place community gauge label below chart

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
@@ -59,7 +59,7 @@ export default function VolunteerGroupStatsCard() {
               fill={theme.palette.primary.main}
             />
           </RadialBarChart>
-          <Typography variant="body2" mt={-2}>{`${stats.monthHours} / ${stats.monthHoursGoal} hrs`}</Typography>
+          <Typography variant="body2" mt={1}>{`${stats.monthHours} / ${stats.monthHoursGoal} hrs`}</Typography>
         </Box>
         {quote && <Typography variant="body2">{quote}</Typography>}
       </Stack>


### PR DESCRIPTION
## Summary
- ensure volunteer group progress text is positioned below radial chart

## Testing
- `npm test src/__tests__/VolunteerDashboard.test.tsx` *(fails: ReferenceError: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b140638950832da3a156671bd72d58