### PR TITLE
feat: debounce entity search requests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/EntitySearch.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/EntitySearch.test.tsx
@@ -2,8 +2,18 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import EntitySearch from '../components/EntitySearch';
 
 describe('EntitySearch', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('clears query after selection when clearOnSelect is true', async () => {
-    const searchFn = jest.fn().mockResolvedValue([{ id: 1, name: 'Client 1', client_id: 1 }]);
+    const searchFn = jest
+      .fn()
+      .mockResolvedValue([{ id: 1, name: 'Client 1', client_id: 1 }]);
     render(
       <EntitySearch
         type="user"
@@ -17,11 +27,32 @@ describe('EntitySearch', () => {
     const input = screen.getByLabelText(/search/i);
     fireEvent.change(input, { target: { value: 'Cli' } });
 
+    expect(searchFn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(500);
     await waitFor(() => expect(searchFn).toHaveBeenCalled());
 
     const button = await screen.findByRole('button', { name: /Client 1 \(1\)/ });
     fireEvent.click(button);
 
     expect((input as HTMLInputElement).value).toBe('');
+  });
+
+  it('cleans up debounce timer on unmount', () => {
+    const searchFn = jest.fn().mockResolvedValue([]);
+    const { unmount } = render(
+      <EntitySearch
+        type="user"
+        placeholder="Search clients"
+        onSelect={() => {}}
+        searchFn={searchFn}
+      />,
+    );
+
+    const input = screen.getByLabelText(/search/i);
+    fireEvent.change(input, { target: { value: 'Cli' } });
+    unmount();
+    jest.advanceTimersByTime(500);
+
+    expect(searchFn).not.toHaveBeenCalled();
   });
 });

--- a/MJ_FB_Frontend/src/components/EntitySearch.tsx
+++ b/MJ_FB_Frontend/src/components/EntitySearch.tsx
@@ -30,20 +30,23 @@ export default function EntitySearch({
       return;
     }
     let active = true;
-    const fn =
-      searchFn ||
-      (type === 'user'
-        ? searchUsers
-        : type === 'volunteer'
-        ? searchVolunteers
-        : searchAgencies);
-    fn(query)
-      .then(data => {
-        if (active) setResults(data);
-      })
-      .catch(() => {});
+    const handler = setTimeout(() => {
+      const fn =
+        searchFn ||
+        (type === 'user'
+          ? searchUsers
+          : type === 'volunteer'
+          ? searchVolunteers
+          : searchAgencies);
+      fn(query)
+        .then(data => {
+          if (active) setResults(data);
+        })
+        .catch(() => {});
+    }, 500);
     return () => {
       active = false;
+      clearTimeout(handler);
     };
   }, [query, type, searchFn]);
 


### PR DESCRIPTION
## Summary
- debounce entity search requests to avoid rapid queries
- add tests for debounce behavior and timer cleanup

## Testing
- `cd MJ_FB_Frontend && npm test` *(fails: Test Suites: 19 failed, 18 passed, 37 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b28f434370832d8af4300291f8ba40