### PR TITLE
Add cancel and reschedule links in email notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 18+ for native `fetch`; the `node-fetch` polyfill has been removed and earlier versions are not supported.
 - Booking emails are sent through Brevo; configure `BREVO_API_KEY`, `BREVO_FROM_EMAIL`, and `BREVO_FROM_NAME` in the backend environment.
+- Booking confirmation and reminder emails include Cancel and Reschedule buttons with links generated from each booking's reschedule token.
 - Email queue retries failed sends with exponential backoff and persists jobs in the `email_queue` table so retries survive restarts. Configure `EMAIL_QUEUE_MAX_RETRIES` and `EMAIL_QUEUE_BACKOFF_MS` to adjust retry behavior.
 - Password setup token expiry is configurable via `PASSWORD_SETUP_TOKEN_TTL_HOURS` (default 24 hours).
 - Use the `sendTemplatedEmail` utility to send Brevo template emails by providing a `templateId` and `params` object.

--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -10,6 +10,7 @@ import {
   findUpcomingBooking,
 } from '../utils/bookingUtils';
 import { enqueueEmail } from '../utils/emailQueue';
+import { buildCancelRescheduleButtons } from '../utils/emailUtils';
 import logger from '../utils/logger';
 import {
   SlotCapacityError,
@@ -111,10 +112,11 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
     client.release();
 
     if (user.email) {
+      const buttons = buildCancelRescheduleButtons(token);
       enqueueEmail(
         user.email,
         'Booking approved',
-        `Your booking for ${date} has been automatically approved`,
+        `Your booking for ${date} has been automatically approved.${buttons}`,
       );
     } else {
       logger.warn(

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import pool from '../../db';
-import { sendEmail } from '../../utils/emailUtils';
+import { sendEmail, buildCancelRescheduleButtons } from '../../utils/emailUtils';
 import logger from '../../utils/logger';
 import {
   CreateRecurringVolunteerBookingRequest,
@@ -144,10 +144,11 @@ export async function createVolunteerBooking(
     );
 
     if (user.email) {
+      const buttons = buildCancelRescheduleButtons(token);
       await sendEmail(
         user.email,
         'Volunteer booking confirmed',
-        `Volunteer booking for role ${roleId} on ${date} has been confirmed`,
+        `Volunteer booking for role ${roleId} on ${date} has been confirmed.${buttons}`,
       );
     } else {
       logger.warn(
@@ -436,10 +437,11 @@ export async function resolveVolunteerBookingConflict(
     );
 
     if (user.email) {
+      const buttons = buildCancelRescheduleButtons(token);
       await sendEmail(
         user.email,
         'Volunteer booking confirmed',
-        `Volunteer booking for role ${roleId} on ${date} has been confirmed`,
+        `Volunteer booking for role ${roleId} on ${date} has been confirmed.${buttons}`,
       );
     } else {
       logger.warn(

--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -156,7 +156,8 @@ export async function fetchBookingsForReminder(
     `SELECT
         COALESCE(u.email, nc.email) as user_email,
         s.start_time,
-        s.end_time
+        s.end_time,
+        b.reschedule_token
        FROM bookings b
        LEFT JOIN clients u ON b.user_id = u.client_id
        LEFT JOIN new_clients nc ON b.new_client_id = nc.id

--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -3,6 +3,7 @@ import { enqueueEmail } from './emailQueue';
 import { formatReginaDate } from './dateUtils';
 import logger from './logger';
 import cron from 'node-cron';
+import { buildCancelRescheduleButtons } from './emailUtils';
 
 /**
  * Send reminder emails for bookings scheduled for the next day.
@@ -16,10 +17,11 @@ export async function sendNextDayBookingReminders(): Promise<void> {
     for (const b of bookings) {
       if (!b.user_email) continue;
       const time = b.start_time && b.end_time ? ` from ${b.start_time} to ${b.end_time}` : '';
+      const buttons = buildCancelRescheduleButtons(b.reschedule_token);
       enqueueEmail(
         b.user_email,
         'Booking Reminder',
-        `This is a reminder for your booking on ${nextDate}${time}.`,
+        `This is a reminder for your booking on ${nextDate}${time}.${buttons}`,
       );
     }
   } catch (err) {

--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -96,3 +96,13 @@ export async function sendTemplatedEmail({
     });
   }
 }
+
+export function buildCancelRescheduleButtons(token: string): string {
+  const base = config.frontendOrigins[0];
+  const cancelLink = `${base}/cancel/${token}`;
+  const rescheduleLink = `${base}/reschedule/${token}`;
+  return `<div style="margin-top:16px;">` +
+    `<a href="${cancelLink}" style="display:inline-block;padding:8px 16px;background-color:#d32f2f;color:#ffffff;text-decoration:none;border-radius:4px;">Cancel</a>` +
+    `<a href="${rescheduleLink}" style="display:inline-block;padding:8px 16px;background-color:#1976d2;color:#ffffff;text-decoration:none;border-radius:4px;margin-left:8px;">Reschedule</a>` +
+    `</div>`;
+}

--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -35,6 +35,7 @@ describe('sendNextDayBookingReminders', () => {
         user_email: 'user@example.com',
         start_time: '09:00:00',
         end_time: '10:00:00',
+        reschedule_token: 'tok',
       },
     ]);
 

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -87,7 +87,7 @@ describe('bookingRepository', () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
     await fetchBookingsForReminder('2024-01-01');
     const call = (pool.query as jest.Mock).mock.calls[0];
-    expect(call[0]).toMatch(/SELECT\s+COALESCE\(u.email, nc.email\) as user_email,\s+s.start_time,\s+s.end_time/);
+    expect(call[0]).toMatch(/SELECT\s+COALESCE\(u.email, nc.email\) as user_email,\s+s.start_time,\s+s.end_time,\s+b.reschedule_token/);
     expect(call[0]).toMatch(/WHERE b.status = 'approved' AND b.date = \$1/);
     expect(call[1]).toEqual(['2024-01-01']);
   });

--- a/MJ_FB_Backend/tests/emailButtons.test.ts
+++ b/MJ_FB_Backend/tests/emailButtons.test.ts
@@ -1,0 +1,9 @@
+import { buildCancelRescheduleButtons } from '../src/utils/emailUtils';
+
+describe('buildCancelRescheduleButtons', () => {
+  it('includes cancel and reschedule links', () => {
+    const html = buildCancelRescheduleButtons('tok');
+    expect(html).toContain('http://localhost:3000/cancel/tok');
+    expect(html).toContain('http://localhost:3000/reschedule/tok');
+  });
+});

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Before merging a pull request, confirm the following:
 - Staff can manage recurring volunteer shift series from the **Recurring Shifts** page under Volunteer Management.
 - Only staff can update volunteer trained roles; volunteers may view but not modify their assigned roles from the dashboard.
 - Daily reminder jobs queue emails for next-day bookings and volunteer shifts using the backend email queue. Each job now runs via `node-cron` at `0 9 * * *` Regina time and exposes start/stop functions.
+- Booking confirmation and reminder emails include Cancel and Reschedule buttons so users can manage their appointments directly from the message.
 - A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.
 - A nightly volunteer no-show cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours and emails coordinators about the changes.
 - Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.


### PR DESCRIPTION
## Summary
- Add helper to generate cancel and reschedule buttons for Brevo emails
- Include action links in booking confirmations and reminder jobs
- Extend tests for email buttons and updated reminder queries

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ae4df1e8832da6dc4b52de3c79cd