### PR TITLE
Count only completed volunteer shifts for achievements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@
   The response also includes `milestoneText`, `familiesServed`, `poundsHandled`,
   and current-month totals `monthFamiliesServed` and `monthPoundsHandled`
   so the dashboard can show appreciation messages.
+  Only shifts marked as `completed` contribute to these hours and shift counts;
+  `approved` or `no_show` statuses are ignored.
 - Volunteer leaderboard available via `GET /volunteer-stats/leaderboard` returning
   `{ rank, percentile }` for the current volunteer without exposing names.
 - Group volunteer statistics via `GET /volunteer-stats/group` return total

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -366,7 +366,7 @@ export async function getVolunteerStats(
     const earlyRes = await pool.query(
       `SELECT 1 FROM volunteer_bookings vb
        JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id
-       WHERE vb.volunteer_id = $1 AND vb.status = 'approved' AND vs.start_time < '09:00:00'
+       WHERE vb.volunteer_id = $1 AND vb.status = 'completed' AND vs.start_time < '09:00:00'
        LIMIT 1`,
       [user.id],
     );
@@ -385,11 +385,11 @@ export async function getVolunteerStats(
              THEN EXTRACT(EPOCH FROM (vs.end_time - vs.start_time)) / 3600
              ELSE 0
            END
-         ), 0) AS month_hours,
-         COUNT(*) AS total_shifts
+       ), 0) AS month_hours,
+        COUNT(*) AS total_shifts
        FROM volunteer_bookings vb
        JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id
-       WHERE vb.volunteer_id = $1 AND vb.status = 'approved' AND vb.date <= CURRENT_DATE`,
+       WHERE vb.volunteer_id = $1 AND vb.status = 'completed' AND vb.date <= CURRENT_DATE`,
       [user.id],
     );
     const statsRow = statsRes.rows[0];
@@ -399,7 +399,7 @@ export async function getVolunteerStats(
 
     const heavyRes = await pool.query<{ count: string }>(
       `SELECT COUNT(*) FROM volunteer_bookings
-       WHERE volunteer_id = $1 AND status = 'approved'`,
+       WHERE volunteer_id = $1 AND status = 'completed'`,
       [user.id],
     );
     if (Number(heavyRes.rows[0].count) >= 10) badges.add('heavy-lifter');
@@ -407,7 +407,7 @@ export async function getVolunteerStats(
     const weeksRes = await pool.query<{ week_start: string }>(
       `SELECT DISTINCT date_trunc('week', date) AS week_start
        FROM volunteer_bookings
-       WHERE volunteer_id = $1 AND status = 'approved' AND date <= CURRENT_DATE
+       WHERE volunteer_id = $1 AND status = 'completed' AND date <= CURRENT_DATE
        ORDER BY week_start DESC`,
       [user.id],
     );

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerStatsController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerStatsController.ts
@@ -16,7 +16,7 @@ export async function getVolunteerLeaderboard(
                 COALESCE(COUNT(vb.*), 0) AS total
          FROM volunteers v
          LEFT JOIN volunteer_bookings vb
-           ON vb.volunteer_id = v.id AND vb.status = 'approved'
+           ON vb.volunteer_id = v.id AND vb.status = 'completed'
          GROUP BY v.id
        ),
        ranked AS (
@@ -58,7 +58,7 @@ export async function getVolunteerGroupStats(
                 ), 0) AS month_hours
          FROM volunteer_bookings vb
          JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id
-         WHERE vb.status = 'approved'
+         WHERE vb.status = 'completed'
        ),
        weight AS (
        SELECT COALESCE(SUM(weight_with_cart - weight_without_cart), 0) AS total_lbs,

--- a/MJ_FB_Backend/tests/volunteerGroupStats.test.ts
+++ b/MJ_FB_Backend/tests/volunteerGroupStats.test.ts
@@ -52,5 +52,6 @@ describe('Volunteer group stats', () => {
     expect(query).toContain('volunteer_bookings');
     expect(query).toContain('client_visits');
     expect(query).toContain('app_config');
+    expect(query).toContain("vb.status = 'completed'");
   });
 });

--- a/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
+++ b/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
@@ -31,5 +31,6 @@ describe('Volunteer leaderboard', () => {
     const query = (pool.query as jest.Mock).mock.calls[0][0];
     expect(query).toContain('volunteer_counts');
     expect(query).toContain('::numeric');
+    expect(query).toContain("vb.status = 'completed'");
   });
 });

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -199,6 +199,11 @@ describe('Volunteer badges', () => {
     const res = await request(app).get('/volunteers/me/stats');
     expect(res.status).toBe(200);
     expect(res.body.badges).toEqual(['early-bird', 'heavy-lifter']);
+    const queries = (pool.query as jest.Mock).mock.calls.map(c => c[0]);
+    expect(queries[1]).toContain("status = 'completed'");
+    expect(queries[2]).toContain("status = 'completed'");
+    expect(queries[3]).toContain("status = 'completed'");
+    expect(queries[4]).toContain("status = 'completed'");
   });
 
   it('awards a badge', async () => {

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.
 - Conflicting volunteer shift requests return a 409 with both the attempted and existing shift details; resolve conflicts via `POST /volunteer-bookings/resolve-conflict`.
 - Volunteer schedule prevents navigating to past dates and hides shifts that have already started.
-- Volunteer badges are calculated from activity and manually awardable. Manual awards are issued via `POST /volunteers/me/badges`. `GET /volunteers/me/stats` returns earned badges along with lifetime hours, this month's hours, total completed shifts, and current streak. The endpoint also flags milestones at 5, 10, and 25 shifts so the dashboard can show a celebration banner.
+- Volunteer badges are calculated from activity and manually awardable. Manual awards are issued via `POST /volunteers/me/badges`. `GET /volunteers/me/stats` returns earned badges along with lifetime hours, this month's hours, total completed shifts, and current streak. Only shifts marked as `completed` contribute to hours and shift totals; `approved` or `no_show` shifts are ignored. The endpoint also flags milestones at 5, 10, and 25 shifts so the dashboard can show a celebration banner.
 - The stats endpoint now provides a milestone message and contribution totals (`familiesServed`, `poundsHandled`) along with current-month figures (`monthFamiliesServed`, `monthPoundsHandled`) so the dashboard can display appreciation.
 - Volunteer leaderboard endpoint `GET /volunteer-stats/leaderboard` returns your rank and percentile.
   The volunteer dashboard shows “You're in the top X%!” based on this data.


### PR DESCRIPTION
## Summary
- Ensure volunteer stats and badges use only `completed` shifts
- Update leaderboard and group stats queries to exclude `approved` and `no_show` statuses
- Document that only completed shifts count toward volunteer achievements and hours

## Testing
- `npm install` *(fails: 403 Forbidden for undici)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3853d8c98832d8f3bb753b97d85d9