### PR TITLE
feat: schedule booking reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Use the `sendTemplatedEmail` utility to send Brevo template emails by providing a `templateId` and `params` object.
 - Bookings for unregistered individuals can be created via `POST /bookings/new-client`; staff may review or delete these records through `/new-clients` routes.
 - The pantry schedule's **Assign User** modal includes a **New client** option; selecting it lets staff enter a name (with optional email and phone) and books the slot via `POST /bookings/new-client`. These bookings appear on the schedule as `[NEW CLIENT] Name`.
+- A daily reminder job (`src/utils/bookingReminderJob.ts`) runs at server startup and emails clients about next-day bookings using the `enqueueEmail` queue.
 
 ## Testing
 

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -3,6 +3,7 @@ import pool from './db';
 import { setupDatabase } from './setupDatabase';
 import logger from './utils/logger';
 import app from './app';
+import { startBookingReminderJob } from './utils/bookingReminderJob';
 
 const PORT = config.port;
 
@@ -16,6 +17,7 @@ async function init() {
     app.listen(PORT, () => {
       logger.info(`Server running at http://localhost:${PORT}`);
     });
+    startBookingReminderJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);

--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -1,0 +1,45 @@
+import { fetchBookings } from '../models/bookingRepository';
+import { enqueueEmail } from './emailQueue';
+import { formatReginaDate } from './dateUtils';
+import logger from './logger';
+
+/**
+ * Send reminder emails for bookings scheduled for the next day.
+ */
+export async function sendNextDayBookingReminders(): Promise<void> {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const nextDate = formatReginaDate(tomorrow);
+  try {
+    const bookings = await fetchBookings('approved', nextDate);
+    for (const b of bookings) {
+      if (!b.user_email) continue;
+      const time = b.start_time && b.end_time ? ` from ${b.start_time} to ${b.end_time}` : '';
+      enqueueEmail(
+        b.user_email,
+        'Booking Reminder',
+        `This is a reminder for your booking on ${nextDate}${time}.`,
+      );
+    }
+  } catch (err) {
+    logger.error('Failed to send booking reminders', err);
+  }
+}
+
+/**
+ * Schedule the reminder job to run once a day.
+ */
+export function startBookingReminderJob(): void {
+  if (process.env.NODE_ENV === 'test') return;
+  // Run immediately and then every 24 hours
+  sendNextDayBookingReminders().catch((err) =>
+    logger.error('Initial reminder run failed', err),
+  );
+  const dayMs = 24 * 60 * 60 * 1000;
+  setInterval(() => {
+    sendNextDayBookingReminders().catch((err) =>
+      logger.error('Scheduled reminder run failed', err),
+    );
+  }, dayMs);
+}
+

--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -1,0 +1,42 @@
+import { sendNextDayBookingReminders } from '../src/utils/bookingReminderJob';
+import { fetchBookings } from '../src/models/bookingRepository';
+import { enqueueEmail } from '../src/utils/emailQueue';
+
+jest.mock('../src/models/bookingRepository', () => ({
+  fetchBookings: jest.fn(),
+}));
+
+jest.mock('../src/utils/emailQueue', () => ({
+  enqueueEmail: jest.fn(),
+}));
+
+describe('sendNextDayBookingReminders', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('fetches next-day bookings and queues reminder emails', async () => {
+    (fetchBookings as jest.Mock).mockResolvedValue([
+      {
+        user_email: 'user@example.com',
+        start_time: '09:00:00',
+        end_time: '10:00:00',
+      },
+    ]);
+
+    await sendNextDayBookingReminders();
+
+    expect(fetchBookings).toHaveBeenCalledWith('approved', '2024-01-02');
+    expect(enqueueEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      expect.stringContaining('Reminder'),
+      expect.stringContaining('2024-01-02'),
+    );
+  });
+});
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Appointment booking workflow for clients with staff approval and rescheduling.
 - Unregistered clients can book directly via `/bookings/new-client`; staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas.
+- Daily job sends reminder emails for next-day bookings using the backend email queue.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Users see a random appreciation message on each login with a link to download their card when available.


### PR DESCRIPTION
## Summary
- add daily job to email next-day booking reminders
- document scheduler in AGENTS and README
- test reminder job logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b288968598832da1e0cfff4425c046