### PR TITLE
Remove password fields and send invitation emails

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffForm.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffForm.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import StaffForm from '../components/StaffForm';
+
+describe('StaffForm', () => {
+  it('submits without password and shows invitation message', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    render(<StaffForm submitLabel="Add" onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'Alice' } });
+    fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'Smith' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@example.com' } });
+    fireEvent.click(screen.getByLabelText(/pantry/i));
+    fireEvent.click(screen.getByRole('button', { name: /Add/i }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        email: 'a@example.com',
+        access: ['pantry'],
+      }),
+    );
+    expect(screen.getByText(/email invitation/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -69,14 +69,13 @@ describe('VolunteerManagement shopper profile', () => {
     fireEvent.click(toggle);
 
     fireEvent.change(await screen.findByLabelText(/client id/i), { target: { value: '123' } });
-    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'pass' } });
+    expect(screen.getByText(/email invitation/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /create/i }));
 
     await waitFor(() =>
       expect(createVolunteerShopperProfile).toHaveBeenCalledWith(
         1,
         '123',
-        'pass',
         undefined,
         undefined,
       )

--- a/MJ_FB_Frontend/src/api/adminStaff.ts
+++ b/MJ_FB_Frontend/src/api/adminStaff.ts
@@ -22,13 +22,12 @@ export async function createStaff(
   firstName: string,
   lastName: string,
   email: string,
-  password: string,
   access: StaffAccess[],
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/admin-staff`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ firstName, lastName, email, password, access }),
+    body: JSON.stringify({ firstName, lastName, email, access }),
   });
   await handleResponse(res);
 }
@@ -39,12 +38,11 @@ export async function updateStaff(
   lastName: string,
   email: string,
   access: StaffAccess[],
-  password?: string,
 ): Promise<void> {
   const res = await apiFetch(`${API_BASE}/admin-staff/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ firstName, lastName, email, access, ...(password ? { password } : {}) }),
+    body: JSON.stringify({ firstName, lastName, email, access }),
   });
   await handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/api/agencies.ts
+++ b/MJ_FB_Frontend/src/api/agencies.ts
@@ -45,13 +45,12 @@ export async function removeAgencyClient(
 export async function createAgency(
   name: string,
   email: string,
-  password: string,
   contactInfo?: string,
 ) {
   const res = await apiFetch(`${API_BASE}/agencies`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, email, password, contactInfo }),
+    body: JSON.stringify({ name, email, contactInfo }),
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -103,7 +103,6 @@ export async function createStaff(
   lastName: string,
   access: StaffAccess[],
   email: string,
-  password: string,
 ): Promise<void> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -115,7 +114,6 @@ export async function createStaff(
       firstName,
       lastName,
       email,
-      password,
       access,
     }),
   });
