### PR TITLE
Use completed shifts for contribution trend

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -426,7 +426,7 @@ beforeEach(() => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
       {
         id: 1,
-        status: 'approved',
+        status: 'completed',
         role_id: 1,
         date: '2024-01-15',
         start_time: '09:00:00',
@@ -435,7 +435,7 @@ beforeEach(() => {
       },
       {
         id: 2,
-        status: 'approved',
+        status: 'completed',
         role_id: 1,
         date: '2024-02-10',
         start_time: '09:00:00',

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -84,7 +84,7 @@ export default function VolunteerDashboard() {
         const monthly: Record<string, { total: number; roles: Record<string, number> }> = {};
         const roleTotals: Record<string, number> = {};
         data
-          .filter(b => b.status === 'approved')
+          .filter(b => b.status === 'completed')
           .forEach(b => {
             const d = toDate(b.date);
             const key = formatRegina(d, 'yyyy-MM');


### PR DESCRIPTION
## Summary
- Count only completed volunteer shifts when building contribution trend
- Update dashboard test to reflect completed shift contribution

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b387962b08832dbc2849bb6e7bac4b