### PR TITLE
feat(agency): show weekday and year in dashboard dates

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyDashboard.test.tsx
@@ -25,12 +25,17 @@ describe('AgencyDashboard', () => {
       {
         id: 1,
         status: 'approved',
-        date: new Date().toISOString(),
+        date: '2024-01-15',
         user_name: 'Client A',
       },
     ]);
     (getSlots as jest.Mock).mockResolvedValue([]);
-    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getHolidays as jest.Mock).mockResolvedValue([
+      {
+        date: '2024-01-20',
+        reason: 'Closed',
+      },
+    ]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
 
     render(
@@ -41,5 +46,9 @@ describe('AgencyDashboard', () => {
 
     await waitFor(() => expect(getBookings).toHaveBeenCalled());
     expect(screen.getByText(/Client A/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/Mon, Jan 15, 2024/)).toBeInTheDocument();
+      expect(screen.getByText(/Sat, Jan 20, 2024 Closed/)).toBeInTheDocument();
+    });
   });
 });

--- a/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
@@ -52,7 +52,12 @@ interface NextSlot {
 
 function formatDate(dateStr: string) {
   const d = toDate(dateStr);
-  return formatReginaDate(d, { month: 'short', day: 'numeric' });
+  return formatReginaDate(d, {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
 }
 
 function statusColor(status: string):


### PR DESCRIPTION
## Summary
- show weekday and year in agency dashboard date helper
- verify new date format in AgencyDashboard test

## Testing
- `npm test` *(fails: VolunteerManagement.test.tsx etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b122b764832d9e7e22df0fae95c3