### PR TITLE
Add ready state for auth refresh and defer login routes

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -99,7 +99,7 @@ const AgencyBookAppointment = React.lazy(() =>
 const Spinner = () => <CircularProgress />;
 
 export default function App() {
-  const { token, role, name, userRole, access, login, logout } = useAuth();
+  const { token, ready, role, name, userRole, access, login, logout } = useAuth();
   const [loading] = useState(false);
   const [error, setError] = useState('');
   const isStaff = role === 'staff';
@@ -426,6 +426,8 @@ export default function App() {
             </Routes>
             </Suspense>
           </MainLayout>
+        ) : !ready ? (
+          <Spinner />
         ) : (
           <>
             <Navbar {...navbarProps} />

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -37,13 +37,19 @@ describe('App authentication persistence', () => {
     }
   });
 
-  it('shows login when not authenticated', () => {
+  it('shows login when not authenticated', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
     render(
       <AuthProvider>
         <App />
       </AuthProvider>,
     );
-    expect(screen.getByText(/client login/i)).toBeInTheDocument();
+    expect(await screen.findByText(/client login/i)).toBeInTheDocument();
   });
 
   it('keeps user logged in when role exists', () => {

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -18,6 +18,7 @@ interface AuthContextValue {
   login: (u: LoginResponse) => Promise<void>;
   logout: () => Promise<void>;
   cardUrl: string;
+  ready: boolean;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -41,6 +42,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState('');
   const [sessionMessage, setSessionMessage] = useState('');
   const [cardUrl, setCardUrl] = useState('');
+  const [ready, setReady] = useState(false);
 
   const clearAuth = useCallback(() => {
     setToken('');
@@ -114,7 +116,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       }
     };
-    attemptRefresh();
+    attemptRefresh().finally(() => {
+      if (active) setReady(true);
+    });
     return () => {
       active = false;
     };
@@ -176,6 +180,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     login,
     logout,
     cardUrl,
+    ready,
   };
 
   return (


### PR DESCRIPTION
## Summary
- track refresh completion via `ready` flag in auth provider
- show placeholder until refresh finishes and expose `ready` in context
- adjust app tests to expect login after refresh attempt

## Testing
- `npm test src/__tests__/App.test.tsx src/__tests__/useAuthRefresh.test.tsx` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b381b6e9d8832db68aebb3d43672a9