### PR TITLE
Add volunteer shift reminder job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Bookings for unregistered individuals can be created via `POST /bookings/new-client`; staff may review or delete these records through `/new-clients` routes.
 - The pantry schedule's **Assign User** modal includes a **New client** option; selecting it lets staff enter a name (with optional email and phone) and books the slot via `POST /bookings/new-client`. These bookings appear on the schedule as `[NEW CLIENT] Name`.
 - A daily reminder job (`src/utils/bookingReminderJob.ts`) runs at server startup and emails clients about next-day bookings using the `enqueueEmail` queue.
+- A volunteer shift reminder job (`MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue.
 
 ## Testing
 

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -4,6 +4,7 @@ import { setupDatabase } from './setupDatabase';
 import logger from './utils/logger';
 import app from './app';
 import { startBookingReminderJob } from './utils/bookingReminderJob';
+import { startVolunteerShiftReminderJob } from './utils/volunteerShiftReminderJob';
 
 const PORT = config.port;
 
@@ -18,6 +19,7 @@ async function init() {
       logger.info(`Server running at http://localhost:${PORT}`);
     });
     startBookingReminderJob();
+    startVolunteerShiftReminderJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);

--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -1,0 +1,52 @@
+import pool from '../db';
+import { enqueueEmail } from './emailQueue';
+import { formatReginaDate } from './dateUtils';
+import logger from './logger';
+
+/**
+ * Send reminder emails for volunteer shifts scheduled for the next day.
+ */
+export async function sendNextDayVolunteerShiftReminders(): Promise<void> {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const nextDate = formatReginaDate(tomorrow);
+  try {
+    const res = await pool.query(
+      `SELECT v.email, vs.start_time, vs.end_time
+       FROM volunteer_bookings vb
+       JOIN volunteers v ON vb.volunteer_id = v.id
+       JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id
+       WHERE vb.status = 'approved' AND vb.date = $1`,
+      [nextDate],
+    );
+    for (const row of res.rows) {
+      if (!row.email) continue;
+      const time = row.start_time && row.end_time ? ` from ${row.start_time} to ${row.end_time}` : '';
+      enqueueEmail(
+        row.email,
+        'Volunteer Shift Reminder',
+        `This is a reminder for your volunteer shift on ${nextDate}${time}.`,
+      );
+    }
+  } catch (err) {
+    logger.error('Failed to send volunteer shift reminders', err);
+  }
+}
+
+/**
+ * Schedule the volunteer shift reminder job to run once a day.
+ */
+export function startVolunteerShiftReminderJob(): void {
+  if (process.env.NODE_ENV === 'test') return;
+  // Run immediately and then every 24 hours
+  sendNextDayVolunteerShiftReminders().catch((err) =>
+    logger.error('Initial volunteer shift reminder run failed', err),
+  );
+  const dayMs = 24 * 60 * 60 * 1000;
+  setInterval(() => {
+    sendNextDayVolunteerShiftReminders().catch((err) =>
+      logger.error('Scheduled volunteer shift reminder run failed', err),
+    );
+  }, dayMs);
+}
+

--- a/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
@@ -1,0 +1,40 @@
+import { sendNextDayVolunteerShiftReminders } from '../src/utils/volunteerShiftReminderJob';
+import pool from '../src/db';
+import { enqueueEmail } from '../src/utils/emailQueue';
+
+jest.mock('../src/db');
+jest.mock('../src/utils/emailQueue', () => ({
+  enqueueEmail: jest.fn(),
+}));
+
+describe('sendNextDayVolunteerShiftReminders', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('queries next-day volunteer bookings and queues reminder emails', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [
+        { email: 'vol@example.com', start_time: '09:00:00', end_time: '12:00:00' },
+      ],
+    });
+
+    await sendNextDayVolunteerShiftReminders();
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM volunteer_bookings'),
+      ['2024-01-02'],
+    );
+    expect(enqueueEmail).toHaveBeenCalledWith(
+      'vol@example.com',
+      expect.stringContaining('Reminder'),
+      expect.stringContaining('2024-01-02'),
+    );
+  });
+});
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
  - Appointment booking workflow for clients with automatic approval and rescheduling.
 - Unregistered clients can book directly via `/bookings/new-client`; staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas.
-- Daily job sends reminder emails for next-day bookings using the backend email queue.
+- Daily job sends reminder emails for next-day bookings using the backend email queue. A separate job queues reminders for next-day volunteer shifts.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Accounts for clients, volunteers, staff, and agencies are created without passwords; a one-time setup link directs them to `/set-password` for initial password creation.


### PR DESCRIPTION
## Summary
- document volunteer shift reminder job
- start volunteer reminder job with server
- implement and test volunteer shift reminder job

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b28e2a6b10832d920069c379dbf16d