### PR TITLE
Validate client ID before API calls

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/usersApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/usersApi.test.ts
@@ -1,0 +1,46 @@
+import { apiFetch, handleResponse } from '../api/client';
+import { loginUser, addUser, sendRegistrationOtp, registerUser } from '../api/users';
+
+jest.mock('../api/client', () => ({
+  API_BASE: '/api',
+  apiFetch: jest.fn(),
+  handleResponse: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('users api', () => {
+  beforeEach(() => {
+    (apiFetch as jest.Mock).mockResolvedValue(new Response(null));
+    jest.clearAllMocks();
+  });
+
+  it('rejects loginUser with invalid clientId', async () => {
+    await expect(loginUser('abc', 'pw')).rejects.toThrow('Invalid client ID');
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects addUser with invalid clientId', async () => {
+    await expect(addUser('John', 'Doe', 'abc', 'shopper', true)).rejects.toThrow(
+      'Invalid client ID',
+    );
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects sendRegistrationOtp with invalid clientId', async () => {
+    await expect(sendRegistrationOtp('abc', 'a@b.com')).rejects.toThrow('Invalid client ID');
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects registerUser with invalid clientId', async () => {
+    await expect(
+      registerUser({
+        clientId: 'abc',
+        firstName: 'A',
+        lastName: 'B',
+        email: 'a@b.com',
+        password: 'pw',
+        otp: '123456',
+      }),
+    ).rejects.toThrow('Invalid client ID');
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -11,10 +11,14 @@ export async function loginUser(
   clientId: string,
   password: string,
 ): Promise<LoginResponse> {
+  const id = Number(clientId);
+  if (!Number.isInteger(id)) {
+    return Promise.reject(new Error("Invalid client ID"));
+  }
   const res = await apiFetch(`${API_BASE}/users/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ clientId: Number(clientId), password }),
+    body: JSON.stringify({ clientId: id, password }),
   });
   return handleResponse(res);
 }
@@ -141,6 +145,10 @@ export async function addUser(
   email?: string,
   phone?: string,
 ): Promise<void> {
+  const id = Number(clientId);
+  if (!Number.isInteger(id)) {
+    return Promise.reject(new Error("Invalid client ID"));
+  }
   const res = await apiFetch(`${API_BASE}/users/add-client`, {
     method: "POST",
     headers: {
@@ -149,7 +157,7 @@ export async function addUser(
     body: JSON.stringify({
       firstName,
       lastName,
-      clientId: Number(clientId),
+      clientId: id,
       role,
       onlineAccess,
       email,
@@ -207,10 +215,14 @@ export async function sendRegistrationOtp(
   clientId: string,
   email: string,
 ): Promise<void> {
+  const id = Number(clientId);
+  if (!Number.isInteger(id)) {
+    return Promise.reject(new Error("Invalid client ID"));
+  }
   const res = await apiFetch(`${API_BASE}/users/register/otp`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ clientId: Number(clientId), email }),
+    body: JSON.stringify({ clientId: id, email }),
   });
   await handleResponse(res);
 }
@@ -224,11 +236,15 @@ export async function registerUser(data: {
   password: string;
   otp: string;
 }): Promise<void> {
+  const id = Number(data.clientId);
+  if (!Number.isInteger(id)) {
+    return Promise.reject(new Error("Invalid client ID"));
+  }
   const res = await apiFetch(`${API_BASE}/users/register`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      clientId: Number(data.clientId),
+      clientId: id,
       firstName: data.firstName,
       lastName: data.lastName,
       email: data.email,


### PR DESCRIPTION
## Summary
- Reject invalid client IDs before performing users API requests
- Add tests ensuring users API functions reject non-numeric IDs

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b295b0b07c832d9daad7945a1813a2