### PR TITLE
feat: add Brevo templated email utility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Ensure tests are added or updated for any code changes and run the relevant test suites after each task.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Booking emails are sent through Brevo; configure `BREVO_API_KEY`, `BREVO_FROM_EMAIL`, and `BREVO_FROM_NAME` in the backend environment.
+- Use the `sendTemplatedEmail` utility to send Brevo template emails by providing a `templateId` and `params` object.
 
 ## Testing
 

--- a/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
+++ b/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
@@ -1,0 +1,33 @@
+import { sendTemplatedEmail } from '../src/utils/emailUtils';
+
+describe('sendTemplatedEmail', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+  });
+
+  it('sends a template email with params', async () => {
+    await sendTemplatedEmail({
+      to: 'user@example.com',
+      templateId: 123,
+      params: { name: 'Tester' },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.brevo.com/v3/smtp/email',
+      expect.objectContaining({ method: 'POST' })
+    );
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      templateId: 123,
+      params: { name: 'Tester' },
+    });
+  });
+});

--- a/MJ_FB_Backend/tests/setupEnv.ts
+++ b/MJ_FB_Backend/tests/setupEnv.ts
@@ -8,5 +8,8 @@ process.env.PG_HOST = 'localhost';
 process.env.PG_PORT = '5432';
 process.env.PG_DATABASE = 'testdb';
 process.env.FRONTEND_ORIGIN = 'http://localhost:3000';
+process.env.BREVO_API_KEY = 'test-api-key';
+process.env.BREVO_FROM_EMAIL = 'noreply@example.com';
+process.env.BREVO_FROM_NAME = 'MJ Food Bank';
 
 export {};

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Volunteer role management and scheduling restricted to trained areas.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
+- Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Users see a random appreciation message on each login with a link to download their card when available.
 - Volunteers also see rotating encouragement messages on the dashboard when no milestone is reached.
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.


### PR DESCRIPTION
## Summary
- add reusable `sendTemplatedEmail` for Brevo template-based emails
- cover new utility with unit tests and document usage in README/AGENTS

## Testing
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b2817e4164832d9d54a2ea932b89af