### PR TITLE
Require VITE_API_BASE env variable for frontend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ The self-service registration endpoints and frontend page are commented out pend
 
 ### Frontend (`MJ_FB_Frontend`)
 - React app built with Vite.
+- Build requires `VITE_API_BASE` to be set in `MJ_FB_Frontend/.env`.
 - `pages/` define top-level views and are organized into feature-based directories (booking, staff, volunteer-management, warehouse-management, etc.).
 - `components/` provide reusable UI elements; use `FeedbackSnackbar` for notifications. The dashboard UI lives in `components/dashboard`.
 - `api/` wraps server requests.

--- a/MJ_FB_Frontend/.env.example
+++ b/MJ_FB_Frontend/.env.example
@@ -1,4 +1,4 @@
-# Backend API base URL (agency login and client assignment use this API)
+# Backend API base URL (required; build fails if missing)
 VITE_API_BASE=http://localhost:4000
 # Origin used in invitation links; should match the first entry in BACKEND `FRONTEND_ORIGIN`
 VITE_FRONTEND_ORIGIN=http://localhost:5173

--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -17,6 +17,16 @@ Run the test suite:
 npm test
 ```
 
+## Environment Variables
+
+The frontend requires `VITE_API_BASE` to be defined. Create a `.env` file in this directory with:
+
+```
+VITE_API_BASE=http://localhost:4000
+```
+
+The build will fail if this variable is missing.
+
 ## Progressive Web App
 
 The app registers a service worker when running in a secure context. Use HTTPS when serving the built site.

--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -5,3 +5,4 @@ import { TextEncoder, TextDecoder } from 'util';
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder as any;
 (Element.prototype as any).scrollIntoView = jest.fn();
+(global as any).VITE_API_BASE = 'http://localhost:4000';

--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -1,7 +1,13 @@
 const API_BASE =
   import.meta.env.VITE_API_BASE ||
-  (globalThis as any).VITE_API_BASE ||
-  'http://localhost:4000';
+  (globalThis as any).VITE_API_BASE;
+
+if (!API_BASE) {
+  const message =
+    'VITE_API_BASE is not defined. Set it in the frontend .env file (e.g. VITE_API_BASE=http://localhost:4000)';
+  console.error(message);
+  throw new Error(message);
+}
 
 function getCsrfToken() {
   return document.cookie

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ npm install
 npm start   # or npm run dev
 ```
 
+### Environment variables
+
+The frontend requires `VITE_API_BASE` to point to the backend API. Create a `.env` file in `MJ_FB_Frontend` with:
+
+```
+VITE_API_BASE=http://localhost:4000
+```
+
+The build will fail if this variable is missing.
+
 Refer to the submodule repositories for detailed configuration and environment variables.
 
 The backend surplus tracking feature uses two optional environment variables to


### PR DESCRIPTION
## Summary
- require VITE_API_BASE and throw with clear message when missing
- document VITE_API_BASE usage in frontend README and example env
- note new requirement in root README and AGENTS guidelines

## Testing
- `npm test src/__tests__/App.test.tsx` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b292b3868c832daefb7880d35be074