### PR TITLE
Add staff recurring volunteer booking helpers

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.ts
@@ -1,9 +1,11 @@
 import { apiFetch, handleResponse } from '../api/client';
 import {
   createVolunteerBookingForVolunteer,
+  createRecurringVolunteerBookingForVolunteer,
   updateVolunteerTrainedAreas,
   getVolunteerMasterRoles,
   getMyRecurringVolunteerBookings,
+  getRecurringVolunteerBookingsForVolunteer,
   updateVolunteerBookingStatus,
   cancelVolunteerBooking,
   getUnmarkedVolunteerBookings,
@@ -69,6 +71,54 @@ describe('volunteers api', () => {
   it('fetches recurring volunteer bookings', async () => {
     await getMyRecurringVolunteerBookings();
     expect(apiFetch).toHaveBeenCalledWith('/api/volunteer-bookings/recurring');
+  });
+
+  it('creates recurring volunteer booking for volunteer', async () => {
+    (handleResponse as jest.Mock).mockResolvedValueOnce({
+      recurringId: 1,
+      successes: [
+        {
+          id: 10,
+          status: 'approved',
+          role_id: 3,
+          date: '2024-01-01T00:00:00.000Z',
+          start_time: '09:00:00',
+          end_time: '12:00:00',
+          role_name: 'Role',
+        },
+      ],
+      skipped: [],
+    });
+    const result = await createRecurringVolunteerBookingForVolunteer(
+      5,
+      3,
+      '2024-01-01',
+      'weekly',
+      [1, 3],
+      '2024-02-01',
+    );
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/volunteer-bookings/recurring/staff',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          volunteerId: 5,
+          roleId: 3,
+          startDate: '2024-01-01',
+          pattern: 'weekly',
+          daysOfWeek: [1, 3],
+          endDate: '2024-02-01',
+        }),
+      }),
+    );
+    expect(result.successes[0].date).toBe('2024-01-01');
+  });
+
+  it('fetches recurring volunteer bookings for volunteer', async () => {
+    await getRecurringVolunteerBookingsForVolunteer(7);
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/volunteer-bookings/recurring/volunteer/7',
+    );
   });
 
   it('updates volunteer booking status with reason', async () => {

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -362,6 +362,45 @@ export async function createVolunteerBookingForVolunteer(
   await handleResponse(res);
 }
 
+export async function createRecurringVolunteerBookingForVolunteer(
+  volunteerId: number,
+  roleId: number,
+  startDate: string,
+  frequency: 'daily' | 'weekly',
+  weekdays?: number[],
+  endDate?: string,
+) {
+  const res = await apiFetch(
+    `${API_BASE}/volunteer-bookings/recurring/staff`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        volunteerId,
+        roleId,
+        startDate,
+        pattern: frequency,
+        daysOfWeek: weekdays,
+        endDate,
+      }),
+    },
+  );
+  const data = await handleResponse(res);
+  return {
+    ...(data || {}),
+    successes: (data?.successes ?? []).map(normalizeVolunteerBooking),
+  };
+}
+
+export async function getRecurringVolunteerBookingsForVolunteer(
+  volunteerId: number,
+): Promise<VolunteerRecurringBooking[]> {
+  const res = await apiFetch(
+    `${API_BASE}/volunteer-bookings/recurring/volunteer/${volunteerId}`,
+  );
+  return handleResponse(res);
+}
+
 export async function getVolunteerBookingHistory(
   volunteerId: number,
 ) {


### PR DESCRIPTION
## Summary
- add API helpers for staff to create and list recurring volunteer bookings
- test API calls and normalization of staff recurring booking helpers

## Testing
- `npm test` *(fails: ReferenceError: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a2237c5c832d9e5630301ce2bda9