### PR TITLE
chore: drop pending volunteer status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ The self-service registration endpoints and frontend page are commented out pend
 ### Status & Colors
 - Status chips:
   - success = approved/ok,
-  - warning = pending/needs attention,
+  - warning = needs attention,
   - error = rejected/failed,
   - default/info = neutral.
 - Never hard-code hex values; use theme palette (`success`, `warning`, `error`, `info`).
@@ -424,7 +424,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 
 - **VolunteerSchedule** lets volunteers choose a role from a dropdown and view a grid of shifts. Columns correspond to slot numbers and rows show shift times (e.g. 9:30–12:00, 12:30–3:30). Cells display *Booked* or *Available* and clicking an available cell creates a request in `volunteer_bookings`. Past dates are disabled and same-day shifts that have already started are omitted.
 - The Volunteer Dashboard's **Available in My Roles** list excludes shifts the volunteer has already requested or booked and shows server-provided error messages when a booking attempt fails.
-- Shift booking confirmations display "Shift booked," and the volunteer dashboard no longer lists pending requests.
+- Shift booking confirmations display "Shift booked" since bookings are auto-approved and the submitted state has been removed; the volunteer dashboard lists only approved bookings.
 - Volunteer and pantry schedules follow the same grid logic. The y‑axis lists shift times and the x‑axis lists sequential slot numbers up to each shift's `max_volunteers`. When a volunteer requests a shift, the booking is immediately approved and occupies the first open slot.
 - **BookingHistory** shows a volunteer's upcoming bookings with Cancel and Reschedule options.
 - **CoordinatorDashboard** is the staff view using `VolunteerScheduleTable`. Staff see volunteer names for booked cells and can cancel or reschedule bookings. Staff can also search volunteers, assign them to roles, and update trained areas.

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -5,6 +5,7 @@ import type {
   RoleOption,
   Shift,
   VolunteerBooking,
+  VolunteerBookingStatus,
   UserProfile,
 } from '../types';
 import type { LoginResponse } from './users';
@@ -296,7 +297,7 @@ export async function getVolunteerBookingsByRole(roleId: number) {
 
 export async function updateVolunteerBookingStatus(
   bookingId: number,
-  status: 'approved' | 'rejected' | 'cancelled' | 'no_show' | 'expired',
+  status: VolunteerBookingStatus,
   reason?: string,
 ): Promise<void> {
   const body = reason ? { status, reason } : { status };

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -108,9 +108,16 @@ export interface VolunteerRoleGroup {
   }[];
 }
 
+export type VolunteerBookingStatus =
+  | 'approved'
+  | 'rejected'
+  | 'cancelled'
+  | 'no_show'
+  | 'expired';
+
 export interface VolunteerBooking {
   id: number;
-  status: string;
+  status: VolunteerBookingStatus;
   role_id: number;
   date: string;
   start_time: string;
@@ -123,7 +130,7 @@ export interface VolunteerBooking {
 
 export interface VolunteerBookingDetail {
   id: number;
-  status: string;
+  status: VolunteerBookingStatus;
   role_id: number;
   volunteer_id: number;
   volunteer_name: string;

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 
 ## Features
 
-- Appointment booking workflow for clients with staff approval and rescheduling.
+ - Appointment booking workflow for clients with automatic approval and rescheduling.
 - Unregistered clients can book directly via `/bookings/new-client`; staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas.
 - Daily job sends reminder emails for next-day bookings using the backend email queue.
@@ -38,7 +38,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Volunteer dashboard groups badges, lifetime hours, this month's hours, total shifts, and current streak into a single stats card.
 - Volunteer search results display profile details, role editor, and booking history side by side in a card layout.
 - Volunteer role assignment uses a simple dropdown without search capability.
-- Volunteer bookings are auto-approved and appear immediately on schedules.
+ - Volunteer bookings are auto-approved with no submitted state and appear immediately on schedules.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
 - Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Volunteer Settings page's **Restore Original Roles & Shifts** button.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
@@ -48,8 +48,8 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Adding a client visit automatically updates any approved booking for that client on the same date to `visited`.
 - The Manage Booking dialog now displays the client's name, a link to their profile, and their visit count for the current month to assist staff decisions.
 - Client booking history tables can filter bookings by `visited` and `no_show` statuses.
-- Booking requests are automatically approved or rejected; the pending approval workflow has been removed.
-- Booking confirmations display "Shift booked," and the volunteer dashboard no longer lists pending requests.
+ - Booking requests are automatically approved or rejected; the submitted state has been removed.
+ - Booking confirmations display "Shift booked"; the volunteer dashboard shows only approved bookings.
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.


### PR DESCRIPTION
## Summary
- remove pending volunteer status from type definitions
- document auto-approved bookings and lack of submitted state
- tidy volunteer API status typing

## Testing
- `npm test` *(fails: React testing warnings and Jest config issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b28b241798832d859dfd36aa051f0e