### PR TITLE
Add availability info tooltips

### DIFF
--- a/MJ_FB_Frontend/src/components/StyledTabs.tsx
+++ b/MJ_FB_Frontend/src/components/StyledTabs.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Paper, Tabs, Tab, Box, type SxProps, type Theme } from '@mui/material';
 
 export interface TabItem {
-  label: string;
-  icon?: React.ReactNode;
-  content: React.ReactNode;
+  label: ReactNode;
+  icon?: ReactNode;
+  content: ReactNode;
 }
 
 interface StyledTabsProps {

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -33,6 +33,7 @@ import type { AlertColor } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs, { type TabItem } from '../../components/StyledTabs';
 import Page from '../../components/Page';
+import InfoTooltip from '../../components/InfoTooltip';
 import {
   getHolidays,
   addHoliday,
@@ -275,7 +276,12 @@ export default function ManageAvailability() {
   };
   const tabs: TabItem[] = [
     {
-      label: 'Holidays',
+      label: (
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <span>Holidays</span>
+          <InfoTooltip title="Add or remove pantry holidays" />
+        </Stack>
+      ),
       icon: <EventBusy />,
       content: (
         <Card sx={{ borderRadius: 3 }}>
@@ -339,7 +345,12 @@ export default function ManageAvailability() {
       ),
     },
     {
-      label: 'Blocked Slots',
+      label: (
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <span>Blocked Slots</span>
+          <InfoTooltip title="Block slots for a date or recurring schedule" />
+        </Stack>
+      ),
       icon: <Block />,
       content: (
         <Card sx={{ borderRadius: 3 }}>
@@ -354,7 +365,10 @@ export default function ManageAvailability() {
                 <Grid container spacing={2}>
                   <Grid item xs={12} sm={6}>
                     <FormControl fullWidth sx={{ minWidth: 200 }}>
-                      <InputLabel id="blocked-day-label">Day</InputLabel>
+                      <InputLabel id="blocked-day-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                        Day
+                        <InfoTooltip title="Day of week for the recurring block" />
+                      </InputLabel>
                       <Select
                         labelId="blocked-day-label"
                         value={blockedDay}
@@ -372,7 +386,10 @@ export default function ManageAvailability() {
                   </Grid>
                   <Grid item xs={12} sm={6}>
                     <FormControl fullWidth sx={{ minWidth: 200 }}>
-                      <InputLabel id="blocked-week-label">Week</InputLabel>
+                      <InputLabel id="blocked-week-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                        Week
+                        <InfoTooltip title="Week of month for the recurring block" />
+                      </InputLabel>
                       <Select
                         labelId="blocked-week-label"
                         value={blockedWeek}
@@ -398,7 +415,10 @@ export default function ManageAvailability() {
                 />
               )}
               <FormControl fullWidth>
-                <InputLabel id="slot-label">Slot</InputLabel>
+                <InputLabel id="slot-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  Slot
+                  <InfoTooltip title="Slot blocked on the selected date or schedule" />
+                </InputLabel>
                 <Select
                   labelId="slot-label"
                   value={blockedSlotId}
@@ -464,7 +484,12 @@ export default function ManageAvailability() {
       ),
     },
     {
-      label: 'Staff Breaks',
+      label: (
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <span>Staff Breaks</span>
+          <InfoTooltip title="Set up recurring staff breaks" />
+        </Stack>
+      ),
       icon: <Restaurant />,
       content: (
         <Card sx={{ borderRadius: 3 }}>
@@ -473,7 +498,10 @@ export default function ManageAvailability() {
             <Grid container spacing={2}>
               <Grid item xs={12} sm={4}>
                 <FormControl fullWidth sx={{ minWidth: 200 }}>
-                  <InputLabel id="break-day-label">Day</InputLabel>
+                  <InputLabel id="break-day-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    Day
+                    <InfoTooltip title="Break repeats on this day each week" />
+                  </InputLabel>
                   <Select
                     labelId="break-day-label"
                     value={breakDay}
@@ -491,7 +519,10 @@ export default function ManageAvailability() {
               </Grid>
               <Grid item xs={12} sm={4}>
                 <FormControl fullWidth sx={{ minWidth: 200 }}>
-                  <InputLabel id="break-slot-label">Slot</InputLabel>
+                  <InputLabel id="break-slot-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    Slot
+                    <InfoTooltip title="Slot unavailable during the break each week" />
+                  </InputLabel>
                   <Select
                     labelId="break-slot-label"
                     value={breakSlotId}


### PR DESCRIPTION
## Summary
- import InfoTooltip and add explanatory icons to Manage Availability tabs
- show tooltips next to Day/Week/Slot fields for blocked slots and staff breaks
- allow StyledTabs labels to render React nodes for richer tab headers

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: ENOTEMPTY directory rename error)*

------
https://chatgpt.com/codex/tasks/task_e_68b39e7d6558832d8e419845d25d6906