### PR TITLE
Queue confirmation email for staff-created bookings

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -461,6 +461,13 @@ export async function createBookingForUser(
       token,
       null,
     );
+    const emailRes = await pool.query('SELECT email FROM clients WHERE client_id=$1', [userId]);
+    const clientEmail = emailRes.rows[0]?.email || 'test@example.com';
+    enqueueEmail(
+      clientEmail,
+      'Booking approved',
+      `Your booking for ${date} has been automatically approved`,
+    );
     res
       .status(201)
       .json({ message: 'Booking created for user', status, rescheduleToken: token });

--- a/MJ_FB_Backend/tests/bookingController.test.ts
+++ b/MJ_FB_Backend/tests/bookingController.test.ts
@@ -1,0 +1,54 @@
+import { Request, Response, NextFunction } from 'express';
+
+describe('createBookingForUser', () => {
+  let createBookingForUser: any;
+  let enqueueEmail: jest.Mock;
+  let pool: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/utils/emailQueue', () => ({
+        __esModule: true,
+        enqueueEmail: jest.fn(),
+      }));
+      jest.doMock('../src/utils/bookingUtils', () => ({
+        __esModule: true,
+        isDateWithinCurrentOrNextMonth: jest.fn().mockReturnValue(true),
+        countVisitsAndBookingsForMonth: jest.fn().mockResolvedValue(0),
+        findUpcomingBooking: jest.fn().mockResolvedValue(null),
+        LIMIT_MESSAGE: 'limit',
+      }));
+      jest.doMock('../src/models/bookingRepository', () => ({
+        __esModule: true,
+        insertBooking: jest.fn().mockResolvedValue(undefined),
+        checkSlotCapacity: jest.fn().mockResolvedValue(undefined),
+      }));
+      jest.doMock('../src/db', () => ({
+        __esModule: true,
+        default: { query: jest.fn(), connect: jest.fn() },
+      }));
+      createBookingForUser = require('../src/controllers/bookingController').createBookingForUser;
+      enqueueEmail = require('../src/utils/emailQueue').enqueueEmail;
+      pool = require('../src/db').default;
+    });
+  });
+
+  it('enqueues confirmation email after booking creation', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [{ email: 'client@example.com' }] });
+    const req = {
+      user: { role: 'staff', id: 99 },
+      body: { userId: 1, slotId: 2, date: '2024-01-15' },
+    } as unknown as Request;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await createBookingForUser(req, res, next);
+
+    expect(enqueueEmail).toHaveBeenCalledWith(
+      'client@example.com',
+      'Booking approved',
+      expect.stringContaining('2024-01-15'),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- queue confirmation email after staff/agency creates a booking
- add unit test verifying email queue when staff books for user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2888a3450832da4b307675a76a874