### PR TITLE
Configure Jest for ESM in frontend tests

### DIFF
--- a/MJ_FB_Frontend/jest.config.cjs
+++ b/MJ_FB_Frontend/jest.config.cjs
@@ -1,6 +1,12 @@
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
   testMatch: [
     '<rootDir>/src/pages/admin/__tests__/**/*.test.tsx',
     '<rootDir>/src/__tests__/**/*.test.tsx',


### PR DESCRIPTION
## Summary
- configure Jest in frontend for ESM modules

## Testing
- `CI=true npx jest --runInBand` *(fails: ReferenceError: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b32b343124832db29248d047b20e51