### PR TITLE
Fix filtering for available volunteer role slots

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -184,7 +184,7 @@ export default function VolunteerDashboard() {
       s =>
         !activeBookings.some(
           b =>
-            b.role_id === s.id &&
+            b.role_id === s.role_id &&
             b.date === s.date &&
             b.start_time === s.start_time &&
             b.end_time === s.end_time,


### PR DESCRIPTION
## Summary
- ensure dashboard compares booking role IDs when removing already requested shifts

## Testing
- `CI=true npx jest src/__tests__/VolunteerDashboard.test.tsx --runInBand` *(fails: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b143aa9048832d8308b24bf3ee48a9