### PR TITLE
Add spacing between next slot buttons

### DIFF
--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -213,7 +213,7 @@ export default function ClientDashboard() {
               title="Next Available Slots"
               icon={<EventAvailable color="primary" />}
             >
-              <List>
+              <List sx={{ '& .MuiListItem-root:not(:last-child)': { mb: 1 } }}>
                 {nextSlots.length ? (
                   nextSlots.map(s => (
                     <ListItem


### PR DESCRIPTION
## Summary
- add margin between Next Available Slot items so Book buttons aren't touching

## Testing
- `npm test` *(fails: Cannot find module 'undici' in jest.setup.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f0c3c54832d9846d0ee60b57245