### PR TITLE
Limit appreciation messages to volunteers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 - `GET /slots` returns an empty array with a 200 status on holidays.
 - Agencies can retrieve holiday dates via `GET /holidays` to disable bookings on those days.
 - Milestone badge awards queue a thank-you card email and expose a downloadable card link via `/stats`.
-- Users see a random appreciation message on login.
+- Volunteers see a random appreciation message on login.
 - The volunteer dashboard rotates encouragement messages when no milestone is reached.
 - The volunteer dashboard shows a monthly contribution line chart of shift counts.
 - Self-service client registration with email OTP verification is implemented but currently disabled.

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -139,7 +139,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       else localStorage.removeItem('id');
       localStorage.removeItem('encouragementOrder');
       localStorage.removeItem('encouragementIndex');
-      setSessionMessage(getRandomAppreciation());
+      setSessionMessage(
+        u.role === 'volunteer' ? getRandomAppreciation() : '',
+      );
       try {
         const statsRes = await apiFetch(`${API_BASE}/stats`);
         if (statsRes.ok) {

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Accounts for clients, volunteers, staff, and agencies are created without passwords; a one-time setup link directs them to `/set-password` for initial password creation.
 - After setting a password, users are redirected to the login page for their role.
 - `POST /auth/resend-password-setup` reissues this link when the original token expires. Requests are rate limited by email or client ID.
-- Users see a random appreciation message on each login with a link to download their card when available.
+- Volunteers see a random appreciation message on each login with a link to download their card when available.
 - Volunteers also see rotating encouragement messages on the dashboard when no milestone is reached.
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.
 - Conflicting volunteer shift requests return a 409 with both the attempted and existing shift details; resolve conflicts via `POST /volunteer-bookings/resolve-conflict`.


### PR DESCRIPTION
## Summary
- show random appreciation messages only to volunteers on login
- test that volunteers see the message and staff do not
- document that appreciation messages apply to volunteers only

## Testing
- `npm test src/__tests__/loginAppreciation.test.tsx` (fails: Cannot find module 'undici')


------
https://chatgpt.com/codex/tasks/task_e_68b33ef37644832dbb48c4720d96e162