### PR TITLE
feat: reorganize volunteers menu with weekly reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,7 +348,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `GET /volunteer-bookings/unmarked` → `[ { id, status, role_id, volunteer_id, date, reschedule_token, start_time, end_time, role_name, category_name, volunteer_name, status_color } ]`
 - `PATCH /volunteer-bookings/:id` → `{ id, role_id, volunteer_id, date, status, status_color }`
 - `POST /volunteer-bookings/reschedule/:token` → `{ message: 'Volunteer booking rescheduled', rescheduleToken }`
-- Volunteer management navigation includes a **Pending Reviews** tab for staff to mark past shifts as `completed` or `no_show`.
+- Volunteer management groups volunteer search, creation, and pending reviews under a **Volunteers** submenu. The **Pending Reviews** tab shows the current week, listing `no_show` shifts and today's overdue `approved` bookings with a status filter.
 
 Volunteer booking statuses include `completed`, and cancellations must include a reason.
 Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid for volunteer bookings and the backend responds with "Use completed instead of visited for volunteer shifts" when submitted.

--- a/MJ_FB_Backend/src/routes/volunteer/volunteerBookings.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteerBookings.ts
@@ -6,6 +6,7 @@ import {
   listMyVolunteerBookings,
   listMyRecurringVolunteerBookings,
   listUnmarkedVolunteerBookings,
+  listVolunteerBookingsForReview,
   updateVolunteerBookingStatus,
   listVolunteerBookingsByVolunteer,
   createVolunteerBookingForVolunteer,
@@ -55,6 +56,12 @@ router.get(
   authMiddleware,
   authorizeRoles('staff'),
   listUnmarkedVolunteerBookings,
+);
+router.get(
+  '/review',
+  authMiddleware,
+  authorizeRoles('staff'),
+  listVolunteerBookingsForReview,
 );
 router.get('/', authMiddleware, authorizeRoles('staff'), listVolunteerBookings);
 router.get('/:role_id', authMiddleware, authorizeRoles('staff'), listVolunteerBookingsByRole);

--- a/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
@@ -1,0 +1,92 @@
+import request from 'supertest';
+import express from 'express';
+import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  authorizeAccess: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  optionalAuthMiddleware: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/volunteer-bookings', volunteerBookingsRouter);
+
+describe('listVolunteerBookingsForReview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns bookings needing review', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          status: 'no_show',
+          role_id: 2,
+          volunteer_id: 3,
+          date: '2024-01-01',
+          reschedule_token: 'abc',
+          recurring_id: null,
+          start_time: '09:00:00',
+          end_time: '12:00:00',
+          max_volunteers: 5,
+          role_name: 'Pantry',
+          category_name: 'Food',
+          volunteer_name: 'Jane Doe',
+        },
+        {
+          id: 2,
+          status: 'approved',
+          role_id: 2,
+          volunteer_id: 4,
+          date: '2024-01-02',
+          reschedule_token: 'def',
+          recurring_id: null,
+          start_time: '09:00:00',
+          end_time: '12:00:00',
+          max_volunteers: 5,
+          role_name: 'Pantry',
+          category_name: 'Food',
+          volunteer_name: 'John Doe',
+        },
+      ],
+    });
+
+    const res = await request(app).get(
+      '/volunteer-bookings/review?start=2024-01-01&end=2024-01-07',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toMatchObject({
+      id: 1,
+      status: 'no_show',
+      volunteer_name: 'Jane Doe',
+    });
+    expect(res.body[1]).toMatchObject({
+      id: 2,
+      status: 'approved',
+      volunteer_name: 'John Doe',
+    });
+  });
+});

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -9,7 +9,8 @@ import FeedbackSnackbar from './components/FeedbackSnackbar';
 import MainLayout from './components/layout/MainLayout';
 import { useAuth, AgencyGuard } from './hooks/useAuth';
 import type { StaffAccess } from './types';
