### PR TITLE
Add volunteer rankings page with dropdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@
   `approved` or `no_show` statuses are ignored.
 - Volunteer leaderboard available via `GET /volunteer-stats/leaderboard` returning
   `{ rank, percentile }` for the current volunteer without exposing names.
+- Staff can view top volunteers via `GET /volunteer-stats/ranking` with an optional
+  `roleId` query parameter to filter by role.
 - Staff can query `GET /volunteer-stats/no-show-ranking` for a list of volunteers with
   high no-show rates to surface in management dashboards.
 - Group volunteer statistics via `GET /volunteer-stats/group` return total

--- a/MJ_FB_Backend/src/routes/volunteerStats.ts
+++ b/MJ_FB_Backend/src/routes/volunteerStats.ts
@@ -3,6 +3,7 @@ import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import {
   getVolunteerLeaderboard,
   getVolunteerGroupStats,
+  getVolunteerRanking,
   getVolunteerNoShowRanking,
 } from '../controllers/volunteer/volunteerStatsController';
 
@@ -10,6 +11,7 @@ const router = express.Router();
 
 router.get('/leaderboard', authMiddleware, authorizeRoles('volunteer'), getVolunteerLeaderboard);
 router.get('/group', authMiddleware, authorizeRoles('volunteer'), getVolunteerGroupStats);
+router.get('/ranking', authMiddleware, authorizeRoles('staff'), getVolunteerRanking);
 router.get('/no-show-ranking', authMiddleware, authorizeRoles('staff'), getVolunteerNoShowRanking);
 
 export default router;

--- a/MJ_FB_Backend/tests/volunteerRanking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRanking.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import volunteerStatsRouter from '../src/routes/volunteerStats';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (req as any).user = { id: 1, role: 'staff' };
+  next();
+});
+app.use('/volunteer-stats', volunteerStatsRouter);
+
+describe('Volunteer ranking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns top volunteers overall', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ id: 1, name: 'Alice', total: 5 }],
+    });
+    const res = await request(app).get('/volunteer-stats/ranking');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 1, name: 'Alice', total: 5 }]);
+    const query = (pool.query as jest.Mock).mock.calls[0][0];
+    expect(query).toContain("vb.status = 'completed'");
+  });
+
+  it('filters by role', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    await request(app).get('/volunteer-stats/ranking?roleId=2');
+    const params = (pool.query as jest.Mock).mock.calls[0][1];
+    expect(params).toEqual([2]);
+  });
+});

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -59,6 +59,9 @@ const VolunteerRecurringBookings = React.lazy(() =>
 const PendingReviews = React.lazy(() =>
   import('./pages/volunteer-management/PendingReviews')
 );
+const VolunteerRankings = React.lazy(() =>
+  import('./pages/volunteer-management/VolunteerRankings')
+);
 const WarehouseDashboard = React.lazy(() =>
   import('./pages/warehouse-management/WarehouseDashboard')
 );
@@ -394,6 +397,10 @@ export default function App() {
                   <Route
                     path="/volunteer-management/pending-reviews"
                     element={<PendingReviews />}
+                  />
+                  <Route
+                    path="/volunteer-management/rankings"
+                    element={<VolunteerRankings />}
                   />
                   <Route
                     path="/volunteer-management/:tab"

--- a/MJ_FB_Frontend/src/__tests__/VolunteerRankings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerRankings.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerRankings from '../pages/volunteer-management/VolunteerRankings';
+import {
+  getVolunteerRoles,
+  getVolunteerRankings,
+  getVolunteerNoShowRanking,
+} from '../api/volunteers';
+
+jest.mock('../api/volunteers', () => ({
+  getVolunteerRoles: jest.fn(),
+  getVolunteerRankings: jest.fn(),
+  getVolunteerNoShowRanking: jest.fn(),
+}));
+
+describe('VolunteerRankings', () => {
+  beforeEach(() => {
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'Driver', category_name: 'Logistics', shifts: [] },
+      { id: 2, name: 'Sorter', category_name: 'Warehouse', shifts: [] },
+    ]);
+    (getVolunteerRankings as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'Alice', total: 5 },
+    ]);
+    (getVolunteerNoShowRanking as jest.Mock).mockResolvedValue([
+      { id: 2, name: 'Bob', totalBookings: 10, noShows: 4, noShowRate: 0.4 },
+    ]);
+  });
+
+  it('shows rankings and switches type', async () => {
+    render(
+      <MemoryRouter>
+        <VolunteerRankings />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalled());
+    await waitFor(() => expect(getVolunteerRankings).toHaveBeenCalledWith(undefined));
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByLabelText('Ranking'));
+    fireEvent.click(screen.getByText('No Shows'));
+
+    await waitFor(() => expect(getVolunteerNoShowRanking).toHaveBeenCalled());
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByLabelText('Ranking'));
+    fireEvent.click(screen.getByText('Sorter (Warehouse)'));
+    await waitFor(() => expect(getVolunteerRankings).toHaveBeenCalledWith(2));
+  });
+});

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -485,6 +485,22 @@ export async function getVolunteerGroupStats(): Promise<VolunteerGroupStats> {
   return handleResponse(res);
 }
 
