### PR TITLE
feat(frontend): add password setup flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ The self-service registration endpoints and frontend page are commented out pend
 - Administrative pages enable staff to manage volunteer master roles and edit volunteer role slots.
 - Volunteer Settings provides separate dialogs for creating sub-roles (with an initial shift) and for adding or editing shifts.
 - Deleting sub-roles and shifts prompts confirmation dialogs to prevent accidental removal.
+- Users complete initial password creation at `/set-password` using a token from the setup email.
 - Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations.
   Initially, the page shows only agency search; selecting an agency reveals a two-column layout with client search on the left and the agency's client list on the right.

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -34,6 +34,7 @@ const ClientHistory = React.lazy(() =>
 const Login = React.lazy(() => import('./pages/auth/Login'));
 const StaffLogin = React.lazy(() => import('./pages/auth/StaffLogin'));
 const VolunteerLogin = React.lazy(() => import('./pages/auth/VolunteerLogin'));
+const PasswordSetup = React.lazy(() => import('./pages/auth/PasswordSetup'));
 // const ClientSignup = React.lazy(() => import('./pages/auth/ClientSignup'));
 const VolunteerDashboard = React.lazy(() =>
   import('./pages/volunteer-management/VolunteerDashboard')
@@ -413,6 +414,7 @@ export default function App() {
                   <Route path="/login/staff" element={<StaffLogin onLogin={login} />} />
                   <Route path="/login/volunteer" element={<VolunteerLogin onLogin={login} />} />
                   <Route path="/login/agency" element={<AgencyLogin onLogin={login} />} />
+                  <Route path="/set-password" element={<PasswordSetup />} />
                   <Route path="/login" element={<Navigate to="/login/user" replace />} />
                   <Route path="*" element={<Navigate to="/login/user" replace />} />
                 </Routes>

--- a/MJ_FB_Frontend/src/__tests__/PasswordSetup.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PasswordSetup.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import PasswordSetup from '../pages/auth/PasswordSetup';
+import { setPassword } from '../api/users';
+
+jest.mock('../api/users', () => ({
+  setPassword: jest.fn(),
+}));
+
+describe('PasswordSetup', () => {
+  it('submits password with token from query', async () => {
+    (setPassword as jest.Mock).mockResolvedValue(undefined);
+    render(
+      <MemoryRouter initialEntries={["/set-password?token=abc123"]}>
+        <Routes>
+          <Route path="/set-password" element={<PasswordSetup />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'Passw0rd!' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /set password/i }));
+    await waitFor(() => expect(setPassword).toHaveBeenCalledWith('abc123', 'Passw0rd!'));
+    await waitFor(() => expect(screen.getByText(/password set/i)).toBeInTheDocument());
+  });
+});

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -75,6 +75,18 @@ export async function changePassword(
   await handleResponse(res);
 }
 
+export async function setPassword(
+  token: string,
+  password: string,
+): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/auth/set-password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token, password }),
+  });
+  await handleResponse(res);
+}
+
 export async function getUserProfile(): Promise<UserProfile> {
   const res = await apiFetch(`${API_BASE}/users/me`);
   return handleResponse(res);

--- a/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { useSearchParams, Link as RouterLink } from 'react-router-dom';
+import { TextField, Button, Link } from '@mui/material';
+import Page from '../../components/Page';
+import FormCard from '../../components/FormCard';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { setPassword as setPasswordApi } from '../../api/users';
+
+export default function PasswordSetup() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') || '';
+  const [password, setPassword] = useState('');
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!token) {
+      setError('Invalid or expired token');
+      return;
+    }
+    try {
+      await setPasswordApi(token, password);
+      setSuccess('Password set. You may now log in.');
+      setPassword('');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <Page title="Set Password">
+      <FormCard
+        onSubmit={handleSubmit}
+        title="Set Password"
+        actions={
+          <Button type="submit" variant="contained" color="primary" fullWidth>
+            Set Password
+          </Button>
+        }
+      >
+        <TextField
+          type="password"
+          label="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          fullWidth
+          required
+        />
+        <Link component={RouterLink} to="/login" underline="hover">
+          Back to login
+        </Link>
+      </FormCard>
+      <FeedbackSnackbar
+        open={!!success}
+        onClose={() => setSuccess('')}
+        message={success}
+        severity="success"
+      />
+      <FeedbackSnackbar
+        open={!!error}
+        onClose={() => setError('')}
+        message={error}
+        severity="error"
+      />
+    </Page>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 - Daily job sends reminder emails for next-day bookings using the backend email queue.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
-- Accounts for clients, volunteers, staff, and agencies are created without passwords; a one-time setup link is emailed for password creation.
+- Accounts for clients, volunteers, staff, and agencies are created without passwords; a one-time setup link directs them to `/set-password` for initial password creation.
 - Users see a random appreciation message on each login with a link to download their card when available.
 - Volunteers also see rotating encouragement messages on the dashboard when no milestone is reached.
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.


### PR DESCRIPTION
## Summary
- add /set-password route and page for initial password creation
- support set-password API call and tests
- document password setup route in AGENTS and README

## Testing
- `npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b28b9c0220832d8e967327131149f4