### PR TITLE
feat(volunteer): fetch recurring booking series

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
@@ -3,6 +3,7 @@ import {
   createVolunteerBookingForVolunteer,
   updateVolunteerTrainedAreas,
   getVolunteerMasterRoles,
+  getMyRecurringVolunteerBookings,
 } from '../api/volunteers';
 
 jest.mock('../api/client', () => ({
@@ -42,5 +43,10 @@ describe('volunteers api', () => {
   it('fetches volunteer master roles', async () => {
     await getVolunteerMasterRoles();
     expect(apiFetch).toHaveBeenCalledWith('/api/volunteer-master-roles');
+  });
+
+  it('fetches recurring volunteer bookings', async () => {
+    await getMyRecurringVolunteerBookings();
+    expect(apiFetch).toHaveBeenCalledWith('/api/volunteer-bookings/recurring');
   });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -7,6 +7,7 @@ import type {
   VolunteerBooking,
   VolunteerBookingStatus,
   UserProfile,
+  RecurringVolunteerBooking,
 } from '../types';
 import type { LoginResponse } from './users';
 
@@ -141,6 +142,13 @@ export async function cancelRecurringVolunteerBooking(
     },
   );
   await handleResponse(res);
+}
+
+export async function getMyRecurringVolunteerBookings(): Promise<
+  RecurringVolunteerBooking[]
+> {
+  const res = await apiFetch(`${API_BASE}/volunteer-bookings/recurring`);
+  return handleResponse<RecurringVolunteerBooking[]>(res);
 }
 
 export async function getMyVolunteerBookings() {

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -144,6 +144,15 @@ export interface VolunteerBookingDetail {
   recurring_id?: number;
 }
 
+export interface RecurringVolunteerBooking {
+  id: number;
+  role_id: number;
+  start_date: string;
+  end_date: string | null;
+  pattern: 'daily' | 'weekly';
+  days_of_week: number[];
+}
+
 export interface UserProfile {
   id?: number;
   firstName: string;


### PR DESCRIPTION
## Summary
- support loading volunteer recurring booking series via new API helper
- cover recurring booking retrieval in volunteers API tests

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b31a40fc30832dbb9f64ba85e7102f