### PR TITLE
feat: add role-based help page

### DIFF
--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -1,6 +1,7 @@
 # MJ Food Bank Frontend
 
 This project is the React + Vite front end for the MJ Food Bank booking system. Volunteers can manage recurring bookings from `/volunteer/recurring`.
+Authenticated users can access a role-based help page at `/help`.
 
 ## Development
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -103,6 +103,7 @@ const AgencyLogin = React.lazy(() => import('./pages/agency/Login'));
 const AgencyBookAppointment = React.lazy(() =>
   import('./pages/agency/AgencyBookAppointment')
 );
+const HelpPage = React.lazy(() => import('./pages/help/HelpPage'));
 
 const Spinner = () => <CircularProgress />;
 
@@ -288,6 +289,7 @@ export default function App() {
                 }
               />
                 <Route path="/profile" element={<Profile role={role} />} />
+                <Route path="/help" element={<HelpPage />} />
               {showStaff && (
                 <Route
                   path="/pantry"

--- a/MJ_FB_Frontend/src/__tests__/HelpPage.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/HelpPage.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import HelpPage from '../pages/help/HelpPage';
+import { useAuth } from '../hooks/useAuth';
+
+jest.mock('../hooks/useAuth');
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <HelpPage />
+    </MemoryRouter>
+  );
+}
+
+describe('HelpPage', () => {
+  it('filters content with search', () => {
+    mockUseAuth.mockReturnValue({
+      role: 'volunteer',
+      access: [],
+      token: '',
+      name: '',
+      userRole: '',
+      login: jest.fn(),
+      logout: jest.fn(),
+      cardUrl: '',
+      ready: true,
+      id: null,
+    } as any);
+    renderPage();
+    expect(screen.getByText(/View schedule/i)).toBeInTheDocument();
+    expect(screen.getByText(/Recurring bookings/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/search/i), {
+      target: { value: 'recurring' },
+    });
+    expect(screen.queryByText(/View schedule/i)).toBeNull();
+    expect(screen.getByText(/Recurring bookings/i)).toBeInTheDocument();
+  });
+
+  it('shows tabs for available roles', () => {
+    mockUseAuth.mockReturnValue({
+      role: 'staff',
+      access: ['pantry', 'warehouse'],
+      token: '',
+      name: '',
+      userRole: '',
+      login: jest.fn(),
+      logout: jest.fn(),
+      cardUrl: '',
+      ready: true,
+      id: null,
+    } as any);
+    renderPage();
+    expect(screen.getByRole('tab', { name: /Pantry/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Warehouse/i })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: /Admin/i })).not.toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -19,6 +19,7 @@ describe('Navbar component', () => {
     expect(screen.getByText(/Hello, Tester/i)).toBeInTheDocument();
     fireEvent.click(screen.getByText(/Hello, Tester/i));
     expect(screen.getByText(/Profile/i)).toBeInTheDocument();
+    expect(screen.getByText(/Help/i)).toBeInTheDocument();
     expect(screen.getByText(/Logout/i)).toBeInTheDocument();
   });
 
@@ -64,6 +65,7 @@ describe('Navbar component', () => {
       fireEvent.click(screen.getByLabelText(/open navigation menu/i));
       expect(screen.getByText(/Hello, Tester/i)).toBeInTheDocument();
       expect(screen.getByText(/Profile/i)).toBeInTheDocument();
+      expect(screen.getByText(/Help/i)).toBeInTheDocument();
       expect(screen.getByText(/Logout/i)).toBeInTheDocument();
     } finally {
       window.matchMedia = originalMatchMedia;

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -206,6 +206,15 @@ export default function Navbar({
                           Profile
                         </MenuItem>
                         <MenuItem
+                          component={RouterLink}
+                          to="/help"
+                          onClick={() => setMobileAnchorEl(null)}
+                          disabled={loading}
+                          sx={DROPDOWN_ITEM_SX}
+                        >
+                          Help
+                        </MenuItem>
+                        <MenuItem
                           onClick={() => {
                             setMobileAnchorEl(null);
                             onLogout?.();
@@ -356,6 +365,15 @@ export default function Navbar({
                     sx={DROPDOWN_ITEM_SX}
                   >
                     Profile
+                  </MenuItem>
+                  <MenuItem
+                    component={RouterLink}
+                    to="/help"
+                    onClick={closeProfileMenu}
+                    disabled={loading}
+                    sx={DROPDOWN_ITEM_SX}
+                  >
+                    Help
                   </MenuItem>
                   <MenuItem
                     onClick={() => {

--- a/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
+++ b/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
@@ -1,0 +1,85 @@
+import { useState, useMemo } from 'react';
+import { Tabs, Tab, TextField, Button, Stack, Box, Typography } from '@mui/material';
+import Page from '../../components/Page';
+import { useAuth } from '../../hooks/useAuth';
+import { helpContent, type HelpSection } from './content';
+
+function roleLabel(role: string) {
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+export default function HelpPage() {
+  const { role, access } = useAuth();
+
+  const roles: string[] = [];
+  if (role === 'shopper') roles.push('client');
+  if (role === 'volunteer') roles.push('volunteer');
+  if (role === 'agency') roles.push('agency');
+  if (role === 'staff') {
+    if (access.includes('pantry')) roles.push('pantry');
+    if (access.includes('warehouse')) roles.push('warehouse');
+    if (access.includes('admin')) roles.push('admin');
+  }
+
+  const [tab, setTab] = useState(0);
+  const [search, setSearch] = useState('');
+  const currentRole = roles[tab];
+
+  const sections: HelpSection[] = useMemo(() => {
+    const query = search.toLowerCase();
+    return helpContent[currentRole]?.filter(
+      s =>
+        s.title.toLowerCase().includes(query) ||
+        s.body.toLowerCase().includes(query),
+    ) ?? [];
+  }, [currentRole, search]);
+
+  return (
+    <Page
+      title="Help"
+      header={
+        <Stack spacing={2} sx={{ mb: 2, '@media print': { display: 'none' } }}>
+          {roles.length > 1 && (
+            <Tabs
+              value={tab}
+              onChange={(_, v) => setTab(v)}
+              variant="scrollable"
+              allowScrollButtonsMobile
+            >
+              {roles.map(r => (
+                <Tab key={r} label={roleLabel(r)} />
+              ))}
+            </Tabs>
+          )}
+          <Stack direction="row" spacing={1} alignItems="center">
+            <TextField
+              label="Search"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              size="small"
+              sx={{ '@media print': { display: 'none' } }}
+            />
+            <Button
+              variant="outlined"
+              onClick={() => window.print()}
+              sx={{ '@media print': { display: 'none' } }}
+            >
+              Print
+            </Button>
+          </Stack>
+        </Stack>
+      }
+    >
+      {sections.map(s => (
+        <Box key={s.title} sx={{ mb: 3 }}>
+          <Typography variant="h5" gutterBottom>
+            {s.title}
+          </Typography>
+          <Typography>{s.body}</Typography>
+        </Box>
+      ))}
+      {!sections.length && <Typography>No matching topics.</Typography>}
+    </Page>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -1,0 +1,55 @@
+export interface HelpSection {
+  title: string;
+  body: string;
+}
+
+export const helpContent: Record<
+  'client' | 'volunteer' | 'agency' | 'pantry' | 'warehouse' | 'admin',
+  HelpSection[]
+> = {
+  client: [
+    {
+      title: 'Booking appointments',
+      body: 'Clients can book, reschedule, or cancel appointments from their dashboard.',
+    },
+    {
+      title: 'View booking history',
+      body: 'Past and upcoming bookings are listed under the booking history page.',
+    },
+  ],
+  volunteer: [
+    {
+      title: 'View schedule',
+      body: 'The volunteer schedule shows available shifts for trained roles.',
+    },
+    {
+      title: 'Recurring bookings',
+      body: 'Set up weekly shifts from the recurring bookings page.',
+    },
+  ],
+  agency: [
+    {
+      title: 'Book for clients',
+      body: 'Agencies may create, reschedule, or cancel bookings for linked clients.',
+    },
+  ],
+  pantry: [
+    {
+      title: 'Manage availability',
+      body: 'Staff can open or block pantry slots and adjust capacities.',
+    },
+  ],
+  warehouse: [
+    {
+      title: 'Track donations',
+      body: 'Warehouse staff record incoming and outgoing donations from the dashboard.',
+    },
+  ],
+  admin: [
+    {
+      title: 'Manage staff',
+      body: 'Admins can add staff members and configure system settings.',
+    },
+  ],
+};
+


### PR DESCRIPTION
## Summary
- add help page with search, print, and role tabs
- link help page from navbar
- document help page in README

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39ba54d30832d80832c55340d1a0b