### PR TITLE
Add InfoTooltip component

### DIFF
--- a/MJ_FB_Frontend/src/components/InfoTooltip.tsx
+++ b/MJ_FB_Frontend/src/components/InfoTooltip.tsx
@@ -1,0 +1,16 @@
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import { Tooltip, type TooltipProps, type SxProps, type Theme } from '@mui/material';
+
+interface InfoTooltipProps {
+  title?: TooltipProps['title'];
+  placement?: TooltipProps['placement'];
+  sx?: SxProps<Theme>;
+}
+
+export default function InfoTooltip({ title, placement = 'top', sx }: InfoTooltipProps) {
+  return (
+    <Tooltip title={title ?? ''} placement={placement}>
+      <HelpOutlineIcon fontSize="small" color="action" sx={sx} />
+    </Tooltip>
+  );
+}

--- a/MJ_FB_Frontend/src/components/README.md
+++ b/MJ_FB_Frontend/src/components/README.md
@@ -1,0 +1,15 @@
+# Components
+
+## InfoTooltip
+
+Displays a small `HelpOutline` question mark icon with a tooltip.
+
+```tsx
+import InfoTooltip from './InfoTooltip'; // adjust path as needed
+
+<InfoTooltip title="Explain this field" placement="right" sx={{ ml: 0.5 }} />
+```
+
+- `title` – tooltip content.
+- `placement` – optional tooltip placement.
+- `sx` – optional style overrides for the icon.


### PR DESCRIPTION
## Summary
- add InfoTooltip component using MUI Tooltip and HelpOutline icon
- document InfoTooltip usage in components README

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b39ba984c8832d9157a43f1550145b