### PR TITLE
Record client visits when marking bookings visited

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -3,7 +3,7 @@ import pool from '../db';
 import logger from '../utils/logger';
 import { formatReginaDate } from '../utils/dateUtils';
 
-async function refreshClientVisitCount(clientId: number) {
+export async function refreshClientVisitCount(clientId: number) {
   await pool.query(
     `UPDATE clients c
      SET bookings_this_month = (

--- a/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
+++ b/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
@@ -58,11 +58,18 @@ describe('booking status updates', () => {
 
   it('allows staff to mark booking as visited', async () => {
     (bookingRepo.updateBooking as jest.Mock).mockResolvedValue(undefined);
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ client_id: 1 }] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
     const res = await request(app)
       .post('/bookings/2/visited')
       .set('x-role', 'staff')
       .send({ requestData: 'note' });
     expect(res.status).toBe(200);
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO client_visits'),
+      expect.any(Array),
+    );
     expect(bookingRepo.updateBooking).toHaveBeenCalledWith(2, {
       status: 'visited',
       request_data: 'note',


### PR DESCRIPTION
## Summary
- insert client visit record when a booking is marked as visited
- refresh monthly visit totals after inserting visit
- update booking status tests to expect client visit insert

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68b38f5b6b2c832da713b7e4daf91e82