### PR TITLE
Handle unauthorized login failures

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyLogin.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyLogin.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AgencyLogin from '../pages/agency/Login';
+import { loginAgency } from '../api/users';
+
+jest.mock('../api/users', () => ({
+  loginAgency: jest.fn(),
+}));
+
+describe('AgencyLogin component', () => {
+  it('shows friendly message on unauthorized error', async () => {
+    const apiErr = Object.assign(new Error('backend'), { status: 401 });
+    (loginAgency as jest.Mock).mockRejectedValue(apiErr);
+    const onLogin = jest.fn();
+    render(
+      <MemoryRouter>
+        <AgencyLogin onLogin={onLogin} />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'pass' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    expect(
+      await screen.findByText('Incorrect email or password')
+    ).toBeInTheDocument();
+    expect(onLogin).not.toHaveBeenCalled();
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -25,6 +25,28 @@ describe('Login component', () => {
     await waitFor(() => expect(onLogin).toHaveBeenCalled());
   });
 
+  it('shows friendly message on unauthorized error', async () => {
+    const apiErr = Object.assign(new Error('backend'), { status: 401 });
+    (loginUser as jest.Mock).mockRejectedValue(apiErr);
+    const onLogin = jest.fn();
+    render(
+      <MemoryRouter>
+        <Login onLogin={onLogin} />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText(/client id/i), {
+      target: { value: '123' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'pass' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    expect(
+      await screen.findByText('Incorrect ID or password')
+    ).toBeInTheDocument();
+    expect(onLogin).not.toHaveBeenCalled();
+  });
+
   // it('includes link to signup', () => {
   //   render(
   //     <MemoryRouter>

--- a/MJ_FB_Frontend/src/__tests__/StaffLogin.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffLogin.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import StaffLogin from '../pages/auth/StaffLogin';
+import { loginStaff, staffExists } from '../api/users';
+
+jest.mock('../api/users', () => ({
+  loginStaff: jest.fn(),
+  staffExists: jest.fn(),
+  createStaff: jest.fn(),
+}));
+
+describe('StaffLogin component', () => {
+  it('shows friendly message on unauthorized error', async () => {
+    (staffExists as jest.Mock).mockResolvedValue(true);
+    const apiErr = Object.assign(new Error('backend'), { status: 401 });
+    (loginStaff as jest.Mock).mockRejectedValue(apiErr);
+    const onLogin = jest.fn();
+    render(
+      <MemoryRouter>
+        <StaffLogin onLogin={onLogin} />
+      </MemoryRouter>
+    );
+    await screen.findByRole('button', { name: /login/i });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'pass' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    expect(
+      await screen.findByText('Incorrect email or password')
+    ).toBeInTheDocument();
+    expect(onLogin).not.toHaveBeenCalled();
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/VolunteerLogin.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerLogin.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerLogin from '../pages/auth/VolunteerLogin';
+import { loginVolunteer } from '../api/volunteers';
+
+jest.mock('../api/volunteers', () => ({
+  loginVolunteer: jest.fn(),
+}));
+
+describe('VolunteerLogin component', () => {
+  it('shows friendly message on unauthorized error', async () => {
+    const apiErr = Object.assign(new Error('backend'), { status: 401 });
+    (loginVolunteer as jest.Mock).mockRejectedValue(apiErr);
+    const onLogin = jest.fn();
+    render(
+      <MemoryRouter>
+        <VolunteerLogin onLogin={onLogin} />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: 'user' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'pass' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    expect(
+      await screen.findByText('Incorrect username or password')
+    ).toBeInTheDocument();
+    expect(onLogin).not.toHaveBeenCalled();
+  });
+});

--- a/MJ_FB_Frontend/src/pages/agency/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/Login.tsx
@@ -4,6 +4,7 @@ import { TextField, Button } from '@mui/material';
 import FormCard from '../../components/FormCard';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import Page from '../../components/Page';
+import type { ApiError } from '../../api/client';
 
 export default function AgencyLogin({
   onLogin,
@@ -23,8 +24,13 @@ export default function AgencyLogin({
     try {
       const user = await loginAgency(email, password);
       await onLogin(user);
-    } catch (err: any) {
-      setError(err.message ?? String(err));
+    } catch (err: unknown) {
+      const apiErr = err as ApiError;
+      if (apiErr?.status === 401) {
+        setError('Incorrect email or password');
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     }
   }
 

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { loginUser } from '../../api/users';
 import type { LoginResponse } from '../../api/users';
+import type { ApiError } from '../../api/client';
 import { Link, TextField, Button } from '@mui/material';
 import Page from '../../components/Page';
 import { Link as RouterLink } from 'react-router-dom';
@@ -30,7 +31,12 @@ export default function Login({
       const user = await loginUser(clientId, password);
       await onLogin(user);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      const apiErr = err as ApiError;
+      if (apiErr?.status === 401) {
+        setError('Incorrect ID or password');
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     }
   }
 

--- a/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { loginStaff, staffExists, createStaff } from '../../api/users';
 import type { LoginResponse } from '../../api/users';
+import type { ApiError } from '../../api/client';
 import { Typography, TextField, Link, Button } from '@mui/material';
 import Page from '../../components/Page';
 import { Link as RouterLink } from 'react-router-dom';
@@ -76,7 +77,12 @@ function StaffLoginForm({
       }
       await onLogin(user);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      const apiErr = err as ApiError;
+      if (apiErr?.status === 401) {
+        setError('Incorrect email or password');
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     }
   }
 

--- a/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { loginVolunteer } from '../../api/volunteers';
 import type { LoginResponse } from '../../api/users';
+import type { ApiError } from '../../api/client';
 import { TextField, Link, Button } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -30,7 +31,12 @@ export default function VolunteerLogin({
       const user = await loginVolunteer(username, password);
       await onLogin(user);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      const apiErr = err as ApiError;
+      if (apiErr?.status === 401) {
+        setError('Incorrect username or password');
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Display user-friendly message for 401 login errors across client, staff, volunteer and agency login pages
- Maintain feedback snackbar for these messages
- Add tests ensuring 401 responses show friendly text

## Testing
- `npm test` *(fails: VolunteerManagement.test.tsx and others: Unable to find element, SyntaxError: import.meta, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3198093e0832db766faa5277299ea