### PR TITLE
Validate pagination params in booking history

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -690,6 +690,13 @@ export async function getBookingHistory(
     const limit = limitParam ? Number(limitParam) : undefined;
     const offset = offsetParam ? Number(offsetParam) : undefined;
 
+    if (limitParam !== undefined && Number.isNaN(limit)) {
+      return res.status(400).json({ message: 'Invalid limit' });
+    }
+    if (offsetParam !== undefined && Number.isNaN(offset)) {
+      return res.status(400).json({ message: 'Invalid offset' });
+    }
+
     const rows = await repoFetchBookingHistory(
       userIds,
       past,

--- a/MJ_FB_Backend/tests/bookingHistoryPagination.test.ts
+++ b/MJ_FB_Backend/tests/bookingHistoryPagination.test.ts
@@ -1,0 +1,64 @@
+import { Request, Response, NextFunction } from 'express';
+
+describe('getBookingHistory pagination', () => {
+  let getBookingHistory: any;
+  let fetchBookingHistory: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/utils/emailQueue', () => ({
+        __esModule: true,
+        enqueueEmail: jest.fn(),
+      }));
+      jest.doMock('../src/models/bookingRepository', () => ({
+        __esModule: true,
+        fetchBookingHistory: jest.fn().mockResolvedValue([]),
+      }));
+      getBookingHistory = require('../src/controllers/bookingController').getBookingHistory;
+      fetchBookingHistory = require('../src/models/bookingRepository').fetchBookingHistory;
+    });
+  });
+
+  function baseReq(query: any = {}): Request {
+    return {
+      user: { id: '1', role: 'volunteer', userId: '1' },
+      query,
+    } as unknown as Request;
+  }
+
+  it('accepts numeric limit and offset', async () => {
+    const req = baseReq({ limit: '5', offset: '10' });
+    const res = { json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await getBookingHistory(req, res, next);
+
+    expect(fetchBookingHistory).toHaveBeenCalledWith([1], false, undefined, false, 5, 10);
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+
+  it('returns 400 for invalid limit', async () => {
+    const req = baseReq({ limit: 'foo' });
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await getBookingHistory(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid limit' });
+    expect(fetchBookingHistory).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid offset', async () => {
+    const req = baseReq({ offset: 'bar' });
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await getBookingHistory(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid offset' });
+    expect(fetchBookingHistory).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate `limit` and `offset` params in booking history endpoint
- add tests for valid and invalid pagination values

## Testing
- `npm test` *(fails: Cannot find module 'node-fetch')*
- `npm test tests/bookingHistoryPagination.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b295473d40832db061fe4ade5c4b47