### PR TITLE
refactor: use manage shift dialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -12,7 +12,6 @@ import {
   updateVolunteerTrainedAreas,
   createVolunteerBookingForVolunteer,
   getVolunteerBookingsByRole,
-  cancelVolunteerBooking,
   resolveVolunteerBookingConflict,
 } from '../api/volunteers';
 
@@ -25,7 +24,6 @@ jest.mock('../api/volunteers', () => ({
   updateVolunteerTrainedAreas: jest.fn(),
   createVolunteerBookingForVolunteer: jest.fn(),
   getVolunteerBookingsByRole: jest.fn(),
-  cancelVolunteerBooking: jest.fn(),
   resolveVolunteerBookingConflict: jest.fn(),
 }));
 
@@ -45,7 +43,6 @@ beforeEach(() => {
   (updateVolunteerTrainedAreas as jest.Mock).mockResolvedValue(undefined);
   (createVolunteerBookingForVolunteer as jest.Mock).mockResolvedValue(undefined);
   (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([]);
-  (cancelVolunteerBooking as jest.Mock).mockResolvedValue(undefined);
 });
 
 describe('VolunteerManagement shopper profile', () => {


### PR DESCRIPTION
## Summary
- replace manual overlay with `ManageVolunteerShiftDialog`
- refresh bookings and history after shift updates
- simplify booking history actions to a single Manage button

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden for undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b3803f524c832d97cdae62718bbe1f