### PR TITLE
Fix volunteer dashboard availability timezone handling

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -181,6 +181,42 @@ beforeEach(() => {
     jest.useRealTimers();
   });
 
+  it('lists upcoming available shifts', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-29T14:00:00Z'));
+
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        name: 'Greeter',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        max_volunteers: 3,
+        booked: 0,
+        available: 3,
+        status: 'available',
+        date: '2024-01-29',
+        category_id: 1,
+        category_name: 'Front',
+        is_wednesday_slot: false,
+      },
+    ]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Greeter •/)).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
   it('shows server error when shift request fails', async () => {
     const today = new Date().toISOString().split('T')[0];
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);

--- a/MJ_FB_Frontend/src/utils/date.ts
+++ b/MJ_FB_Frontend/src/utils/date.ts
@@ -14,8 +14,10 @@ export function toDayjs(input?: ConfigType) {
   if (input === undefined || input === null || input === '') {
     return dayjs();
   }
-  const parsed = dayjs(input);
-  return parsed.isValid() ? parsed.tz(REGINA_TIMEZONE) : dayjs(NaN);
+  const isLocalString =
+    typeof input === 'string' && !/([zZ]|[+-]\d{2}:?\d{2})$/.test(input);
+  const parsed = dayjs(input).tz(REGINA_TIMEZONE, isLocalString);
+  return parsed.isValid() ? parsed : dayjs(NaN);
 }
 
 export function toDate(input?: ConfigType) {


### PR DESCRIPTION
## Summary
- parse naive dates in Regina timezone so future shifts appear in Available in My Roles
- test that upcoming shifts are listed

## Testing
- `npm test src/__tests__/date.test.tsx src/__tests__/VolunteerDashboard.test.tsx` *(fails: Could not find leaderboard percentile; milestone banner duplicates; chart missing)*
- `npm test` *(fails: multiple suites with jsdom warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aed0a838832d9c8b41f4e667c130