### PR TITLE
fix: import SelectChangeEvent as type in LanguageSelector

### DIFF
--- a/MJ_FB_Frontend/src/components/LanguageSelector.tsx
+++ b/MJ_FB_Frontend/src/components/LanguageSelector.tsx
@@ -1,4 +1,5 @@
-import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { MenuItem, Select } from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
 import { useTranslation } from 'react-i18next';
 
 const languages = [


### PR DESCRIPTION
## Summary
- avoid runtime import error by importing SelectChangeEvent as a type from `@mui/material/Select`

## Testing
- `npm test` *(fails: Test Suites: 20 failed, 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a949bb90832d846686f959326661