### PR TITLE
Remove pending volunteer booking state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,7 +423,8 @@ Volunteer management coordinates role-based staffing for the food bank.
 
 - **VolunteerSchedule** lets volunteers choose a role from a dropdown and view a grid of shifts. Columns correspond to slot numbers and rows show shift times (e.g. 9:30–12:00, 12:30–3:30). Cells display *Booked* or *Available* and clicking an available cell creates a request in `volunteer_bookings`. Past dates are disabled and same-day shifts that have already started are omitted.
 - The Volunteer Dashboard's **Available in My Roles** list excludes shifts the volunteer has already requested or booked and shows server-provided error messages when a booking attempt fails.
-- Volunteer and pantry schedules follow the same grid logic. The y‑axis lists shift times and the x‑axis lists sequential slot numbers up to each shift's `max_volunteers`. When a volunteer requests a shift, their booking occupies the first open slot. Pending requests highlight (e.g., yellow) and staff approve by clicking the cell, mirroring the shopping appointment schedule.
+- Shift booking confirmations display "Shift booked," and the volunteer dashboard no longer lists pending requests.
+- Volunteer and pantry schedules follow the same grid logic. The y‑axis lists shift times and the x‑axis lists sequential slot numbers up to each shift's `max_volunteers`. When a volunteer requests a shift, the booking is immediately approved and occupies the first open slot.
 - **BookingHistory** shows a volunteer's upcoming bookings with Cancel and Reschedule options.
 - **CoordinatorDashboard** is the staff view using `VolunteerScheduleTable`. Staff see volunteer names for booked cells and can cancel or reschedule bookings. Staff can also search volunteers, assign them to roles, and update trained areas.
 - The volunteer search page shows the selected volunteer's profile and role editor alongside their booking history in a two-column card layout.

--- a/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
@@ -44,7 +44,7 @@ describe('VolunteerBooking', () => {
       role_id: 1,
       volunteer_id: 1,
       date: '2024-01-01',
-      status: 'pending',
+      status: 'approved',
     });
 
     const queryClient = new QueryClient();
@@ -64,7 +64,7 @@ describe('VolunteerBooking', () => {
       expect(requestVolunteerBooking).toHaveBeenCalledWith(1, expect.any(String)),
     );
     await waitFor(() =>
-      expect(screen.getByText('Request submitted')).toBeInTheDocument(),
+      expect(screen.getByText('Shift booked')).toBeInTheDocument(),
     );
   });
 

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -91,7 +91,7 @@ export default function VolunteerBooking() {
     setBooking(true);
     try {
       await requestVolunteerBooking(selected.id, selected.date);
-      setSnackbar({ open: true, message: 'Request submitted', severity: 'success' });
+      setSnackbar({ open: true, message: 'Shift booked', severity: 'success' });
       setSelected(null);
       refetch();
     } catch (e) {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -192,19 +192,12 @@ export default function VolunteerDashboard() {
     return upcoming[0];
   }, [bookings]);
 
-  const pending = useMemo(
-    () => bookings.filter(b => b.status === 'pending'),
-    [bookings],
-  );
-
   const availableSlots = useMemo(() => {
     const now = toDate();
     const slots = availability
       .filter(a => a.status === 'available' && a.available > 0)
       .filter(s => toDate(`${s.date}T${s.start_time}`) > now);
-    const activeBookings = bookings.filter(b =>
-      ['pending', 'approved'].includes(b.status),
-    );
+    const activeBookings = bookings.filter(b => b.status === 'approved');
     const filtered = slots.filter(
       s =>
         !activeBookings.some(
@@ -230,7 +223,7 @@ export default function VolunteerDashboard() {
     try {
       const booking = await requestVolunteerBooking(role.id, role.date);
       setSnackbarSeverity('success');
-      setMessage('Request submitted');
+      setMessage('Shift booked');
       setBookings(prev => [
         ...prev,
         {
@@ -430,22 +423,6 @@ export default function VolunteerDashboard() {
 
         <Grid size={{ xs: 12, md: 6 }}>
           <Stack spacing={2}>
-            <SectionCard title="Pending Requests">
-              <List>
-                {pending.map(p => (
-                  <ListItem key={p.id} disableGutters>
-                    <ListItemText
-                      primary={`${p.role_name} • ${formatDateLabel(p.date)} ${formatTime(p.start_time)}-${formatTime(p.end_time)}`}
-                    />
-                    <Chip label="Pending" color="warning" size="small" />
-                  </ListItem>
-                ))}
-                {pending.length === 0 && (
-                  <Typography>No pending requests</Typography>
-                )}
-              </List>
-            </SectionCard>
-
             <SectionCard title="Quick Actions">
               <Stack direction="row" spacing={1} flexWrap="wrap">
                 <Button

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -121,7 +121,7 @@ export default function VolunteerSchedule() {
       const filteredBookings = bookingData.filter(
         (b: VolunteerBooking) =>
           b.date === dateStr &&
-          ['approved', 'pending'].includes(b.status) &&
+          b.status === 'approved' &&
           allowedIds.has(b.role_id),
       );
       setBookings(filteredBookings);
@@ -167,7 +167,7 @@ export default function VolunteerSchedule() {
         requestRole.end_time,
       )}`;
       setSnackbarSeverity('success');
-      setMessage(`Booking request for ${dateLabel} · ${timeLabel} submitted`);
+      setMessage(`Shift booked for ${dateLabel} · ${timeLabel}`);
       setRequestRole(null);
       await loadData();
     } catch (err) {
@@ -304,10 +304,7 @@ export default function VolunteerSchedule() {
     if (myBooking) {
       cells.push({
         content: 'My Booking',
-        backgroundColor:
-          myBooking.status === 'pending'
-            ? theme.palette.warning.light
-            : approvedColor,
+        backgroundColor: approvedColor,
         onClick: () => {
           setDecisionBooking(myBooking);
           setDecisionReason('');

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - The Manage Booking dialog now displays the client's name, a link to their profile, and their visit count for the current month to assist staff decisions.
 - Client booking history tables can filter bookings by `visited` and `no_show` statuses.
 - Booking requests are automatically approved or rejected; the pending approval workflow has been removed.
+- Booking confirmations display "Shift booked," and the volunteer dashboard no longer lists pending requests.
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.


### PR DESCRIPTION
## Summary
- Confirm volunteer shift bookings with "Shift booked" notifications
- Drop pending booking logic from volunteer schedule and dashboard
- Update tests and docs to reflect immediate shift approval

## Testing
- `npm test src/__tests__/VolunteerBooking.test.tsx` *(fails: MUI X: Can not find the date and time pickers localization context)*

------
https://chatgpt.com/codex/tasks/task_e_68b287fbab10832d98955767dbb19014