### PR TITLE
Whitelist booking update fields

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -78,7 +78,14 @@ export async function updateBooking(
   fields: Record<string, any>,
   client: Queryable = pool,
 ) {
-  const keys = Object.keys(fields);
+  const whitelist = [
+    'slot_id',
+    'date',
+    'status',
+    'request_data',
+    'reschedule_token',
+  ];
+  const keys = Object.keys(fields).filter((k) => whitelist.includes(k));
   if (keys.length === 0) return;
   const setClause = keys.map((key, idx) => `${key}=$${idx + 2}`).join(', ');
   const params = [id, ...keys.map((k) => fields[k])];

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -56,13 +56,22 @@ describe('bookingRepository', () => {
     ]);
   });
 
-  it('updateBooking builds dynamic query', async () => {
+  it('updateBooking ignores disallowed keys', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({});
-    await updateBooking(1, { status: 'cancelled', request_data: 'reason' });
+    await updateBooking(1, {
+      status: 'cancelled',
+      request_data: 'reason',
+      hacker: 'nope',
+    });
     expect(pool.query).toHaveBeenCalledWith(
       'UPDATE bookings SET status=$2, request_data=$3 WHERE id=$1',
       [1, 'cancelled', 'reason'],
     );
+  });
+
+  it('updateBooking returns early when only disallowed keys provided', async () => {
+    await updateBooking(1, { hacker: 'nope' });
+    expect(pool.query).not.toHaveBeenCalled();
   });
 
   it('fetchBookings applies optional filters', async () => {


### PR DESCRIPTION
## Summary
- filter updateBooking fields against an allowed list
- skip update when no valid fields provided
- test that disallowed fields are ignored

## Testing
- `npm test` *(fails: Cannot find module 'node-fetch')*
- `npm install node-fetch@2 @types/node-fetch@2` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2955175c8832d8027272691336b2f