### PR TITLE
refactor: persist React Query client

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/QueryClientCache.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/QueryClientCache.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { queryClient } from '../queryClient';
+
+const fetcher = jest.fn().mockResolvedValue('data');
+
+function TestComponent() {
+  const { data } = useQuery({ queryKey: ['test'], queryFn: fetcher });
+  return <div>{data}</div>;
+}
+
+test('query cache persists across re-renders', async () => {
+  const { findByText, rerender } = render(
+    <QueryClientProvider client={queryClient}>
+      <TestComponent />
+    </QueryClientProvider>
+  );
+
+  await findByText('data');
+  expect(fetcher).toHaveBeenCalledTimes(1);
+
+  rerender(
+    <QueryClientProvider client={queryClient}>
+      <TestComponent />
+    </QueryClientProvider>
+  );
+
+  await findByText('data');
+  expect(fetcher).toHaveBeenCalledTimes(1);
+
+  queryClient.clear();
+});

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -4,7 +4,8 @@ import App from './App';
 import './index.css';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import { theme } from './theme';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './queryClient';
 import { registerServiceWorker } from './registerServiceWorker';
 import { AuthProvider } from './hooks/useAuth';
 import { LocalizationProvider } from '@mui/x-date-pickers';
@@ -12,8 +13,6 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs from './utils/date';
 
 function Main() {
-  const queryClient = new QueryClient();
-
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>

--- a/MJ_FB_Frontend/src/queryClient.ts
+++ b/MJ_FB_Frontend/src/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();


### PR DESCRIPTION
## Summary
- instantiate a single React Query client and share via provider
- add test confirming cache persists across re-renders

## Testing
- `npm test` *(fails: MUI Grid prop warnings, missing localization context, SyntaxError: Cannot use 'import.meta' outside a module, etc.)*
- `npm test src/__tests__/QueryClientCache.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b31541a3b4832d8ca8b12c172abf0a