### PR TITLE
Notify volunteers of recurring booking changes

### DIFF
--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -49,3 +49,32 @@ describe('updateVolunteerBookingStatus', () => {
   });
 });
 
+describe('cancelVolunteerBookingOccurrence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends volunteer and coordinator emails when occurrence is cancelled', async () => {
+    const booking = {
+      id: 1,
+      slot_id: 2,
+      volunteer_id: 3,
+      date: '2025-09-01',
+      status: 'approved',
+      recurring_id: null,
+    };
+    const slot = { start_time: '09:00:00', end_time: '12:00:00' };
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ email: 'vol@example.com' }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [slot] });
+
+    const res = await request(app).patch('/volunteer-bookings/1/cancel');
+
+    expect(res.status).toBe(200);
+    expect((sendEmail as jest.Mock).mock.calls).toHaveLength(3);
+    expect((sendEmail as jest.Mock).mock.calls[0][0]).toBe('vol@example.com');
+  });
+});
+


### PR DESCRIPTION
## Summary
- email volunteers for each successful recurring booking and notify coordinators
- send cancellation emails for single and recurring volunteer booking cancellations
- add tests covering new notification flows

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-cron)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31ce101e0832d81a16dbcd1ffeeb3