### PR TITLE
feat: add volunteer recurring bookings page

### DIFF
--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -1,6 +1,6 @@
 # MJ Food Bank Frontend
 
-This project is the React + Vite front end for the MJ Food Bank booking system.
+This project is the React + Vite front end for the MJ Food Bank booking system. Volunteers can manage recurring bookings from `/volunteer/recurring`.
 
 ## Development
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -53,6 +53,9 @@ const VolunteerBookingHistory = React.lazy(() =>
 const VolunteerBooking = React.lazy(() =>
   import('./pages/volunteer-management/VolunteerBooking')
 );
+const VolunteerRecurringBookings = React.lazy(() =>
+  import('./pages/volunteer-management/VolunteerRecurringBookings')
+);
 const WarehouseDashboard = React.lazy(() =>
   import('./pages/warehouse-management/WarehouseDashboard')
 );
@@ -201,6 +204,7 @@ export default function App() {
       links: [
         { label: 'Dashboard', to: '/' },
         { label: 'Schedule', to: '/volunteer/schedule' },
+        { label: 'Recurring Bookings', to: '/volunteer/recurring' },
         { label: 'Booking History', to: '/volunteer/history' },
       ],
     });
@@ -382,6 +386,10 @@ export default function App() {
                   <Route
                     path="/volunteer/schedule"
                     element={<VolunteerBooking />}
+                  />
+                  <Route
+                    path="/volunteer/recurring"
+                    element={<VolunteerRecurringBookings />}
                   />
                   <Route
                     path="/volunteer/history"

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -6,6 +6,7 @@ import type {
   Shift,
   VolunteerBooking,
   VolunteerBookingStatus,
+  VolunteerRecurringBooking,
   UserProfile,
 } from '../types';
 import type { LoginResponse } from './users';
@@ -114,6 +115,13 @@ export async function createRecurringVolunteerBooking(
     }),
   });
   await handleResponse(res);