-import { getUnmarkedVolunteerBookings } from './api/volunteers';
+import { getVolunteerBookingsForReview } from './api/volunteers';
+import dayjs, { formatDate } from './utils/date';
 
 const Profile = React.lazy(() => import('./pages/booking/Profile'));
 const ManageAvailability = React.lazy(() =>
@@ -61,6 +62,9 @@ const PendingReviews = React.lazy(() =>
 );
 const VolunteerRankings = React.lazy(() =>
   import('./pages/volunteer-management/VolunteerRankings')
+);
+const VolunteerTabs = React.lazy(() =>
+  import('./pages/volunteer-management/VolunteerTabs')
 );
 const WarehouseDashboard = React.lazy(() =>
   import('./pages/warehouse-management/WarehouseDashboard')
@@ -128,7 +132,9 @@ export default function App() {
 
   useEffect(() => {
     if (showVolunteerManagement) {
-      getUnmarkedVolunteerBookings()
+      const start = formatDate(dayjs().startOf('week'));
+      const end = formatDate(dayjs().startOf('week').add(6, 'day'));
+      getVolunteerBookingsForReview(start, end)
         .then(b => setPendingReviews(b.length))
         .catch(() => setPendingReviews(0));
     }
@@ -166,13 +172,11 @@ export default function App() {
         links: [
           { label: 'Dashboard', to: '/volunteer-management' },
           { label: 'Schedule', to: '/volunteer-management/schedule' },
-          { label: 'Search', to: '/volunteer-management/search' },
           {
-            label: 'Pending Reviews',
-            to: '/volunteer-management/pending-reviews',
+            label: 'Volunteers',
+            to: '/volunteer-management/volunteers',
             badge: pendingReviews,
           },
-          { label: 'Create', to: '/volunteer-management/create' },
         ],
       });
 
@@ -395,9 +399,23 @@ export default function App() {
                     element={<VolunteerManagement />}
                   />
                   <Route
-                    path="/volunteer-management/pending-reviews"
-                    element={<PendingReviews />}
-                  />
+                    path="/volunteer-management/volunteers/*"
+                    element={<VolunteerTabs />}
+                  >
+                    <Route index element={<Navigate to="search" replace />} />
+                    <Route
+                      path="search"
+                      element={<VolunteerManagement initialTab="search" />}
+                    />
+                    <Route
+                      path="create"
+                      element={<VolunteerManagement initialTab="create" />}
+                    />
+                    <Route
+                      path="pending-reviews"
+                      element={<PendingReviews />}
+                    />
+                  </Route>
                   <Route
                     path="/volunteer-management/rankings"
                     element={<VolunteerRankings />}

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -7,17 +7,20 @@ const originalFetch = (global as any).fetch;
 jest.mock('../pages/volunteer-management/VolunteerManagement', () => () => (
   <div>VolunteerManagement</div>
 ));
+jest.mock('../pages/volunteer-management/VolunteerTabs', () => () => (
+  <div>VolunteerTabs</div>
+));
 jest.mock('../pages/warehouse-management/WarehouseDashboard', () => () => (
   <div>WarehouseDashboard</div>
-));
-jest.mock('../pages/volunteer-management/PendingReviews', () => () => (
-  <div>PendingReviews</div>
 ));
 
 jest.mock('../api/bookings', () => ({
   getBookingHistory: jest.fn().mockResolvedValue([]),
   getSlots: jest.fn().mockResolvedValue([]),
   getHolidays: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../api/volunteers', () => ({
+  getVolunteerBookingsForReview: jest.fn().mockResolvedValue([]),
 }));
 
 describe('App authentication persistence', () => {

--- a/MJ_FB_Frontend/src/__tests__/PendingReviews.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PendingReviews.test.tsx
@@ -2,12 +2,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PendingReviews from '../pages/volunteer-management/PendingReviews';
 import {
-  getUnmarkedVolunteerBookings,
+  getVolunteerBookingsForReview,
   updateVolunteerBookingStatus,
 } from '../api/volunteers';
 
 jest.mock('../api/volunteers', () => ({
-  getUnmarkedVolunteerBookings: jest.fn(),
+  getVolunteerBookingsForReview: jest.fn(),
   updateVolunteerBookingStatus: jest.fn(),
 }));
 
@@ -21,27 +21,34 @@ const sample = [
     volunteer_id: 1,
     volunteer_name: 'Alice',
     role_name: 'Pantry',
-    date: '2024-01-01',
+    date: '2024-01-02',
     start_time: '09:00:00',
     end_time: '12:00:00',
   },
   {
     id: 2,
-    status: 'approved',
+    status: 'no_show',
     role_id: 1,
     volunteer_id: 2,
     volunteer_name: 'Bob',
     role_name: 'Pantry',
     date: '2024-01-02',
-    start_time: '09:00:00',
-    end_time: '12:00:00',
+    start_time: '13:00:00',
+    end_time: '15:00:00',
   },
 ];
 
 describe('PendingReviews', () => {
   beforeEach(() => {
-    (getUnmarkedVolunteerBookings as jest.Mock).mockResolvedValue(sample);
+    (getVolunteerBookingsForReview as jest.Mock).mockResolvedValue(sample);
     (updateVolunteerBookingStatus as jest.Mock).mockResolvedValue(undefined);
+    jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(new Date('2024-01-02T16:00:00-06:00').valueOf());
+  });
+
+  afterEach(() => {
+    (Date.now as jest.Mock).mockRestore();
   });
 
   it('bulk updates selected bookings', async () => {
@@ -50,10 +57,9 @@ describe('PendingReviews', () => {
     expect(await screen.findByText('Alice')).toBeInTheDocument();
     const checkboxes = screen.getAllByRole('checkbox');
     fireEvent.click(checkboxes[1]);
-    fireEvent.click(checkboxes[2]);
     fireEvent.click(screen.getByRole('button', { name: /mark completed/i }));
-    await waitFor(() => expect(updateVolunteerBookingStatus).toHaveBeenCalledTimes(2));
-    expect(updateVolunteerBookingStatus).toHaveBeenCalledWith(1, 'completed');
-    expect(updateVolunteerBookingStatus).toHaveBeenCalledWith(2, 'completed');
+    await waitFor(() =>
+      expect(updateVolunteerBookingStatus).toHaveBeenCalledWith(1, 'completed'),
+    );
   });
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -319,6 +319,17 @@ export async function getUnmarkedVolunteerBookings(): Promise<VolunteerBooking[]
   return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
 }
 
+export async function getVolunteerBookingsForReview(
+  start: string,
+  end: string,
+): Promise<VolunteerBooking[]> {
+  const res = await apiFetch(
+    `${API_BASE}/volunteer-bookings/review?start=${start}&end=${end}`,
+  );
+  const data = await handleResponse(res);
+  return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
+}
+
 export async function updateVolunteerBookingStatus(
   bookingId: number,
   status: VolunteerBookingStatus,

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -80,16 +80,20 @@ interface VolunteerResult {
   hasShopper: boolean;
 }
 
+interface VolunteerManagementProps {
+  initialTab?: 'dashboard' | 'schedule' | 'search' | 'create';
+}
 
-export default function VolunteerManagement() {
+export default function VolunteerManagement({ initialTab }: VolunteerManagementProps = {}) {
   const { tab: tabParam } = useParams<{ tab?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const tab: 'dashboard' | 'schedule' | 'search' | 'create' =
-    tabParam === 'schedule' ||
+    initialTab ??
+    (tabParam === 'schedule' ||
     tabParam === 'search' ||
     tabParam === 'create'
       ? (tabParam as 'schedule' | 'search' | 'create')
-      : 'dashboard';
+      : 'dashboard');
   const tabTitles: Record<typeof tab, string> = {
     dashboard: 'Dashboard',
     schedule: 'Schedule',

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerTabs.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerTabs.tsx
@@ -1,0 +1,29 @@
+import { Tabs, Tab } from '@mui/material';
+import { Link as RouterLink, Outlet, useLocation } from 'react-router-dom';
+import Page from '../../components/Page';
+
+export default function VolunteerTabs() {
+  const location = useLocation();
+  const base = '/volunteer-management/volunteers';
+  const path = location.pathname.replace(base, '');
+  const value = path.startsWith('/create')
+    ? 1
+    : path.startsWith('/pending-reviews')
+    ? 2
+    : 0;
+
+  return (
+    <Page
+      title="Volunteers"
+      header={
+        <Tabs value={value} sx={{ mb: 2 }}>
+          <Tab label="Search" component={RouterLink} to={`${base}/search`} />
+          <Tab label="Add Volunteer" component={RouterLink} to={`${base}/create`} />
+          <Tab label="Pending Reviews" component={RouterLink} to={`${base}/pending-reviews`} />
+        </Tabs>
+      }
+    >
+      <Outlet />
+    </Page>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
  - Appointment booking workflow for clients with automatic approval and rescheduling.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas; volunteers can only book shifts in roles they are trained for.
-- Staff can review past volunteer shifts from the **Pending Reviews** tab and mark them completed or no_show.
+- Volunteer management groups volunteer search, creation, and review under a **Volunteers** submenu. Its **Pending Reviews** tab shows the current week with `no_show` shifts and today's overdue `approved` bookings, allowing staff to mark them `completed` or `no_show`.
 - Only staff can update volunteer trained roles; volunteers may view but not modify their assigned roles from the dashboard.
 - Daily reminder jobs queue emails for next-day bookings and volunteer shifts using the backend email queue. Each job now runs via `node-cron` at `0 9 * * *` Regina time and exposes start/stop functions.
 - A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.


### PR DESCRIPTION
## Summary
- Add `/volunteer-bookings/review` endpoint for weekly no-show and overdue approved shift review
- Group volunteer search, creation, and pending reviews under new Volunteers submenu
- Show 7-day pending review view with status filters

## Testing
- `npm test` (backend) *(fails: jest not found / npm install 403)*
- `npm test` (frontend) *(fails: jest not found / npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b398a3aba8832d88f063a21846430f