### PR TITLE
feat: remove warehouse rebuild button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,7 +374,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 
 ### Warehouse Management
 - `/warehouse-overall` routes provide yearly summaries of donations, surplus, pig pound, and outgoing donations.
-- `GET /warehouse-overall?year=YYYY` lists monthly aggregates, `POST /warehouse-overall/rebuild?year=YYYY` rebuilds data, and `GET /warehouse-overall/export?year=YYYY` exports it as a spreadsheet.
+- `GET /warehouse-overall?year=YYYY` lists monthly aggregates, and `GET /warehouse-overall/export?year=YYYY` exports it as a spreadsheet. Aggregates update in real time; manual rebuilds are no longer needed.
 - Frontend pages under `/warehouse-management/*` (Dashboard, Donation Log, Track Pigpound, Track Outgoing Donations, Track Surplus, Aggregations) surface these warehouse features.
 
 ## Slot API

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -18,7 +18,6 @@ import {
   Stack,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import Autorenew from '@mui/icons-material/Autorenew';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import TrendingUp from '@mui/icons-material/TrendingUp';
 import WarningAmber from '@mui/icons-material/WarningAmber';
@@ -41,11 +40,7 @@ import { useAuth } from '../../hooks/useAuth';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import VolunteerCoverageCard from '../../components/dashboard/VolunteerCoverageCard';
 import EventList from '../../components/EventList';
-import {
-  getWarehouseOverall,
-  getWarehouseOverallYears,
-  rebuildWarehouseOverall,
-} from '../../api/warehouseOverall';
+import { getWarehouseOverall, getWarehouseOverallYears } from '../../api/warehouseOverall';
 import {
   getTopDonors,
   type TopDonor,
@@ -95,7 +90,6 @@ export default function WarehouseDashboard() {
   const [receivers, setReceivers] = useState<TopReceiver[]>([]);
   const [events, setEvents] = useState<EventGroups>({ today: [], upcoming: [], past: [] });
   const [, setLoadingTotals] = useState(false);
-  const [loadingRebuild, setLoadingRebuild] = useState(false);
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: string;
@@ -247,20 +241,6 @@ export default function WarehouseDashboard() {
     navigate(path);
   }
 
-  async function handleRebuild() {
-    setLoadingRebuild(true);
-    try {
-      await rebuildWarehouseOverall(year!);
-      setSnackbar({ open: true, message: 'Rebuilt aggregates' });
-      loadData(year!);
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Rebuild failed';
-      setSnackbar({ open: true, message, severity: 'error' });
-    } finally {
-      setLoadingRebuild(false);
-    }
-  }
-
 
   const kpis = [
     { title: 'Incoming (Donations)', value: currentTotals?.donationsLbs ?? 0, prev: prevTotals?.donationsLbs ?? 0 },
@@ -318,16 +298,6 @@ export default function WarehouseDashboard() {
             )}
             sx={{ minWidth: 200 }}
           />
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<Autorenew />}
-            onClick={handleRebuild}
-            disabled={loadingRebuild}
-            aria-busy={loadingRebuild}
-          >
-            Rebuild Year
-          </Button>
         </Stack>
       </Stack>
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ control weight calculations:
 - Pages are organized into feature-based directories (e.g., booking, staff, volunteer-management, warehouse-management).
 - A shared dashboard component lives in `src/components/dashboard`.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
+- Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.
 - Page and form titles render in uppercase with a lighter font weight for clarity.
 - Admin staff creation page provides a link back to the staff list for easier navigation.
 - Admin navigation includes Pantry Settings and Volunteer Settings pages.


### PR DESCRIPTION
## Summary
- remove manual "Rebuild Year" button from warehouse dashboard now that aggregates are real-time
- document that warehouse totals update automatically and remove rebuild mention

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci` *(fails: 403 Forbidden for undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b3779e23ec832d8c152a0e6dd19e3a