### PR TITLE
Handle auth refresh 409 responses

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider } from '../hooks/useAuth';
+import { AuthProvider, useAuth } from '../hooks/useAuth';
 
 const realFetch = global.fetch;
 
@@ -25,5 +25,25 @@ describe('AuthProvider refresh handling', () => {
 
     await waitFor(() => expect(localStorage.getItem('role')).toBeNull());
     expect(await screen.findByText('Session expired')).toBeInTheDocument();
+  });
+
+  it('retains auth when refresh returns 409', async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 409 });
+
+    function Child() {
+      const { token, ready } = useAuth();
+      return <div>{ready ? token : ''}</div>;
+    }
+
+    render(
+      <AuthProvider>
+        <Child />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('cookie')).toBeInTheDocument());
+    expect(localStorage.getItem('role')).toBe('staff');
   });
 });

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -94,8 +94,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (res.ok) {
           if (active) setToken('cookie');
         } else if (res.status === 409) {
-          // 409 indicates another tab or request refreshed already
-          // do not set token until this tab successfully refreshes
+          // Another tab already refreshed; token cookie is still valid
+          if (active) setToken('cookie');
         } else if (res.status === 401) {
           if (active) {
             clearAuth();


### PR DESCRIPTION
## Summary
- Treat 409 refresh responses as successful in AuthProvider
- Add test ensuring session persists when refresh returns 409

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b383ed20cc832d9700681d69398167