### PR TITLE
Handle month overlap for walk-in visits

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -2,9 +2,15 @@ import { Request, Response, NextFunction } from 'express';
 import pool from '../db';
 import logger from '../utils/logger';
 import { formatReginaDate } from '../utils/dateUtils';
+import { Pool, PoolClient } from 'pg';
 
-async function refreshClientVisitCount(clientId: number) {
-  await pool.query(
+type Queryable = Pool | PoolClient;
+
+async function refreshClientVisitCount(
+  clientId: number,
+  client: Queryable = pool,
+) {
+  await client.query(
     `UPDATE clients c
      SET bookings_this_month = (
        SELECT COUNT(*) FROM client_visits v
@@ -39,43 +45,75 @@ export async function listVisits(req: Request, res: Response, next: NextFunction
 }
 
 export async function addVisit(req: Request, res: Response, next: NextFunction) {
+  const client = await pool.connect();
   try {
+    await client.query('BEGIN');
     const { date, clientId, weightWithCart, weightWithoutCart, petItem, anonymous } = req.body;
-    const result = await pool.query(
+    const result = await client.query(
       `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous)
        VALUES ($1, $2, $3, $4, COALESCE($5,0), $6)
        RETURNING id, date, client_id as "clientId", weight_with_cart as "weightWithCart",
                  weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous"`,
-      [date, clientId ?? null, weightWithCart, weightWithoutCart, petItem ?? 0, anonymous ?? false]
+      [date, clientId ?? null, weightWithCart, weightWithoutCart, petItem ?? 0, anonymous ?? false],
     );
     let clientName: string | null = null;
     if (clientId) {
-      const clientRes = await pool.query(
+      const clientRes = await client.query(
         'SELECT first_name, last_name FROM clients WHERE client_id = $1',
-        [clientId]
+        [clientId],
       );
       if ((clientRes.rowCount ?? 0) > 0) {
         clientName = `${clientRes.rows[0].first_name ?? ''} ${clientRes.rows[0].last_name ?? ''}`.trim();
       }
-      await refreshClientVisitCount(clientId);
 
       // If the client had an approved booking on this date, mark it visited
-      const bookingRes = await pool.query(
+      const bookingRes = await client.query(
         `SELECT b.id
            FROM bookings b
            INNER JOIN clients c ON b.user_id = c.client_id
            WHERE c.client_id = $1 AND b.date = $2 AND b.status = 'approved'`,
-        [clientId, formatReginaDate(date)]
+        [clientId, formatReginaDate(date)],
       );
       if ((bookingRes.rowCount ?? 0) > 0) {
-        await pool.query('UPDATE bookings SET status = $1 WHERE id = $2', [
+        await client.query('UPDATE bookings SET status = $1 WHERE id = $2', [
           'visited',
           bookingRes.rows[0].id,
         ]);
       }
+
+      // Handle other approved bookings in the same month
+      const otherRes = await client.query(
+        `SELECT id, date FROM bookings
+         WHERE user_id = $1
+           AND status = 'approved'
+           AND DATE_TRUNC('month', date) = DATE_TRUNC('month', $2::date)
+           AND date <> $2::date`,
+        [clientId, formatReginaDate(date)],
+      );
+      for (const b of otherRes.rows) {
+        const bookingDate = new Date(b.date);
+        const visitDate = new Date(formatReginaDate(date));
+        if (bookingDate > visitDate) {
+          await client.query(
+            'UPDATE bookings SET status=$1, date=$2, slot_id=NULL WHERE id=$3',
+            ['visited', formatReginaDate(date), b.id],
+          );
+        } else {
+          await client.query(
+            'UPDATE bookings SET status=$1, slot_id=NULL WHERE id=$2',
+            ['no_show', b.id],
+          );
+        }
+      }
+
+      await refreshClientVisitCount(clientId, client);
     }
+    await client.query('COMMIT');
+    client.release();
     res.status(201).json({ ...result.rows[0], clientName });
   } catch (error) {
+    await client.query('ROLLBACK');
+    client.release();
     logger.error('Error adding client visit:', error);
     next(error);
   }

--- a/MJ_FB_Backend/tests/clientVisitOtherBooking.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitOtherBooking.test.ts
@@ -47,18 +47,16 @@ app.use(
   },
 );
 
-describe('client visit booking integration', () => {
+describe('adjust other bookings on visit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('updates booking to visited and avoids duplicate history record', async () => {
+  it('marks future booking as visited and moves date', async () => {
     const mockClient = { query: jest.fn(), release: jest.fn() };
     (pool.connect as jest.Mock).mockResolvedValue(mockClient);
     mockClient.query
-      // BEGIN
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
-      // insert visit
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
       .mockResolvedValueOnce({
         rows: [
           {
@@ -72,32 +70,28 @@ describe('client visit booking integration', () => {
           },
         ],
         rowCount: 1,
-      })
-      // select client name
+      }) // insert visit
       .mockResolvedValueOnce({
         rows: [{ first_name: 'Ann', last_name: 'Client' }],
         rowCount: 1,
-      })
-      // find existing booking
-      .mockResolvedValueOnce({ rows: [{ id: 55 }], rowCount: 1 })
-      // update booking status
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
-      // other bookings query
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
-      // refresh visit count
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
-      // COMMIT
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      }) // select client
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // same-day booking
+      .mockResolvedValueOnce({
+        rows: [{ id: 55, date: '2024-01-20' }],
+        rowCount: 1,
+      }) // other booking
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // update booking
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // refresh count
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // COMMIT
 
-    (pool.query as jest.Mock)
-      // booking history query
+    ;(pool.query as jest.Mock)
       .mockResolvedValueOnce({
         rows: [
           {
             id: 55,
             status: 'visited',
             date: '2024-01-02',
-            slot_id: 1,
+            slot_id: null,
             reason: null,
             start_time: '09:00:00',
             end_time: '09:30:00',
@@ -108,7 +102,6 @@ describe('client visit booking integration', () => {
         ],
         rowCount: 1,
       })
-      // visits query should return empty because booking exists
       .mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
     const visitRes = await request(app)
@@ -124,16 +117,65 @@ describe('client visit booking integration', () => {
     expect(visitRes.status).toBe(201);
 
     expect(mockClient.query).toHaveBeenCalledWith(
-      expect.stringContaining('UPDATE bookings SET status = $1 WHERE id = $2'),
-      ['visited', 55],
+      expect.stringContaining('UPDATE bookings SET status=$1, date=$2, slot_id=NULL WHERE id=$3'),
+      ['visited', '2024-01-02', 55],
     );
 
     const historyRes = await request(app)
       .get('/bookings/history?userId=1&includeVisits=true');
-
     expect(historyRes.status).toBe(200);
     expect(historyRes.body).toHaveLength(1);
+    expect(historyRes.body[0].date).toBe('2024-01-02');
     expect(historyRes.body[0].status).toBe('visited');
   });
-});
 
+  it('marks past booking as no_show', async () => {
+    const mockClient = { query: jest.fn(), release: jest.fn() };
+    (pool.connect as jest.Mock).mockResolvedValue(mockClient);
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 7,
+            date: '2024-01-15',
+            clientId: 123,
+            weightWithCart: 10,
+            weightWithoutCart: 8,
+            petItem: 0,
+            anonymous: false,
+          },
+        ],
+        rowCount: 1,
+      }) // insert visit
+      .mockResolvedValueOnce({
+        rows: [{ first_name: 'Ann', last_name: 'Client' }],
+        rowCount: 1,
+      }) // select client
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // same-day booking
+      .mockResolvedValueOnce({
+        rows: [{ id: 66, date: '2024-01-10' }],
+        rowCount: 1,
+      }) // other booking earlier in month
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // update booking
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // refresh count
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // COMMIT
+
+    const visitRes = await request(app)
+      .post('/client-visits')
+      .send({
+        date: '2024-01-15',
+        clientId: 123,
+        weightWithCart: 10,
+        weightWithoutCart: 8,
+        petItem: 0,
+        anonymous: false,
+      });
+    expect(visitRes.status).toBe(201);
+
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE bookings SET status=$1, slot_id=NULL WHERE id=$2'),
+      ['no_show', 66],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- refresh client visit count within transaction
- adjust other monthly bookings to visited or no_show when walk-in occurs
- add tests for future and past booking scenarios

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test tests/clientVisitBookingStatus.test.ts tests/clientVisitOtherBooking.test.ts` *(not run: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b38f3317ac832d904fb5c3382d5abd