### PR TITLE
Format dates in overlap shift conflict dialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/OverlapBookingDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/OverlapBookingDialog.test.tsx
@@ -30,3 +30,36 @@ test('calls resolve with choice', () => {
   fireEvent.click(screen.getByText(/Replace with New Shift/i));
   expect(onResolve).toHaveBeenCalledWith('new');
 });
+
+test('formats ISO date strings', () => {
+  const attempted = {
+    role_id: 1,
+    role_name: 'Greeter',
+    date: '2024-01-01T06:00:00.000Z',
+    start_time: '09:00:00',
+    end_time: '12:00:00',
+  };
+  const existing = {
+    id: 2,
+    role_id: 3,
+    role_name: 'Sorter',
+    date: '2024-01-01',
+    start_time: '10:00:00',
+    end_time: '13:00:00',
+  };
+  render(
+    <OverlapBookingDialog
+      open
+      attempted={attempted}
+      existing={existing}
+      onClose={() => {}}
+      onResolve={() => {}}
+    />,
+  );
+  expect(
+    screen.getByText('2024-01-01 · 9:00 AM–12:00 PM'),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText('2024-01-01 · 10:00 AM–1:00 PM'),
+  ).toBeInTheDocument();
+});

--- a/MJ_FB_Frontend/src/components/OverlapBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/OverlapBookingDialog.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
 } from '@mui/material';
 import { formatTime } from '../utils/time';
+import { formatReginaDate } from '../utils/date';
 
 interface BookingInfo {
   id?: number;
@@ -45,7 +46,7 @@ export default function OverlapBookingDialog({
             <Typography variant="subtitle2">Existing Shift</Typography>
             <Typography>{existing.role_name}</Typography>
             <Typography>
-              {existing.date} · {formatTime(existing.start_time)}–
+              {formatReginaDate(existing.date)} · {formatTime(existing.start_time)}–
               {formatTime(existing.end_time)}
             </Typography>
           </Grid>
@@ -53,7 +54,7 @@ export default function OverlapBookingDialog({
             <Typography variant="subtitle2">New Shift</Typography>
             <Typography>{attempted.role_name}</Typography>
             <Typography>
-              {attempted.date} · {formatTime(attempted.start_time)}–
+              {formatReginaDate(attempted.date)} · {formatTime(attempted.start_time)}–
               {formatTime(attempted.end_time)}
             </Typography>
           </Grid>


### PR DESCRIPTION
## Summary
- format existing and attempted shift dates in conflict dialog for readability
- verify ISO date strings render correctly in overlap dialog tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b387cfdb70832dad8fd24902681d1b