### PR TITLE
Use monthly stats in community impact card

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -54,6 +54,7 @@ beforeEach(() => {
     monthHoursGoal: 0,
     totalLbs: 0,
     weekLbs: 0,
+    monthLbs: 0,
     monthFamilies: 0,
   });
   localStorage.clear();
@@ -395,6 +396,7 @@ beforeEach(() => {
       monthHoursGoal: 8,
       totalLbs: 100,
       weekLbs: 25,
+      monthLbs: 25,
       monthFamilies: 0,
     });
     const rand = jest.spyOn(Math, 'random').mockReturnValue(0);
@@ -406,7 +408,7 @@ beforeEach(() => {
     );
 
     expect(
-      await screen.findByText(/Volunteers distributed 25 lbs this week/),
+      await screen.findByText(/Volunteers distributed 25 lbs this month/),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/4 \/ 8 hrs/),
@@ -449,6 +451,7 @@ beforeEach(() => {
       monthHoursGoal: 10,
       totalLbs: 100,
       weekLbs: 25,
+      monthLbs: 25,
       monthFamilies: 0,
     });
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
@@ -31,7 +31,7 @@ export default function VolunteerGroupStatsCard() {
   return (
     <SectionCard title="Community Impact">
       <Stack spacing={2} alignItems="center">
-        <Typography>{`Volunteers distributed ${stats.weekLbs} lbs this week`}</Typography>
+        <Typography>{`Volunteers distributed ${stats.monthLbs} lbs this month`}</Typography>
         <Typography>{`Served ${stats.monthFamilies} families this month`}</Typography>
         <Box
           display="flex"


### PR DESCRIPTION
## Summary
- show monthly pounds distributed in the Community Impact card
- update volunteer dashboard tests for new monthly metric

## Testing
- `npx jest src/__tests__/VolunteerDashboard.test.tsx --runInBand` *(fails: Unable to find element, other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b3af2e6a2c832dbfe6c3ed2f2d3c69