### PR TITLE
Add volunteer no-show cleanup job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - A daily reminder job (`src/utils/bookingReminderJob.ts`) runs at server startup and emails clients about next-day bookings using the `enqueueEmail` queue. It now uses `node-cron` to run at `0 9 * * *` Regina time and exposes `startBookingReminderJob`/`stopBookingReminderJob`.
 - A volunteer shift reminder job (`MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue. It also uses `node-cron` with the same schedule and exposes `startVolunteerShiftReminderJob`/`stopVolunteerShiftReminderJob`.
 - A nightly no-show cleanup job (`MJ_FB_Backend/src/utils/noShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved bookings as `no_show`. It exposes `startNoShowCleanupJob`/`stopNoShowCleanupJob`.
+- A nightly volunteer no-show cleanup job (`MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results, emails coordinators, and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
 
 ## Testing
 

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -21,6 +21,7 @@ const envSchema = z.object({
   BREVO_FROM_NAME: z.string().optional(),
   EMAIL_QUEUE_MAX_RETRIES: z.coerce.number().default(5),
   EMAIL_QUEUE_BACKOFF_MS: z.coerce.number().default(1000),
+  VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
 
 const parsedEnv = envSchema.safeParse(process.env);
@@ -52,4 +53,5 @@ export default {
   brevoFromName: env.BREVO_FROM_NAME ?? '',
   emailQueueMaxRetries: env.EMAIL_QUEUE_MAX_RETRIES,
   emailQueueBackoffMs: env.EMAIL_QUEUE_BACKOFF_MS,
+  volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -6,6 +6,7 @@ import app from './app';
 import { startBookingReminderJob } from './utils/bookingReminderJob';
 import { startVolunteerShiftReminderJob } from './utils/volunteerShiftReminderJob';
 import { startNoShowCleanupJob } from './utils/noShowCleanupJob';
+import { startVolunteerNoShowCleanupJob } from './utils/volunteerNoShowCleanupJob';
 import { initEmailQueue } from './utils/emailQueue';
 
 const PORT = config.port;
@@ -24,6 +25,7 @@ async function init() {
     startBookingReminderJob();
     startVolunteerShiftReminderJob();
     startNoShowCleanupJob();
+    startVolunteerNoShowCleanupJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);

--- a/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
@@ -1,0 +1,70 @@
+import pool from '../db';
+import logger from './logger';
+import cron from 'node-cron';
+import config from '../config';
+import { formatReginaDate } from './dateUtils';
+import coordinatorEmailsConfig from '../config/coordinatorEmails.json';
+import { sendEmail } from './emailUtils';
+
+const coordinatorEmails: string[] = coordinatorEmailsConfig.coordinatorEmails || [];
+
+/**
+ * Mark past approved volunteer bookings as no-show.
+ */
+export async function cleanupVolunteerNoShows(): Promise<void> {
+  const hours = config.volunteerNoShowHours;
+  const cutoff = new Date();
+  cutoff.setHours(cutoff.getHours() - hours);
+  const cutoffDate = formatReginaDate(cutoff);
+  try {
+    const res = await pool.query(
+      `UPDATE volunteer_bookings vb
+       SET status='no_show'
+       WHERE vb.status='approved' AND vb.date < $1
+       RETURNING vb.id`,
+      [cutoffDate],
+    );
+    if (res.rowCount && res.rowCount > 0) {
+      const ids = res.rows.map((r: any) => r.id).join(', ');
+      logger.info('Marked volunteer bookings as no_show', { ids });
+      const subject = 'Volunteer bookings marked as no_show';
+      const body = `The following volunteer bookings were automatically marked as no_show: ${ids}`;
+      await Promise.all(
+        coordinatorEmails.map(email => sendEmail(email, subject, body)),
+      );
+    } else {
+      logger.info('No volunteer bookings to mark as no_show');
+    }
+  } catch (err) {
+    logger.error('Failed to clean up volunteer no-shows', err);
+  }
+}
+
+/**
+ * Schedule the volunteer no-show cleanup job to run nightly at 8:00 PM Regina time.
+ */
+let volunteerNoShowCleanupTask: cron.ScheduledTask | undefined;
+
+export function startVolunteerNoShowCleanupJob(): void {
+  if (process.env.NODE_ENV === 'test') return;
+  // Run immediately and then on the scheduled interval.
+  cleanupVolunteerNoShows().catch(err =>
+    logger.error('Initial volunteer no-show cleanup failed', err),
+  );
+  volunteerNoShowCleanupTask = cron.schedule(
+    '0 20 * * *',
+    () => {
+      cleanupVolunteerNoShows().catch(err =>
+        logger.error('Scheduled volunteer no-show cleanup failed', err),
+      );
+    },
+    { timezone: 'America/Regina' },
+  );
+}
+
+export function stopVolunteerNoShowCleanupJob(): void {
+  if (volunteerNoShowCleanupTask) {
+    volunteerNoShowCleanupTask.stop();
+    volunteerNoShowCleanupTask = undefined;
+  }
+}

--- a/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
@@ -1,0 +1,68 @@
+process.env.NODE_ENV = 'development';
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+const job = require('../src/utils/volunteerNoShowCleanupJob');
+const {
+  cleanupVolunteerNoShows,
+  startVolunteerNoShowCleanupJob,
+  stopVolunteerNoShowCleanupJob,
+} = job;
+import pool from '../src/db';
+jest.mock('../src/db');
+import { sendEmail } from '../src/utils/emailUtils';
+jest.mock('../src/utils/emailUtils');
+
+describe('cleanupVolunteerNoShows', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-02T12:00:00Z'));
+    (pool.query as jest.Mock).mockResolvedValue({ rowCount: 1, rows: [{ id: 1 }] });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('marks past approved volunteer bookings as no_show and notifies coordinators', async () => {
+    await cleanupVolunteerNoShows();
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE volunteer_bookings'),
+      ['2024-01-01'],
+    );
+    expect(sendEmail).toHaveBeenCalled();
+  });
+});
+
+describe('startVolunteerNoShowCleanupJob/stopVolunteerNoShowCleanupJob', () => {
+  let scheduleMock: jest.Mock;
+  let stopMock: jest.Mock;
+  let cleanupSpy: jest.SpyInstance;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    scheduleMock = require('node-cron').schedule as jest.Mock;
+    stopMock = jest.fn();
+    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+    cleanupSpy = jest.spyOn(job, 'cleanupVolunteerNoShows').mockResolvedValue();
+    process.env.NODE_ENV = 'development';
+  });
+
+  afterEach(async () => {
+    stopVolunteerNoShowCleanupJob();
+    await Promise.resolve();
+    jest.useRealTimers();
+    scheduleMock.mockReset();
+    cleanupSpy.mockRestore();
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('schedules and stops the cron job', async () => {
+    startVolunteerNoShowCleanupJob();
+    await Promise.resolve();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '0 20 * * *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+    stopVolunteerNoShowCleanupJob();
+    expect(stopMock).toHaveBeenCalled();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Only staff can update volunteer trained roles; volunteers may view but not modify their assigned roles from the dashboard.
 - Daily reminder jobs queue emails for next-day bookings and volunteer shifts using the backend email queue. Each job now runs via `node-cron` at `0 9 * * *` Regina time and exposes start/stop functions.
 - A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.
+- A nightly volunteer no-show cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours and emails coordinators about the changes.
 - Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.


### PR DESCRIPTION
## Summary
- auto-mark past volunteer bookings as `no_show` after a configurable delay
- notify coordinators when volunteer no-shows are marked and log results
- document VOLUNTEER_NO_SHOW_HOURS env var and new cleanup job

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38c1999f8832dbf29261335fd068a