### PR TITLE
fix: unique keys for client booking history list

### DIFF
--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -282,7 +282,7 @@ export default function ClientDashboard() {
                 const time = b.start_time ? formatTime(b.start_time) : '';
                 return (
                   <ListItem
-                    key={b.id}
+                    key={`${b.id}-${b.date}`}
                     secondaryAction={
                       <Chip label={b.status} color={statusColor(b.status)} />
                     }


### PR DESCRIPTION
## Summary
- ensure ClientDashboard uses a composite key of booking id and date for recent booking items to avoid duplicate React keys

## Testing
- `npm test src/__tests__/App.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/admin/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68b3afa3a3e4832dba61458813a8c269