### PR TITLE
Display full weekday and year in staff dashboard dates

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -63,7 +63,12 @@ function parseLocalDate(dateStr: string) {
 
 function formatDate(dateStr: string) {
   const d = parseLocalDate(dateStr);
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
 }
 
 function formatLocalDate(date: Date) {

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ page and cached on the server:
 - Pages are organized into feature-based directories (e.g., booking, staff, volunteer-management, warehouse-management).
 - Client login and password pages include a language selector so clients can switch between English and Spanish.
 - A shared dashboard component lives in `src/components/dashboard`.
+- Staff dashboard dates display weekday, month, day, and year (e.g., 'Tue, Jan 2, 2024').
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.
 - Page and form titles render in uppercase with a lighter font weight for clarity.


### PR DESCRIPTION
## Summary
- Show weekday and year when formatting dashboard dates
- Document that staff dashboard dates include weekday and year

## Testing
- `npm test` *(fails: 18 failed, 32 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68b3b11dc668832db6b650957f6d35fd