### PR TITLE
Add volunteer no-show ranking to management dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@
   so the dashboard can show appreciation messages.
 - Volunteer leaderboard available via `GET /volunteer-stats/leaderboard` returning
   `{ rank, percentile }` for the current volunteer without exposing names.
+- Staff can query `GET /volunteer-stats/no-show-ranking` for a list of volunteers with
+  high no-show rates to surface in management dashboards.
 - Group volunteer statistics via `GET /volunteer-stats/group` return total
   volunteer hours, weekly and monthly food pounds handled, distinct families
   served in the current month, along with current-month hours and a

--- a/MJ_FB_Backend/src/routes/volunteerStats.ts
+++ b/MJ_FB_Backend/src/routes/volunteerStats.ts
@@ -3,11 +3,13 @@ import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import {
   getVolunteerLeaderboard,
   getVolunteerGroupStats,
+  getVolunteerNoShowRanking,
 } from '../controllers/volunteer/volunteerStatsController';
 
 const router = express.Router();
 
 router.get('/leaderboard', authMiddleware, authorizeRoles('volunteer'), getVolunteerLeaderboard);
 router.get('/group', authMiddleware, authorizeRoles('volunteer'), getVolunteerGroupStats);
+router.get('/no-show-ranking', authMiddleware, authorizeRoles('staff'), getVolunteerNoShowRanking);
 
 export default router;

