### PR TITLE
Add dynamic RoleTabs component for multi-role help pages

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RoleTabs.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RoleTabs.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import RoleTabs from '../components/RoleTabs';
+
+describe('RoleTabs', () => {
+  it('switches content when tabs are clicked', () => {
+    const tabs = [
+      { label: 'First', content: <div>First Content</div> },
+      { label: 'Second', content: <div>Second Content</div> },
+    ];
+    render(<RoleTabs tabs={tabs} />);
+    expect(screen.getByText(/First Content/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Second Content/i)).toBeNull();
+    fireEvent.click(screen.getByRole('tab', { name: /Second/i }));
+    expect(screen.getByText(/Second Content/i)).toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/components/RoleTabs.tsx
+++ b/MJ_FB_Frontend/src/components/RoleTabs.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { Tabs, Tab, Box } from '@mui/material';
+
+export interface RoleTabItem {
+  label: string;
+  content: React.ReactNode;
+}
+
+interface RoleTabsProps {
+  tabs: RoleTabItem[];
+}
+
+export default function RoleTabs({ tabs }: RoleTabsProps) {
+  const [value, setValue] = useState(0);
+
+  return (
+    <>
+      <Tabs
+        value={value}
+        onChange={(_, v) => setValue(v)}
+        variant="scrollable"
+        allowScrollButtonsMobile
+        sx={{ mb: 2 }}
+      >
+        {tabs.map(t => (
+          <Tab key={t.label} label={t.label} />
+        ))}
+      </Tabs>
+      {tabs.map((t, i) => (
+        <Box key={t.label} hidden={value !== i}>
+          {value === i && t.content}
+        </Box>
+      ))}
+    </>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
+++ b/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
@@ -1,8 +1,9 @@
-import { useState, useMemo } from 'react';
-import { Tabs, Tab, TextField, Button, Stack, Box, Typography } from '@mui/material';
+import { useState } from 'react';
+import { TextField, Button, Stack, Box, Typography } from '@mui/material';
 import Page from '../../components/Page';
+import RoleTabs from '../../components/RoleTabs';
 import { useAuth } from '../../hooks/useAuth';
-import { helpContent, type HelpSection } from './content';
+import { helpContent } from './content';
 
 function roleLabel(role: string) {
   return role.charAt(0).toUpperCase() + role.slice(1);
@@ -21,36 +22,37 @@ export default function HelpPage() {
     if (access.includes('admin')) roles.push('admin');
   }
 
-  const [tab, setTab] = useState(0);
   const [search, setSearch] = useState('');
-  const currentRole = roles[tab];
 
-  const sections: HelpSection[] = useMemo(() => {
+  const renderSections = (r: string) => {
     const query = search.toLowerCase();
-    return helpContent[currentRole]?.filter(
-      s =>
-        s.title.toLowerCase().includes(query) ||
-        s.body.toLowerCase().includes(query),
-    ) ?? [];
-  }, [currentRole, search]);
+    const sections =
+      helpContent[r]?.filter(
+        s =>
+          s.title.toLowerCase().includes(query) ||
+          s.body.toLowerCase().includes(query),
+      ) ?? [];
+    return sections.length ? (
+      sections.map(s => (
+        <Box key={s.title} sx={{ mb: 3 }}>
+          <Typography variant="h5" gutterBottom>
+            {s.title}
+          </Typography>
+          <Typography>{s.body}</Typography>
+        </Box>
+      ))
+    ) : (
+      <Typography>No matching topics.</Typography>
+    );
+  };
+
+  const tabs = roles.map(r => ({ label: roleLabel(r), content: renderSections(r) }));
 
   return (
     <Page
       title="Help"
       header={
         <Stack spacing={2} sx={{ mb: 2, '@media print': { display: 'none' } }}>
-          {roles.length > 1 && (
-            <Tabs
-              value={tab}
-              onChange={(_, v) => setTab(v)}
-              variant="scrollable"
-              allowScrollButtonsMobile
-            >
-              {roles.map(r => (
-                <Tab key={r} label={roleLabel(r)} />
-              ))}
-            </Tabs>
-          )}
           <Stack direction="row" spacing={1} alignItems="center">
             <TextField
               label="Search"
@@ -70,15 +72,7 @@ export default function HelpPage() {
         </Stack>
       }
     >
-      {sections.map(s => (
-        <Box key={s.title} sx={{ mb: 3 }}>
-          <Typography variant="h5" gutterBottom>
-            {s.title}
-          </Typography>
-          <Typography>{s.body}</Typography>
-        </Box>
-      ))}
-      {!sections.length && <Typography>No matching topics.</Typography>}
+      {roles.length > 1 ? tabs.length && <RoleTabs tabs={tabs} /> : tabs[0]?.content}
     </Page>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `RoleTabs` for rendering tabbed content from `{label, content}` arrays
- switch `HelpPage` to use `RoleTabs` when multiple roles are available
- add unit test covering `RoleTabs` behavior

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39e63ce94832d89e5079972b8549e