### PR TITLE
Expand client help topics for appointments and profiles

### DIFF
--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -10,11 +10,23 @@ export const helpContent: Record<
   client: [
     {
       title: 'Booking appointments',
-      body: 'Clients can book, reschedule, or cancel appointments from their dashboard.',
+      body: 'Reserve pantry visits from your dashboard.',
+    },
+    {
+      title: 'Rescheduling or canceling',
+      body: 'Change or cancel a booking from the booking history list.',
     },
     {
       title: 'View booking history',
       body: 'Past and upcoming bookings are listed under the booking history page.',
+    },
+    {
+      title: 'Manage profile and password',
+      body: 'Update contact information or change your password from the profile page.',
+    },
+    {
+      title: 'Visit counts and reminders',
+      body: 'The dashboard shows your monthly visit totals and upcoming booking reminders.',
     },
   ],
   volunteer: [


### PR DESCRIPTION
## Summary
- expand client help with sections for rescheduling or canceling appointments
- add guidance for updating profile info and passwords
- mention visit counts and booking reminders in help content

## Testing
- `npm test` *(fails: unable to find elements, missing localization context, multiple test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a7854354832d8f439ecc015ee43d