### PR TITLE
Clarify optional email for unregistered bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 ## Features
 
  - Appointment booking workflow for clients with automatic approval and rescheduling.
-- Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
+ - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas.
  - Daily reminder jobs queue emails for next-day bookings and volunteer shifts using the backend email queue. Each job now runs via `node-cron` at `0 9 * * *` Regina time and exposes start/stop functions.
  - Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.


### PR DESCRIPTION
## Summary
- document that `/bookings/new-client` email field is optional and bookings work without an email address

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm test` (frontend) *(fails: 19 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b328ffc9b4832db29e55fd4ab59741