### PR TITLE
feat: add New Clients management tab

### DIFF
--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -233,3 +233,21 @@ export async function registerUser(data: {
   });
   await handleResponse(res);
 }
+
+export interface NewClient {
+  id: number;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  created_at: string;
+}
+
+export async function getNewClients(): Promise<NewClient[]> {
+  const res = await apiFetch(`${API_BASE}/new-clients`);
+  return handleResponse(res);
+}
+
+export async function deleteNewClient(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/new-clients/${id}`, { method: "DELETE" });
+  await handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 import AddClient from './client-management/AddClient';
 import UpdateClientData from './client-management/UpdateClientData';
 import UserHistory from './client-management/UserHistory';
+import NewClients from './client-management/NewClients';
 
 export default function ClientManagement() {
   const [searchParams] = useSearchParams();
@@ -15,6 +16,8 @@ export default function ClientManagement() {
         return 1;
       case 'history':
         return 2;
+      case 'new':
+        return 3;
       default:
         return 0;
     }
@@ -24,12 +27,14 @@ export default function ClientManagement() {
     const t = searchParams.get('tab');
     if (t === 'update') setTab(1);
     else if (t === 'history') setTab(2);
+    else if (t === 'new') setTab(3);
     else setTab(0);
   }, [searchParams]);
   const tabs = [
     { label: 'Add', content: <AddClient /> },
     { label: 'Update', content: <UpdateClientData /> },
     { label: 'History', content: <UserHistory /> },
+    { label: 'New Clients', content: <NewClients /> },
   ];
 
   return (

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ClientManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ClientManagement.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ClientManagement from '../ClientManagement';
+import { getNewClients, deleteNewClient } from '../../../api/users';
+
+jest.mock('../../../api/users', () => ({
+  ...jest.requireActual('../../../api/users'),
+  getNewClients: jest.fn(),
+  deleteNewClient: jest.fn(),
+}));
+
+const mockClients = [
+  {
+    id: 1,
+    name: 'John Doe',
+    email: 'john@example.com',
+    phone: '123',
+    created_at: '2024-01-01',
+  },
+];
+
+describe('ClientManagement New Clients tab', () => {
+  beforeEach(() => {
+    (getNewClients as jest.Mock).mockResolvedValue(mockClients);
+    (deleteNewClient as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('displays new clients and handles deletion', async () => {
+    render(
+      <MemoryRouter>
+        <ClientManagement />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /new clients/i }));
+
+    expect(await screen.findByText('John Doe')).toBeInTheDocument();
+
+    const deleteBtn = await screen.findByLabelText('delete');
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(deleteNewClient).toHaveBeenCalledWith(1);
+    });
+    expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NewClients.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NewClients.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import {
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  IconButton,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import Page from '../../../components/Page';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import {
+  getNewClients,
+  deleteNewClient,
+  type NewClient,
+} from '../../../api/users';
+import type { AlertColor } from '@mui/material';
+
+export default function NewClients() {
+  const [clients, setClients] = useState<NewClient[]>([]);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: AlertColor;
+  } | null>(null);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  function load() {
+    getNewClients()
+      .then(setClients)
+      .catch(() => setClients([]));
+  }
+
+  async function handleDelete(id: number) {
+    try {
+      await deleteNewClient(id);
+      setClients(prev => prev.filter(c => c.id !== id));
+      setSnackbar({ open: true, message: 'Client deleted', severity: 'success' });
+    } catch (err: unknown) {
+      setSnackbar({
+        open: true,
+        message: err instanceof Error ? err.message : String(err),
+        severity: 'error',
+      });
+    }
+  }
+
+  return (
+    <Page title="New Clients">
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Email</TableCell>
+            <TableCell>Phone</TableCell>
+            <TableCell>Created</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {clients.map(c => (
+            <TableRow key={c.id}>
+              <TableCell>{c.name}</TableCell>
+              <TableCell>{c.email}</TableCell>
+              <TableCell>{c.phone}</TableCell>
+              <TableCell>{c.created_at}</TableCell>
+              <TableCell align="right">
+                <IconButton aria-label="delete" onClick={() => handleDelete(c.id)} size="small">
+                  <DeleteIcon />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <FeedbackSnackbar
+        open={!!snackbar}
+        onClose={() => setSnackbar(null)}
+        message={snackbar?.message ?? ''}
+        severity={snackbar?.severity}
+      />
+    </Page>
+  );
+}
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 ## Features
 
 - Appointment booking workflow for clients with staff approval and rescheduling.
-- Unregistered clients can book directly via `/bookings/new-client`; staff can list or delete these pending clients through `/new-clients`.
+- Unregistered clients can book directly via `/bookings/new-client`; staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.


### PR DESCRIPTION
## Summary
- add API wrappers to list and delete new clients
- build New Clients tab for staff client management
- test New Clients tab loads and removes entries

## Testing
- `npm test` *(fails: Jest encountered unexpected token and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b286e64ce8832d9173b02a1d07ad0a