### PR TITLE
Remove pending volunteer approval workflow

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -148,7 +148,6 @@ export default function App() {
           { label: 'Schedule', to: '/volunteer-management/schedule' },
           { label: 'Search', to: '/volunteer-management/search' },
           { label: 'Create', to: '/volunteer-management/create' },
-          { label: 'Pending', to: '/volunteer-management/pending' },
         ],
       });
 

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -12,7 +12,7 @@ import {
   updateVolunteerTrainedAreas,
   createVolunteerBookingForVolunteer,
   getVolunteerBookingsByRole,
-  updateVolunteerBookingStatus,
+  cancelVolunteerBooking,
   resolveVolunteerBookingConflict,
 } from '../api/volunteers';
 
@@ -25,7 +25,7 @@ jest.mock('../api/volunteers', () => ({
   updateVolunteerTrainedAreas: jest.fn(),
   createVolunteerBookingForVolunteer: jest.fn(),
   getVolunteerBookingsByRole: jest.fn(),
-  updateVolunteerBookingStatus: jest.fn(),
+  cancelVolunteerBooking: jest.fn(),
   resolveVolunteerBookingConflict: jest.fn(),
 }));
 
@@ -45,7 +45,7 @@ beforeEach(() => {
   (updateVolunteerTrainedAreas as jest.Mock).mockResolvedValue(undefined);
   (createVolunteerBookingForVolunteer as jest.Mock).mockResolvedValue(undefined);
   (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([]);
-  (updateVolunteerBookingStatus as jest.Mock).mockResolvedValue(undefined);
+  (cancelVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
 });
 
 describe('VolunteerManagement shopper profile', () => {
@@ -181,61 +181,3 @@ describe('VolunteerManagement role updates', () => {
   });
 });
 
-describe('VolunteerManagement pending approvals', () => {
-  it('removes booking from pending list after approval', async () => {
-    (getVolunteerRoles as jest.Mock).mockResolvedValue([
-      {
-        id: 5,
-        category_id: 1,
-        name: 'Greeter',
-        max_volunteers: 2,
-        category_name: 'Front',
-        shifts: [
-          {
-            id: 10,
-            start_time: '09:00:00',
-            end_time: '12:00:00',
-            is_wednesday_slot: false,
-            is_active: true,
-          },
-        ],
-      },
-    ]);
-    (getVolunteerBookingsByRole as jest.Mock)
-      .mockResolvedValueOnce([
-        {
-          id: 1,
-          role_id: 5,
-          volunteer_id: 2,
-          volunteer_name: 'Alice',
-          role_name: 'Greeter',
-          date: '2024-01-01',
-          start_time: '09:00:00',
-          end_time: '12:00:00',
-          status: 'pending',
-        },
-      ])
-      .mockResolvedValueOnce([]);
-
-    render(
-      <MemoryRouter initialEntries={['/volunteers/pending']}>
-        <Routes>
-          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    await screen.findByText('Pending Volunteer Bookings');
-    await screen.findByText('Alice');
-
-    fireEvent.click(screen.getByRole('button', { name: /approve/i }));
-
-    await waitFor(() =>
-      expect(updateVolunteerBookingStatus).toHaveBeenCalledWith(1, 'approved', undefined),
-    );
-
-    await waitFor(() =>
-      expect(screen.queryByText('Alice')).not.toBeInTheDocument(),
-    );
-  });
-});


### PR DESCRIPTION
## Summary
- drop pending volunteer approval tab and related logic
- allow staff to only cancel or reschedule existing bookings
- update staff volunteer management tests to match new behavior

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module; multiple suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b28967d388832dae6368414d1947d1