### PR TITLE
Redirect to role-specific login after password setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@
 - Volunteer Settings provides separate dialogs for creating sub-roles (with an initial shift) and for adding or editing shifts.
 - Deleting sub-roles and shifts prompts confirmation dialogs to prevent accidental removal.
 - Users complete initial password creation at `/set-password` using a token from the setup email.
+- After setting a password, users are redirected to the login page for their role.
 - Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations.
   Initially, the page shows only agency search; selecting an agency reveals a two-column layout with client search on the left and the agency's client list on the right.

--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -191,7 +191,13 @@ export async function setPassword(
       [hash, row.user_id],
     );
     await markPasswordTokenUsed(row.id);
-    res.status(204).send();
+    const loginPathMap: Record<string, string> = {
+      staff: '/login/staff',
+      volunteers: '/login/volunteer',
+      agencies: '/login/agency',
+      clients: '/login/user',
+    };
+    res.json({ loginPath: loginPathMap[row.user_type] });
   } catch (err) {
     next(err);
   }

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -86,7 +86,8 @@ describe('setPassword', () => {
     const res = await request(app)
       .post('/auth/set-password')
       .send({ token: 'tok', password: 'Abcd1234!' });
-    expect(res.status).toBe(204);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ loginPath: '/login/staff' });
     expect(bcrypt.hash).toHaveBeenCalledWith('Abcd1234!', 10);
     expect(pool.query).toHaveBeenNthCalledWith(
       1,

--- a/MJ_FB_Frontend/src/__tests__/PasswordSetup.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PasswordSetup.test.tsx
@@ -3,14 +3,24 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import PasswordSetup from '../pages/auth/PasswordSetup';
 import { setPassword, resendPasswordSetup } from '../api/users';
 
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
 jest.mock('../api/users', () => ({
   setPassword: jest.fn(),
   resendPasswordSetup: jest.fn(),
 }));
 
 describe('PasswordSetup', () => {
-  it('submits password with token from query', async () => {
-    (setPassword as jest.Mock).mockResolvedValue(undefined);
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+  it('submits password with token from query and redirects', async () => {
+    (setPassword as jest.Mock).mockResolvedValue('/login/user');
     render(
       <MemoryRouter initialEntries={["/set-password?token=abc123"]}>
         <Routes>
@@ -23,7 +33,7 @@ describe('PasswordSetup', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /set password/i }));
     await waitFor(() => expect(setPassword).toHaveBeenCalledWith('abc123', 'Passw0rd!'));
-    await waitFor(() => expect(screen.getByText(/password set/i)).toBeInTheDocument());
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login/user'));
   });
 
   it('shows resend link dialog when token expired', async () => {

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -94,13 +94,14 @@ export async function changePassword(
 export async function setPassword(
   token: string,
   password: string,
-): Promise<void> {
+): Promise<string> {
   const res = await apiFetch(`${API_BASE}/auth/set-password`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ token, password }),
   });
-  await handleResponse(res);
+  const data = (await handleResponse(res)) as { loginPath: string };
+  return data.loginPath;
 }
 
 export async function getUserProfile(): Promise<UserProfile> {

--- a/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSearchParams, Link as RouterLink } from 'react-router-dom';
+import { useSearchParams, Link as RouterLink, useNavigate } from 'react-router-dom';
 import { TextField, Button, Link } from '@mui/material';
 import Page from '../../components/Page';
 import FormCard from '../../components/FormCard';
@@ -11,9 +11,9 @@ export default function PasswordSetup() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token') || '';
   const [password, setPassword] = useState('');
-  const [success, setSuccess] = useState('');
   const [error, setError] = useState('');
   const [resendOpen, setResendOpen] = useState(false);
+  const navigate = useNavigate();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -22,9 +22,8 @@ export default function PasswordSetup() {
       return;
     }
     try {
-      await setPasswordApi(token, password);
-      setSuccess('Password set. You may now log in.');
-      setPassword('');
+      const loginPath = await setPasswordApi(token, password);
+      navigate(loginPath);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       setError(msg);
@@ -62,12 +61,6 @@ export default function PasswordSetup() {
           </Link>
         )}
       </FormCard>
-      <FeedbackSnackbar
-        open={!!success}
-        onClose={() => setSuccess('')}
-        message={success}
-        severity="success"
-      />
       <FeedbackSnackbar
         open={!!error}
         onClose={() => setError('')}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Backend email queue retries failed sends with exponential backoff and persists jobs in an `email_queue` table so retries survive restarts. The maximum retries and initial delay are configurable.
 - Accounts for clients, volunteers, staff, and agencies are created without passwords; a one-time setup link directs them to `/set-password` for initial password creation.
+- After setting a password, users are redirected to the login page for their role.
 - `POST /auth/resend-password-setup` reissues this link when the original token expires. Requests are rate limited by email or client ID.
 - Users see a random appreciation message on each login with a link to download their card when available.
 - Volunteers also see rotating encouragement messages on the dashboard when no milestone is reached.
@@ -123,6 +124,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 ### Invitation flow
 
 New clients, volunteers, staff, and agencies are created without passwords. The backend generates a one-time token and emails a setup link using the Brevo template defined by `PASSWORD_SETUP_TEMPLATE_ID`. The link points to `/set-password` on the first origin listed in `FRONTEND_ORIGIN`.
+After setting a password, users are redirected to the login page for their role.
 
 ### Agency setup
 


### PR DESCRIPTION
## Summary
- return login path from password setup API and redirect users accordingly
- adjust frontend password setup flow and tests for redirection
- document automatic post-setup login redirect

## Testing
- `npm test tests/passwordResetFlow.test.ts` *(fails: Cannot find module 'undici')*
- `npm test src/__tests__/PasswordSetup.test.tsx` *(fails: Cannot find module 'undici')*

------
https://chatgpt.com/codex/tasks/task_e_68b33d156710832db0d62d8a161ab546