### PR TITLE
Allow password setup without redirect

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/clearAuthRedirect.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/clearAuthRedirect.test.tsx
@@ -1,0 +1,50 @@
+import { apiFetch } from '../api/client';
+
+describe('clearAuthAndRedirect', () => {
+  const realFetch = global.fetch;
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    window.location = originalLocation;
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('redirects to /login by default', async () => {
+    const assign = jest.fn();
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/some', assign },
+      writable: true,
+    });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 401,
+      ok: false,
+      headers: new Headers(),
+    } as Response);
+
+    await apiFetch('/auth/refresh');
+
+    expect(assign).toHaveBeenCalledWith('/login');
+  });
+
+  it('does not redirect from set-password path', async () => {
+    const assign = jest.fn();
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/set-password', assign },
+      writable: true,
+    });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 401,
+      ok: false,
+      headers: new Headers(),
+    } as Response);
+
+    await apiFetch('/auth/refresh');
+
+    expect(assign).not.toHaveBeenCalled();
+  });
+});
+

--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -148,7 +148,8 @@ function clearAuthAndRedirect() {
   localStorage.removeItem('userRole');
   localStorage.removeItem('access');
   localStorage.removeItem('id');
-  if (!window.location.pathname.startsWith('/login')) {
+  const path = window.location.pathname;
+  if (!path.startsWith('/login') && !path.startsWith('/set-password')) {
     window.location.assign('/login');
   }
 }


### PR DESCRIPTION
## Summary
- Avoid redirecting to login when visiting `/set-password`
- Test redirect behavior for set-password path

## Testing
- `npm test` *(fails: Cannot find module 'undici' from 'jest.setup.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68b336847014832dbf0bf5745305b6e8