### PR TITLE
chore: remove node-fetch dependency

### DIFF
--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -10,7 +10,6 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^3.0.3",
-    "node-fetch": "^2.6.7",
     "pg": "^8.16.3",
     "write-excel-file": "^2.1.0",
     "zod": "^4.1.1"


### PR DESCRIPTION
## Summary
- remove node-fetch from backend dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-cron)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3153a1cd8832db65fc6bb43a2c661