### PR TITLE
Remove default email fallbacks for bookings

### DIFF
--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -35,7 +35,8 @@ describe('rescheduleVolunteerBooking', () => {
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ count: 0 }] })
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] });
 
     const res = await request(app)
       .post('/volunteer-bookings/reschedule/token123')


### PR DESCRIPTION
## Summary
- send booking emails only when user or volunteer has an address
- log warnings instead of sending to placeholder test address
- adjust volunteer reschedule test for extra query

## Testing
- `cd MJ_FB_Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28ef6d578832d8b9bb2bff2914e6a