### PR TITLE
fix: import type for MasterRole in VolunteerSettings

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -24,7 +24,7 @@ import AddIcon from '@mui/icons-material/Add';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import MasterRoleDialog, { MasterRole } from './components/MasterRoleDialog';
+import MasterRoleDialog, { type MasterRole } from './components/MasterRoleDialog';
 import SubRoleDialog from './components/SubRoleDialog';
 import ShiftDialog from './components/ShiftDialog';
 import {


### PR DESCRIPTION
## Summary
- fix VolunteerSettings to import MasterRole type as type-only to avoid runtime export error

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b215c050c8832d8fd1556bd4ce78aa