### PR TITLE
Document trained-role requirement for volunteer bookings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,6 +448,7 @@ Volunteer booking statuses include `completed`, and cancellations must include a
 - **VolunteerSchedule** lets volunteers choose a role from a dropdown and view a grid of shifts. Columns correspond to slot numbers and rows show shift times (e.g. 9:30–12:00, 12:30–3:30). Cells display *Booked* or *Available* and clicking an available cell creates a request in `volunteer_bookings`. Past dates are disabled and same-day shifts that have already started are omitted.
 - The Volunteer Dashboard's **Available in My Roles** list excludes shifts the volunteer has already requested or booked and shows server-provided error messages when a booking attempt fails.
 - Volunteers can view their trained roles on the dashboard but cannot update them; staff manage trained areas through the volunteer search interface.
+- Volunteers may only book shifts for roles they are trained in; attempts to book untrained roles must be blocked and handled by staff.
 - Shift booking confirmations display "Shift booked" since bookings are auto-approved and the submitted state has been removed; the volunteer dashboard lists only approved bookings.
 - Volunteer and pantry schedules follow the same grid logic. The y‑axis lists shift times and the x‑axis lists sequential slot numbers up to each shift's `max_volunteers`. When a volunteer requests a shift, the booking is immediately approved and occupies the first open slot.
 - **BookingHistory** shows a volunteer's upcoming bookings with Cancel and Reschedule options.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 
  - Appointment booking workflow for clients with automatic approval and rescheduling.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
-- Volunteer role management and scheduling restricted to trained areas.
+- Volunteer role management and scheduling restricted to trained areas; volunteers can only book shifts in roles they are trained for.
 - Staff can review past volunteer shifts from the **Pending Reviews** tab and mark them completed or no_show.
 - Only staff can update volunteer trained roles; volunteers may view but not modify their assigned roles from the dashboard.
 - Daily reminder jobs queue emails for next-day bookings and volunteer shifts using the backend email queue. Each job now runs via `node-cron` at `0 9 * * *` Regina time and exposes start/stop functions.


### PR DESCRIPTION
## Summary
- Clarify in documentation that volunteers can only book shifts for roles where they are trained
- Reflect trained-role booking restriction in repository README

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm install` (backend) *(fails: 403 Forbidden for undici)*
- `npm test` (frontend) *(fails: jest not found)*
- `npm install` (frontend) *(fails: 403 Forbidden for undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b39254c024832db0d317ea02b04236