+export interface VolunteerRanking {
+  id: number;
+  name: string;
+  total: number;
+}
+
+export async function getVolunteerRankings(
+  roleId?: number,
+): Promise<VolunteerRanking[]> {
+  const url = `${API_BASE}/volunteer-stats/ranking${
+    roleId ? `?roleId=${roleId}` : ''
+  }`;
+  const res = await apiFetch(url);
+  return handleResponse(res);
+}
+
 export interface VolunteerNoShowRanking {
   id: number;
   name: string;

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerRankings.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerRankings.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import {
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+import Page from '../../components/Page';
+import PageCard from '../../components/layout/PageCard';
+import {
+  getVolunteerRoles,
+  getVolunteerRankings,
+  getVolunteerNoShowRanking,
+  type VolunteerRanking,
+  type VolunteerNoShowRanking,
+} from '../../api/volunteers';
+import type { VolunteerRoleWithShifts } from '../../types';
+
+export default function VolunteerRankings() {
+  const [roles, setRoles] = useState<VolunteerRoleWithShifts[]>([]);
+  const [option, setOption] = useState<string>('all');
+  const [rankings, setRankings] = useState<(
+    VolunteerRanking & Partial<VolunteerNoShowRanking>
+  )[]>([]);
+
+  useEffect(() => {
+    getVolunteerRoles()
+      .then(setRoles)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (option === 'noShows') {
+      getVolunteerNoShowRanking()
+        .then(r => setRankings(r as any))
+        .catch(() => {});
+    } else {
+      const roleId = option === 'all' ? undefined : Number(option);
+      getVolunteerRankings(roleId)
+        .then(setRankings)
+        .catch(() => {});
+    }
+  }, [option]);
+
+  return (
+    <Page title="Volunteer Rankings">
+      <PageCard>
+        <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+          <InputLabel id="ranking-select">Ranking</InputLabel>
+          <Select
+            labelId="ranking-select"
+            label="Ranking"
+            value={option}
+            onChange={e => setOption(e.target.value)}
+          >
+            <MenuItem value="all">All Roles</MenuItem>
+            {roles.map(r => (
+              <MenuItem key={r.id} value={String(r.id)}>
+                {`${r.name} (${r.category_name})`}
+              </MenuItem>
+            ))}
+            <MenuItem value="noShows">No Shows</MenuItem>
+          </Select>
+        </FormControl>
+        <List>
+          {rankings.map((v, idx) => (
+            <ListItem key={v.id}>
+              <ListItemText
+                primary={`${idx + 1}. ${v.name}`}
+                secondary={
+                  option === 'noShows'
+                    ? `${v.noShows}/${v.totalBookings} (${Math.round(
+                        (v.noShowRate || 0) * 100,
+                      )}%)`
+                    : `${v.total} shifts`
+                }
+              />
+            </ListItem>
+          ))}
+        </List>
+      </PageCard>
+    </Page>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - The stats endpoint now provides a milestone message and contribution totals (`familiesServed`, `poundsHandled`) along with current-month figures (`monthFamiliesServed`, `monthPoundsHandled`) so the dashboard can display appreciation.
 - Volunteer leaderboard endpoint `GET /volunteer-stats/leaderboard` returns your rank and percentile.
   The volunteer dashboard shows “You're in the top X%!” based on this data.
+- Staff can view top volunteers via `GET /volunteer-stats/ranking` with an optional
+  `roleId` query parameter to filter by role.
 - Staff can retrieve a no-show ranking via `GET /volunteer-stats/no-show-ranking` to highlight
   volunteers who frequently miss booked shifts. The volunteer management dashboard displays this ranking.
 - Group volunteer stats endpoint `GET /volunteer-stats/group` aggregates total hours,


### PR DESCRIPTION
## Summary
- add `/volunteer-stats/ranking` endpoint with optional role filter
- show volunteer rankings in new volunteer-management page with role/no-show dropdown
- document ranking API and update configuration

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm install` (backend) *(fails: 403 Forbidden)*
- `npm test` (frontend) *(fails: jest: not found)*
- `npm install` (frontend) *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b38eaaac48832d959be1812b9d4627