### PR TITLE
Add pantry visit search

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -74,6 +74,7 @@ export default function PantryVisits() {
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: AlertColor } | null>(null);
 
   const [cartTare, setCartTare] = useState(0);
+  const [search, setSearch] = useState('');
 
   const weekDates = useMemo(() => {
     const start = startOfWeek(toDate());
@@ -92,6 +93,16 @@ export default function PantryVisits() {
   });
   const [autoWeight, setAutoWeight] = useState(true);
   const [clientFound, setClientFound] = useState<boolean | null>(null);
+
+  const filteredVisits = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return visits;
+    return visits.filter(v => {
+      const name = v.clientName?.toLowerCase() || '';
+      const id = v.clientId ? String(v.clientId) : '';
+      return name.includes(q) || id.includes(q);
+    });
+  }, [visits, search]);
 
   const loadVisits = useCallback(() => {
     getClientVisits(format(selectedDate))
@@ -194,7 +205,7 @@ export default function PantryVisits() {
           </TableRow>
         </TableHead>
         <TableBody>
-          {visits.map(v => (
+          {filteredVisits.map(v => (
             <TableRow key={v.id}>
               <TableCell>{formatDisplay(v.date)}</TableCell>
               <TableCell>{v.clientId ?? 'N/A'}</TableCell>
@@ -262,25 +273,33 @@ export default function PantryVisits() {
     <Page
       title="Pantry Visits"
       header={
-        <Button
-          size="small"
-          variant="contained"
-          onClick={() => {
-            setForm({
-              date: format(selectedDate),
-              anonymous: false,
-              clientId: '',
-              weightWithCart: '',
-              weightWithoutCart: '',
-              petItem: '0',
-            });
-            setAutoWeight(true);
-            setEditing(null);
-            setRecordOpen(true);
-          }}
-        >
-          Record Visit
-        </Button>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => {
+              setForm({
+                date: format(selectedDate),
+                anonymous: false,
+                clientId: '',
+                weightWithCart: '',
+                weightWithoutCart: '',
+                petItem: '0',
+              });
+              setAutoWeight(true);
+              setEditing(null);
+              setRecordOpen(true);
+            }}
+          >
+            Record Visit
+          </Button>
+          <TextField
+            size="small"
+            label="Search"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+        </Stack>
       }
     >
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -36,6 +36,10 @@ describe('PantryVisits', () => {
       })) as any);
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('uses cart tare from config when calculating weight', async () => {
     (getClientVisits as jest.Mock).mockResolvedValue([]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 10 });
@@ -55,5 +59,49 @@ describe('PantryVisits', () => {
 
     const withoutCart = screen.getByLabelText('Weight Without Cart');
     expect(withoutCart).toHaveValue('40');
+  });
+
+  it('filters visits by search input', async () => {
+    (getClientVisits as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        date: '2024-01-01',
+        clientId: 111,
+        clientName: 'Alice',
+        anonymous: false,
+        weightWithCart: 10,
+        weightWithoutCart: 5,
+        petItem: 0,
+      },
+      {
+        id: 2,
+        date: '2024-01-02',
+        clientId: 222,
+        clientName: 'Bob',
+        anonymous: false,
+        weightWithCart: 20,
+        weightWithoutCart: 15,
+        petItem: 1,
+      },
+    ]);
+    (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <PantryVisits />
+      </ThemeProvider>,
+    );
+
+    await screen.findByText('Alice');
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+
+    const search = screen.getByLabelText('Search');
+    fireEvent.change(search, { target: { value: 'Bob' } });
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: '111' } });
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.queryByText('Bob')).not.toBeInTheDocument();
   });
 });

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ page and cached on the server:
 - Agency profile page shows the agency's name, email, and contact info with editable fields and password reset support.
 - Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.
 - Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list for managing associations.
+- Pantry Visits page includes a search field to filter visits by client name or ID.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- add search input to pantry visits for filtering by client name or ID
- document new search capability
- test visit filtering

## Testing
- ⚠️ `npm install` (403 Forbidden - undici)
- ⚠️ `npm test` (sh: 1: jest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b386749d90832dbbd1a35db8243559