### PR TITLE
feat(client-management): add weekly no-show tab

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -6,6 +6,7 @@ import AddClient from './client-management/AddClient';
 import UpdateClientData from './client-management/UpdateClientData';
 import UserHistory from './client-management/UserHistory';
 import NewClients from './client-management/NewClients';
+import NoShowWeek from './client-management/NoShowWeek';
 
 export default function ClientManagement() {
   const [searchParams] = useSearchParams();
@@ -18,6 +19,8 @@ export default function ClientManagement() {
         return 2;
       case 'new':
         return 3;
+      case 'noshow':
+        return 4;
       default:
         return 0;
     }
@@ -28,6 +31,7 @@ export default function ClientManagement() {
     if (t === 'update') setTab(1);
     else if (t === 'history') setTab(2);
     else if (t === 'new') setTab(3);
+    else if (t === 'noshow') setTab(4);
     else setTab(0);
   }, [searchParams]);
   const tabs = [
@@ -35,6 +39,7 @@ export default function ClientManagement() {
     { label: 'Update', content: <UpdateClientData /> },
     { label: 'History', content: <UserHistory /> },
     { label: 'New Clients', content: <NewClients /> },
+    { label: 'No Shows', content: <NoShowWeek /> },
   ];
 
   return (

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/NoShowWeek.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/NoShowWeek.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import NoShowWeek from '../client-management/NoShowWeek';
+import { getBookings } from '../../../api/bookings';
+
+jest.mock('../../../api/bookings', () => ({
+  getBookings: jest.fn(),
+}));
+
+describe('NoShowWeek', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T12:00:00'));
+    (getBookings as jest.Mock).mockImplementation(({ date }) => {
+      if (date === '2024-01-01') {
+        return Promise.resolve([
+          {
+            id: 1,
+            status: 'no_show',
+            date,
+            slot_id: 1,
+            user_name: 'No Show',
+            user_id: 1,
+            client_id: 1,
+            visits_this_month: 0,
+            approved_bookings_this_month: 0,
+            is_staff_booking: false,
+            reschedule_token: 't1',
+            profile_link: '',
+            start_time: '09:00:00',
+          },
+          {
+            id: 2,
+            status: 'approved',
+            date,
+            slot_id: 1,
+            user_name: 'Approved Past',
+            user_id: 1,
+            client_id: 1,
+            visits_this_month: 0,
+            approved_bookings_this_month: 0,
+            is_staff_booking: false,
+            reschedule_token: 't2',
+            profile_link: '',
+            start_time: '08:00:00',
+          },
+          {
+            id: 3,
+            status: 'approved',
+            date,
+            slot_id: 1,
+            user_name: 'Approved Future',
+            user_id: 1,
+            client_id: 1,
+            visits_this_month: 0,
+            approved_bookings_this_month: 0,
+            is_staff_booking: false,
+            reschedule_token: 't3',
+            profile_link: '',
+            start_time: '23:59:00',
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    (getBookings as jest.Mock).mockReset();
+  });
+
+  it('filters today bookings by status', async () => {
+    render(
+      <MemoryRouter>
+        <NoShowWeek />
+      </MemoryRouter>,
+    );
+
+    const table = await screen.findByTestId('today-bookings');
+
+    expect(within(table).getByText('No Show')).toBeInTheDocument();
+    expect(within(table).getByText('Approved Past')).toBeInTheDocument();
+    expect(within(table).queryByText('Approved Future')).not.toBeInTheDocument();
+
+    const filter = screen.getByLabelText('Status');
+    fireEvent.mouseDown(filter);
+    let listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText(/Approved/i));
+
+    expect(within(table).queryByText('No Show')).not.toBeInTheDocument();
+    expect(within(table).getByText('Approved Past')).toBeInTheDocument();
+
+    fireEvent.mouseDown(filter);
+    listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText(/No Show/i));
+
+    expect(within(table).getByText('No Show')).toBeInTheDocument();
+    expect(within(table).queryByText('Approved Past')).not.toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
@@ -1,0 +1,172 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { getBookings } from '../../../api/bookings';
+import { formatDate, toDayjs } from '../../../utils/date';
+import { formatTime } from '../../../utils/time';
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Stack,
+} from '@mui/material';
+import type { AlertColor } from '@mui/material';
+import ManageBookingDialog from '../../../components/ManageBookingDialog';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+
+interface Booking {
+  id: number;
+  status: string;
+  date: string;
+  slot_id: number;
+  user_name: string;
+  user_id: number | null;
+  client_id: number | null;
+  newClientId?: number | null;
+  visits_this_month: number;
+  approved_bookings_this_month: number;
+  is_staff_booking: boolean;
+  reschedule_token: string;
+  profile_link: string;
+}
+
+export default function NoShowWeek() {
+  const [start] = useState(() => toDayjs().startOf('week'));
+  const days = useMemo(() => Array.from({ length: 7 }, (_, i) => start.add(i, 'day')), [start]);
+  const today = useMemo(() => toDayjs(), []);
+
+  const [byDate, setByDate] = useState<Record<string, Booking[]>>({});
+  const [filter, setFilter] = useState<'all' | 'approved' | 'no_show'>('all');
+  const [manageBooking, setManageBooking] = useState<Booking | null>(null);
+  const [snackbar, setSnackbar] = useState<{ message: string; severity: AlertColor } | null>(null);
+
+  const loadWeek = useCallback(async () => {
+    const results = await Promise.all(
+      days.map(d => getBookings({ date: formatDate(d) }))
+    );
+    const map: Record<string, Booking[]> = {};
+    results.forEach((res, idx) => {
+      const arr = Array.isArray(res) ? res : [res];
+      map[formatDate(days[idx])] = arr as Booking[];
+    });
+    setByDate(map);
+  }, [days]);
+
+  useEffect(() => {
+    loadWeek().catch(() => {});
+  }, [loadWeek]);
+
+  function filtered(dateStr: string) {
+    const list = byDate[dateStr] || [];
+    if (dateStr !== formatDate(today)) {
+      return list.filter(b => b.status === 'no_show');
+    }
+    const now = toDayjs();
+    const approvedPast = list.filter(
+      b =>
+        b.status === 'approved' &&
+        toDayjs(`${dateStr}T${b.start_time}`).isBefore(now),
+    );
+    const noShows = list.filter(b => b.status === 'no_show');
+    if (filter === 'approved') return approvedPast;
+    if (filter === 'no_show') return noShows;
+    return [...approvedPast, ...noShows];
+  }
+
+  function handleUpdated(message: string, severity: AlertColor) {
+    setSnackbar({ message, severity });
+    loadWeek();
+  }
+
+  return (
+    <Box>
+      {days.map(d => {
+        const dateStr = formatDate(d);
+        const list = filtered(dateStr);
+        return (
+          <Box key={dateStr} mb={3}>
+            <Stack direction="row" spacing={2} alignItems="center" mb={1}>
+              <Typography variant="h6">
+                {formatDate(d, 'dddd, MMM D')}
+              </Typography>
+              {dateStr === formatDate(today) && (
+                <FormControl size="small">
+                  <InputLabel>Status</InputLabel>
+                  <Select
+                    label="Status"
+                    value={filter}
+                    onChange={e =>
+                      setFilter(e.target.value as 'all' | 'approved' | 'no_show')
+                    }
+                  >
+                    <MenuItem value="all">All</MenuItem>
+                    <MenuItem value="approved">Approved</MenuItem>
+                    <MenuItem value="no_show">No Show</MenuItem>
+                  </Select>
+                </FormControl>
+              )}
+            </Stack>
+            {list.length === 0 ? (
+              <Typography>No bookings</Typography>
+            ) : (
+              <TableContainer>
+                <Table
+                  size="small"
+                  data-testid={
+                    dateStr === formatDate(today) ? 'today-bookings' : undefined
+                  }
+                >
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Time</TableCell>
+                      <TableCell>Client</TableCell>
+                      <TableCell>Status</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {list.map(b => (
+                      <TableRow
+                        key={b.id}
+                        hover
+                        sx={{ cursor: 'pointer' }}
+                        onClick={() => setManageBooking(b)}
+                      >
+                        <TableCell>{formatTime(b.start_time)}</TableCell>
+                        <TableCell>{b.user_name}</TableCell>
+                        <TableCell sx={{ textTransform: 'capitalize' }}>
+                          {b.status.replace('_', ' ')}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
+          </Box>
+        );
+      })}
+      {manageBooking && (
+        <ManageBookingDialog
+          open
+          booking={manageBooking}
+          onClose={() => setManageBooking(null)}
+          onUpdated={handleUpdated}
+        />
+      )}
+      <FeedbackSnackbar
+        open={!!snackbar}
+        message={snackbar?.message || ''}
+        severity={snackbar?.severity || 'success'}
+        onClose={() => setSnackbar(null)}
+      />
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `NoShowWeek` tab to Client Management for reviewing weekly no-shows
- allow filtering of today's appointments by status
- include unit test for status filtering

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68b397616640832d89f365fb8c24eb33