### PR TITLE
feat: add client language selector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@
 - Volunteer Settings provides separate dialogs for creating sub-roles (with an initial shift) and for adding or editing shifts.
 - Deleting sub-roles and shifts prompts confirmation dialogs to prevent accidental removal.
 - Users complete initial password creation at `/set-password` using a token from the setup email.
+- Client login and password pages provide a language selector for English and Spanish.
 - After setting a password, users are redirected to the login page for their role.
 - Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations.

--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
 import { ReadableStream, WritableStream } from 'stream/web';
+import './src/i18n';
 
 // Polyfill TextEncoder/Decoder for testing environment
 (global as any).TextEncoder = TextEncoder;

--- a/MJ_FB_Frontend/src/components/LanguageSelector.tsx
+++ b/MJ_FB_Frontend/src/components/LanguageSelector.tsx
@@ -1,0 +1,31 @@
+import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+const languages = [
+  { code: 'en', labelKey: 'english' },
+  { code: 'es', labelKey: 'spanish' },
+];
+
+export default function LanguageSelector() {
+  const { i18n, t } = useTranslation();
+
+  const handleChange = (e: SelectChangeEvent) => {
+    i18n.changeLanguage(e.target.value);
+  };
+
+  return (
+    <Select
+      value={i18n.language}
+      onChange={handleChange}
+      variant="standard"
+      sx={{ minWidth: 80, color: 'inherit', '&::before, &::after': { borderBottom: 'none' } }}
+      disableUnderline
+    >
+      {languages.map(lang => (
+        <MenuItem key={lang.code} value={lang.code}>
+          {t(lang.labelKey)}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}

--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -15,6 +15,7 @@ import { useTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
+import LanguageSelector from './LanguageSelector';
 
 export type NavLink = { label: string; to: string; badge?: number };
 export type NavGroup = { label: string; links: NavLink[] };
@@ -316,6 +317,8 @@ export default function Navbar({
               )
             )
           )}
+
+          {role === 'client' && <LanguageSelector />}
 
           {/* Profile menu / Logout on desktop */}
           {onLogout &&

--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -5,6 +5,8 @@ import FeedbackSnackbar from './FeedbackSnackbar';
 import FormCard from './FormCard';
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
+import LanguageSelector from './LanguageSelector';
+import { useTranslation } from 'react-i18next';
 
 export default function PasswordResetDialog({
   open,
@@ -19,10 +21,11 @@ export default function PasswordResetDialog({
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
+  const { t } = useTranslation();
 
   const label =
-    type === 'staff' ? 'Email' : type === 'volunteer' ? 'Username' : 'Client ID';
-  const formTitle = 'Reset Password';
+    type === 'staff' ? 'Email' : type === 'volunteer' ? 'Username' : t('client_id');
+  const formTitle = t('reset_password');
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -53,7 +56,8 @@ export default function PasswordResetDialog({
           <FormCard
             title={formTitle}
             onSubmit={handleSubmit}
-            actions={<Button type="submit" variant="contained">Submit</Button>}
+            header={type === 'user' ? <LanguageSelector /> : undefined}
+            actions={<Button type="submit" variant="contained">{t('submit')}</Button>}
             boxProps={{ minHeight: 'auto', p: 0 }}
           >
             <TextField

--- a/MJ_FB_Frontend/src/i18n.ts
+++ b/MJ_FB_Frontend/src/i18n.ts
@@ -1,0 +1,16 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en.json';
+import es from './locales/es.json';
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    es: { translation: es },
+  },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -1,0 +1,22 @@
+{
+  "language": "Language",
+  "english": "English",
+  "spanish": "Español",
+  "login": "Login",
+  "client_login": "Client Login",
+  "client_id": "Client ID",
+  "password": "Password",
+  "forgot_password": "Forgot password?",
+  "client_id_required": "Client ID is required",
+  "password_required": "Password is required",
+  "set_password": "Set Password",
+  "back_to_login": "Back to login",
+  "resend_link": "Resend link",
+  "change_password": "Change Password",
+  "current_password": "Current Password",
+  "new_password": "New Password",
+  "reset_password": "Reset Password",
+  "submit": "Submit",
+  "invalid_or_expired_token": "Invalid or expired token",
+  "client_dashboard": "Client Dashboard"
+}

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -1,0 +1,22 @@
+{
+  "language": "Idioma",
+  "english": "English",
+  "spanish": "Español",
+  "login": "Iniciar sesión",
+  "client_login": "Acceso de cliente",
+  "client_id": "ID del cliente",
+  "password": "Contraseña",
+  "forgot_password": "¿Olvidó su contraseña?",
+  "client_id_required": "Se requiere ID del cliente",
+  "password_required": "Se requiere la contraseña",
+  "set_password": "Crear contraseña",
+  "back_to_login": "Volver al inicio",
+  "resend_link": "Reenviar enlace",
+  "change_password": "Cambiar contraseña",
+  "current_password": "Contraseña actual",
+  "new_password": "Nueva contraseña",
+  "reset_password": "Restablecer contraseña",
+  "submit": "Enviar",
+  "invalid_or_expired_token": "Token inválido o expirado",
+  "client_dashboard": "Panel del cliente"
+}

--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -11,6 +11,7 @@ import { AuthProvider } from './hooks/useAuth';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs from './utils/date';
+import './i18n';
 
 function Main() {
   return (

--- a/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
@@ -1,15 +1,18 @@
 import { useState } from 'react';
-import { TextField, Button } from '@mui/material';
+import { TextField, Button, Box } from '@mui/material';
 import Page from '../../components/Page';
 import { changePassword } from '../../api/users';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
+import LanguageSelector from '../../components/LanguageSelector';
+import { useTranslation } from 'react-i18next';
 
 export default function ChangePasswordForm() {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [success, setSuccess] = useState('');
   const [error, setError] = useState('');
+  const { t } = useTranslation();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -24,27 +27,27 @@ export default function ChangePasswordForm() {
   }
 
   return (
-    <Page title="Change Password">
+    <Page title={t('change_password')} header={<Box textAlign="right"><LanguageSelector /></Box>}>
       <FormCard
         onSubmit={handleSubmit}
-        title="Change Password"
+        title={t('change_password')}
         centered={false}
         actions={
           <Button type="submit" variant="contained" color="primary" fullWidth>
-            Reset Password
+            {t('reset_password')}
           </Button>
         }
       >
         <TextField
           type="password"
-          label="Current Password"
+          label={t('current_password')}
           value={currentPassword}
           onChange={e => setCurrentPassword(e.target.value)}
           fullWidth
         />
         <TextField
           type="password"
-          label="New Password"
+          label={t('new_password')}
           value={newPassword}
           onChange={e => setNewPassword(e.target.value)}
           fullWidth

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react';
 import { loginUser } from '../../api/users';
 import type { LoginResponse } from '../../api/users';
 import type { ApiError } from '../../api/client';
-import { Link, TextField, Button } from '@mui/material';
+import { Link, TextField, Button, Box } from '@mui/material';
 import Page from '../../components/Page';
-import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
 import PasswordResetDialog from '../../components/PasswordResetDialog';
 import ResendPasswordSetupDialog from '../../components/ResendPasswordSetupDialog';
+import LanguageSelector from '../../components/LanguageSelector';
+import { useTranslation } from 'react-i18next';
 
 export default function Login({
   onLogin,
@@ -21,6 +22,7 @@ export default function Login({
   const [resetOpen, setResetOpen] = useState(false);
   const [resendOpen, setResendOpen] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const { t } = useTranslation();
 
   const clientIdError = submitted && clientId === '';
   const passwordError = submitted && password === '';
@@ -46,10 +48,10 @@ export default function Login({
   }
 
   return (
-    <Page title="Client Login">
+    <Page title={t('client_login')} header={<Box textAlign="right"><LanguageSelector /></Box>}>
       <FormCard
         onSubmit={handleSubmit}
-        title="Client Login"
+        title={t('client_login')}
         actions={
           <Button
             type="submit"
@@ -57,35 +59,35 @@ export default function Login({
             color="primary"
             fullWidth
           >
-            Login
+            {t('login')}
           </Button>
         }
       >
         <TextField
           value={clientId}
           onChange={e => setClientId(e.target.value)}
-          label="Client ID"
+          label={t('client_id')}
           name="clientId"
           autoComplete="username"
           fullWidth
           required
           error={clientIdError}
-          helperText={clientIdError ? 'Client ID is required' : ''}
+          helperText={clientIdError ? t('client_id_required') : ''}
         />
         <TextField
           type="password"
           value={password}
           onChange={e => setPassword(e.target.value)}
-          label="Password"
+          label={t('password')}
           name="password"
           autoComplete="current-password"
           fullWidth
           required
           error={passwordError}
-          helperText={passwordError ? 'Password is required' : ''}
+          helperText={passwordError ? t('password_required') : ''}
         />
         <Link component="button" onClick={() => setResetOpen(true)} underline="hover">
-          Forgot password?
+          {t('forgot_password')}
         </Link>
       </FormCard>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="user" />

--- a/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { useSearchParams, Link as RouterLink, useNavigate } from 'react-router-dom';
-import { TextField, Button, Link } from '@mui/material';
+import { TextField, Button, Link, Box } from '@mui/material';
 import Page from '../../components/Page';
 import FormCard from '../../components/FormCard';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { setPassword as setPasswordApi } from '../../api/users';
 import ResendPasswordSetupDialog from '../../components/ResendPasswordSetupDialog';
+import LanguageSelector from '../../components/LanguageSelector';
+import { useTranslation } from 'react-i18next';
 
 export default function PasswordSetup() {
   const [searchParams] = useSearchParams();
@@ -14,11 +16,12 @@ export default function PasswordSetup() {
   const [error, setError] = useState('');
   const [resendOpen, setResendOpen] = useState(false);
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!token) {
-      setError('Invalid or expired token');
+      setError(t('invalid_or_expired_token'));
       return;
     }
     try {
@@ -34,19 +37,19 @@ export default function PasswordSetup() {
   }
 
   return (
-    <Page title="Set Password">
+    <Page title={t('set_password')} header={<Box textAlign="right"><LanguageSelector /></Box>}>
       <FormCard
         onSubmit={handleSubmit}
-        title="Set Password"
+        title={t('set_password')}
         actions={
           <Button type="submit" variant="contained" color="primary" fullWidth>
-            Set Password
+            {t('set_password')}
           </Button>
         }
       >
         <TextField
           type="password"
-          label="Password"
+          label={t('password')}
           name="password"
           autoComplete="new-password"
           value={password}
@@ -55,11 +58,11 @@ export default function PasswordSetup() {
           required
         />
         <Link component={RouterLink} to="/login" underline="hover">
-          Back to login
+          {t('back_to_login')}
         </Link>
         {error.toLowerCase().includes('expired token') && (
           <Link component="button" onClick={() => setResendOpen(true)} underline="hover">
-            Resend link
+            {t('resend_link')}
           </Link>
         )}
       </FormCard>

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -28,6 +28,7 @@ import SectionCard from '../../components/dashboard/SectionCard';
 import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 import Page from '../../components/Page';
+import { useTranslation } from 'react-i18next';
 
 interface Booking {
   id: number;
@@ -77,6 +78,7 @@ export default function ClientDashboard() {
   const [cancelId, setCancelId] = useState<number | null>(null);
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
+  const { t } = useTranslation();
 
   useEffect(() => {
     getBookingHistory({ includeVisits: true })
@@ -134,7 +136,7 @@ export default function ClientDashboard() {
   }
 
   return (
-    <Page title="Client Dashboard">
+    <Page title={t('client_dashboard')}>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <Stack spacing={2}>

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ page and cached on the server:
 ### Frontend features
 
 - Pages are organized into feature-based directories (e.g., booking, staff, volunteer-management, warehouse-management).
+- Client login and password pages include a language selector so clients can switch between English and Spanish.
 - A shared dashboard component lives in `src/components/dashboard`.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.


### PR DESCRIPTION
## Summary
- add i18n setup with English and Spanish translations
- provide language selector on client auth and navbar
- document language selector in repo docs

## Testing
- `CI=1 npm test` *(fails: many suites, see output)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a5e8b604832db7cf225b88e5b4a3