### PR TITLE
docs: document invitation flow and env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 
 - For changes in `MJ_FB_Backend`, run `npm test` from the `MJ_FB_Backend` directory.
 - For changes in `MJ_FB_Frontend`, run `npm test` from the `MJ_FB_Frontend` directory.
+- Tests for invitation and password setup flows live in `MJ_FB_Backend/tests/passwordResetFlow.test.ts`; run `npm test tests/passwordResetFlow.test.ts` when working on these features.
 
 - Volunteers can earn badges. Use `GET /volunteers/me/stats` to retrieve badges and
   `POST /volunteers/me/badges` to manually award one. The stats endpoint also returns

--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -17,7 +17,7 @@ PG_DATABASE=mj_fb_db
 JWT_SECRET=
 # Secret used for signing refresh JWT tokens for all roles
 JWT_REFRESH_SECRET=
-# Allowed frontend origins for CORS (comma separated)
+# Allowed frontend origins for CORS and password setup links (comma separated)
 # Include both localhost and 127.0.0.1 for local development
 FRONTEND_ORIGIN=http://localhost:5173,http://127.0.0.1:5173
 # Optional domain to scope authentication cookies
@@ -31,3 +31,5 @@ BREVO_API_KEY=your_api_key
 BREVO_FROM_EMAIL=noreply@example.com
 # Optional sender name
 BREVO_FROM_NAME=MJ Food Bank
+# Brevo template ID used for invitation and password reset emails
+PASSWORD_SETUP_TEMPLATE_ID=1

--- a/MJ_FB_Frontend/.env.example
+++ b/MJ_FB_Frontend/.env.example
@@ -1,4 +1,6 @@
 # Backend API base URL (agency login and client assignment use this API)
 VITE_API_BASE=http://localhost:4000
+# Origin used in invitation links; should match the first entry in BACKEND `FRONTEND_ORIGIN`
+VITE_FRONTEND_ORIGIN=http://localhost:5173
 
 # Agency authentication relies on JWT secrets configured in `MJ_FB_Backend/.env`.

--- a/README.md
+++ b/README.md
@@ -102,11 +102,16 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `PG_DATABASE` | PostgreSQL database name |
 | `JWT_SECRET` | Secret used to sign JWT tokens for clients, staff, volunteers, and agencies. Generate a strong random value, e.g., `openssl rand -hex 32` |
 | `JWT_REFRESH_SECRET` | Secret used to sign refresh JWT tokens for all roles. Use a different strong value from `JWT_SECRET`. |
-| `FRONTEND_ORIGIN` | Allowed origins for CORS (comma separated) |
+| `FRONTEND_ORIGIN` | Allowed origins for CORS and base URL for password setup links (comma separated) |
 | `PORT` | Port for the backend server (defaults to 4000) |
 | `BREVO_API_KEY` | Brevo API key for transactional emails |
 | `BREVO_FROM_EMAIL` | Email address used as the sender |
 | `BREVO_FROM_NAME` | Optional sender name displayed in emails |
+| `PASSWORD_SETUP_TEMPLATE_ID` | Brevo template ID for invitation and password reset emails |
+
+### Invitation flow
+
+New clients, volunteers, staff, and agencies are created without passwords. The backend generates a one-time token and emails a setup link using the Brevo template defined by `PASSWORD_SETUP_TEMPLATE_ID`. The link points to `/set-password` on the first origin listed in `FRONTEND_ORIGIN`.
 
 ### Agency setup
 


### PR DESCRIPTION
## Summary
- document invitation flow and password setup environment variables
- note password-setup tests in AGENTS
- add new env vars to `.env.example` files

## Testing
- `npm test tests/passwordResetFlow.test.ts` (backend)
- `npm test` (backend)
- `npm test` (frontend) *(fails: multiple suites fail to run)*

------
https://chatgpt.com/codex/tasks/task_e_68b28d73ac18832dba5f4cc146b1d9ac