### PR TITLE
fix: expose VITE_API_BASE in module context

### DIFF
--- a/MJ_FB_Frontend/index.html
+++ b/MJ_FB_Frontend/index.html
@@ -20,7 +20,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <script>
+    <script type="module">
       window.VITE_API_BASE = window.VITE_API_BASE || import.meta.env.VITE_API_BASE;
     </script>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
## Summary
- ensure VITE_API_BASE is initialized within ES module context

## Testing
- `npm test` *(fails: Test Suites: 15 failed, 25 passed, 40 total; Tests: 25 failed, 67 passed, 92 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b331b6db50832d9387e49426e8d500