### PR TITLE
Exclude past approved bookings from monthly visit count

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingUtils.ts
+++ b/MJ_FB_Backend/src/utils/bookingUtils.ts
@@ -86,7 +86,7 @@ export async function countVisitsAndBookingsForMonth(
     const res = await client.query(
       `SELECT (
         SELECT COUNT(*) FROM bookings
-        WHERE user_id=$1 AND status='approved' AND date BETWEEN $2 AND $3
+        WHERE user_id=$1 AND status='approved' AND date BETWEEN $2 AND $3 AND date >= CURRENT_DATE
       ) + (
         SELECT COUNT(*) FROM client_visits cv
         INNER JOIN clients c ON cv.client_id = c.client_id

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -57,3 +57,22 @@ describe('startNoShowCleanupJob/stopNoShowCleanupJob', () => {
     expect(stopMock).toHaveBeenCalled();
   });
 });
+
+describe('countVisitsAndBookingsForMonth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('excludes past approved bookings', async () => {
+    const { countVisitsAndBookingsForMonth, getMonthRange } = require('../src/utils/bookingUtils');
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ total: '0' }] });
+    const userId = 1;
+    const date = '2024-05-15';
+    await countVisitsAndBookingsForMonth(userId, date);
+    const { start, end } = getMonthRange(date)!;
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("status='approved' AND date BETWEEN $2 AND $3 AND date >= CURRENT_DATE"),
+      [userId, start, end],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Ignore past approved bookings in monthly visit calculations
- Add test to ensure old approved bookings are excluded

## Testing
- `npm test` *(fails: jest: not found; npm install 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68b3900904f4832db2f7ae4e29c86e31