### PR TITLE
Show full dates in NoShowWeek

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/NoShowWeek.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/NoShowWeek.test.tsx
@@ -98,5 +98,26 @@ describe('NoShowWeek', () => {
     expect(within(table).getByText('No Show')).toBeInTheDocument();
     expect(within(table).queryByText('Approved Past')).not.toBeInTheDocument();
   });
+
+  it('shows full dates for each day', () => {
+    render(
+      <MemoryRouter>
+        <NoShowWeek />
+      </MemoryRouter>,
+    );
+
+    const dates = [
+      'Sunday, Dec 31, 2023',
+      'Monday, Jan 1, 2024',
+      'Tuesday, Jan 2, 2024',
+      'Wednesday, Jan 3, 2024',
+      'Thursday, Jan 4, 2024',
+      'Friday, Jan 5, 2024',
+      'Saturday, Jan 6, 2024',
+    ];
+    dates.forEach(date => {
+      expect(screen.getByText(date)).toBeInTheDocument();
+    });
+  });
 });
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
@@ -94,7 +94,7 @@ export default function NoShowWeek() {
           <Box key={dateStr} mb={3}>
             <Stack direction="row" spacing={2} alignItems="center" mb={1}>
               <Typography variant="h6">
-                {formatDate(d, 'dddd, MMM D')}
+                {formatDate(d, 'dddd, MMM D, YYYY')}
               </Typography>
               {dateStr === formatDate(today) && (
                 <FormControl size="small">


### PR DESCRIPTION
## Summary
- Display full date including year in NoShowWeek headers
- Add test confirming each day in the weekly view shows a full date

## Testing
- `npm test` *(fails: VolunteerManagement.test.tsx, VolunteerBooking.test.tsx, App.test.tsx, ManageVolunteerShiftDialog.test.tsx, BookingUI.test.tsx, PasswordSetup.test.tsx, HelpPage.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b12b8ef4832db251423524706982