### PR TITLE
fix: add name and autocomplete attributes to client login fields

### DIFF
--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -65,6 +65,8 @@ export default function Login({
           value={clientId}
           onChange={e => setClientId(e.target.value)}
           label="Client ID"
+          name="clientId"
+          autoComplete="username"
           fullWidth
           required
           error={clientIdError}
@@ -75,6 +77,8 @@ export default function Login({
           value={password}
           onChange={e => setPassword(e.target.value)}
           label="Password"
+          name="password"
+          autoComplete="current-password"
           fullWidth
           required
           error={passwordError}


### PR DESCRIPTION
## Summary
- add `name` and `autoComplete` attributes to client ID and password fields in the client login form

## Testing
- `npm test` (fails: jest not found)
- `npm ci` (fails: 403 Forbidden retrieving dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68b39bbd20a4832dadfc76ab6cd9a764