### PR TITLE
Add form autocomplete attributes for password setup and staff forms

### DIFF
--- a/MJ_FB_Frontend/src/components/StaffForm.tsx
+++ b/MJ_FB_Frontend/src/components/StaffForm.tsx
@@ -65,9 +65,28 @@ export default function StaffForm({ initial, submitLabel, onSubmit }: StaffFormP
           </Button>
         }
       >
-        <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
-        <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
-        <TextField label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} />
+        <TextField
+          label="First Name"
+          name="firstName"
+          autoComplete="given-name"
+          value={firstName}
+          onChange={e => setFirstName(e.target.value)}
+        />
+        <TextField
+          label="Last Name"
+          name="lastName"
+          autoComplete="family-name"
+          value={lastName}
+          onChange={e => setLastName(e.target.value)}
+        />
+        <TextField
+          label="Email"
+          type="email"
+          name="email"
+          autoComplete="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
         <Typography variant="body2" color="text.secondary">
           An email invitation will be sent.
         </Typography>

--- a/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
@@ -47,6 +47,8 @@ export default function PasswordSetup() {
         <TextField
           type="password"
           label="Password"
+          name="password"
+          autoComplete="new-password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           fullWidth


### PR DESCRIPTION
## Summary
- add `name` and `autoComplete` attributes to password setup form field
- include appropriate `name` and `autoComplete` props for staff form inputs

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org/undici)*

------
https://chatgpt.com/codex/tasks/task_e_68b39c55adbc832da06c6ad1a4fc6a3b