### PR TITLE
Guard routes using auth token refresh

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -96,7 +96,7 @@ const AgencyBookAppointment = React.lazy(() =>
 const Spinner = () => <CircularProgress />;
 
 export default function App() {
-  const { role, name, userRole, access, login, logout } = useAuth();
+  const { token, role, name, userRole, access, login, logout } = useAuth();
   const [loading] = useState(false);
   const [error, setError] = useState('');
   const isStaff = role === 'staff';
@@ -219,8 +219,8 @@ export default function App() {
 
   const navbarProps = {
     groups: navGroups,
-    onLogout: role ? logout : undefined,
-    name: role ? name || undefined : undefined,
+    onLogout: token ? logout : undefined,
+    name: token ? name || undefined : undefined,
     loading,
     role,
     profileLinks,
@@ -236,7 +236,7 @@ export default function App() {
           severity="error"
         />
 
-        {role ? (
+        {token ? (
           <MainLayout {...navbarProps}>
             <Suspense fallback={<Spinner />}>
               <Routes>

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -38,7 +38,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const stored = localStorage.getItem('id');
     return stored ? Number(stored) : null;
   });
-  const [token, setToken] = useState(role ? 'cookie' : '');
+  const [token, setToken] = useState('');
   const [sessionMessage, setSessionMessage] = useState('');
   const [cardUrl, setCardUrl] = useState('');
 
@@ -75,7 +75,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setUserRole((newUserRole as UserRole) || '');
         setAccess(newAccess ? JSON.parse(newAccess) : []);
         setId(newId ? Number(newId) : null);
-        setToken('cookie');
         setSessionMessage('Session updated in another tab');
       }
     }
@@ -90,9 +89,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const res = await apiFetch(`${API_BASE}/auth/refresh`, {
           method: 'POST',
         });
-        if (res.ok || res.status === 409) {
-          // 409 indicates another tab or request refreshed already
+        if (res.ok) {
           if (active) setToken('cookie');
+        } else if (res.status === 409) {
+          // 409 indicates another tab or request refreshed already
+          // do not set token until this tab successfully refreshes
         } else if (res.status === 401) {
           if (active) {
             clearAuth();


### PR DESCRIPTION
## Summary
- Avoid assuming a user session from stored role by initializing `token` empty
- Mark the auth `token` after a successful refresh request
- Gate `App`'s private routes on a valid `token` instead of stored `role`

## Testing
- `npm test` *(fails: multiple suites fail, e.g., `Test Suites: 15 failed, 25 passed, 40 total`)*

------
https://chatgpt.com/codex/tasks/task_e_68b32f6e3d70832d8bcc6e4c2d7dabb0