### PR TITLE
Restrict volunteer booking cancel options to approved status

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -164,6 +164,57 @@ test('cancels single and recurring bookings', async () => {
   );
 });
 
+test('hides cancel options for non-approved bookings', async () => {
+  (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
+    {
+      id: 1,
+      role_id: 1,
+      role_name: 'Visited Role',
+      date: '2024-05-01',
+      start_time: '09:00:00',
+      end_time: '10:00:00',
+      status: 'visited',
+    },
+    {
+      id: 2,
+      role_id: 1,
+      role_name: 'Cancelled Role',
+      date: '2024-05-02',
+      start_time: '09:00:00',
+      end_time: '10:00:00',
+      status: 'cancelled',
+    },
+    {
+      id: 3,
+      role_id: 1,
+      role_name: 'NoShow Role',
+      date: '2024-05-03',
+      start_time: '09:00:00',
+      end_time: '10:00:00',
+      status: 'no_show',
+    },
+    {
+      id: 4,
+      role_id: 1,
+      role_name: 'Approved Role',
+      date: '2024-05-04',
+      start_time: '09:00:00',
+      end_time: '10:00:00',
+      status: 'approved',
+    },
+  ]);
+
+  render(<VolunteerBookingHistory />);
+  await screen.findByText('Approved Role');
+  expect(screen.getAllByText('Cancel')).toHaveLength(1);
+  const visitedRow = screen.getByText('Visited Role').closest('tr')!;
+  expect(within(visitedRow).queryByText('Cancel')).toBeNull();
+  const cancelledRow = screen.getByText('Cancelled Role').closest('tr')!;
+  expect(within(cancelledRow).queryByText('Cancel')).toBeNull();
+  const noShowRow = screen.getByText('NoShow Role').closest('tr')!;
+  expect(within(noShowRow).queryByText('Cancel')).toBeNull();
+});
+
 test('formats recurring booking dates', async () => {
   (getRecurringVolunteerBookings as jest.Mock).mockResolvedValue([
     {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
@@ -106,19 +106,23 @@ export default function VolunteerBookingHistory() {
                   </TableCell>
                   <TableCell>{h.status}</TableCell>
                   <TableCell>
-                    <Button
-                      size="small"
-                      onClick={() => setCancelBooking(h)}
-                    >
-                      Cancel
-                    </Button>
-                    {h.recurring_id && (
-                      <Button
-                        size="small"
-                        onClick={() => setCancelSeriesId(h.recurring_id!)}
-                      >
-                        Cancel all upcoming
-                      </Button>
+                    {h.status.toLowerCase() === 'approved' && (
+                      <>
+                        <Button
+                          size="small"
+                          onClick={() => setCancelBooking(h)}
+                        >
+                          Cancel
+                        </Button>
+                        {h.recurring_id && (
+                          <Button
+                            size="small"
+                            onClick={() => setCancelSeriesId(h.recurring_id!)}
+                          >
+                            Cancel all upcoming
+                          </Button>
+                        )}
+                      </>
                     )}
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
## Summary
- hide cancel actions in volunteer booking history unless booking status is approved
- cover non-approved cases with unit test

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3871586c0832d853c802d60f54e69