### PR TITLE
Add autocomplete attributes to login forms

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/Login.tsx
@@ -58,6 +58,8 @@ export default function AgencyLogin({
       >
         <TextField
           type="email"
+          name="email"
+          autoComplete="email"
           value={email}
           onChange={e => setEmail(e.target.value)}
           label="Email"
@@ -68,6 +70,8 @@ export default function AgencyLogin({
         />
         <TextField
           type="password"
+          name="password"
+          autoComplete="current-password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           label="Password"

--- a/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
@@ -62,6 +62,8 @@ export default function VolunteerLogin({
         }
       >
         <TextField
+          name="username"
+          autoComplete="username"
           value={username}
           onChange={e => setUsername(e.target.value)}
           label="Username"
@@ -72,6 +74,8 @@ export default function VolunteerLogin({
         />
         <TextField
           type="password"
+          name="password"
+          autoComplete="current-password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           label="Password"


### PR DESCRIPTION
## Summary
- add name and autocomplete attributes to volunteer login username and password fields
- add name and autocomplete attributes to agency login email and password fields

## Testing
- `npm test` *(fails: jest not found, dependency installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b39c4f0290832dae9255d6efbf1f38