### PR TITLE
Add help page search filtering and print support

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/HelpPage.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/HelpPage.test.tsx
@@ -38,6 +38,26 @@ describe('HelpPage', () => {
     expect(screen.getByText(/Recurring bookings/i)).toBeInTheDocument();
   });
 
+  it('calls window.print when clicking Print', () => {
+    mockUseAuth.mockReturnValue({
+      role: 'volunteer',
+      access: [],
+      token: '',
+      name: '',
+      userRole: '',
+      login: jest.fn(),
+      logout: jest.fn(),
+      cardUrl: '',
+      ready: true,
+      id: null,
+    } as any);
+    const printSpy = jest.spyOn(window, 'print').mockImplementation(() => {});
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /print/i }));
+    expect(printSpy).toHaveBeenCalled();
+    printSpy.mockRestore();
+  });
+
   it('shows tabs for available roles', () => {
     mockUseAuth.mockReturnValue({
       role: 'staff',

--- a/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
+++ b/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
@@ -1,8 +1,9 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Tabs, Tab, TextField, Button, Stack, Box, Typography } from '@mui/material';
 import Page from '../../components/Page';
 import { useAuth } from '../../hooks/useAuth';
 import { helpContent, type HelpSection } from './content';
+import resetCss from '../../reset.css?url';
 
 function roleLabel(role: string) {
   return role.charAt(0).toUpperCase() + role.slice(1);
@@ -24,6 +25,17 @@ export default function HelpPage() {
   const [tab, setTab] = useState(0);
   const [search, setSearch] = useState('');
   const currentRole = roles[tab];
+
+  useEffect(() => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = resetCss;
+    link.media = 'print';
+    document.head.appendChild(link);
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, []);
 
   const sections: HelpSection[] = useMemo(() => {
     const query = search.toLowerCase();

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 ## Features
 
  - Appointment booking workflow for clients with automatic approval and rescheduling.
+- Help page offers role-specific guidance with real-time search and a printable view.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas; volunteers can only book shifts in roles they are trained for.
 - Volunteer management groups volunteer search, creation, and review under a **Volunteers** submenu. Its **Pending Reviews** tab shows the current week with `no_show` shifts and today's overdue `approved` bookings, allowing staff to mark them `completed` or `no_show`.


### PR DESCRIPTION
## Summary
- enable real-time filtering of help topics and allow printing
- include print-specific styles so printed help respects reset.css
- document new Help page features

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39e5fee60832d9e8f139e3c4f87cb