### PR TITLE
Default volunteer bookings to approved and remove pending flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,7 @@ The booking flow uses the following PostgreSQL tables. **PK** denotes a primary 
 - **volunteer_slots** – PK `slot_id`; FK `role_id` → `volunteer_roles.id` (cascade); tracks `max_volunteers`, `is_wednesday_slot`, `is_active`.
 - **volunteers** – PK `id`; unique `username`.
 - **volunteer_trained_roles** – composite PK `(volunteer_id, role_id)`; FK `volunteer_id` → `volunteers.id` (cascade); FK `role_id` → `volunteer_roles.id` (cascade); FK `category_id` → `volunteer_master_roles.id`.
-- **volunteer_bookings** – PK `id`; FK `volunteer_id` → `volunteers.id` (cascade); FK `slot_id` → `volunteer_slots.slot_id` (cascade); `status` in `pending|approved|rejected|cancelled`; includes `reschedule_token`.
+- **volunteer_bookings** – PK `id`; FK `volunteer_id` → `volunteers.id` (cascade); FK `slot_id` → `volunteer_slots.slot_id` (cascade); `status` in `approved|rejected|cancelled|no_show|expired`; includes `reschedule_token`.
 - **volunteer_recurring_bookings** – PK `id`; FK `volunteer_id` → `volunteers.id` (cascade); FK `slot_id` → `volunteer_slots.slot_id` (cascade); includes `start_date`, optional `end_date`, `pattern` (`daily|weekly`), `days_of_week` array, and an `active` flag.
 
 ## Volunteer Management
@@ -421,9 +421,8 @@ Volunteer management coordinates role-based staffing for the food bank.
 - **VolunteerSchedule** lets volunteers choose a role from a dropdown and view a grid of shifts. Columns correspond to slot numbers and rows show shift times (e.g. 9:30–12:00, 12:30–3:30). Cells display *Booked* or *Available* and clicking an available cell creates a request in `volunteer_bookings`. Past dates are disabled and same-day shifts that have already started are omitted.
 - The Volunteer Dashboard's **Available in My Roles** list excludes shifts the volunteer has already requested or booked and shows server-provided error messages when a booking attempt fails.
 - Volunteer and pantry schedules follow the same grid logic. The y‑axis lists shift times and the x‑axis lists sequential slot numbers up to each shift's `max_volunteers`. When a volunteer requests a shift, their booking occupies the first open slot. Pending requests highlight (e.g., yellow) and staff approve by clicking the cell, mirroring the shopping appointment schedule.
