### PR TITLE
Refactor API base initialization

### DIFF
--- a/MJ_FB_Frontend/index.html
+++ b/MJ_FB_Frontend/index.html
@@ -20,6 +20,9 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      window.VITE_API_BASE = window.VITE_API_BASE || import.meta.env.VITE_API_BASE;
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -1,6 +1,4 @@
-const API_BASE =
-  import.meta.env.VITE_API_BASE ||
-  (globalThis as any).VITE_API_BASE;
+const API_BASE = (globalThis as any).VITE_API_BASE;
 
 if (!API_BASE) {
   const message =


### PR DESCRIPTION
## Summary
- inject VITE_API_BASE into window from index.html
- reference global API base constant so jest no longer parses import.meta

## Testing
- `npm test src/__tests__/Page.test.tsx` *(fails: sets document title from props)*

------
https://chatgpt.com/codex/tasks/task_e_68b32d603264832d93816b8b198e6ab8