### PR TITLE
chore: temporarily disable client signups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,14 @@
 - The volunteer dashboard rotates encouragement messages when no milestone is reached.
 - The volunteer dashboard shows a monthly contribution line chart of shift counts.
 
+### Client self-registration (temporarily disabled)
+
+The self-service registration endpoints and frontend page are commented out pending further testing. To restore this feature:
+
+- Uncomment `/register` and `/register/otp` routes in `MJ_FB_Backend/src/routes/users.ts`.
+- Restore the signup route and navigation in `MJ_FB_Frontend/src/App.tsx` and the link in `src/pages/auth/Login.tsx`.
+- Re-enable the related tests in `MJ_FB_Backend/tests` and `MJ_FB_Frontend/src/__tests__`.
+
 ## Project Layout
 
 ### Backend (`MJ_FB_Backend`)

--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import {
   loginUser,
-  registerUser,
-  sendRegistrationOtp,
+  // registerUser,
+  // sendRegistrationOtp,
   createUser,
   searchUsers,
   getUserProfile,
@@ -15,8 +15,8 @@ import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import {
   loginSchema,
-  registerSchema,
-  sendRegistrationOtpSchema,
+  // registerSchema,
+  // sendRegistrationOtpSchema,
   createUserSchema,
   updateUserSchema,
   updateMyProfileSchema,
@@ -24,13 +24,13 @@ import {
 
 const router = express.Router();
 
-router.post('/register', validate(registerSchema), registerUser);
 router.post('/login', validate(loginSchema), loginUser);
-router.post(
-  '/register/otp',
-  validate(sendRegistrationOtpSchema),
-  sendRegistrationOtp,
-);
+// router.post('/register', validate(registerSchema), registerUser);
+// router.post(
+//   '/register/otp',
+//   validate(sendRegistrationOtpSchema),
+//   sendRegistrationOtp,
+// );
 router.post(
   '/add-client',
   authMiddleware,

--- a/MJ_FB_Backend/tests/register.test.ts
+++ b/MJ_FB_Backend/tests/register.test.ts
@@ -1,3 +1,7 @@
+// Client self-registration feature is temporarily disabled.
+// The tests below verify the registration flow and should be re-enabled when
+// the signup feature is restored.
+/*
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';
@@ -113,4 +117,5 @@ describe('POST /api/users/register', () => {
     expect(res.status).toBe(400);
   });
 });
+*/
 

--- a/MJ_FB_Backend/tests/sendRegistrationOtp.test.ts
+++ b/MJ_FB_Backend/tests/sendRegistrationOtp.test.ts
@@ -1,3 +1,7 @@
+// Client self-registration feature is temporarily disabled.
+// The tests below verify the OTP flow and should be re-enabled when the
+// signup feature is restored.
+/*
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';
@@ -33,3 +37,4 @@ describe('POST /api/users/register/otp', () => {
     expect(sendEmail).toHaveBeenCalled();
   });
 });
+*/

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -34,7 +34,7 @@ const ClientHistory = React.lazy(() =>
 const Login = React.lazy(() => import('./pages/auth/Login'));
 const StaffLogin = React.lazy(() => import('./pages/auth/StaffLogin'));
 const VolunteerLogin = React.lazy(() => import('./pages/auth/VolunteerLogin'));
-const ClientSignup = React.lazy(() => import('./pages/auth/ClientSignup'));
+// const ClientSignup = React.lazy(() => import('./pages/auth/ClientSignup'));
 const VolunteerDashboard = React.lazy(() =>
   import('./pages/volunteer-management/VolunteerDashboard')
 );
@@ -128,7 +128,7 @@ export default function App() {
           { label: 'Agency Login', to: '/login/agency' },
         ],
       },
-      { label: 'Client Sign Up', links: [{ label: 'Sign Up', to: '/signup' }] },
+      // { label: 'Client Sign Up', links: [{ label: 'Sign Up', to: '/signup' }] },
     );
   } else if (isStaff) {
     const staffLinks = [
@@ -409,7 +409,7 @@ export default function App() {
             <main>
               <Suspense fallback={<Spinner />}>
                 <Routes>
-                  <Route path="/signup" element={<ClientSignup />} />
+                  {/* <Route path="/signup" element={<ClientSignup />} /> */}
                   <Route path="/login/user" element={<Login onLogin={login} />} />
                   <Route path="/login/staff" element={<StaffLogin onLogin={login} />} />
                   <Route path="/login/volunteer" element={<VolunteerLogin onLogin={login} />} />

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -106,15 +106,15 @@ describe('App authentication persistence', () => {
     await waitFor(() => expect(window.location.pathname).toBe('/warehouse-management'));
   });
 
-  it('renders signup page when visiting /signup', () => {
-    window.history.pushState({}, '', '/signup');
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>,
-    );
-    expect(screen.getByText(/client sign up/i)).toBeInTheDocument();
-  });
+  // it('renders signup page when visiting /signup', () => {
+  //   window.history.pushState({}, '', '/signup');
+  //   render(
+  //     <AuthProvider>
+  //       <App />
+  //     </AuthProvider>,
+  //   );
+  //   expect(screen.getByText(/client sign up/i)).toBeInTheDocument();
+  // });
 
   it('shows App Config link for admin staff', () => {
     localStorage.setItem('role', 'staff');

--- a/MJ_FB_Frontend/src/__tests__/ClientSignup.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientSignup.test.tsx
@@ -1,3 +1,6 @@
+// Client self-registration feature is temporarily disabled.
+// Tests for the ClientSignup component are commented out until the feature is restored.
+/*
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ClientSignup from '../pages/auth/ClientSignup';
@@ -60,3 +63,4 @@ describe('ClientSignup', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/login/user');
   });
 });
+*/

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -25,13 +25,13 @@ describe('Login component', () => {
     await waitFor(() => expect(onLogin).toHaveBeenCalled());
   });
 
-  it('includes link to signup', () => {
-    render(
-      <MemoryRouter>
-        <Login onLogin={async () => {}} />
-      </MemoryRouter>
-    );
-    const link = screen.getByRole('link', { name: /sign up/i });
-    expect(link).toHaveAttribute('href', '/signup');
-  });
+  // it('includes link to signup', () => {
+  //   render(
+  //     <MemoryRouter>
+  //       <Login onLogin={async () => {}} />
+  //     </MemoryRouter>
+  //   );
+  //   const link = screen.getByRole('link', { name: /sign up/i });
+  //   expect(link).toHaveAttribute('href', '/signup');
+  // });
 });

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -72,9 +72,9 @@ export default function Login({
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">
           Forgot password?
         </Link>
-        <Link component={RouterLink} to="/signup" underline="hover">
+        {/* <Link component={RouterLink} to="/signup" underline="hover">
           Need an account? Sign up
-        </Link>
+        </Link> */}
       </FormCard>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="user" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.
 - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts).
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
-- Self-service client registration with email OTP verification ([userController](MJ_FB_Backend/src/controllers/userController.ts)).
+- Self-service client registration with email OTP verification (currently disabled pending further testing).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Configurable cart tare and surplus weight multipliers managed through the Admin → App Configurations page, accessible via the Admin menu.
 - Staff can set a single maximum booking capacity applied to all pantry time slots through the Admin → Pantry Settings page or `PUT /slots/capacity`.
@@ -206,6 +206,18 @@ control weight calculations:
 - Agency profile page shows the agency's name, email, and contact info with editable fields and password reset support.
 - Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.
 - Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list for managing associations.
+
+### Client self-registration (temporarily disabled)
+
+The application previously allowed existing clients to enable online access via a self-service registration flow. Clients would request an email OTP and submit it along with their account details to activate online access.
+
+This feature is currently disabled pending further testing. The backend routes `/api/users/register` and `/api/users/register/otp`, the frontend signup page, and associated tests have been commented out. To re-enable the flow:
+
+1. Uncomment the routes in `MJ_FB_Backend/src/routes/users.ts`.
+2. Restore the signup navigation and route in `MJ_FB_Frontend/src/App.tsx` and the link in `src/pages/auth/Login.tsx`.
+3. Re-enable signup tests in `MJ_FB_Backend/tests` and `MJ_FB_Frontend/src/__tests__`.
+
+Refer to the comments in those files for additional context when reinstating the feature.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- comment out backend `/register` and `/register/otp` routes
- remove frontend signup link and route and skip associated tests
- document temporary signup disablement in README and AGENTS

## Testing
- `npm test` *(fails: jest: not found)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b0e46208832da98fc3ecc83edef7