### PR TITLE
Handle Brevo email failures

### DIFF
--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -8,7 +8,7 @@ export async function sendEmail(to: string, subject: string, body: string): Prom
   }
 
   try {
-    await fetch('https://api.brevo.com/v3/smtp/email', {
+    const response = await fetch('https://api.brevo.com/v3/smtp/email', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -24,6 +24,17 @@ export async function sendEmail(to: string, subject: string, body: string): Prom
         htmlContent: body,
       }),
     });
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      logger.error('Failed to send email via Brevo', {
+        status: response.status,
+        responseText,
+        to,
+        subject,
+        body,
+      });
+    }
   } catch (error) {
     logger.warn('Email not sent. Check Brevo configuration or running in local environment.', { to, subject, body });
   }
@@ -50,7 +61,7 @@ export async function sendTemplatedEmail({
   }
 
   try {
-    await fetch('https://api.brevo.com/v3/smtp/email', {
+    const response = await fetch('https://api.brevo.com/v3/smtp/email', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -66,6 +77,17 @@ export async function sendTemplatedEmail({
         params: params || undefined,
       }),
     });
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      logger.error('Failed to send template email via Brevo', {
+        status: response.status,
+        responseText,
+        to,
+        templateId,
+        params,
+      });
+    }
   } catch (error) {
     logger.warn('Template email not sent. Check Brevo configuration or running in local environment.', {
       to,

--- a/MJ_FB_Backend/tests/emailUtilsFailure.test.ts
+++ b/MJ_FB_Backend/tests/emailUtilsFailure.test.ts
@@ -1,0 +1,46 @@
+import { sendEmail, sendTemplatedEmail } from '../src/utils/emailUtils';
+import logger from '../src/utils/logger';
+
+describe('emailUtils error logging', () => {
+  const originalFetch = global.fetch;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'error',
+    });
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    errorSpy.mockRestore();
+    jest.resetAllMocks();
+  });
+
+  it('logs error when sendEmail receives non-2xx response', async () => {
+    await sendEmail('user@example.com', 'Subject', '<p>Hello</p>');
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to send email via Brevo',
+      expect.objectContaining({
+        status: 500,
+        to: 'user@example.com',
+        subject: 'Subject',
+      })
+    );
+  });
+
+  it('logs error when sendTemplatedEmail receives non-2xx response', async () => {
+    await sendTemplatedEmail({ to: 'user@example.com', templateId: 123 });
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to send template email via Brevo',
+      expect.objectContaining({
+        status: 500,
+        to: 'user@example.com',
+        templateId: 123,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- log non-OK Brevo responses when sending emails
- add tests for email utilities error logging

## Testing
- `cd MJ_FB_Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b28efa56d0832d8f50b765ab762629