### PR TITLE
feat: auto mark volunteer no-shows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - The `new_clients.email` field is nullable; `POST /bookings/new-client` accepts requests without an email address.
 - A daily reminder job (`src/utils/bookingReminderJob.ts`) runs at server startup and emails clients about next-day bookings using the `enqueueEmail` queue. It now uses `node-cron` to run at `0 9 * * *` Regina time and exposes `startBookingReminderJob`/`stopBookingReminderJob`.
 - A volunteer shift reminder job (`MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue. It also uses `node-cron` with the same schedule and exposes `startVolunteerShiftReminderJob`/`stopVolunteerShiftReminderJob`.
+- A nightly no-show job (`MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts`) marks past approved volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default 12). Coordinators are emailed a summary of automatic changes.
 
 ## Testing
 

--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -41,6 +41,8 @@ Authentication cookies are scoped to the `/` path and use the same options when 
 
 `PASSWORD_SETUP_TOKEN_TTL_HOURS` – Hours until password setup tokens expire (default 24).
 
+`VOLUNTEER_NO_SHOW_HOURS` – Hours after a volunteer shift before unmarked bookings are automatically set to `no_show` (default 12).
+
 ## Password Policy
 
 Passwords must be at least 8 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character. Requests with weak passwords are rejected before hashing.

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -21,6 +21,7 @@ const envSchema = z.object({
   BREVO_FROM_NAME: z.string().optional(),
   EMAIL_QUEUE_MAX_RETRIES: z.coerce.number().default(5),
   EMAIL_QUEUE_BACKOFF_MS: z.coerce.number().default(1000),
+  VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(12),
 });
 
 const parsedEnv = envSchema.safeParse(process.env);
@@ -52,4 +53,5 @@ export default {
   brevoFromName: env.BREVO_FROM_NAME ?? '',
   emailQueueMaxRetries: env.EMAIL_QUEUE_MAX_RETRIES,
   emailQueueBackoffMs: env.EMAIL_QUEUE_BACKOFF_MS,
+  volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -4,7 +4,7 @@ import { setupDatabase } from './setupDatabase';
 import logger from './utils/logger';
 import app from './app';
 import { startBookingReminderJob } from './utils/bookingReminderJob';
-import { startVolunteerShiftReminderJob } from './utils/volunteerShiftReminderJob';
+import { startVolunteerShiftReminderJob, startVolunteerNoShowJob } from './utils/volunteerShiftReminderJob';
 import { initEmailQueue } from './utils/emailQueue';
 
 const PORT = config.port;
@@ -22,6 +22,7 @@ async function init() {
     });
     startBookingReminderJob();
     startVolunteerShiftReminderJob();
+    startVolunteerNoShowJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);

--- a/MJ_FB_Backend/tests/setupEnv.ts
+++ b/MJ_FB_Backend/tests/setupEnv.ts
@@ -12,5 +12,6 @@ process.env.BREVO_API_KEY = 'test-api-key';
 process.env.BREVO_FROM_EMAIL = 'noreply@example.com';
 process.env.BREVO_FROM_NAME = 'MJ Food Bank';
 process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS = '24';
+process.env.VOLUNTEER_NO_SHOW_HOURS = '12';
 
 export {};

--- a/MJ_FB_Backend/tests/volunteerNoShowJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowJob.test.ts
@@ -1,0 +1,63 @@
+process.env.NODE_ENV = 'development';
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
+jest.mock('../src/config/coordinatorEmails.json', () => ({ coordinatorEmails: ['coord@example.com'] }));
+jest.mock('../src/db', () => ({ __esModule: true, default: { query: jest.fn() } }));
+
+const volunteerJobs = require('../src/utils/volunteerShiftReminderJob');
+const { markPastVolunteerNoShows, startVolunteerNoShowJob, stopVolunteerNoShowJob } = volunteerJobs;
+const { sendEmail } = require('../src/utils/emailUtils');
+const pool = require('../src/db').default;
+
+describe('markPastVolunteerNoShows', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [
+        { first_name: 'Jane', last_name: 'Doe', date: '2024-01-01', start_time: '09:00:00', end_time: '12:00:00' },
+      ],
+    });
+  });
+
+  it('marks past bookings and notifies coordinators', async () => {
+    await markPastVolunteerNoShows();
+    expect(pool.query).toHaveBeenCalled();
+    expect(sendEmail).toHaveBeenCalledWith(
+      'coord@example.com',
+      expect.stringContaining('no-show'),
+      expect.stringContaining('Jane Doe'),
+    );
+  });
+});
+
+describe('startVolunteerNoShowJob/stopVolunteerNoShowJob', () => {
+  let scheduleMock: jest.Mock;
+  let stopMock: jest.Mock;
+  let runSpy: jest.SpyInstance;
+  beforeEach(() => {
+    scheduleMock = require('node-cron').schedule as jest.Mock;
+    stopMock = jest.fn();
+    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+    runSpy = jest.spyOn(volunteerJobs, 'markPastVolunteerNoShows').mockResolvedValue();
+  });
+
+  afterEach(async () => {
+    stopVolunteerNoShowJob();
+    await Promise.resolve();
+    scheduleMock.mockReset();
+    runSpy.mockRestore();
+  });
+
+  it('schedules and stops the cron job', async () => {
+    startVolunteerNoShowJob();
+    await Promise.resolve();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '0 0 * * *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+    stopVolunteerNoShowJob();
+    expect(stopMock).toHaveBeenCalled();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Volunteer role management and scheduling restricted to trained areas.
 - Only staff can update volunteer trained roles; volunteers may view but not modify their assigned roles from the dashboard.
 - Daily reminder jobs queue emails for next-day bookings and volunteer shifts using the backend email queue. Each job now runs via `node-cron` at `0 9 * * *` Regina time and exposes start/stop functions.
+- A nightly no-show job marks past approved volunteer bookings as `no_show` after the configured delay. Coordinators are emailed a summary of shifts changed automatically.
 - Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
@@ -220,10 +221,13 @@ The build will fail if this variable is missing.
 
 Refer to the submodule repositories for detailed configuration and environment variables.
 
+The backend automatically marks past volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default `12`).
+
 The backend surplus tracking feature uses two optional environment variables to
 set default multipliers; values are editable in the Admin → Warehouse Settings
 page and cached on the server:
 
+- `VOLUNTEER_NO_SHOW_HOURS` (default `12`)
 - `BREAD_WEIGHT_MULTIPLIER` (default `10`)
 - `CANS_WEIGHT_MULTIPLIER` (default `20`)
 


### PR DESCRIPTION
## Summary
- add nightly job to flag past volunteer bookings as no-shows and notify coordinators
- expose VOLUNTEER_NO_SHOW_HOURS env var to control delay
- document volunteer no-show automation

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38a98572c832daa3aa5522029b0ea