### PR TITLE
Add unique index for password setup token hash

### DIFF
--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -332,6 +332,10 @@ CREATE TABLE IF NOT EXISTS email_queue (
 );
 `);
 
+  await client.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS password_setup_tokens_token_hash_idx ON password_setup_tokens (token_hash);`
+  );
+
   // Remove duplicate slots and enforce uniqueness
   await client.query(`
     DELETE FROM slots a


### PR DESCRIPTION
## Summary
- ensure password setup tokens token_hash is unique by adding database index

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching node-cron)*

------
https://chatgpt.com/codex/tasks/task_e_68b323d7a1a4832d9bdc724a48f9ea89