### PR TITLE
Notify agencies when clients change

### DIFF
--- a/MJ_FB_Backend/src/models/agency.ts
+++ b/MJ_FB_Backend/src/models/agency.ts
@@ -76,6 +76,28 @@ export async function clientExists(clientId: number): Promise<boolean> {
   return (res.rowCount ?? 0) > 0;
 }
 
+export async function getAgencyEmail(
+  agencyId: number,
+): Promise<string | undefined> {
+  const res = await pool.query('SELECT email FROM agencies WHERE id = $1', [agencyId]);
+  return res.rows[0]?.email as string | undefined;
+}
+
+export interface ClientName {
+  first_name: string;
+  last_name: string;
+}
+
+export async function getClientName(
+  clientId: number,
+): Promise<ClientName | undefined> {
+  const res = await pool.query(
+    'SELECT first_name, last_name FROM clients WHERE client_id = $1',
+    [clientId],
+  );
+  return res.rows[0] as ClientName | undefined;
+}
+
 export async function addAgencyClient(
   agencyId: number,
   clientId: number,


### PR DESCRIPTION
## Summary
- send an email to agency whenever a client is added or removed
- provide helpers to fetch agency emails and client names
- test that client add/remove routes queue notification emails

## Testing
- `npm test --prefix MJ_FB_Backend`

------
https://chatgpt.com/codex/tasks/task_e_68b28e4221d4832dbc3e7aafa0fb16af