### PR TITLE
Add index for new client bookings lookups

### DIFF
--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -375,6 +375,9 @@ CREATE TABLE IF NOT EXISTS email_queue (
     `CREATE INDEX IF NOT EXISTS bookings_user_id_idx ON bookings (user_id);`
   );
   await client.query(
+    `CREATE INDEX IF NOT EXISTS bookings_new_client_id_idx ON bookings (new_client_id);`
+  );
+  await client.query(
     `CREATE INDEX IF NOT EXISTS bookings_slot_date_status_idx ON bookings (slot_id, date, status);`
   );
   await client.query(


### PR DESCRIPTION
## Summary
- add `bookings_new_client_id_idx` index for faster lookups of `new_client_id`

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci` *(fails: 403 Forbidden retrieving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b323d4f964832dbd5abd6245b70fdb