### PR TITLE
feat: staff recurring volunteer booking endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,8 @@ Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid 
 ### Volunteer Recurring Bookings (`src/routes/volunteer/volunteerBookings.ts`)
 - `POST /volunteer-bookings/recurring` `{ roleId, startDate, endDate, pattern, daysOfWeek }` → `{ recurringId, successes, skipped }`
 - `GET /volunteer-bookings/recurring` → `[ { id, role_id, start_date, end_date, pattern, days_of_week } ]`
+- `POST /volunteer-bookings/recurring/staff` `{ volunteerId, roleId, startDate, endDate, pattern, daysOfWeek, force? }` → `{ recurringId, successes, skipped }`
+- `GET /volunteer-bookings/recurring/volunteer/:volunteer_id` → `[ { id, role_id, start_date, end_date, pattern, days_of_week } ]`
 - `DELETE /volunteer-bookings/recurring/:id?from=YYYY-MM-DD` → `{ message: 'Recurring bookings cancelled' }`
 - `PATCH /volunteer-bookings/:id/cancel` → `{ id, role_id, volunteer_id, date, status }`
 

--- a/MJ_FB_Backend/src/routes/volunteer/volunteerBookings.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteerBookings.ts
@@ -12,8 +12,10 @@ import {
   createVolunteerBookingForVolunteer,
   rescheduleVolunteerBooking,
   createRecurringVolunteerBooking,
+  createRecurringVolunteerBookingForVolunteer,
   cancelRecurringVolunteerBooking,
   cancelVolunteerBookingOccurrence,
+  listRecurringVolunteerBookingsByVolunteer,
   resolveVolunteerBookingConflict,
 } from '../../controllers/volunteer/volunteerBookingController';
 import {
@@ -21,7 +23,10 @@ import {
   authorizeRoles,
   optionalAuthMiddleware,
 } from '../../middleware/authMiddleware';
-import { CreateRecurringVolunteerBookingRequest } from '../../types/volunteerBooking';
+import {
+  CreateRecurringVolunteerBookingRequest,
+  CreateRecurringVolunteerBookingForVolunteerRequest,
+} from '../../types/volunteerBooking';
 
 const router = express.Router();
 
@@ -38,11 +43,23 @@ router.post<{}, any, CreateRecurringVolunteerBookingRequest>(
   authorizeRoles('volunteer'),
   createRecurringVolunteerBooking,
 );
+router.post<{}, any, CreateRecurringVolunteerBookingForVolunteerRequest>(
+  '/recurring/staff',
+  authMiddleware,
+  authorizeRoles('staff'),
+  createRecurringVolunteerBookingForVolunteer,
+);
 router.get(
   '/recurring',
   authMiddleware,
   authorizeRoles('volunteer'),
   listMyRecurringVolunteerBookings,
+);
+router.get(
+  '/recurring/volunteer/:volunteer_id',
+  authMiddleware,
+  authorizeRoles('staff'),
+  listRecurringVolunteerBookingsByVolunteer,
 );
 router.get('/mine', authMiddleware, authorizeRoles('volunteer'), listMyVolunteerBookings);
 router.get(

--- a/MJ_FB_Backend/src/schemas/volunteer/volunteerBookingSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/volunteer/volunteerBookingSchemas.ts
@@ -9,3 +9,12 @@ export const recurringBookingSchema = z.object({
 });
 
 export type RecurringBookingSchema = z.infer<typeof recurringBookingSchema>;
+
+export const recurringBookingForVolunteerSchema = recurringBookingSchema.extend({
+  volunteerId: z.number().int(),
+  force: z.boolean().optional(),
+});
+
+export type RecurringBookingForVolunteerSchema = z.infer<
+  typeof recurringBookingForVolunteerSchema
+>;

--- a/MJ_FB_Backend/src/types/volunteerBooking.ts
+++ b/MJ_FB_Backend/src/types/volunteerBooking.ts
@@ -6,7 +6,23 @@ export interface CreateRecurringVolunteerBookingRequest {
   daysOfWeek?: number[];
 }
 
-export interface RecurringVolunteerBookingResponse {
+export interface CreateRecurringVolunteerBookingForVolunteerRequest
+  extends CreateRecurringVolunteerBookingRequest {
+  volunteerId: number;
+  force?: boolean;
+}
+
+export interface RecurringVolunteerBookingResult {
   recurringId: number;
-  count: number;
+  successes: string[];
+  skipped: { date: string; reason: string }[];
+}
+
+export interface RecurringVolunteerBooking {
+  id: number;
+  role_id: number;
+  start_date: string;
+  end_date: string;
+  pattern: 'daily' | 'weekly';
+  days_of_week: number[];
 }

--- a/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
@@ -1,0 +1,76 @@
+import request from 'supertest';
+import express from 'express';
+import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
+import pool from '../src/db';
+import { sendEmail } from '../src/utils/emailUtils';
+
+jest.mock('../src/db');
+jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: any, _res: express.Response, next: express.NextFunction) => {
+    req.user = { id: 1, role: 'staff', email: 'staff@example.com' };
+    next();
+  },
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  optionalAuthMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/volunteer-bookings', volunteerBookingsRouter);
+
+describe('staff recurring volunteer bookings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates recurring bookings for a volunteer', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ role_id: 2, max_volunteers: 3, category_name: 'Pantry' }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ email: 'vol@example.com' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 30 }] })
+      .mockResolvedValue({ rowCount: 0, rows: [{ count: '0' }] });
+
+    const res = await request(app)
+      .post('/volunteer-bookings/recurring/staff')
+      .send({ volunteerId: 5, roleId: 2, startDate: '2025-01-01', endDate: '2025-01-03', pattern: 'daily' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.recurringId).toBe(30);
+    expect(res.body.successes).toEqual(['2025-01-01', '2025-01-02', '2025-01-03']);
+    expect(res.body.skipped).toEqual([]);
+    expect((sendEmail as jest.Mock).mock.calls).toHaveLength(9);
+  });
+
+  it('lists recurring bookings for a volunteer', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          role_id: 2,
+          start_date: '2025-01-01',
+          end_date: '2025-01-10',
+          pattern: 'daily',
+          days_of_week: [],
+        },
+      ],
+    });
+    const res = await request(app).get('/volunteer-bookings/recurring/volunteer/5');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: 1,
+        role_id: 2,
+        start_date: '2025-01-01',
+        end_date: '2025-01-10',
+        pattern: 'daily',
+        days_of_week: [],
+      },
+    ]);
+  });
+});

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.
- - **Volunteer Recurring Bookings** let volunteers schedule repeating shifts with start and end dates, choose daily, weekly, or weekday patterns, and cancel individual occurrences or the remaining series.
+- **Volunteer Recurring Bookings** let volunteers schedule repeating shifts with start and end dates, choose daily, weekly, or weekday patterns, and cancel individual occurrences or the remaining series.
+- Staff can create recurring volunteer booking series for volunteers via `POST /volunteer-bookings/recurring/staff` and list active series with `GET /volunteer-bookings/recurring/volunteer/:volunteer_id`.
  - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts). Volunteers can create new series and manage existing ones from separate tabs on the **Recurring Bookings** page.
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification (currently disabled pending further testing).


### PR DESCRIPTION
## Summary
- allow staff to create recurring volunteer bookings for a volunteer
- list recurring booking series by volunteer for staff
- document new staff recurring booking endpoints

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b39b845e04832dbcfe8f25a24dee8e