--- a/MJ_FB_Backend/tests/volunteerNoShowRanking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowRanking.test.ts
@@ -1,0 +1,41 @@
+import request from 'supertest';
+import express from 'express';
+import volunteerStatsRouter from '../src/routes/volunteerStats';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (req as any).user = { id: 1, role: 'staff' };
+  next();
+});
+app.use('/volunteer-stats', volunteerStatsRouter);
+
+describe('Volunteer no-show ranking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns ranking list', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        { id: 1, name: 'Alice', total_bookings: 10, no_shows: 4, no_show_rate: 0.4 },
+      ],
+    });
+    const res = await request(app).get('/volunteer-stats/no-show-ranking');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: 1, name: 'Alice', totalBookings: 10, noShows: 4, noShowRate: 0.4 },
+    ]);
+    const query = (pool.query as jest.Mock).mock.calls[0][0];
+    expect(query).toContain('no_show');
+    expect(query).toContain('ORDER BY');
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Dashboard from '../components/dashboard/Dashboard';
+import { getBookings, getSlotsRange } from '../api/bookings';
+import { getEvents } from '../api/events';
+import { getVolunteerNoShowRanking } from '../api/volunteers';
+
+jest.mock('../api/bookings', () => ({
+  getBookings: jest.fn(),
+  getSlotsRange: jest.fn(),
+}));
+
+jest.mock('../api/events', () => ({
+  getEvents: jest.fn(),
+}));
+
+jest.mock('../api/volunteers', () => ({
+  getVolunteerNoShowRanking: jest.fn(),
+}));
+
+describe('StaffDashboard', () => {
+  it('displays no-show ranking', async () => {
+    (getBookings as jest.Mock).mockResolvedValue([]);
+    (getSlotsRange as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerNoShowRanking as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'Alice', totalBookings: 10, noShows: 4, noShowRate: 0.4 },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <Dashboard role="staff" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getVolunteerNoShowRanking).toHaveBeenCalled());
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText(/4\/10/)).toBeInTheDocument();
+    expect(screen.getByText(/40%/)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
@@ -6,6 +6,7 @@ import {
   getMyRecurringVolunteerBookings,
   updateVolunteerBookingStatus,
   cancelVolunteerBooking,
+  getVolunteerNoShowRanking,
 } from '../api/volunteers';
 
 jest.mock('../api/client', () => ({
@@ -82,6 +83,13 @@ describe('volunteers api', () => {
         method: 'PATCH',
         body: JSON.stringify({ reason: 'sick' }),
       }),
+    );
+  });
+
+  it('fetches volunteer no-show ranking', async () => {
+    await getVolunteerNoShowRanking();
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/volunteer-stats/no-show-ranking',
     );
   });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -479,6 +479,19 @@ export async function getVolunteerGroupStats(): Promise<VolunteerGroupStats> {
   return handleResponse(res);
 }
 
+export interface VolunteerNoShowRanking {
+  id: number;
+  name: string;
+  totalBookings: number;
+  noShows: number;
+  noShowRate: number;
+}
+
+export async function getVolunteerNoShowRanking(): Promise<VolunteerNoShowRanking[]> {
+  const res = await apiFetch(`${API_BASE}/volunteer-stats/no-show-ranking`);
+  return handleResponse(res);
+}
+
 export async function awardVolunteerBadge(badgeCode: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/volunteers/me/badges`, {
     method: 'POST',

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -17,6 +17,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import EventAvailable from '@mui/icons-material/EventAvailable';
 import Announcement from '@mui/icons-material/Announcement';
 import { getBookings, getSlotsRange } from '../../api/bookings';
+import { getVolunteerNoShowRanking } from '../../api/volunteers';
 import type { Role } from '../../types';
 import { formatTime } from '../../utils/time';
 import EntitySearch from '../EntitySearch';
@@ -80,12 +81,16 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
     upcoming: [],
     past: [],
   });
+  const [noShowRanking, setNoShowRanking] = useState<
+    { id: number; name: string; totalBookings: number; noShows: number; noShowRate: number }[]
+  >([]);
   const [searchType, setSearchType] = useState<'user' | 'volunteer'>('user');
   const navigate = useNavigate();
 
   useEffect(() => {
     getBookings().then(setBookings).catch(() => {});
     getEvents().then(setEvents).catch(() => {});
+    getVolunteerNoShowRanking().then(setNoShowRanking).catch(() => {});
 
     const today = new Date();
     const start = new Date(today);
@@ -236,6 +241,20 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
                   </Button>
                 </Stack>
               </Stack>
+            </SectionCard>
+          </Grid>
+          <Grid size={12}>
+            <SectionCard title="No-Show Rankings" icon={<WarningAmber color="warning" />}>
+              <List>
+                {noShowRanking.map(v => (
+                  <ListItem key={v.id}>
+                    <ListItemText
+                      primary={v.name}
+                      secondary={`${v.noShows}/${v.totalBookings} (${Math.round(v.noShowRate * 100)}%)`}
+                    />
+                  </ListItem>
+                ))}
+              </List>
             </SectionCard>
           </Grid>
           <Grid size={12}>

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - The stats endpoint now provides a milestone message and contribution totals (`familiesServed`, `poundsHandled`) along with current-month figures (`monthFamiliesServed`, `monthPoundsHandled`) so the dashboard can display appreciation.
 - Volunteer leaderboard endpoint `GET /volunteer-stats/leaderboard` returns your rank and percentile.
   The volunteer dashboard shows “You're in the top X%!” based on this data.
+- Staff can retrieve a no-show ranking via `GET /volunteer-stats/no-show-ranking` to highlight
+  volunteers who frequently miss booked shifts. The volunteer management dashboard displays this ranking.
 - Group volunteer stats endpoint `GET /volunteer-stats/group` aggregates total hours,
   weekly and monthly pounds handled, and distinct families served this month, returning
   current-month hours alongside a configurable goal for dashboard progress.


### PR DESCRIPTION
## Summary
- expose `/volunteer-stats/no-show-ranking` for staff to list volunteers with high no-show rates
- show a no-show ranking card on the volunteer management dashboard
- test API hook and dashboard rendering

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm install` (backend) *(fails: 403 Forbidden - undici)*
- `npm test` (frontend) *(fails: jest not found)*
- `npm install` (frontend) *(fails: 403 Forbidden - undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b385d8b130832daeed63bad81f04f3