### PR TITLE
test: use client_id in new client routes test

### DIFF
--- a/MJ_FB_Backend/tests/newClientsRoutes.test.ts
+++ b/MJ_FB_Backend/tests/newClientsRoutes.test.ts
@@ -25,10 +25,12 @@ beforeEach(() => {
 
 describe('new clients routes', () => {
   it('lists new clients', async () => {
-    (model.fetchNewClients as jest.Mock).mockResolvedValue([{ id: 1, name: 'A' }]);
+    (model.fetchNewClients as jest.Mock).mockResolvedValue([
+      { client_id: 1, name: 'A' },
+    ]);
     const res = await request(app).get('/new-clients');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([{ id: 1, name: 'A' }]);
+    expect(res.body).toEqual([{ client_id: 1, name: 'A' }]);
   });
 
   it('validates id on delete', async () => {


### PR DESCRIPTION
## Summary
- align new client route tests with client_id schema

## Testing
- `npm test` *(fails: Cannot find module 'undici')*

------
https://chatgpt.com/codex/tasks/task_e_68b33692eb98832da79063660126f83e