### PR TITLE
Polyfill fetch in tests and clarify Node 18 requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 
 - For changes in `MJ_FB_Backend`, run `npm test` from the `MJ_FB_Backend` directory.
 - For changes in `MJ_FB_Frontend`, run `npm test` from the `MJ_FB_Frontend` directory.
+- Tests polyfill `global.fetch` with `undici` in a `beforeAll`; keep this setup for compatibility.
 - Tests for invitation and password setup flows live in `MJ_FB_Backend/tests/passwordResetFlow.test.ts`; run `npm test tests/passwordResetFlow.test.ts` when working on these features.
 
 - Volunteers can earn badges. Use `GET /volunteers/me/stats` to retrieve badges and

--- a/MJ_FB_Backend/jest.config.js
+++ b/MJ_FB_Backend/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
   setupFiles: ['<rootDir>/tests/setupEnv.ts'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setupFetch.ts'],
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "license": "ISC",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "bcrypt": "^6",
@@ -33,7 +33,8 @@
     "supertest": "^7",
     "ts-jest": "^29",
     "tsx": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "undici": "^6"
   },
   "overrides": {
     "test-exclude": "^7"

--- a/MJ_FB_Backend/tests/setupFetch.ts
+++ b/MJ_FB_Backend/tests/setupFetch.ts
@@ -1,0 +1,10 @@
+import { fetch, Headers, Request, Response, FormData, File } from 'undici';
+
+beforeAll(() => {
+  (global as any).fetch = fetch;
+  (global as any).Headers = Headers as any;
+  (global as any).Request = Request as any;
+  (global as any).Response = Response as any;
+  (global as any).FormData = FormData as any;
+  (global as any).File = File as any;
+});

--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -1,11 +1,21 @@
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
+import { fetch, Headers, Request, Response, FormData, File } from 'undici';
 
 // Polyfill TextEncoder/Decoder for testing environment
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder as any;
 (Element.prototype as any).scrollIntoView = jest.fn();
 (global as any).VITE_API_BASE = 'http://localhost:4000';
+
+beforeAll(() => {
+  (global as any).fetch = fetch;
+  (global as any).Headers = Headers as any;
+  (global as any).Request = Request as any;
+  (global as any).Response = Response as any;
+  (global as any).FormData = FormData as any;
+  (global as any).File = File as any;
+});
 
 // Mock ResizeObserver and IntersectionObserver for testing environment
 class ResizeObserver {

--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "dev": "vite",
@@ -56,6 +56,7 @@
     "ts-jest": "^29",
     "typescript": "^5",
     "typescript-eslint": "^8",
+    "undici": "^6",
     "vite": "^7"
   },
   "overrides": {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 
 ## Contribution Guidelines
 
+- Use Node.js 18 or later for development; the backend relies on the native `fetch` API.
 - The frontend requires a live internet connection; offline caching or offline-first optimizations must not be added.
 - Run the relevant backend and frontend test suites (`npm test`) after making changes.
 - Update `AGENTS.md` with new repository instructions.
@@ -191,7 +192,7 @@ openssl rand -hex 32
 ## Frontend setup (`MJ_FB_Frontend`)
 
 Prerequisites:
-- Node.js and npm
+- Node.js 18 or later and npm
 
 Install and run:
 ```bash


### PR DESCRIPTION
## Summary
- document Node 18+ requirement for contributors and frontend setup
- use undici to polyfill global.fetch in backend and frontend tests
- note fetch polyfill in AGENTS guidelines

## Testing
- `node --version`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test` (backend) *(fails: Cannot find module 'undici' from 'tests/setupFetch.ts')*
- `CI=true npx jest src/__tests__/App.test.tsx` *(fails: Cannot find module 'undici' from 'jest.setup.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68b331a4e61c832d80e35d5afda31c6f