### PR TITLE
Simplify agency client validation in booking listing

### DIFF
--- a/MJ_FB_Backend/src/models/agency.ts
+++ b/MJ_FB_Backend/src/models/agency.ts
@@ -58,6 +58,18 @@ export async function isAgencyClient(
   return (res.rowCount ?? 0) > 0;
 }
 
+export async function getAgencyClientSet(
+  agencyId: number,
+  clientIds: number[],
+): Promise<Set<number>> {
+  if (clientIds.length === 0) return new Set();
+  const res = await pool.query(
+    'SELECT client_id FROM agency_clients WHERE agency_id = $1 AND client_id = ANY($2)',
+    [agencyId, clientIds],
+  );
+  return new Set(res.rows.map((r) => r.client_id as number));
+}
+
 export async function getAgencyForClient(
   clientId: number,
 ): Promise<AgencySummary | undefined> {

--- a/MJ_FB_Backend/tests/listBookingsClientList.test.ts
+++ b/MJ_FB_Backend/tests/listBookingsClientList.test.ts
@@ -1,0 +1,58 @@
+import { Request, Response, NextFunction } from 'express';
+
+describe('listBookings client list validation', () => {
+  let listBookings: any;
+  let getAgencyClientSet: jest.Mock;
+  let repoFetchBookings: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/models/agency', () => ({
+        __esModule: true,
+        getAgencyClientSet: jest.fn(),
+        isAgencyClient: jest.fn(),
+      }));
+      jest.doMock('../src/models/bookingRepository', () => ({
+        __esModule: true,
+        fetchBookings: jest.fn(),
+      }));
+      listBookings = require('../src/controllers/bookingController').listBookings;
+      getAgencyClientSet = require('../src/models/agency').getAgencyClientSet;
+      repoFetchBookings = require('../src/models/bookingRepository').fetchBookings;
+    });
+  });
+
+  it('allows agency to list bookings for associated clients', async () => {
+    getAgencyClientSet.mockResolvedValue(new Set([1, 2]));
+    repoFetchBookings.mockResolvedValue([{ id: 1 }]);
+    const req = {
+      user: { role: 'agency', id: 5 },
+      query: { clientIds: '1,2' },
+    } as unknown as Request;
+    const res = { json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await listBookings(req, res, next);
+
+    expect(getAgencyClientSet).toHaveBeenCalledWith(5, [1, 2]);
+    expect(repoFetchBookings).toHaveBeenCalledWith(undefined, undefined, [1, 2]);
+    expect(res.json).toHaveBeenCalledWith([{ id: 1 }]);
+  });
+
+  it('rejects client lists containing unassociated clients', async () => {
+    getAgencyClientSet.mockResolvedValue(new Set([1]));
+    const req = {
+      user: { role: 'agency', id: 5 },
+      query: { clientIds: '1,2' },
+    } as unknown as Request;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await listBookings(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Client not associated with agency' });
+    expect(repoFetchBookings).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add repository helper to fetch allowed client IDs for an agency
- check agency client list using a single Set lookup in listBookings
- test valid and invalid client list scenarios for listBookings

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-cron)*

------
https://chatgpt.com/codex/tasks/task_e_68b31557f134832d8e376f750e2abe35