### PR TITLE
Ensure tests set NODE_ENV before reminder job imports

### DIFF
--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -1,6 +1,11 @@
+process.env.NODE_ENV = 'development';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
-import * as bookingReminder from '../src/utils/bookingReminderJob';
-const { sendNextDayBookingReminders, startBookingReminderJob, stopBookingReminderJob } = bookingReminder;
+const bookingReminder = require('../src/utils/bookingReminderJob');
+const {
+  sendNextDayBookingReminders,
+  startBookingReminderJob,
+  stopBookingReminderJob,
+} = bookingReminder;
 import { fetchBookingsForReminder } from '../src/models/bookingRepository';
 import { enqueueEmail } from '../src/utils/emailQueue';
 
@@ -16,10 +21,12 @@ describe('sendNextDayBookingReminders', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+    process.env.NODE_ENV = 'development';
   });
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
+    process.env.NODE_ENV = 'test';
   });
 
   it('fetches next-day bookings and queues reminder emails', async () => {

--- a/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
@@ -1,6 +1,10 @@
+process.env.NODE_ENV = 'development';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
-import * as volunteerJob from '../src/utils/volunteerShiftReminderJob';
-const { startVolunteerShiftReminderJob, stopVolunteerShiftReminderJob } = volunteerJob;
+const volunteerJob = require('../src/utils/volunteerShiftReminderJob');
+const {
+  startVolunteerShiftReminderJob,
+  stopVolunteerShiftReminderJob,
+} = volunteerJob;
 
 describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
   let scheduleMock: jest.Mock;


### PR DESCRIPTION
## Summary
- Set `NODE_ENV` to development before importing reminder job modules in booking and volunteer shift reminder tests
- Reset `NODE_ENV` to test after each test to avoid leakage

## Testing
- `npm test` *(fails: Argument of type 'Error' is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68b3319caff4832dbe81af84dc0264ba