### PR TITLE
test: cover staff recurring booking flows

### DIFF
--- a/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
@@ -73,4 +73,28 @@ describe('staff recurring volunteer bookings', () => {
       },
     ]);
   });
+
+  it('cancels future recurring bookings for a volunteer', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            volunteer_id: 5,
+            slot_id: 2,
+            email: 'vol@example.com',
+            start_time: '09:00:00',
+            end_time: '12:00:00',
+          },
+        ],
+      })
+      .mockResolvedValue({});
+
+    const res = await request(app).delete(
+      '/volunteer-bookings/recurring/10?from=2025-01-02',
+    );
+
+    expect(res.status).toBe(200);
+    expect((sendEmail as jest.Mock).mock.calls).toHaveLength(3);
+  });
 });

--- a/MJ_FB_Frontend/src/__tests__/StaffRecurringBookingsSearch.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffRecurringBookingsSearch.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import StaffRecurringBookings from '../pages/volunteer-management/StaffRecurringBookings';
+import {
+  searchVolunteers,
+  getVolunteerRoles,
+  getRecurringVolunteerBookingsForVolunteer,
+  getVolunteerBookingHistory,
+  createRecurringVolunteerBookingForVolunteer,
+  cancelVolunteerBooking,
+  cancelRecurringVolunteerBooking,
+} from '../api/volunteers';
+
+jest.mock('../api/volunteers', () => ({
+  searchVolunteers: jest.fn(),
+  getVolunteerRoles: jest.fn(),
+  getRecurringVolunteerBookingsForVolunteer: jest.fn(),
+  getVolunteerBookingHistory: jest.fn(),
+  createRecurringVolunteerBookingForVolunteer: jest.fn(),
+  cancelVolunteerBooking: jest.fn(),
+  cancelRecurringVolunteerBooking: jest.fn(),
+}));
+
+describe('StaffRecurringBookings volunteer search', () => {
+  beforeEach(() => {
+    (searchVolunteers as jest.Mock).mockResolvedValue([
+      { id: 7, name: 'Test Vol' },
+    ]);
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
+    (getRecurringVolunteerBookingsForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getVolunteerBookingHistory as jest.Mock).mockResolvedValue([]);
+  });
+
+  test('searches for volunteers and selects one', async () => {
+    render(<StaffRecurringBookings />);
+    const input = screen.getByLabelText(/search/i);
+    fireEvent.change(input, { target: { value: 'Test' } });
+
+    await waitFor(() => expect(searchVolunteers).toHaveBeenCalledWith('Test'));
+
+    const button = await screen.findByRole('button', { name: 'Test Vol' });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalled());
+    expect(await screen.findByText(/add a recurring shift/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add backend tests for staff recurring booking creation, listing, and cancellation
- test volunteer search integration on staff recurring booking page

## Testing
- `npm test` (MJ_FB_Backend) *(fails: jest not found)*
- `npm test` (MJ_FB_Frontend) *(fails: VolunteerManagement.test.tsx, VolunteerDashboard.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a77a8300832da7edfa6158729442