+}
+
+export async function getRecurringVolunteerBookings(): Promise<
+  VolunteerRecurringBooking[]
+> {
+  const res = await apiFetch(`${API_BASE}/volunteer-bookings/recurring`);
+  return handleResponse(res);
 }
 
 export async function cancelVolunteerBooking(

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerRecurringBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerRecurringBookings.tsx
@@ -1,0 +1,243 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  getVolunteerRolesForVolunteer,
+  createRecurringVolunteerBooking,
+  getRecurringVolunteerBookings,
+  getMyVolunteerBookings,
+  cancelVolunteerBooking,
+  cancelRecurringVolunteerBooking,
+} from '../../api/volunteers';
+import type {
+  VolunteerRole,
+  VolunteerRecurringBooking,
+  VolunteerBooking,
+} from '../../types';
+import Page from '../../components/Page';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  ListSubheader,
+  TextField,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Typography,
+} from '@mui/material';
+import type { AlertColor } from '@mui/material';
+import { formatDate } from '../../utils/date';
+import { formatTime } from '../../utils/time';
+
+const weekdayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export default function VolunteerRecurringBookings() {
+  const today = formatDate();
+  const [startDate, setStartDate] = useState(today);
+  const [endDate, setEndDate] = useState('');
+  const [frequency, setFrequency] = useState<'daily' | 'weekly'>('daily');
+  const [weekdays, setWeekdays] = useState<number[]>([]);
+  const [roles, setRoles] = useState<VolunteerRole[]>([]);
+  const [selectedRole, setSelectedRole] = useState('');
+  const [series, setSeries] = useState<VolunteerRecurringBooking[]>([]);
+  const [bookings, setBookings] = useState<VolunteerBooking[]>([]);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<AlertColor>('success');
+
+  const roleMap = new Map(roles.map(r => [r.id, r]));
+
+  const loadData = useCallback(async () => {
+    try {
+      const [roleData, seriesData, bookingData] = await Promise.all([
+        getVolunteerRolesForVolunteer(startDate),
+        getRecurringVolunteerBookings(),
+        getMyVolunteerBookings(),
+      ]);
+      setRoles(roleData);
+      setSeries(seriesData);
+      setBookings(bookingData);
+    } catch (err) {
+      console.error(err);
+    }
+  }, [startDate]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const roleId = Number(selectedRole);
+    if (!roleId) return;
+    try {
+      await createRecurringVolunteerBooking(
+        roleId,
+        startDate,
+        frequency,
+        frequency === 'weekly' ? weekdays : undefined,
+        endDate || undefined,
+      );
+      setSeverity('success');
+      setMessage('Recurring booking created');
+      setSelectedRole('');
+      setWeekdays([]);
+      setEndDate('');
+      await loadData();
+    } catch (err: any) {
+      setSeverity('error');
+      setMessage(err.message || 'Failed to create booking');
+    }
+  }
+
+  async function cancelOccurrence(id: number) {
+    try {
+      await cancelVolunteerBooking(id);
+      setSeverity('success');
+      setMessage('Booking cancelled');
+      await loadData();
+    } catch {
+      setSeverity('error');
+      setMessage('Failed to cancel booking');
+    }
+  }
+
+  async function cancelSeries(id: number) {
+    try {
+      await cancelRecurringVolunteerBooking(id);
+      setSeverity('success');
+      setMessage('Series cancelled');
+      await loadData();
+    } catch {
+      setSeverity('error');
+      setMessage('Failed to cancel series');
+    }
+  }
+
+  const groupedRoles = roles.reduce((acc: any, r) => {
+    const group = acc.get(r.category_id) || { category: r.category_name, roles: [] };
+    group.roles.push(r);
+    acc.set(r.category_id, group);
+    return acc;
+  }, new Map<number, { category: string; roles: VolunteerRole[] }>());
+
+  return (
+    <Page title="Recurring Bookings">
+      <Box component="form" onSubmit={submit} sx={{ mb: 4, display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 400 }}>
+        <FormControl size="small">
+          <InputLabel id="role-label">Role</InputLabel>
+          <Select labelId="role-label" value={selectedRole} label="Role" onChange={e => setSelectedRole(e.target.value as string)}>
+            <MenuItem value="">Select role</MenuItem>
+            {Array.from(groupedRoles.values()).flatMap(g => [
+              <ListSubheader key={`${g.category}-header`}>{g.category}</ListSubheader>,
+              ...g.roles.map(r => (
+                <MenuItem key={r.id} value={r.id}>
+                  {r.name} ({formatTime(r.start_time)}–{formatTime(r.end_time)})
+                </MenuItem>
+              )),
+            ])}
+          </Select>
+        </FormControl>
+        <TextField
+          label="Start date"
+          type="date"
+          size="small"
+          value={startDate}
+          onChange={e => setStartDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+        <FormControl size="small">
+          <InputLabel id="freq-label">Frequency</InputLabel>
+          <Select labelId="freq-label" value={frequency} label="Frequency" onChange={e => setFrequency(e.target.value as 'daily' | 'weekly')}>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+          </Select>
+        </FormControl>
+        {frequency === 'weekly' && (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
+            {weekdayLabels.map((d, i) => (
+              <FormControlLabel
+                key={d}
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={weekdays.includes(i)}
+                    onChange={() =>
+                      setWeekdays(prev =>
+                        prev.includes(i) ? prev.filter(x => x !== i) : [...prev, i],
+                      )
+                    }
+                  />
+                }
+                label={d}
+              />
+            ))}
+          </Box>
+        )}
+        <TextField
+          label="End date"
+          type="date"
+          size="small"
+          value={endDate}
+          onChange={e => setEndDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+        <Button type="submit" variant="outlined" color="primary">
+          Create
+        </Button>
+      </Box>
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity={severity}
+      />
+      <Box>
+        {series.map(s => {
+          const role = roleMap.get(s.role_id);
+          const occ = bookings.filter(
+            b => b.recurring_id === s.id && b.date >= today,
+          );
+          return (
+            <Box key={s.id} sx={{ mb: 3 }}>
+              <Typography variant="h6">
+                {role?.name} ({formatTime(role?.start_time || '')}–{formatTime(role?.end_time || '')})
+              </Typography>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                {s.start_date} - {s.end_date || 'No end'} · {s.pattern}
+                {s.pattern === 'weekly' && s.days_of_week
+                  ? ` (${s.days_of_week.map(d => weekdayLabels[d]).join(', ')})`
+                  : ''}
+              </Typography>
+              <Button
+                onClick={() => cancelSeries(s.id)}
+                variant="outlined"
+                color="primary"
+                sx={{ mb: 1 }}
+              >
+                Cancel Series
+              </Button>
+              {occ.map(o => (
+                <Box key={o.id} sx={{ display: 'flex', alignItems: 'center', mb: 0.5 }}>
+                  <Typography sx={{ flexGrow: 1 }}>
+                    {o.date} ({formatTime(o.start_time)}–{formatTime(o.end_time)})
+                  </Typography>
+                  <Button
+                    onClick={() => cancelOccurrence(o.id)}
+                    variant="outlined"
+                    color="primary"
+                    size="small"
+                  >
+                    Cancel
+                  </Button>
+                </Box>
+              ))}
+            </Box>
+          );
+        })}
+      </Box>
+    </Page>
+  );
+}
+

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -128,6 +128,15 @@ export interface VolunteerBooking {
   recurring_id?: number;
 }
 
+export interface VolunteerRecurringBooking {
+  id: number;
+  role_id: number;
+  start_date: string;
+  end_date: string | null;
+  pattern: 'daily' | 'weekly';
+  days_of_week: number[] | null;
+}
+
 export interface VolunteerBookingDetail {
   id: number;
   status: VolunteerBookingStatus;

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.
-- Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts).
+- Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts). Volunteers can manage their recurring bookings from the **Recurring Bookings** page.
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification (currently disabled pending further testing).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.


### PR DESCRIPTION
## Summary
- allow volunteers to create recurring shift bookings and manage existing series
- expose API helper for fetching recurring volunteer bookings
- wire up recurring bookings page in volunteer navigation

## Testing
- `npm test` *(fails: Jest encountered an unexpected token and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b31a394d3c832d97bfd67b24ca765e