### PR TITLE
Memoize week start in volunteer PendingReviews

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/PendingReviews.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/PendingReviews.tsx
@@ -34,9 +34,9 @@ export default function PendingReviews() {
   const [dialog, setDialog] = useState<VolunteerBookingDetail | null>(null);
   const [message, setMessage] = useState('');
   const [severity, setSeverity] = useState<'success' | 'error' | 'info' | 'warning'>('success');
+  const weekStart = useMemo(() => dayjs().startOf('week'), []);
   const today = dayjs();
-  const weekStart = today.startOf('week');
-  const days = Array.from({ length: 7 }, (_, i) => weekStart.add(i, 'day'));
+  const days = useMemo(() => Array.from({ length: 7 }, (_, i) => weekStart.add(i, 'day')), [weekStart]);
   const [dayIdx, setDayIdx] = useState(today.day());
   const [statusFilter, setStatusFilter] = useState<'all' | 'approved' | 'no_show'>('all');
 


### PR DESCRIPTION
## Summary
- memoize start of the current week in PendingReviews
- derive week days from memoized week start so fetch effect runs once

## Testing
- `npm test` *(fails: 20 failed, 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ac019ee4832d856620480b761214