### PR TITLE
Use computed ID column in password update

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -157,7 +157,10 @@ export async function changePassword(
       return res.status(400).json({ message: 'Current password incorrect' });
     }
     const hash = await bcrypt.hash(newPassword, 10);
-    await pool.query(`UPDATE ${table} SET password=$1 WHERE id=$2`, [hash, user.id]);
+    await pool.query(
+      `UPDATE ${table} SET password=$1 WHERE ${idColumn}=$2`,
+      [hash, user.id],
+    );
     res.status(204).send();
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- ensure `changePassword` updates use the dynamic `idColumn` rather than a hard-coded `id`

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b28ebb5acc832d8b1ef271bbf3e899