### PR TITLE
feat: add volunteer shift management dialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageVolunteerShiftDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageVolunteerShiftDialog.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ManageVolunteerShiftDialog from '../components/ManageVolunteerShiftDialog';
+
+jest.mock('../api/volunteers', () => ({
+  getRoleShifts: jest.fn(),
+  getVolunteerBookingsByRole: jest.fn(),
+  rescheduleVolunteerBookingByToken: jest.fn(),
+  updateVolunteerBookingStatus: jest.fn(),
+}));
+
+const {
+  getRoleShifts,
+  getVolunteerBookingsByRole,
+  rescheduleVolunteerBookingByToken,
+  updateVolunteerBookingStatus,
+} = jest.requireMock('../api/volunteers');
+
+describe('ManageVolunteerShiftDialog', () => {
+  const booking = {
+    id: 1,
+    role_id: 1,
+    volunteer_id: 2,
+    volunteer_name: 'Vol',
+    role_name: 'Pantry',
+    date: '2024-02-01',
+    start_time: '09:00:00',
+    end_time: '12:00:00',
+    status: 'approved',
+    reschedule_token: 'abc',
+  } as any;
+
+  beforeAll(() => {
+    window.matchMedia =
+      window.matchMedia ||
+      ((() => ({
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+      })) as any);
+  });
+
+  beforeEach(() => {
+    (getRoleShifts as jest.Mock).mockReset();
+    (getVolunteerBookingsByRole as jest.Mock).mockReset();
+    (rescheduleVolunteerBookingByToken as jest.Mock).mockReset();
+    (updateVolunteerBookingStatus as jest.Mock).mockReset();
+  });
+
+  it('marks shift completed', async () => {
+    const onUpdated = jest.fn();
+    render(
+      <ManageVolunteerShiftDialog open booking={booking} onClose={() => {}} onUpdated={onUpdated} />,
+    );
+
+    fireEvent.mouseDown(screen.getByLabelText(/status/i));
+    fireEvent.click(await screen.findByRole('option', { name: /completed/i }));
+    fireEvent.click(screen.getByText(/submit/i));
+
+    await waitFor(() =>
+      expect(updateVolunteerBookingStatus).toHaveBeenCalledWith(1, 'completed'),
+    );
+    expect(onUpdated).toHaveBeenCalledWith('Status updated', 'success');
+  });
+
+  it('reschedules shift', async () => {
+    (getRoleShifts as jest.Mock).mockResolvedValue([
+      { shiftId: 10, startTime: '09:00:00', endTime: '12:00:00', maxVolunteers: 2 },
+    ]);
+    (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([]);
+
+    const onUpdated = jest.fn();
+    render(
+      <ManageVolunteerShiftDialog open booking={booking} onClose={() => {}} onUpdated={onUpdated} />,
+    );
+
+    fireEvent.mouseDown(screen.getByLabelText(/status/i));
+    fireEvent.click(await screen.findByRole('option', { name: /reschedule/i }));
+
+    fireEvent.change(screen.getByLabelText(/date/i), {
+      target: { value: '2024-02-02' },
+    });
+
+    fireEvent.mouseDown(screen.getByLabelText(/shift/i));
+    fireEvent.click(await screen.findByRole('option', { name: /9:00/i }));
+
+    fireEvent.click(screen.getByText(/submit/i));
+
+    await waitFor(() =>
+      expect(rescheduleVolunteerBookingByToken).toHaveBeenCalledWith('abc', 10, '2024-02-02'),
+    );
+    expect(onUpdated).toHaveBeenCalledWith('Booking rescheduled', 'success');
+  });
+});
+

--- a/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  MenuItem,
+  Stack,
+  Typography,
+} from '@mui/material';
+import type { AlertColor } from '@mui/material';
+import DialogCloseButton from './DialogCloseButton';
+import FeedbackSnackbar from './FeedbackSnackbar';
+import {
+  getRoleShifts,
+  getVolunteerBookingsByRole,
+  rescheduleVolunteerBookingByToken,
+  updateVolunteerBookingStatus,
+} from '../api/volunteers';
+import type { VolunteerBookingDetail, Shift } from '../types';
+import type { ApiError } from '../api/client';
+import { formatTime } from '../utils/time';
+
+interface ManageVolunteerShiftDialogProps {
+  open: boolean;
+  booking: VolunteerBookingDetail;
+  onClose: () => void;
+  onUpdated: (message: string, severity: AlertColor) => void;
+}
+
+export default function ManageVolunteerShiftDialog({
+  open,
+  booking,
+  onClose,
+  onUpdated,
+}: ManageVolunteerShiftDialogProps) {
+  const [status, setStatus] = useState('');
+  const [date, setDate] = useState('');
+  const [shiftId, setShiftId] = useState('');
+  const [shifts, setShifts] = useState<Shift[]>([]);
+  const [bookings, setBookings] = useState<any[]>([]);
+  const [reason, setReason] = useState('');
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<AlertColor>('success');
+  const todayStr = new Date().toISOString().split('T')[0];
+
+  useEffect(() => {
+    if (open) {
+      setStatus('');
+      setDate('');
+      setShiftId('');
+      setShifts([]);
+      setBookings([]);
+      setReason('');
+      setMessage('');
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (status === 'reschedule') {
+      (async () => {
+        try {
+          const s = await getRoleShifts(booking.role_id);
+          setShifts(s);
+          const data = await Promise.all(
+            s.map(sh => getVolunteerBookingsByRole(sh.shiftId)),
+          );
+          setBookings(data.flat());
+        } catch {
+          setShifts([]);
+          setBookings([]);
+        }
+      })();
+    } else {
+      setShifts([]);
+      setBookings([]);
+      setDate('');
+      setShiftId('');
+    }
+  }, [status, booking.role_id]);
+
+  function timesOverlap(
+    startA: string,
+    endA: string,
+    startB: string,
+    endB: string,
+  ) {
+    return startA < endB && startB < endA;
+  }
+
+  function isShiftDisabled(shift: Shift): boolean {
+    if (!date) return true;
+    const bookingsForShift = bookings.filter(
+      b =>
+        b.role_id === shift.shiftId &&
+        b.date === date &&
+        b.id !== booking.id &&
+        b.status !== 'cancelled',
+    );
+    const isFull = bookingsForShift.length >= shift.maxVolunteers;
+    const volunteerConflict = bookings.some(
+      b =>
+        b.volunteer_id === booking.volunteer_id &&
+        b.id !== booking.id &&
+        b.date === date &&
+        timesOverlap(b.start_time, b.end_time, shift.startTime, shift.endTime),
+    );
+    return isFull || volunteerConflict;
+  }
+
+  async function handleSubmit() {
+    try {
+      switch (status) {
+        case 'reschedule':
+          if (!date || !shiftId) {
+            setSeverity('error');
+            setMessage('Please select date and time');
+            return;
+          }
+          await rescheduleVolunteerBookingByToken(
+            booking.reschedule_token || '',
+            Number(shiftId),
+            date,
+          );
+          onUpdated('Booking rescheduled', 'success');
+          onClose();
+          return;
+        case 'cancel':
+          if (!reason.trim()) {
+            setSeverity('error');
+            setMessage('Reason required');
+            return;
+          }
+          await updateVolunteerBookingStatus(booking.id, 'cancelled', reason);
+          onUpdated('Booking cancelled', 'success');
+          onClose();
+          return;
+        case 'completed':
+        case 'no_show':
+          await updateVolunteerBookingStatus(booking.id, status as any);
+          onUpdated('Status updated', 'success');
+          onClose();
+          return;
+        default:
+          setSeverity('error');
+          setMessage('Please select a status');
+          return;
+      }
+    } catch (e) {
+      const err = e as ApiError;
+      setSeverity('error');
+      setMessage(err.message || 'Action failed');
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogCloseButton onClose={onClose} />
+      <DialogTitle>Manage Shift</DialogTitle>
+      <DialogContent sx={{ pt: 2 }}>
+        <Stack spacing={2}>
+          <Typography>Volunteer: {booking.volunteer_name}</Typography>
+          <Typography>
+            {booking.role_name} on {booking.date} {formatTime(booking.start_time)} - {formatTime(booking.end_time)}
+          </Typography>
+          <TextField
+            select
+            label="Status"
+            value={status}
+            onChange={e => setStatus(e.target.value)}
+            fullWidth
+          >
+            <MenuItem value="completed">Completed</MenuItem>
+            <MenuItem value="no_show">No Show</MenuItem>
+            <MenuItem value="cancel">Cancel</MenuItem>
+            <MenuItem value="reschedule">Reschedule</MenuItem>
+          </TextField>
+          {status === 'cancel' && (
+            <TextField
+              label="Reason"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+              fullWidth
+            />
+          )}
+          {status === 'reschedule' && (
+            <>
+              <TextField
+                type="date"
+                label="Date"
+                value={date}
+                onChange={e => setDate(e.target.value)}
+                fullWidth
+                margin="normal"
+                InputLabelProps={{ shrink: true }}
+                inputProps={{ min: todayStr }}
+              />
+              <TextField
+                select
+                label="Shift"
+                value={shiftId}
+                onChange={e => setShiftId(e.target.value)}
+                fullWidth
+                margin="normal"
+                disabled={!date}
+              >
+                {shifts.map(s => (
+                  <MenuItem
+                    key={s.shiftId}
+                    value={s.shiftId.toString()}
+                    disabled={isShiftDisabled(s)}
+                  >
+                    {`${formatTime(s.startTime)} - ${formatTime(s.endTime)}`}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </>
+          )}
+          <FeedbackSnackbar
+            open={!!message}
+            message={message}
+            onClose={() => setMessage('')}
+            severity={severity}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleSubmit} variant="outlined" color="primary">
+          Submit
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -113,6 +113,7 @@ export type VolunteerBookingStatus =
   | 'rejected'
   | 'cancelled'
   | 'no_show'
+  | 'completed'
   | 'expired';
 
 export interface VolunteerBooking {


### PR DESCRIPTION
## Summary
- add ManageVolunteerShiftDialog for staff to reschedule or update volunteer shift statuses
- support completed status in volunteer booking types
- test volunteer shift management actions

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden on undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b37afb3afc832d9452c36ac8dd89bf