### PR TITLE
Make initial passwords optional in creation schemas

### DIFF
--- a/MJ_FB_Backend/src/schemas/admin/staffSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/admin/staffSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { passwordSchema } from '../../utils/passwordUtils';
 
 export const staffAccessEnum = z.enum(['pantry','volunteer_management','warehouse','admin']);
 
@@ -7,12 +8,12 @@ export const createStaffSchema = z.object({
   lastName: z.string().min(1),
   email: z.string().email(),
   access: z.array(staffAccessEnum).optional(),
+  password: passwordSchema.optional(),
 });
 
 export type CreateStaffInput = z.infer<typeof createStaffSchema>;
 
 export const updateStaffSchema = createStaffSchema.extend({
-  password: z.string().min(1).optional(),
   access: z.array(staffAccessEnum),
 });
 

--- a/MJ_FB_Backend/src/schemas/agencySchemas.ts
+++ b/MJ_FB_Backend/src/schemas/agencySchemas.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
+import { passwordSchema } from '../utils/passwordUtils';
 
 export const createAgencySchema = z.object({
   name: z.string().min(1),
   email: z.string().email(),
   contactInfo: z.string().optional(),
+  password: passwordSchema.optional(),
 });
 
 export type CreateAgencySchema = z.infer<typeof createAgencySchema>;

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -49,6 +49,7 @@ export const createUserSchema = z
     clientId: z.coerce.number().int().min(1).max(9_999_999),
     role: z.enum(['shopper', 'delivery']),
     onlineAccess: z.boolean(),
+    password: passwordSchema.optional(),
   })
   .refine(
     data =>
@@ -69,9 +70,9 @@ export const updateUserSchema = z.object({
   onlineAccess: z.boolean().optional(),
   password: passwordSchema.optional(),
 }).refine(
-  data => !data.onlineAccess || (!!data.firstName && !!data.lastName && !!data.password),
+  data => !data.onlineAccess || (!!data.firstName && !!data.lastName),
   {
-    message: 'firstName, lastName and password required for online access',
+    message: 'firstName and lastName required for online access',
     path: ['onlineAccess'],
   },
 );

--- a/MJ_FB_Backend/tests/adminStaff.test.ts
+++ b/MJ_FB_Backend/tests/adminStaff.test.ts
@@ -49,7 +49,7 @@ describe('POST /admin/staff', () => {
 
     const res = await request(app)
       .post('/admin/staff')
-      .send({ firstName: 'A', lastName: 'B', email: 'a@b.com', access: ['pantry'] });
+      .send({ firstName: 'A', lastName: 'B', email: 'a@b.com', access: ['pantry'], password: 'Secret123!' });
 
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ message: 'Staff created' });

--- a/MJ_FB_Backend/tests/createAgency.test.ts
+++ b/MJ_FB_Backend/tests/createAgency.test.ts
@@ -53,7 +53,7 @@ describe('POST /agencies', () => {
 
     const res = await request(app)
       .post('/agencies')
-      .send({ name: 'A', email: 'a@a.com' });
+      .send({ name: 'A', email: 'a@a.com', password: 'Secret123!' });
 
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id', 5);

--- a/MJ_FB_Backend/tests/createUser.test.ts
+++ b/MJ_FB_Backend/tests/createUser.test.ts
@@ -53,6 +53,7 @@ describe('POST /users/add-client', () => {
         clientId: 123,
         role: 'shopper',
         onlineAccess: true,
+        password: 'Secret123!',
       });
 
     expect(res.status).toBe(201);

--- a/MJ_FB_Backend/tests/staffCreation.test.ts
+++ b/MJ_FB_Backend/tests/staffCreation.test.ts
@@ -34,6 +34,7 @@ describe('POST /staff (first staff member)', () => {
         lastName: 'Admin',
         email: 'harvestpantry@mjfoodbank.org',
         access: ['admin'],
+        password: 'Secret123!',
       });
 
     expect(res.status).toBe(201);

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
    ```bash
    curl -X POST http://localhost:4000/agencies \
      -H "Authorization: Bearer <staff-token>" \
-     -H "Content-Type: application/json" \
-     -d '{"name":"Sample Agency","email":"agency@example.com","password":"Secret123!","contactInfo":"123-4567"}'
-   ```
+    -H "Content-Type: application/json" \
+    -d '{"name":"Sample Agency","email":"agency@example.com","contactInfo":"123-4567"}'
+  ```
 
-   The endpoint hashes the password and returns the new agency ID. You can also create one directly in SQL if needed:
+   The endpoint emails a password setup link and returns the new agency ID. You can also create one directly in SQL if needed:
 
    ```bash
    node -e "console.log(require('bcrypt').hashSync('secret123', 10))"


### PR DESCRIPTION
## Summary
- allow optional password in user, staff, and agency creation schemas
- drop password requirement when enabling online access
- update creation tests and docs for new validation

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b28add8788832d8f211fb9159de45f