### PR TITLE
Remove no-show ranking card from dashboard

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
@@ -1,9 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Dashboard from '../components/dashboard/Dashboard';
 import { getBookings, getSlotsRange } from '../api/bookings';
 import { getEvents } from '../api/events';
-import { getVolunteerNoShowRanking } from '../api/volunteers';
 
 jest.mock('../api/bookings', () => ({
   getBookings: jest.fn(),
@@ -14,18 +13,11 @@ jest.mock('../api/events', () => ({
   getEvents: jest.fn(),
 }));
 
-jest.mock('../api/volunteers', () => ({
-  getVolunteerNoShowRanking: jest.fn(),
-}));
-
 describe('StaffDashboard', () => {
-  it('displays no-show ranking', async () => {
+  it('does not display no-show rankings card', async () => {
     (getBookings as jest.Mock).mockResolvedValue([]);
     (getSlotsRange as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
-    (getVolunteerNoShowRanking as jest.Mock).mockResolvedValue([
-      { id: 1, name: 'Alice', totalBookings: 10, noShows: 4, noShowRate: 0.4 },
-    ]);
 
     render(
       <MemoryRouter>
@@ -33,9 +25,7 @@ describe('StaffDashboard', () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(getVolunteerNoShowRanking).toHaveBeenCalled());
-    expect(screen.getByText('Alice')).toBeInTheDocument();
-    expect(screen.getByText(/4\/10/)).toBeInTheDocument();
-    expect(screen.getByText(/40%/)).toBeInTheDocument();
+    await screen.findByText('Today at a Glance');
+    expect(screen.queryByText('No-Show Rankings')).toBeNull();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
@@ -6,7 +6,6 @@ import {
   getMyRecurringVolunteerBookings,
   updateVolunteerBookingStatus,
   cancelVolunteerBooking,
-  getVolunteerNoShowRanking,
   getUnmarkedVolunteerBookings,
 } from '../api/volunteers';
 
@@ -94,10 +93,4 @@ describe('volunteers api', () => {
     );
   });
 
-  it('fetches volunteer no-show ranking', async () => {
-    await getVolunteerNoShowRanking();
-    expect(apiFetch).toHaveBeenCalledWith(
-      '/api/volunteer-stats/no-show-ranking',
-    );
-  });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -485,19 +485,6 @@ export async function getVolunteerGroupStats(): Promise<VolunteerGroupStats> {
   return handleResponse(res);
 }
 
-export interface VolunteerNoShowRanking {
-  id: number;
-  name: string;
-  totalBookings: number;
-  noShows: number;
-  noShowRate: number;
-}
-
-export async function getVolunteerNoShowRanking(): Promise<VolunteerNoShowRanking[]> {
-  const res = await apiFetch(`${API_BASE}/volunteer-stats/no-show-ranking`);
-  return handleResponse(res);
-}
-
 export async function awardVolunteerBadge(badgeCode: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/volunteers/me/badges`, {
     method: 'POST',

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -12,12 +12,10 @@ import {
 } from '@mui/material';
 import CalendarToday from '@mui/icons-material/CalendarToday';
 import People from '@mui/icons-material/People';
-import WarningAmber from '@mui/icons-material/WarningAmber';
 import CancelIcon from '@mui/icons-material/Cancel';
 import EventAvailable from '@mui/icons-material/EventAvailable';
 import Announcement from '@mui/icons-material/Announcement';
 import { getBookings, getSlotsRange } from '../../api/bookings';
-import { getVolunteerNoShowRanking } from '../../api/volunteers';
 import type { Role } from '../../types';
 import { formatTime } from '../../utils/time';
 import EntitySearch from '../EntitySearch';
@@ -81,16 +79,12 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
     upcoming: [],
     past: [],
   });
-  const [noShowRanking, setNoShowRanking] = useState<
-    { id: number; name: string; totalBookings: number; noShows: number; noShowRate: number }[]
-  >([]);
   const [searchType, setSearchType] = useState<'user' | 'volunteer'>('user');
   const navigate = useNavigate();
 
   useEffect(() => {
     getBookings().then(setBookings).catch(() => {});
     getEvents().then(setEvents).catch(() => {});
-    getVolunteerNoShowRanking().then(setNoShowRanking).catch(() => {});
 
     const today = new Date();
     const start = new Date(today);
@@ -241,20 +235,6 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
                   </Button>
                 </Stack>
               </Stack>
-            </SectionCard>
-          </Grid>
-          <Grid size={12}>
-            <SectionCard title="No-Show Rankings" icon={<WarningAmber color="warning" />}>
-              <List>
-                {noShowRanking.map(v => (
-                  <ListItem key={v.id}>
-                    <ListItemText
-                      primary={v.name}
-                      secondary={`${v.noShows}/${v.totalBookings} (${Math.round(v.noShowRate * 100)}%)`}
-                    />
-                  </ListItem>
-                ))}
-              </List>
             </SectionCard>
           </Grid>
           <Grid size={12}>


### PR DESCRIPTION
## Summary
- remove volunteer no-show rankings card from staff dashboard
- drop unused no-show ranking API wrapper
- update tests for dashboard and volunteer APIs

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38ef3eb8c832d82aa8e86617e69b5