### PR TITLE
Allow admins to view all help sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
   - [ ] Added or modified a user-facing route or UI element?
   - [ ] Updated `src/pages/help/content.ts` accordingly?
   - [ ] Verified that the Help page renders the change?
+- Admins can view all help sections, including client and volunteer topics.
 
 ## Testing
 

--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -1,7 +1,7 @@
 # MJ Food Bank Frontend
 
 This project is the React + Vite front end for the MJ Food Bank booking system. Volunteers can manage recurring bookings from `/volunteer/recurring`.
-Authenticated users can access a role-based help page at `/help`.
+Authenticated users can access a role-based help page at `/help`. Admins can view all help topics, including client and volunteer guidance.
 
 ## Development
 

--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -1,10 +1,15 @@
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
-import { fetch, Headers, Request, Response, FormData, File } from 'undici';
+import { ReadableStream, WritableStream } from 'stream/web';
 
 // Polyfill TextEncoder/Decoder for testing environment
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder as any;
+(global as any).ReadableStream = ReadableStream as any;
+(global as any).WritableStream = WritableStream as any;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { fetch, Headers, Request, Response, FormData, File } = require('undici');
 (Element.prototype as any).scrollIntoView = jest.fn();
 (global as any).VITE_API_BASE = 'http://localhost:4000';
 

--- a/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
+++ b/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
@@ -17,9 +17,12 @@ export default function HelpPage() {
   if (role === 'volunteer') roles.push('volunteer');
   if (role === 'agency') roles.push('agency');
   if (role === 'staff') {
-    if (access.includes('pantry')) roles.push('pantry');
-    if (access.includes('warehouse')) roles.push('warehouse');
-    if (access.includes('admin')) roles.push('admin');
+    if (access.includes('admin'))
+      roles.push('client', 'volunteer', 'agency', 'pantry', 'warehouse', 'admin');
+    else {
+      if (access.includes('pantry')) roles.push('pantry');
+      if (access.includes('warehouse')) roles.push('warehouse');
+    }
   }
 
   const [tab, setTab] = useState(0);

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Before merging a pull request, confirm the following:
 ## Features
 
  - Appointment booking workflow for clients with automatic approval and rescheduling.
-- Help page offers role-specific guidance with real-time search and a printable view.
+ - Help page offers role-specific guidance with real-time search and a printable view. Admins can view all help topics, including client and volunteer guidance.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas; volunteers can only book shifts in roles they are trained for.
 - Volunteer management groups volunteer search, creation, and review under a **Volunteers** submenu. Its **Pending Reviews** tab shows the current week with `no_show` shifts and today's overdue `approved` bookings, allowing staff to mark them `completed` or `no_show`.


### PR DESCRIPTION
## Summary
- allow admin staff to view every help topic, including client and volunteer guides
- note admin visibility of all help topics in documentation
- ensure Jest environment polyfills browser streams before using `undici`

## Testing
- `npm test` *(fails: unable to find various elements, failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a1d05388832d9bd288e0974578f6