### PR TITLE
test: isolate fetch calls

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
@@ -10,6 +10,8 @@ jest.mock('../api/users', () => ({
 jest.mock('../pages/agency/AgencyBookAppointment', () => () => <div>AgencyBookAppointment</div>);
 jest.mock('../pages/agency/ClientHistory', () => () => <div>AgencyClientHistory</div>);
 
+const realFetch = global.fetch;
+
 describe('Agency UI access', () => {
   beforeEach(() => {
     (global as any).fetch = jest.fn().mockResolvedValue({
@@ -20,6 +22,10 @@ describe('Agency UI access', () => {
     });
     localStorage.clear();
     window.history.pushState({}, '', '/');
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
   });
 
   it('allows agency login and shows agency links', async () => {

--- a/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
 
+const realFetch = global.fetch;
+
 describe('AgencyManagement', () => {
   beforeEach(() => {
     (global as any).fetch = jest.fn().mockResolvedValue({
@@ -11,6 +13,10 @@ describe('AgencyManagement', () => {
       headers: new Headers(),
     });
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
   });
 
   it('shows tabs for adding agencies and managing clients', async () => {

--- a/MJ_FB_Frontend/src/__tests__/apiFetchRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/apiFetchRefresh.test.tsx
@@ -1,5 +1,7 @@
 import { apiFetch } from '../api/client';
 
+const realFetch = global.fetch;
+
 describe('apiFetch refresh handling', () => {
   beforeEach(() => {
     document.cookie = 'csrfToken=test';
@@ -8,15 +10,16 @@ describe('apiFetch refresh handling', () => {
       value: { assign: jest.fn(), pathname: '/' },
       writable: true,
     });
+    global.fetch = jest.fn().mockResolvedValue(new Response(null));
   });
 
   afterEach(() => {
+    global.fetch = realFetch;
     jest.resetAllMocks();
   });
 
   it('redirects when refresh returns unexpected status', async () => {
-    global.fetch = jest
-      .fn()
+    (global.fetch as jest.Mock)
       .mockResolvedValueOnce(new Response(null, { status: 401 }))
       .mockResolvedValueOnce(new Response(null, { status: 500 }));
 
@@ -25,8 +28,7 @@ describe('apiFetch refresh handling', () => {
   });
 
   it('redirects when refresh encounters network error', async () => {
-    global.fetch = jest
-      .fn()
+    (global.fetch as jest.Mock)
       .mockResolvedValueOnce(new Response(null, { status: 401 }))
       .mockRejectedValueOnce(new Error('network'))
       .mockRejectedValueOnce(new Error('network'));


### PR DESCRIPTION
## Summary
- mock global.fetch in AgencyAccess test and restore after each run
- add fetch stubs for AgencyManagement tests
- initialize and reset fetch in apiFetch refresh tests

## Testing
- `npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b32b384578832d98496708f587f786