### PR TITLE
Add index on email_queue next_attempt field

### DIFF
--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -421,6 +421,9 @@ CREATE TABLE IF NOT EXISTS email_queue (
   await client.query(
     `CREATE INDEX IF NOT EXISTS donor_aggregations_year_idx ON donor_aggregations (year);`
   );
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS email_queue_next_attempt_idx ON email_queue (next_attempt);`
+  );
 
   // Insert master data
   await client.query(`


### PR DESCRIPTION
## Summary
- improve email queue performance by indexing `next_attempt`

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-cron)*

------
https://chatgpt.com/codex/tasks/task_e_68b323da9c88832db10e0f3f1d2c3c7a