### PR TITLE
fix: remove padding from navbar menus

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -144,6 +144,7 @@ export default function Navbar({
                 PaperProps={menuPaperProps}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                 transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                MenuListProps={{ disablePadding: true }}
               >
                 {groups.map((group) => (
                   <Box key={group.label} sx={{ px: 1, py: 0.5 }}>
@@ -267,7 +268,7 @@ export default function Navbar({
                     PaperProps={menuPaperProps}
                     anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                     transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-                    MenuListProps={{ dense: true, disablePadding: false, sx: { p: 1 } }}
+                    MenuListProps={{ dense: true, disablePadding: true }}
                   >
                     {group.links.map(({ label, to }) => (
                       <MenuItem
@@ -313,7 +314,7 @@ export default function Navbar({
                   PaperProps={menuPaperProps}
                   anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                   transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-                  MenuListProps={{ dense: true, disablePadding: false, sx: { p: 1 } }}
+                  MenuListProps={{ dense: true, disablePadding: true }}
                 >
                   {role === 'staff' &&
                     profileLinks?.map(({ label, to }) => (


### PR DESCRIPTION
## Summary
- remove extra list padding from navbar menus so submenu items control their own spacing

## Testing
- `npm test` *(fails: Cannot find module 'undici' from 'jest.setup.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68b33d69d4ec832d985feab14e5d83f3