### PR TITLE
Expand volunteer booking summary date format

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -229,7 +229,7 @@ export default function VolunteerBooking() {
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Typography>
             {selected
-              ? `${selected.name} • ${formatTime(selected.start_time)}–${formatTime(selected.end_time)} on ${date.format('MMM D')}`
+              ? `${selected.name} • ${formatTime(selected.start_time)}–${formatTime(selected.end_time)} on ${date.format('ddd, MMM D, YYYY')}`
               : 'No slot selected'}
           </Typography>
           <Button


### PR DESCRIPTION
## Summary
- Expand volunteer booking summary footer to show weekday and year

## Testing
- `CI=1 npm test -- --runInBand` *(fails: TestingLibraryElementError: Unable to find an element with the text: You're in the top 75%!...)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b12a81f8832db056ab872845d10e