### PR TITLE
Require auth for new-client bookings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - Email queue retries failed sends with exponential backoff. Configure `EMAIL_QUEUE_MAX_RETRIES` and `EMAIL_QUEUE_BACKOFF_MS` to adjust retry behavior.
 - Use the `sendTemplatedEmail` utility to send Brevo template emails by providing a `templateId` and `params` object.
 - Coordinator notification addresses for volunteer booking updates live in `MJ_FB_Backend/src/config/coordinatorEmails.json`.
-- Bookings for unregistered individuals can be created via `POST /bookings/new-client`; staff may review or delete these records through `/new-clients` routes.
+- Staff or agency users can create bookings for unregistered individuals via `POST /bookings/new-client`; staff may review or delete these records through `/new-clients` routes.
 - The pantry schedule's **Assign User** modal includes a **New client** option; selecting it lets staff enter a name (with optional email and phone) and books the slot via `POST /bookings/new-client`. These bookings appear on the schedule as `[NEW CLIENT] Name`.
 - A daily reminder job (`src/utils/bookingReminderJob.ts`) runs at server startup and emails clients about next-day bookings using the `enqueueEmail` queue. It now uses `node-cron` to run at `0 9 * * *` Regina time and exposes `startBookingReminderJob`/`stopBookingReminderJob`.
 - A volunteer shift reminder job (`MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue. It also uses `node-cron` with the same schedule and exposes `startVolunteerShiftReminderJob`/`stopVolunteerShiftReminderJob`.

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -89,6 +89,11 @@ router.post(
 );
 
 // Booking for new client without account
-router.post('/new-client', createBookingForNewClient);
+router.post(
+  '/new-client',
+  authMiddleware,
+  authorizeRoles('staff', 'agency'),
+  createBookingForNewClient
+);
 
 export default router;

--- a/MJ_FB_Backend/tests/bookingNewClient.test.ts
+++ b/MJ_FB_Backend/tests/bookingNewClient.test.ts
@@ -18,6 +18,26 @@ jest.mock('../src/models/newClient', () => ({
 jest.mock('../src/utils/bookingUtils', () => ({
   isDateWithinCurrentOrNextMonth: jest.fn().mockReturnValue(true),
 }));
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: 'staff1', role: 'staff' };
+    next();
+  },
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  optionalAuthMiddleware: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
 
 const app = express();
 app.use(express.json());

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 ## Features
 
  - Appointment booking workflow for clients with automatic approval and rescheduling.
-- Unregistered clients can book directly via `/bookings/new-client`; staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
+- Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas.
  - Daily reminder jobs queue emails for next-day bookings and volunteer shifts using the backend email queue. Each job now runs via `node-cron` at `0 9 * * *` Regina time and exposes start/stop functions.
  - Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.


### PR DESCRIPTION
## Summary
- require authentication and staff/agency roles for `/bookings/new-client`
- mock auth middleware in tests for new-client booking
- document that only staff or agency can create bookings for unregistered clients

## Testing
- `npm test tests/bookingNewClient.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b31216918c832d9d2a214ed19f9ea3