### PR TITLE
feat: index new clients by creation date

### DIFF
--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -390,6 +390,11 @@ CREATE TABLE IF NOT EXISTS email_queue (
     `CREATE UNIQUE INDEX IF NOT EXISTS volunteer_bookings_reschedule_token_idx ON volunteer_bookings (reschedule_token);`
   );
 
+  // Create index for new_clients creation date
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS new_clients_created_at_idx ON new_clients (created_at DESC);`
+  );
+
   // Create indexes for donation and warehouse log tables
   await client.query(
     `CREATE INDEX IF NOT EXISTS donations_donor_id_idx ON donations (donor_id);`


### PR DESCRIPTION
## Summary
- index `new_clients` table on `created_at` for faster lookups

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b323d2771c832da051cd175966a3fd