@@ -127,7 +125,6 @@ export async function addUser(
   lastName: string,
   clientId: string,
   role: UserRole,
-  password: string | undefined,
   onlineAccess: boolean,
   email?: string,
   phone?: string,
@@ -142,7 +139,6 @@ export async function addUser(
       lastName,
       clientId: Number(clientId),
       role,
-      password,
       onlineAccess,
       email,
       phone,
@@ -186,7 +182,6 @@ export async function updateUserInfo(
     email?: string;
     phone?: string;
     onlineAccess: boolean;
-    password?: string;
   },
 ): Promise<IncompleteUser> {
   const res = await apiFetch(`${API_BASE}/users/id/${clientId}`, {

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -339,7 +339,6 @@ export async function createVolunteer(
   firstName: string,
   lastName: string,
   username: string,
-  password: string,
   roleIds: number[],
   email?: string,
   phone?: string
@@ -353,7 +352,6 @@ export async function createVolunteer(
       firstName,
       lastName,
       username,
-      password,
       roleIds,
       email,
       phone,
@@ -392,7 +390,6 @@ export async function rescheduleVolunteerBookingByToken(
 export async function createVolunteerShopperProfile(
   volunteerId: number,
   clientId: string,
-  password: string,
   email?: string,
   phone?: string,
 ): Promise<void> {
@@ -401,7 +398,6 @@ export async function createVolunteerShopperProfile(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       clientId: Number(clientId),
-      password,
       email,
       phone,
     }),

--- a/MJ_FB_Frontend/src/components/StaffForm.tsx
+++ b/MJ_FB_Frontend/src/components/StaffForm.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { TextField, Checkbox, FormControlLabel, Button } from '@mui/material';
+import { TextField, Checkbox, FormControlLabel, Button, Typography } from '@mui/material';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormCard from './FormCard';
 import type { StaffAccess } from '../types';
@@ -16,7 +16,6 @@ interface StaffFormProps {
     firstName: string;
     lastName: string;
     email: string;
-    password?: string;
     access: StaffAccess[];
   }) => Promise<void>;
 }
@@ -25,25 +24,23 @@ export default function StaffForm({ initial, submitLabel, onSubmit }: StaffFormP
   const [firstName, setFirstName] = useState(initial?.firstName || '');
   const [lastName, setLastName] = useState(initial?.lastName || '');
   const [email, setEmail] = useState(initial?.email || '');
-  const [password, setPassword] = useState('');
   const [access, setAccess] = useState<StaffAccess[]>(initial?.access || []);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!firstName || !lastName || !email || (!initial && !password)) {
+    if (!firstName || !lastName || !email) {
       setError('All fields required');
       return;
     }
     try {
-      await onSubmit({ firstName, lastName, email, password: password || undefined, access });
+      await onSubmit({ firstName, lastName, email, access });
       setSuccess('Saved');
       if (!initial) {
         setFirstName('');
         setLastName('');
         setEmail('');
-        setPassword('');
         setAccess([]);
       }
     } catch (err: any) {
@@ -71,7 +68,9 @@ export default function StaffForm({ initial, submitLabel, onSubmit }: StaffFormP
         <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
         <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
         <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} />
-        <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+        <Typography variant="body2" color="text.secondary">
+          An email invitation will be sent.
+        </Typography>
         <FormControlLabel
           control={<Checkbox checked={access.includes('pantry')} onChange={() => toggleAccess('pantry')} />}
           label="Pantry"

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffForm.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffForm.tsx
@@ -38,14 +38,12 @@ export default function AdminStaffForm() {
                 data.lastName,
                 data.email,
                 data.access,
-                data.password,
               );
             } else {
               await createStaff(
                 data.firstName,
                 data.lastName,
                 data.email,
-                data.password || '',
                 data.access,
               );
             }

--- a/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
@@ -128,7 +128,6 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [error, setError] = useState(initError);
   const [message, setMessage] = useState('');
   const [submitted, setSubmitted] = useState(false);
@@ -136,14 +135,13 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
   const firstNameError = submitted && firstName === '';
   const lastNameError = submitted && lastName === '';
   const emailError = submitted && email === '';
-  const passwordError = submitted && password === '';
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     setSubmitted(true);
-    if (firstName === '' || lastName === '' || email === '' || password === '') return;
+    if (firstName === '' || lastName === '' || email === '') return;
     try {
-      await createStaff(firstName, lastName, ['admin'], email, password);
+      await createStaff(firstName, lastName, ['admin'], email);
       setMessage('Staff account created. You can login now.');
       setTimeout(onCreated, 1000);
     } catch (err: unknown) {
@@ -195,16 +193,9 @@ function CreateStaffForm({ onCreated, error: initError }: { onCreated: () => voi
           error={emailError}
           helperText={emailError ? 'Email is required' : ''}
         />
-        <TextField
-          type="password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-          label="Password"
-          fullWidth
-          required
-          error={passwordError}
-          helperText={passwordError ? 'Password is required' : ''}
-        />
+        <Typography variant="body2" color="text.secondary">
+          An email invitation will be sent.
+        </Typography>
       </FormCard>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <FeedbackModal open={!!message} onClose={() => setMessage('')} message={message} />

--- a/MJ_FB_Frontend/src/pages/staff/AddAgency.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AddAgency.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react';
-import { Grid, TextField, Button, Box } from '@mui/material';
+import { Grid, TextField, Button, Box, Typography } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { createAgency } from '../../api/agencies';
 
 export default function AddAgency() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [contactInfo, setContactInfo] = useState('');
   const [snackbar, setSnackbar] = useState<{
     message: string;
@@ -16,11 +15,10 @@ export default function AddAgency() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await createAgency(name, email, password, contactInfo || undefined);
+      await createAgency(name, email, contactInfo || undefined);
       setSnackbar({ message: 'Agency created', severity: 'success' });
       setName('');
       setEmail('');
-      setPassword('');
       setContactInfo('');
     } catch (err: any) {
       setSnackbar({
@@ -52,16 +50,9 @@ export default function AddAgency() {
               required
               margin="normal"
             />
-            <TextField
-              label="Password"
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              fullWidth
-              required
-              margin="normal"
-              helperText="Min 8 chars with upper, lower, number & special"
-            />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              An email invitation will be sent.
+            </Typography>
             <TextField
               label="Contact Info"
               value={contactInfo}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -16,13 +16,12 @@ export default function AddClient() {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [clientId, setClientId] = useState('');
-  const [password, setPassword] = useState('');
   const [onlineAccess, setOnlineAccess] = useState(false);
 
   async function submitUser() {
     if (onlineAccess) {
-      if (!firstName || !lastName || !clientId || !password) {
-        setError('First name, last name, client ID and password required');
+      if (!firstName || !lastName || !clientId) {
+        setError('First name, last name and client ID required');
         return;
       }
     } else if (!clientId) {
@@ -35,7 +34,6 @@ export default function AddClient() {
         lastName,
         clientId,
         role,
-        onlineAccess ? password : undefined,
         onlineAccess,
         email || undefined,
         phone || undefined
@@ -46,7 +44,6 @@ export default function AddClient() {
       setClientId('');
       setEmail('');
       setPhone('');
-      setPassword('');
       setOnlineAccess(false);
       setRole('shopper');
     } catch (err: unknown) {
@@ -61,10 +58,15 @@ export default function AddClient() {
           <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
           <FeedbackModal open={!!success} onClose={() => setSuccess('')} message={success} />
           <Stack spacing={2}>
-            <FormControlLabel
-              control={<Checkbox checked={onlineAccess} onChange={e => setOnlineAccess(e.target.checked)} />}
-              label="Online Access"
-            />
+          <FormControlLabel
+            control={<Checkbox checked={onlineAccess} onChange={e => setOnlineAccess(e.target.checked)} />}
+            label="Online Access"
+          />
+          {onlineAccess && (
+            <Typography variant="body2" color="text.secondary">
+              An email invitation will be sent.
+            </Typography>
+          )}
           <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
           <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
           <TextField label="Client ID" value={clientId} onChange={e => setClientId(e.target.value)} />
@@ -75,9 +77,6 @@ export default function AddClient() {
             value={phone}
             onChange={e => setPhone(e.target.value)}
           />
-          {onlineAccess && (
-            <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
-          )}
           <TextField select label="Role" value={role} onChange={e => setRole(e.target.value as UserRole)}>
             <MenuItem value="shopper">Shopper</MenuItem>
             <MenuItem value="delivery">Delivery</MenuItem>

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -15,6 +15,7 @@ import {
   Link,
   FormControlLabel,
   Checkbox,
+  Typography,
 } from "@mui/material";
 import Page from "../../../components/Page";
 import FeedbackSnackbar from "../../../components/FeedbackSnackbar";
@@ -35,7 +36,6 @@ export default function UpdateClientData() {
     email: "",
     phone: "",
     onlineAccess: false,
-    password: "",
   });
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -61,7 +61,6 @@ export default function UpdateClientData() {
       email: client.email || "",
       phone: client.phone || "",
       onlineAccess: false,
-      password: "",
     });
   }
 
@@ -74,7 +73,6 @@ export default function UpdateClientData() {
         email: form.email || undefined,
         phone: form.phone || undefined,
         onlineAccess: form.onlineAccess,
-        password: form.onlineAccess ? form.password : undefined,
       });
       setSnackbar({
         open: true,
@@ -153,13 +151,17 @@ export default function UpdateClientData() {
                     setForm({
                       ...form,
                       onlineAccess: e.target.checked,
-                      password: "",
                     })
                   }
                 />
               }
               label="Online Access"
             />
+            {form.onlineAccess && (
+              <Typography variant="body2" color="text.secondary">
+                An email invitation will be sent.
+              </Typography>
+            )}
             <TextField
               label="First Name"
               value={form.firstName}
@@ -184,16 +186,6 @@ export default function UpdateClientData() {
               value={form.phone}
               onChange={(e) => setForm({ ...form, phone: e.target.value })}
             />
-            {form.onlineAccess && (
-              <TextField
-                label="Password"
-                type="password"
-                value={form.password}
-                onChange={(e) => setForm({ ...form, password: e.target.value })}
-                required
-                error={form.onlineAccess && !form.password}
-              />
-            )}
           </Stack>
         </DialogContent>
           <DialogActions>
@@ -201,8 +193,7 @@ export default function UpdateClientData() {
               onClick={handleSave}
               disabled={
                 !form.firstName ||
-                !form.lastName ||
-                (form.onlineAccess && !form.password)
+                !form.lastName
               }
             >
               Save

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -123,7 +123,6 @@ export default function VolunteerManagement() {
 
   const [shopperOpen, setShopperOpen] = useState(false);
   const [shopperClientId, setShopperClientId] = useState('');
-  const [shopperPassword, setShopperPassword] = useState('');
   const [shopperEmail, setShopperEmail] = useState('');
   const [shopperPhone, setShopperPhone] = useState('');
   const [removeShopperOpen, setRemoveShopperOpen] = useState(false);
@@ -133,7 +132,6 @@ export default function VolunteerManagement() {
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
-  const [password, setPassword] = useState('');
   const [selectedCreateRoles, setSelectedCreateRoles] = useState<string[]>([]);
   const [createMsg, setCreateMsg] = useState('');
   const [createSeverity, setCreateSeverity] = useState<'success' | 'error'>('success');
@@ -454,7 +452,6 @@ export default function VolunteerManagement() {
       await createVolunteerShopperProfile(
         selectedVolunteer.id,
         shopperClientId,
-        shopperPassword,
         shopperEmail || undefined,
         shopperPhone || undefined,
       );
@@ -462,7 +459,6 @@ export default function VolunteerManagement() {
       setEditMsg('Shopper profile created');
       setShopperOpen(false);
       setShopperClientId('');
-      setShopperPassword('');
       setShopperEmail('');
       setShopperPhone('');
       await refreshVolunteer();
@@ -491,12 +487,11 @@ export default function VolunteerManagement() {
       !firstName ||
       !lastName ||
       !username ||
-      !password ||
       selectedCreateRoles.length === 0
     ) {
       setCreateSeverity('error');
       setCreateMsg(
-        'First name, last name, username, password and at least one role required'
+        'First name, last name, username and at least one role required'
       );
       return;
     }
@@ -510,7 +505,6 @@ export default function VolunteerManagement() {
         firstName,
         lastName,
         username,
-        password,
         ids,
         email || undefined,
         phone || undefined
@@ -522,7 +516,6 @@ export default function VolunteerManagement() {
       setUsername('');
       setEmail('');
       setPhone('');
-      setPassword('');
       setSelectedCreateRoles([]);
     } catch (e) {
       setCreateSeverity('error');
@@ -833,14 +826,9 @@ export default function VolunteerManagement() {
               size="small"
               fullWidth
             />
-            <TextField
-              label="Password"
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              size="small"
-              fullWidth
-            />
+            <Typography variant="body2" color="text.secondary">
+              An email invitation will be sent.
+            </Typography>
             <div ref={dropdownRef} style={{ position: 'relative' }}>
               <label>Role: </label>
               <Button type="button" onClick={() => setRoleDropdownOpen(o => !o)} variant="outlined" color="primary">
@@ -894,23 +882,17 @@ export default function VolunteerManagement() {
           <Dialog open onClose={() => setShopperOpen(false)}>
             <DialogCloseButton onClose={() => setShopperOpen(false)} />
             <DialogContent>
-              <TextField
-                label="Client ID"
+            <TextField
+              label="Client ID"
               value={shopperClientId}
               onChange={e => setShopperClientId(e.target.value)}
               fullWidth
               size="small"
               margin="dense"
             />
-            <TextField
-              label="Password"
-              type="password"
-              value={shopperPassword}
-              onChange={e => setShopperPassword(e.target.value)}
-              fullWidth
-              size="small"
-              margin="dense"
-            />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              An email invitation will be sent.
+            </Typography>
             <TextField
               label="Email (optional)"
               type="email"


### PR DESCRIPTION
## Summary
- Drop password inputs across client, volunteer, staff and agency forms and show that invitations will be emailed
- Simplify related API wrappers to omit password parameters
- Cover new invitation flow in StaffForm and volunteer management tests

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b28b92a3e4832dac58a329aed0d7a4