### PR TITLE
feat: persist email queue in database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 18+ for native `fetch`; the `node-fetch` polyfill has been removed and earlier versions are not supported.
 - Booking emails are sent through Brevo; configure `BREVO_API_KEY`, `BREVO_FROM_EMAIL`, and `BREVO_FROM_NAME` in the backend environment.
-- Email queue retries failed sends with exponential backoff. Configure `EMAIL_QUEUE_MAX_RETRIES` and `EMAIL_QUEUE_BACKOFF_MS` to adjust retry behavior.
+- Email queue retries failed sends with exponential backoff and persists jobs in the `email_queue` table so retries survive restarts. Configure `EMAIL_QUEUE_MAX_RETRIES` and `EMAIL_QUEUE_BACKOFF_MS` to adjust retry behavior.
 - Use the `sendTemplatedEmail` utility to send Brevo template emails by providing a `templateId` and `params` object.
 - Coordinator notification addresses for volunteer booking updates live in `MJ_FB_Backend/src/config/coordinatorEmails.json`.
 - Staff or agency users can create bookings for unregistered individuals via `POST /bookings/new-client`; staff may review or delete these records through `/new-clients` routes.

--- a/MJ_FB_Backend/src/migrations/20251201000000_create_email_queue.ts
+++ b/MJ_FB_Backend/src/migrations/20251201000000_create_email_queue.ts
@@ -1,0 +1,21 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('email_queue', {
+    id: 'id',
+    to: { type: 'text', notNull: true },
+    subject: { type: 'text', notNull: true },
+    body: { type: 'text', notNull: true },
+    retries: { type: 'integer', notNull: true, default: 0 },
+    next_attempt: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('email_queue');
+}
+

--- a/MJ_FB_Backend/src/utils/emailQueue.ts
+++ b/MJ_FB_Backend/src/utils/emailQueue.ts
@@ -1,42 +1,78 @@
-import logger from './logger';
-import { sendEmail } from './emailUtils';
+import pool from '../db';
 import config from '../config';
+import { sendEmail } from './emailUtils';
+import logger from './logger';
 
 interface EmailJob {
+  id: number;
   to: string;
   subject: string;
   body: string;
   retries: number;
+  next_attempt: Date;
 }
 
-const queue: EmailJob[] = [];
 let processing = false;
+let scheduled = false;
 
 export function enqueueEmail(to: string, subject: string, body: string, retries = 0): void {
-  queue.push({ to, subject, body, retries });
-  processQueue().catch((err) => logger.error('Email queue processing error:', err));
+  pool
+    .query('INSERT INTO email_queue (to, subject, body, retries, next_attempt) VALUES ($1,$2,$3,$4, now())', [
+      to,
+      subject,
+      body,
+      retries,
+    ])
+    .then(() => processQueue().catch((err) => logger.error('Email queue processing error:', err)))
+    .catch((err) => logger.error('Failed to enqueue email', err));
+}
+
+async function scheduleNextRun(): Promise<void> {
+  if (scheduled) return;
+  const res = await pool.query('SELECT next_attempt FROM email_queue ORDER BY next_attempt ASC LIMIT 1');
+  if (res.rowCount === 0) return;
+  const next = res.rows[0].next_attempt as Date;
+  const delay = Math.max(0, next.getTime() - Date.now());
+  scheduled = true;
+  setTimeout(() => {
+    scheduled = false;
+    processQueue().catch((err) => logger.error('Email queue processing error:', err));
+  }, delay);
 }
 
 async function processQueue(): Promise<void> {
   if (processing) return;
   processing = true;
-  while (queue.length > 0) {
-    const job = queue.shift()!;
-    try {
-      await sendEmail(job.to, job.subject, job.body);
-    } catch (err) {
-      if (job.retries < config.emailQueueMaxRetries) {
-        job.retries += 1;
-        const delay = config.emailQueueBackoffMs * 2 ** (job.retries - 1);
-        setTimeout(() => {
-          queue.push(job);
-          processQueue().catch((e) => logger.error('Email queue processing error:', e));
-        }, delay);
-      } else {
-        logger.error('Failed to send email job after max retries', err);
+  try {
+    while (true) {
+      const res = await pool.query<EmailJob>(
+        'SELECT id, to, subject, body, retries, next_attempt FROM email_queue WHERE next_attempt <= now() ORDER BY id LIMIT 1'
+      );
+      if (res.rowCount === 0) break;
+      const job = res.rows[0];
+      try {
+        await sendEmail(job.to, job.subject, job.body);
+        await pool.query('DELETE FROM email_queue WHERE id=$1', [job.id]);
+      } catch (err) {
+        if (job.retries < config.emailQueueMaxRetries) {
+          const newRetries = job.retries + 1;
+          const delay = config.emailQueueBackoffMs * 2 ** (newRetries - 1);
+          await pool.query(
+            'UPDATE email_queue SET retries=$1, next_attempt=now() + $2::int * interval \'1 millisecond\' WHERE id=$3',
+            [newRetries, delay, job.id]
+          );
+        } else {
+          logger.error('Failed to send email job after max retries', err);
+          await pool.query('DELETE FROM email_queue WHERE id=$1', [job.id]);
+        }
       }
     }
+  } finally {
+    processing = false;
+    await scheduleNextRun();
   }
-  processing = false;
 }
+
+// kick off processing for existing jobs on startup
+processQueue().catch((err) => logger.error('Email queue processing error:', err));
 

--- a/MJ_FB_Backend/tests/emailQueue.test.ts
+++ b/MJ_FB_Backend/tests/emailQueue.test.ts
@@ -1,14 +1,79 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-describe('emailQueue retry behavior', () => {
+interface Job {
+  id: number;
+  to: string;
+  subject: string;
+  body: string;
+  retries: number;
+  next_attempt: number;
+}
+
+const jobs: Job[] = [];
+let idCounter = 1;
+
+const db = {
+  query: jest.fn(async (sql: string, params: any[] = []) => {
+    if (sql.startsWith('INSERT INTO email_queue')) {
+      const job: Job = {
+        id: idCounter++,
+        to: params[0],
+        subject: params[1],
+        body: params[2],
+        retries: params[3],
+        next_attempt: Date.now(),
+      };
+      jobs.push(job);
+      return { rows: [{ id: job.id }], rowCount: 1 };
+    }
+    if (sql.startsWith('SELECT next_attempt FROM email_queue')) {
+      if (jobs.length === 0) return { rows: [], rowCount: 0 };
+      const job = [...jobs].sort((a, b) => a.next_attempt - b.next_attempt)[0];
+      return { rows: [{ next_attempt: new Date(job.next_attempt) }], rowCount: 1 };
+    }
+    if (sql.startsWith('SELECT id, to, subject')) {
+      const now = Date.now();
+      const job = jobs.filter((j) => j.next_attempt <= now).sort((a, b) => a.id - b.id)[0];
+      if (!job) return { rows: [], rowCount: 0 };
+      return { rows: [{ ...job, next_attempt: new Date(job.next_attempt) }], rowCount: 1 };
+    }
+    if (sql.startsWith('UPDATE email_queue SET retries')) {
+      const newRetries = params[0];
+      const delay = params[1];
+      const id = params[2];
+      const job = jobs.find((j) => j.id === id);
+      if (job) {
+        job.retries = newRetries;
+        job.next_attempt = Date.now() + delay;
+      }
+      return { rowCount: job ? 1 : 0 };
+    }
+    if (sql.startsWith('DELETE FROM email_queue')) {
+      const id = params[0];
+      const idx = jobs.findIndex((j) => j.id === id);
+      if (idx >= 0) jobs.splice(idx, 1);
+      return { rowCount: idx >= 0 ? 1 : 0 };
+    }
+    throw new Error('Unknown SQL: ' + sql);
+  }),
+};
+
+function mockDb() {
+  jest.doMock('../src/db', () => ({ __esModule: true, default: db }));
+}
+
+describe('persistent email queue', () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
+
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllTimers();
     jest.resetModules();
     jest.clearAllMocks();
+    jobs.length = 0;
+    idCounter = 1;
     delete process.env.EMAIL_QUEUE_MAX_RETRIES;
     delete process.env.EMAIL_QUEUE_BACKOFF_MS;
   });
@@ -16,14 +81,16 @@ describe('emailQueue retry behavior', () => {
   it('retries failed jobs with exponential backoff', async () => {
     process.env.EMAIL_QUEUE_MAX_RETRIES = '2';
     process.env.EMAIL_QUEUE_BACKOFF_MS = '1';
-    const sendEmailMock: jest.Mock = jest.fn();
-    // @ts-ignore
-    sendEmailMock.mockRejectedValueOnce(new Error('fail1'));
-    // @ts-ignore
-    sendEmailMock.mockRejectedValueOnce(new Error('fail2'));
-    // @ts-ignore
-    sendEmailMock.mockResolvedValueOnce(undefined);
+    const sendEmailMock: jest.Mock = jest
+      .fn()
+      // @ts-ignore
+      .mockRejectedValueOnce(new Error('fail1'))
+      // @ts-ignore
+      .mockRejectedValueOnce(new Error('fail2'))
+      // @ts-ignore
+      .mockResolvedValueOnce(undefined);
     jest.doMock('../src/utils/emailUtils', () => ({ sendEmail: sendEmailMock }));
+    mockDb();
     const { enqueueEmail } = require('../src/utils/emailQueue');
 
     enqueueEmail('user@example.com', 'Sub', 'Body');
@@ -37,14 +104,42 @@ describe('emailQueue retry behavior', () => {
     expect(sendEmailMock).toHaveBeenCalledTimes(3);
   });
 
+  it('resumes pending jobs after a restart', async () => {
+    process.env.EMAIL_QUEUE_MAX_RETRIES = '2';
+    process.env.EMAIL_QUEUE_BACKOFF_MS = '1';
+    const sendEmailMock: jest.Mock = jest
+      .fn()
+      // @ts-ignore
+      .mockRejectedValueOnce(new Error('fail1'))
+      // @ts-ignore
+      .mockResolvedValueOnce(undefined);
+    jest.doMock('../src/utils/emailUtils', () => ({ sendEmail: sendEmailMock }));
+    mockDb();
+    const { enqueueEmail } = require('../src/utils/emailQueue');
+
+    enqueueEmail('user@example.com', 'Sub', 'Body');
+    await Promise.resolve();
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+
+    // simulate restart before retry
+    jest.clearAllTimers();
+    jest.resetModules();
+    jest.doMock('../src/utils/emailUtils', () => ({ sendEmail: sendEmailMock }));
+    mockDb();
+    require('../src/utils/emailQueue');
+
+    await jest.advanceTimersByTimeAsync(1);
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+  });
+
   it('stops retrying after max retries', async () => {
     process.env.EMAIL_QUEUE_MAX_RETRIES = '1';
     process.env.EMAIL_QUEUE_BACKOFF_MS = '1';
-    // @ts-ignore
     const sendEmailMock: jest.Mock = jest.fn().mockRejectedValue(new Error('fail'));
     jest.doMock('../src/utils/emailUtils', () => ({ sendEmail: sendEmailMock }));
     const logger = require('../src/utils/logger').default;
     const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    mockDb();
     const { enqueueEmail } = require('../src/utils/emailQueue');
 
     enqueueEmail('user@example.com', 'Sub', 'Body');
@@ -59,3 +154,4 @@ describe('emailQueue retry behavior', () => {
     expect(errorSpy).toHaveBeenCalledWith('Failed to send email job after max retries', expect.any(Error));
   });
 });
+

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
  - Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
-- Backend email queue retries failed sends with exponential backoff. The maximum retries and initial delay are configurable.
+- Backend email queue retries failed sends with exponential backoff and persists jobs in an `email_queue` table so retries survive restarts. The maximum retries and initial delay are configurable.
 - Accounts for clients, volunteers, staff, and agencies are created without passwords; a one-time setup link directs them to `/set-password` for initial password creation.
 - Users see a random appreciation message on each login with a link to download their card when available.
 - Volunteers also see rotating encouragement messages on the dashboard when no milestone is reached.


### PR DESCRIPTION
## Summary
- use `email_queue` table for durable email jobs and schedule retries after restart
- add migration and tests covering exponential backoff and restart persistence
- document new persistent queue behavior in AGENTS and README

## Testing
- `npm test` *(fails: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b315bede84832d986a75c59192e7d1