### PR TITLE
docs: note recurring bookings submenu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Pull Request Guidelines
 
 - Ensure tests are added or updated for any code changes and run the relevant test suites after each task.
+- Keep recurring-booking tests current in both the backend and frontend whenever this feature changes.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 18+ for native `fetch`; the `node-fetch` polyfill has been removed and earlier versions are not supported.
@@ -79,6 +80,7 @@
 - Agencies can book appointments for their associated clients from the Agency → Book Appointment page. Clients load once and display only after entering a search term, with filtering performed client-side to avoid long lists.
 - Agency navigation provides Dashboard, Book Appointment, and Booking History pages, all protected by `AgencyGuard`.
 - Agencies can view pantry slot availability and manage bookings—including creating, cancelling, and rescheduling—for their linked clients.
+- Volunteer navigation includes a **Recurring Bookings** submenu for managing repeating shifts; keep related documentation up to date.
 
 ## Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.
+- **Volunteer Recurring Bookings** let volunteers schedule repeating shifts with start and end dates, choose daily, weekly, or weekday patterns, and cancel individual occurrences or the remaining series.
 - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts). Volunteers can manage their recurring bookings from the **Recurring Bookings** page.
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification (currently disabled pending further testing).


### PR DESCRIPTION
## Summary
- remind contributors to keep recurring-booking tests current and document the new volunteer Recurring Bookings submenu
- document volunteer recurring bookings features in README

## Testing
- `npm test` (MJ_FB_Backend) *(fails: jest not found)*
- `npm install` (MJ_FB_Backend) *(fails: 403 Forbidden fetching node-cron)*
- `npm test` (MJ_FB_Frontend)
- `CI=true npm test` (MJ_FB_Frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b31e544424832db637756f2bda8e87