### PR TITLE
Implement password setup token flow

### DIFF
--- a/MJ_FB_Backend/src/migrations/20251001000000_add_password_setup_tokens.ts
+++ b/MJ_FB_Backend/src/migrations/20251001000000_add_password_setup_tokens.ts
@@ -1,0 +1,26 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('password_setup_tokens', {
+    id: 'id',
+    user_type: { type: 'text', notNull: true },
+    user_id: { type: 'integer', notNull: true },
+    token_hash: { type: 'text', notNull: true },
+    expires_at: { type: 'timestamp', notNull: true },
+    used: { type: 'boolean', notNull: true, default: false },
+  });
+
+  pgm.alterColumn('clients', 'password', { notNull: false });
+  pgm.alterColumn('volunteers', 'password', { notNull: false });
+  pgm.alterColumn('staff', 'password', { notNull: false });
+  pgm.alterColumn('agencies', 'password', { notNull: false });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.alterColumn('clients', 'password', { notNull: true });
+  pgm.alterColumn('volunteers', 'password', { notNull: true });
+  pgm.alterColumn('staff', 'password', { notNull: true });
+  pgm.alterColumn('agencies', 'password', { notNull: true });
+
+  pgm.dropTable('password_setup_tokens');
+}

--- a/MJ_FB_Backend/src/routes/auth.ts
+++ b/MJ_FB_Backend/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   requestPasswordReset,
+  setPassword,
   changePassword,
   refreshToken,
   logout,
@@ -11,6 +12,7 @@ import { authMiddleware } from '../middleware/authMiddleware';
 const router = Router();
 
 router.post('/request-password-reset', requestPasswordReset);
+router.post('/set-password', setPassword);
 router.post('/change-password', authMiddleware, changePassword);
 router.post('/refresh', refreshToken);
 router.post('/logout', logout);

--- a/MJ_FB_Backend/src/utils/passwordSetupUtils.ts
+++ b/MJ_FB_Backend/src/utils/passwordSetupUtils.ts
@@ -1,0 +1,48 @@
+import { randomBytes, createHash } from 'crypto';
+import pool from '../db';
+
+export type PasswordTokenRow = {
+  id: number;
+  user_type: 'clients' | 'volunteers' | 'staff' | 'agencies';
+  user_id: number;
+  token_hash: string;
+  expires_at: Date;
+  used: boolean;
+};
+
+const TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+
+export async function generatePasswordSetupToken(
+  userType: PasswordTokenRow['user_type'],
+  userId: number,
+): Promise<string> {
+  const token = randomBytes(32).toString('hex');
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+  const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_MS);
+  await pool.query(
+    `INSERT INTO password_setup_tokens (user_type, user_id, token_hash, expires_at, used)
+     VALUES ($1,$2,$3,$4,false)`,
+    [userType, userId, tokenHash, expiresAt],
+  );
+  return token;
+}
+
+export async function verifyPasswordSetupToken(
+  token: string,
+): Promise<PasswordTokenRow | null> {
+  const hash = createHash('sha256').update(token).digest('hex');
+  const res = await pool.query(
+    `SELECT id, user_type, user_id, token_hash, expires_at, used
+       FROM password_setup_tokens WHERE token_hash=$1`,
+    [hash],
+  );
+  if ((res.rowCount ?? 0) === 0) return null;
+  const row = res.rows[0] as PasswordTokenRow;
+  if (row.used) return null;
+  if (new Date(row.expires_at).getTime() < Date.now()) return null;
+  return row;
+}
+
+export async function markPasswordTokenUsed(id: number): Promise<void> {
+  await pool.query('UPDATE password_setup_tokens SET used=true WHERE id=$1', [id]);
+}

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -1,0 +1,70 @@
+import request from 'supertest';
+import express from 'express';
+import authRouter from '../src/routes/auth';
+import pool from '../src/db';
+import bcrypt from 'bcrypt';
+import {
+  generatePasswordSetupToken,
+  verifyPasswordSetupToken,
+  markPasswordTokenUsed,
+} from '../src/utils/passwordSetupUtils';
+import { sendTemplatedEmail } from '../src/utils/emailUtils';
+
+jest.mock('../src/db');
+jest.mock('../src/utils/passwordSetupUtils');
+jest.mock('../src/utils/emailUtils', () => ({
+  sendTemplatedEmail: jest.fn(),
+}));
+jest.mock('bcrypt');
+
+const app = express();
+app.use(express.json());
+app.use('/auth', authRouter);
+
+describe('requestPasswordReset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a token and sends an email', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 7 }],
+    });
+    (generatePasswordSetupToken as jest.Mock).mockResolvedValue('tok');
+    const res = await request(app)
+      .post('/auth/request-password-reset')
+      .send({ email: 'user@example.com' });
+    expect(res.status).toBe(204);
+    expect(generatePasswordSetupToken).toHaveBeenCalledWith('staff', 7);
+    expect(sendTemplatedEmail).toHaveBeenCalled();
+    const link = (sendTemplatedEmail as jest.Mock).mock.calls[0][0].params.link;
+    expect(link).toBe('http://localhost:3000/set-password?token=tok');
+  });
+});
+
+describe('setPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('verifies token, hashes password, and marks token used', async () => {
+    (verifyPasswordSetupToken as jest.Mock).mockResolvedValue({
+      id: 1,
+      user_type: 'staff',
+      user_id: 7,
+    });
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+    const res = await request(app)
+      .post('/auth/set-password')
+      .send({ token: 'tok', password: 'Abcd1234!' });
+    expect(res.status).toBe(204);
+    expect(bcrypt.hash).toHaveBeenCalledWith('Abcd1234!', 10);
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      'UPDATE staff SET password=$1 WHERE id=$2',
+      ['hashed', 7],
+    );
+    expect(markPasswordTokenUsed).toHaveBeenCalledWith(1);
+  });
+});

--- a/MJ_FB_Backend/tests/passwordSetupUtils.test.ts
+++ b/MJ_FB_Backend/tests/passwordSetupUtils.test.ts
@@ -1,0 +1,45 @@
+import { createHash } from 'crypto';
+import pool from '../src/db';
+import {
+  generatePasswordSetupToken,
+  verifyPasswordSetupToken,
+} from '../src/utils/passwordSetupUtils';
+
+jest.mock('../src/db');
+
+describe('passwordSetupUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('generates a token and stores its hash', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({});
+    const token = await generatePasswordSetupToken('staff', 1);
+    expect(typeof token).toBe('string');
+    const expectedHash = createHash('sha256').update(token).digest('hex');
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toContain(
+      'INSERT INTO password_setup_tokens',
+    );
+    expect((pool.query as jest.Mock).mock.calls[0][1][2]).toBe(expectedHash);
+  });
+
+  it('verifies a stored token', async () => {
+    const token = 'abc123';
+    const hash = createHash('sha256').update(token).digest('hex');
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [
+        {
+          id: 2,
+          user_type: 'staff',
+          user_id: 5,
+          token_hash: hash,
+          expires_at: new Date(Date.now() + 1000).toISOString(),
+          used: false,
+        },
+      ],
+    });
+    const row = await verifyPasswordSetupToken(token);
+    expect(row).toMatchObject({ id: 2, user_type: 'staff', user_id: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- add migration creating `password_setup_tokens` table and allow nullable passwords
- implement helpers to generate and verify password setup tokens
- extend auth controller with reset and set-password endpoints and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b28682a8ec832da30a770e34f848b1