### PR TITLE
feat: lazy load dashboard

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -1,7 +1,9 @@
 import React, { useState, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import CircularProgress from '@mui/material/CircularProgress';
-import Dashboard from './components/dashboard/Dashboard';
+const Dashboard = React.lazy(
+  () => import('./components/dashboard/Dashboard')
+);
 import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import MainLayout from './components/layout/MainLayout';
@@ -249,7 +251,9 @@ export default function App() {
                     singleAccessOnly && staffRootPath !== '/' ? (
                       <Navigate to={staffRootPath} replace />
                     ) : (
+                      <Suspense fallback={<Spinner />}>
                         <Dashboard role="staff" masterRoleFilter={['Pantry']} />
+                      </Suspense>
                     )
                   ) : (
                     <ClientDashboard />
@@ -258,7 +262,14 @@ export default function App() {
               />
                 <Route path="/profile" element={<Profile role={role} />} />
               {showStaff && (
-                <Route path="/pantry" element={<Dashboard role="staff" masterRoleFilter={['Pantry']} />} />
+                <Route
+                  path="/pantry"
+                  element={
+                    <Suspense fallback={<Spinner />}>
+                      <Dashboard role="staff" masterRoleFilter={['Pantry']} />
+                    </Suspense>
+                  }
+                />
               )}
               {showStaff && (
                 <Route path="/pantry/manage-availability" element={<ManageAvailability />} />

--- a/MJ_FB_Frontend/src/pages/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/Dashboard.tsx
@@ -1,10 +1,17 @@
-import Dashboard, { type DashboardProps } from '../components/dashboard/Dashboard';
+import React, { Suspense } from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
 import Page from '../components/Page';
+const Dashboard = React.lazy(
+  () => import('../components/dashboard/Dashboard')
+);
+import type { DashboardProps } from '../components/dashboard/Dashboard';
 
 export default function DashboardPage(props: DashboardProps) {
   return (
     <Page title="Dashboard">
-      <Dashboard {...props} masterRoleFilter={['Pantry']} />
+      <Suspense fallback={<CircularProgress />}>
+        <Dashboard {...props} masterRoleFilter={['Pantry']} />
+      </Suspense>
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import {
   getVolunteerRoles,
@@ -48,9 +48,12 @@ import {
   Grid,
   Stack,
   Chip,
+  CircularProgress,
 } from '@mui/material';
 import { lighten } from '@mui/material/styles';
-import Dashboard from '../../components/dashboard/Dashboard';
+const Dashboard = React.lazy(
+  () => import('../../components/dashboard/Dashboard')
+);
 import EntitySearch from '../../components/EntitySearch';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { formatDate, addDays } from '../../utils/date';
@@ -587,7 +590,9 @@ export default function VolunteerManagement() {
   return (
     <Page title={title}>
       {tab === 'dashboard' && (
-        <Dashboard role="staff" masterRoleFilter={undefined} />
+        <Suspense fallback={<CircularProgress />}>
+          <Dashboard role="staff" masterRoleFilter={undefined} />
+        </Suspense>
       )}
       {tab === 'schedule' && (
         <div>


### PR DESCRIPTION
## Summary
- lazy load Dashboard component and wrap its routes in Suspense
- defer Dashboard loading in volunteer management and page components

## Testing
- `npm test` *(fails: Test Suites: 19 failed, 18 passed, 37 total)*
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_e_68b31561a470832d8e81d74c05af4fa5