### PR TITLE
Show full date in volunteer schedule messages

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -162,7 +162,7 @@ export default function VolunteerSchedule() {
           endDate || undefined,
         );
       }
-      const dateLabel = formatDate(currentDate, 'ddd, MMM D');
+      const dateLabel = formatDate(currentDate, 'ddd, MMM D, YYYY');
       const timeLabel = `${formatTime(requestRole.start_time)}–${formatTime(
         requestRole.end_time,
       )}`;


### PR DESCRIPTION
## Summary
- include year in volunteer shift confirmation snackbar

## Testing
- `npm test` *(fails: Missing testing dependencies, MUI Grid prop warnings, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b3b12946ac832dad8da26fbcfa8fb4