### PR TITLE
docs: remind devs to update help content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,14 @@
 - A nightly no-show cleanup job (`MJ_FB_Backend/src/utils/noShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved bookings as `no_show`. It exposes `startNoShowCleanupJob`/`stopNoShowCleanupJob`.
 - A nightly volunteer no-show cleanup job (`MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results, emails coordinators, and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
 
+## Help Page Maintenance
+
+- Update `MJ_FB_Frontend/src/pages/help/content.ts` whenever user-facing features or routes change so the Help page remains accurate.
+- Before merging a pull request, ensure new routes and UI elements are reflected in the Help page:
+  - [ ] Added or modified a user-facing route or UI element?
+  - [ ] Updated `src/pages/help/content.ts` accordingly?
+  - [ ] Verified that the Help page renders the change?
+
 ## Testing
 
 - For changes in `MJ_FB_Backend`, run `npm test` from the `MJ_FB_Backend` directory.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ The `clients` table uses `client_id` as its primary key. Do not reference an `id
 - Update `AGENTS.md` with new repository instructions.
 - Reflect user-facing or setup changes in this `README.md`.
 
+## Help Page Updates
+
+Keep the Help page current whenever user-facing features change. Update
+`MJ_FB_Frontend/src/pages/help/content.ts` whenever you add or modify a
+route or UI element so users see accurate guidance.
+
+Before merging a pull request, confirm the following:
+
+- [ ] Added or changed a user-facing route or UI element?
+- [ ] Updated `src/pages/help/content.ts` with the new information?
+- [ ] Viewed the Help page to ensure the change appears?
+
 ## Features
 
  - Appointment booking workflow for clients with automatic approval and rescheduling.


### PR DESCRIPTION
## Summary
- highlight need to update `src/pages/help/content.ts` whenever UI or routes change
- add checklist to ensure Help page stays in sync

## Testing
- `npm test` in `MJ_FB_Backend` *(fails: jest not found)*
- `npm install` in `MJ_FB_Backend` *(fails: 403 Forbidden)*
- `npm test` in `MJ_FB_Frontend` *(fails: jest not found)*
- `npm ping` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b39e526cfc832d956220b1a2b1c3b1