### PR TITLE
test: set brevo env vars for email tests

### DIFF
--- a/MJ_FB_Backend/tests/emailUtilsFailure.test.ts
+++ b/MJ_FB_Backend/tests/emailUtilsFailure.test.ts
@@ -4,6 +4,11 @@ import logger from '../src/utils/logger';
 describe('emailUtils error logging', () => {
   const originalFetch = global.fetch;
   let errorSpy: jest.SpyInstance;
+  const {
+    BREVO_API_KEY: originalApiKey,
+    BREVO_FROM_EMAIL: originalFromEmail,
+    BREVO_FROM_NAME: originalFromName,
+  } = process.env;
 
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({
@@ -12,11 +17,17 @@ describe('emailUtils error logging', () => {
       text: async () => 'error',
     });
     errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    process.env.BREVO_API_KEY = 'test-key';
+    process.env.BREVO_FROM_EMAIL = 'from@example.com';
+    process.env.BREVO_FROM_NAME = 'Test Sender';
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
     errorSpy.mockRestore();
+    process.env.BREVO_API_KEY = originalApiKey;
+    process.env.BREVO_FROM_EMAIL = originalFromEmail;
+    process.env.BREVO_FROM_NAME = originalFromName;
     jest.resetAllMocks();
   });
 

--- a/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
+++ b/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
@@ -2,13 +2,24 @@ import { sendTemplatedEmail } from '../src/utils/emailUtils';
 
 describe('sendTemplatedEmail', () => {
   const originalFetch = global.fetch;
+  const {
+    BREVO_API_KEY: originalApiKey,
+    BREVO_FROM_EMAIL: originalFromEmail,
+    BREVO_FROM_NAME: originalFromName,
+  } = process.env;
 
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({});
+    process.env.BREVO_API_KEY = 'test-key';
+    process.env.BREVO_FROM_EMAIL = 'from@example.com';
+    process.env.BREVO_FROM_NAME = 'Test Sender';
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
+    process.env.BREVO_API_KEY = originalApiKey;
+    process.env.BREVO_FROM_EMAIL = originalFromEmail;
+    process.env.BREVO_FROM_NAME = originalFromName;
     jest.resetAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- set BREVO env vars in sendTemplatedEmail tests
- set BREVO env vars in email utility failure tests

## Testing
- `npm test` *(fails: tests/emailQueue.test.ts:138:55 - error TS2345: Argument of type 'Error' is not assignable to parameter of type 'never'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3319a1e20832d850a2ae4cb43bc2f