### PR TITLE
Use tab UI for volunteer management

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -57,9 +57,6 @@ const VolunteerBooking = React.lazy(() =>
 const VolunteerRecurringBookings = React.lazy(() =>
   import('./pages/volunteer-management/VolunteerRecurringBookings')
 );
-const PendingReviews = React.lazy(() =>
-  import('./pages/volunteer-management/PendingReviews')
-);
 const VolunteerRankings = React.lazy(() =>
   import('./pages/volunteer-management/VolunteerRankings')
 );
@@ -401,23 +398,9 @@ export default function App() {
                     element={<VolunteerManagement />}
                   />
                   <Route
-                    path="/volunteer-management/volunteers/*"
+                    path="/volunteer-management/volunteers"
                     element={<VolunteerTabs />}
-                  >
-                    <Route index element={<Navigate to="search" replace />} />
-                    <Route
-                      path="search"
-                      element={<VolunteerManagement initialTab="search" />}
-                    />
-                    <Route
-                      path="create"
-                      element={<VolunteerManagement initialTab="create" />}
-                    />
-                    <Route
-                      path="pending-reviews"
-                      element={<PendingReviews />}
-                    />
-                  </Route>
+                  />
                   <Route
                     path="/volunteer-management/rankings"
                     element={<VolunteerRankings />}

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -38,6 +38,10 @@ export const helpContent: Record<
       title: 'Manage availability',
       body: 'Staff can open or block pantry slots and adjust capacities.',
     },
+    {
+      title: 'Manage volunteers',
+      body: 'Search, add, and review volunteers from the Volunteers page.',
+    },
   ],
   warehouse: [
     {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerTabs.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerTabs.tsx
@@ -1,29 +1,25 @@
-import { Tabs, Tab } from '@mui/material';
-import { Link as RouterLink, Outlet, useLocation } from 'react-router-dom';
+import React, { useState, Suspense } from 'react';
+import { Tabs, Tab, CircularProgress } from '@mui/material';
 import Page from '../../components/Page';
 
+const VolunteerManagement = React.lazy(() => import('./VolunteerManagement'));
+const PendingReviews = React.lazy(() => import('./PendingReviews'));
+
 export default function VolunteerTabs() {
-  const location = useLocation();
-  const base = '/volunteer-management/volunteers';
-  const path = location.pathname.replace(base, '');
-  const value = path.startsWith('/create')
-    ? 1
-    : path.startsWith('/pending-reviews')
-    ? 2
-    : 0;
+  const [tab, setTab] = useState(0);
 
   return (
-    <Page
-      title="Volunteers"
-      header={
-        <Tabs value={value} sx={{ mb: 2 }}>
-          <Tab label="Search" component={RouterLink} to={`${base}/search`} />
-          <Tab label="Add Volunteer" component={RouterLink} to={`${base}/create`} />
-          <Tab label="Pending Reviews" component={RouterLink} to={`${base}/pending-reviews`} />
-        </Tabs>
-      }
-    >
-      <Outlet />
+    <Page title="Volunteers">
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label="Search" />
+        <Tab label="Add Volunteer" />
+        <Tab label="Pending Reviews" />
+      </Tabs>
+      <Suspense fallback={<CircularProgress />}>
+        {tab === 0 && <VolunteerManagement initialTab="search" />}
+        {tab === 1 && <VolunteerManagement initialTab="create" />}
+        {tab === 2 && <PendingReviews />}
+      </Suspense>
     </Page>
   );
 }


### PR DESCRIPTION
## Summary
- simplify volunteer tab navigation to internal state rather than nested routes
- show page title above volunteer management tabs
- add help page note about managing volunteers

## Testing
- `npm test` (fails: ReferenceError TextEncoder is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68b3a168cfa0832db5f6bcc4a8eec9af