-- **BookingHistory** shows a volunteer's pending and upcoming bookings with Cancel and Reschedule options.
-- **CoordinatorDashboard** is the staff view using `VolunteerScheduleTable`. Staff see volunteer names for booked cells, approve/reject/reschedule pending requests, and cancel or reschedule approved bookings. Staff can also search volunteers, assign them to roles, and update trained areas.
-- Approving a pending volunteer booking removes it from the Pending page immediately.
+- **BookingHistory** shows a volunteer's upcoming bookings with Cancel and Reschedule options.
+- **CoordinatorDashboard** is the staff view using `VolunteerScheduleTable`. Staff see volunteer names for booked cells and can cancel or reschedule bookings. Staff can also search volunteers, assign them to roles, and update trained areas.
 - The volunteer search page shows the selected volunteer's profile and role editor alongside their booking history in a two-column card layout.
 - Role selection in the volunteer search role editor uses a simple dropdown without search.
 - These workflows rely on `volunteer_slots`, `volunteer_roles`, `volunteer_master_roles`, `volunteer_bookings`, `volunteers`, and `volunteer_trained_roles`. Training records in `volunteer_trained_roles` restrict which roles a volunteer can book.

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -333,7 +333,7 @@ export async function listVolunteerRolesForVolunteer(
        LEFT JOIN (
          SELECT slot_id, COUNT(*) AS count
          FROM volunteer_bookings
-         WHERE status IN ('pending','approved') AND date = $1
+         WHERE status='approved' AND date = $1
          GROUP BY slot_id
        ) b ON vs.slot_id = b.slot_id
        WHERE vs.role_id = ANY($2::int[])

--- a/MJ_FB_Backend/src/migrations/20250830045341_auto_approve_volunteer_bookings.ts
+++ b/MJ_FB_Backend/src/migrations/20250830045341_auto_approve_volunteer_bookings.ts
@@ -1,0 +1,19 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql("UPDATE volunteer_bookings SET status='approved' WHERE status='pending'");
+  pgm.alterColumn('volunteer_bookings', 'status', { default: 'approved' });
+  pgm.dropConstraint('volunteer_bookings', 'volunteer_bookings_status_check', { ifExists: true });
+  pgm.addConstraint('volunteer_bookings', 'volunteer_bookings_status_check', {
+    check: "status IN ('approved', 'rejected', 'cancelled', 'no_show', 'expired')",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.alterColumn('volunteer_bookings', 'status', { default: 'pending' });
+  pgm.dropConstraint('volunteer_bookings', 'volunteer_bookings_status_check', { ifExists: true });
+  pgm.addConstraint('volunteer_bookings', 'volunteer_bookings_status_check', {
+    check: "status IN ('pending', 'approved', 'rejected', 'cancelled', 'no_show', 'expired')",
+  });
+  pgm.sql("UPDATE volunteer_bookings SET status='pending' WHERE status='approved'");
+}

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -295,7 +295,7 @@ CREATE TABLE IF NOT EXISTS volunteer_bookings (
     volunteer_id integer NOT NULL,
     slot_id integer NOT NULL,
     date date NOT NULL,
-    status text DEFAULT 'pending' NOT NULL CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled', 'no_show', 'expired')),
+    status text DEFAULT 'approved' NOT NULL CHECK (status IN ('approved', 'rejected', 'cancelled', 'no_show', 'expired')),
     reason text,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     reschedule_token text,

--- a/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
@@ -42,7 +42,7 @@ describe('listVolunteerBookings', () => {
       rows: [
         {
           id: 1,
-          status: 'pending',
+          status: 'approved',
           role_id: 2,
           volunteer_id: 3,
           date: '2025-01-01',

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -28,40 +28,21 @@ describe('rescheduleVolunteerBooking', () => {
 
   it('keeps status approved when volunteer reschedules an approved booking', async () => {
     const booking = { id: 1, volunteer_id: 2, status: 'approved' };
-      (pool.query as jest.Mock)
-        .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
-        .mockResolvedValueOnce({ rowCount: 1, rows: [{ role_id: 1, max_volunteers: 5 }] })
-        .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })
-        .mockResolvedValueOnce({ rowCount: 0, rows: [] })
-        .mockResolvedValueOnce({ rowCount: 1, rows: [{ count: 0 }] })
-        .mockResolvedValueOnce({});
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ role_id: 1, max_volunteers: 5, start_time: '09:00', end_time: '12:00' }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({});
 
     const res = await request(app)
       .post('/volunteer-bookings/reschedule/token123')
       .send({ roleId: 4, date: '2025-09-01' });
 
     expect(res.status).toBe(200);
-    const updateCall = (pool.query as jest.Mock).mock.calls[5];
-    expect(updateCall[1][3]).toBe('approved');
-  });
-
-  it('sets status to pending when staff reschedules', async () => {
-    const booking = { id: 1, volunteer_id: 2, status: 'approved' };
-      (pool.query as jest.Mock)
-        .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
-        .mockResolvedValueOnce({ rowCount: 1, rows: [{ role_id: 1, max_volunteers: 5 }] })
-        .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })
-        .mockResolvedValueOnce({ rowCount: 0, rows: [] })
-        .mockResolvedValueOnce({ rowCount: 1, rows: [{ count: 0 }] })
-        .mockResolvedValueOnce({});
-
-    const res = await request(app)
-      .post('/volunteer-bookings/reschedule/token123')
-      .set('x-staff', 'true')
-      .send({ roleId: 4, date: '2025-09-01' });
-
-    expect(res.status).toBe(200);
-      const updateCall = (pool.query as jest.Mock).mock.calls[5];
-    expect(updateCall[1][3]).toBe('pending');
+    const updateCall = (pool.query as jest.Mock).mock.calls[6];
+    expect(updateCall[0]).toContain("status='approved'");
   });
 });

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Volunteer dashboard groups badges, lifetime hours, this month's hours, total shifts, and current streak into a single stats card.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.
-- Approving a pending volunteer booking immediately removes it from the Pending list.
+- Volunteer bookings are auto-approved and appear immediately on schedules.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
 - Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Volunteer Settings page's **Restore Original Roles & Shifts** button.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).


### PR DESCRIPTION
## Summary
- Default volunteer_bookings status to `approved` and migrate existing records
- Auto-approve new volunteer bookings with overlap checks and simplified cancellation logic
- Drop pending status references across controllers, schema docs, and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2836f47b4832dbf50a986bfde2a7e