### PR TITLE
feat: add nightly no-show cleanup job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - The `new_clients.email` field is nullable; `POST /bookings/new-client` accepts requests without an email address.
 - A daily reminder job (`src/utils/bookingReminderJob.ts`) runs at server startup and emails clients about next-day bookings using the `enqueueEmail` queue. It now uses `node-cron` to run at `0 9 * * *` Regina time and exposes `startBookingReminderJob`/`stopBookingReminderJob`.
 - A volunteer shift reminder job (`MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue. It also uses `node-cron` with the same schedule and exposes `startVolunteerShiftReminderJob`/`stopVolunteerShiftReminderJob`.
+- A nightly no-show cleanup job (`MJ_FB_Backend/src/utils/noShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved bookings as `no_show`. It exposes `startNoShowCleanupJob`/`stopNoShowCleanupJob`.
 
 ## Testing
 

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -5,6 +5,7 @@ import logger from './utils/logger';
 import app from './app';
 import { startBookingReminderJob } from './utils/bookingReminderJob';
 import { startVolunteerShiftReminderJob } from './utils/volunteerShiftReminderJob';
+import { startNoShowCleanupJob } from './utils/noShowCleanupJob';
 import { initEmailQueue } from './utils/emailQueue';
 
 const PORT = config.port;
@@ -22,6 +23,7 @@ async function init() {
     });
     startBookingReminderJob();
     startVolunteerShiftReminderJob();
+    startNoShowCleanupJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);

--- a/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
@@ -1,0 +1,46 @@
+import pool from '../db';
+import logger from './logger';
+import cron from 'node-cron';
+
+/**
+ * Mark past approved bookings as no-show.
+ */
+export async function cleanupNoShows(): Promise<void> {
+  try {
+    await pool.query(
+      "UPDATE bookings SET status='no_show' WHERE status='approved' AND date < CURRENT_DATE",
+    );
+  } catch (err) {
+    logger.error('Failed to clean up no-shows', err);
+  }
+}
+
+/**
+ * Schedule the cleanup job to run nightly at 8:00 PM Regina time.
+ */
+let noShowCleanupTask: cron.ScheduledTask | undefined;
+
+export function startNoShowCleanupJob(): void {
+  if (process.env.NODE_ENV === 'test') return;
+  // Run immediately and then on the scheduled interval.
+  cleanupNoShows().catch((err) =>
+    logger.error('Initial no-show cleanup failed', err),
+  );
+  noShowCleanupTask = cron.schedule(
+    '0 20 * * *',
+    () => {
+      cleanupNoShows().catch((err) =>
+        logger.error('Scheduled no-show cleanup failed', err),
+      );
+    },
+    { timezone: 'America/Regina' },
+  );
+}
+
+export function stopNoShowCleanupJob(): void {
+  if (noShowCleanupTask) {
+    noShowCleanupTask.stop();
+    noShowCleanupTask = undefined;
+  }
+}
+

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -1,0 +1,59 @@
+process.env.NODE_ENV = 'development';
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+const noShowJob = require('../src/utils/noShowCleanupJob');
+const {
+  cleanupNoShows,
+  startNoShowCleanupJob,
+  stopNoShowCleanupJob,
+} = noShowJob;
+import pool from '../src/db';
+jest.mock('../src/db');
+
+describe('cleanupNoShows', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('marks past approved bookings as no_show', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1 });
+    await cleanupNoShows();
+    expect(pool.query).toHaveBeenCalledWith(
+      "UPDATE bookings SET status='no_show' WHERE status='approved' AND date < CURRENT_DATE",
+    );
+  });
+});
+
+describe('startNoShowCleanupJob/stopNoShowCleanupJob', () => {
+  let scheduleMock: jest.Mock;
+  let stopMock: jest.Mock;
+  let cleanupSpy: jest.SpyInstance;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    scheduleMock = require('node-cron').schedule as jest.Mock;
+    stopMock = jest.fn();
+    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+    cleanupSpy = jest.spyOn(noShowJob, 'cleanupNoShows').mockResolvedValue();
+    process.env.NODE_ENV = 'development';
+  });
+
+  afterEach(async () => {
+    stopNoShowCleanupJob();
+    await Promise.resolve();
+    jest.useRealTimers();
+    scheduleMock.mockReset();
+    cleanupSpy.mockRestore();
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('schedules and stops the cron job', async () => {
+    startNoShowCleanupJob();
+    await Promise.resolve();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '0 20 * * *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+    stopNoShowCleanupJob();
+    expect(stopMock).toHaveBeenCalled();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Volunteer role management and scheduling restricted to trained areas.
 - Only staff can update volunteer trained roles; volunteers may view but not modify their assigned roles from the dashboard.
 - Daily reminder jobs queue emails for next-day bookings and volunteer shifts using the backend email queue. Each job now runs via `node-cron` at `0 9 * * *` Regina time and exposes start/stop functions.
+- A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.
 - Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.


### PR DESCRIPTION
## Summary
- schedule nightly no-show cleanup to mark past approved bookings as no_show
- wire cleanup job to server startup and document behavior
- test cleanup logic and scheduling

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b38aa83cec832d83f8a9bef68262be