### PR TITLE
Allow volunteers to list pantry slots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,7 +406,7 @@ Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid 
 
 ## Slot API
 
-`/slots` returns each slot with an `overbooked` flag when approved bookings exceed `max_capacity`, and `available` values are never negative.
+`/slots` returns each slot with an `overbooked` flag when approved bookings exceed `max_capacity`, and `available` values are never negative. Volunteers can access this endpoint alongside shoppers, delivery, staff, and agencies.
 
 `GET /volunteer-roles` returns all volunteer roles with their active shifts by default. Append `?includeInactive=true` to include inactive shifts:
 

--- a/MJ_FB_Backend/src/routes/slots.ts
+++ b/MJ_FB_Backend/src/routes/slots.ts
@@ -21,13 +21,13 @@ router.get(
 router.get(
   '/',
   authMiddleware,
-  authorizeRoles('shopper', 'delivery', 'staff', 'agency'),
+  authorizeRoles('shopper', 'delivery', 'staff', 'agency', 'volunteer'),
   listSlots,
 );
 router.get(
   '/range',
   authMiddleware,
-  authorizeRoles('shopper', 'delivery', 'staff', 'agency'),
+  authorizeRoles('shopper', 'delivery', 'staff', 'agency', 'volunteer'),
   listSlotsRange,
 );
 

--- a/MJ_FB_Backend/tests/authorization.test.ts
+++ b/MJ_FB_Backend/tests/authorization.test.ts
@@ -84,6 +84,20 @@ describe('Authorization middleware', () => {
     expect(res.status).toBe(200);
   });
 
+  it('allows volunteer to access slots', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 3, role: 'volunteer', type: 'volunteer' });
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [{ id: 3, first_name: 'Vol', last_name: 'unteer', email: 'vol@example.com' }],
+    });
+
+    const res = await request(app)
+      .get('/slots')
+      .set('Authorization', 'Bearer token')
+      .query({ date: '2024-06-18' });
+    expect(res.status).toBe(200);
+  });
+
   it('allows staff to access staff endpoint', async () => {
     (jwt.verify as jest.Mock).mockReturnValue({ id: 2, role: 'staff', type: 'staff' });
     (pool.query as jest.Mock).mockResolvedValue({

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Before merging a pull request, confirm the following:
 - Creating volunteer role slots (`POST /volunteer-roles`) accepts either an existing `roleId` or a new `name` with `categoryId`.
 - Volunteer role start and end times are selected via a native time picker and stored as `HH:MM:SS`.
 - Listing volunteer roles (`GET /volunteer-roles`) accepts `includeInactive=true` to return inactive shifts.
-- Slot listing endpoint `/slots` returns an empty array and 200 status on holidays. Each slot includes an `overbooked` flag when approved bookings exceed `max_capacity`, and the `available` count never goes below zero.
+- Slot listing endpoint `/slots` (accessible to shoppers, delivery, staff, agency, and volunteer users) returns an empty array and 200 status on holidays. Each slot includes an `overbooked` flag when approved bookings exceed `max_capacity`, and the `available` count never goes below zero.
 - Staff can add or remove holidays from the Manage Availability page, which persists changes to the backend.
 - Holiday listings via `GET /holidays` are available to agencies so booking interfaces can disable those dates.
 


### PR DESCRIPTION
## Summary
- allow volunteer role access to `/slots` and `/slots/range`
- cover volunteer access to slot listings with a test
- document volunteer eligibility for slot listings

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aaede3fc832dbafd738b3f281240