### PR TITLE
Clarify volunteer shift status handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 - Volunteer management navigation includes a **Pending Reviews** tab for staff to mark past shifts as `completed` or `no_show`.
 
 Volunteer booking statuses include `completed`, and cancellations must include a reason.
+Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid for volunteer bookings and the backend responds with "Use completed instead of visited for volunteer shifts" when submitted.
 
 ### Volunteer Recurring Bookings (`src/routes/volunteer/volunteerBookings.ts`)
 - `POST /volunteer-bookings/recurring` `{ roleId, startDate, endDate, pattern, daysOfWeek }` → `{ recurringId, successes, skipped }`

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -597,7 +597,15 @@ export async function updateVolunteerBookingStatus(
 ) {
   const { id } = req.params;
   const { status, reason } = req.body as { status?: string; reason?: string };
-  if (!status || !['cancelled', 'no_show', 'completed'].includes(status)) {
+  if (!status) {
+    return res.status(400).json({ message: 'Status is required' });
+  }
+  if (status === 'visited') {
+    return res
+      .status(400)
+      .json({ message: 'Use completed instead of visited for volunteer shifts' });
+  }
+  if (!['cancelled', 'no_show', 'completed'].includes(status)) {
     return res
       .status(400)
       .json({ message: 'Status must be cancelled, no_show or completed' });

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -60,6 +60,15 @@ describe('updateVolunteerBookingStatus', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects visited status with guidance', async () => {
+    const res = await request(app)
+      .patch('/volunteer-bookings/1')
+      .send({ status: 'visited' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/completed/);
+    expect((pool.query as jest.Mock)).not.toHaveBeenCalled();
+  });
+
   it('allows status completed', async () => {
     const booking = { id: 1, slot_id: 2, volunteer_id: 3, date: '2025-09-01', status: 'approved' };
     (pool.query as jest.Mock)

--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -169,11 +169,11 @@ test('hides cancel options for non-approved bookings', async () => {
     {
       id: 1,
       role_id: 1,
-      role_name: 'Visited Role',
+      role_name: 'Completed Role',
       date: '2024-05-01',
       start_time: '09:00:00',
       end_time: '10:00:00',
-      status: 'visited',
+      status: 'completed',
     },
     {
       id: 2,
@@ -207,8 +207,8 @@ test('hides cancel options for non-approved bookings', async () => {
   render(<VolunteerBookingHistory />);
   await screen.findByText('Approved Role');
   expect(screen.getAllByText('Cancel')).toHaveLength(1);
-  const visitedRow = screen.getByText('Visited Role').closest('tr')!;
-  expect(within(visitedRow).queryByText('Cancel')).toBeNull();
+  const completedRow = screen.getByText('Completed Role').closest('tr')!;
+  expect(within(completedRow).queryByText('Cancel')).toBeNull();
   const cancelledRow = screen.getByText('Cancelled Role').closest('tr')!;
   expect(within(cancelledRow).queryByText('Cancel')).toBeNull();
   const noShowRow = screen.getByText('NoShow Role').closest('tr')!;

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Volunteer role assignment uses a simple dropdown without search capability.
 - Volunteer bookings are auto-approved with no submitted state and appear immediately on schedules.
 - Volunteer booking statuses include `completed`, and cancelling a booking now requires a reason.
+- Volunteer interfaces show `completed` or `no_show`; submitting `visited` for a volunteer shift now returns `Use completed instead of visited for volunteer shifts`.
 - Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
 - Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Volunteer Settings page's **Restore Original Roles & Shifts** button.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).


### PR DESCRIPTION
## Summary
- Show volunteer shift test data as `completed` rather than `visited`
- Reject `visited` status for volunteer shifts with clear guidance
- Document volunteer UI and validator expectations

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b39476fcb8832d932d74d30dfee5a0