### PR TITLE
Show year in volunteer dashboard date labels

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -460,6 +460,56 @@ beforeEach(() => {
     rand.mockRestore();
   });
 
+  it('displays year in date labels', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-10T12:00:00Z'));
+
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'approved',
+        role_id: 1,
+        date: '2024-01-15',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        role_name: 'Greeter',
+      },
+    ]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
+      {
+        id: 2,
+        role_id: 2,
+        name: 'Cook',
+        start_time: '13:00:00',
+        end_time: '16:00:00',
+        max_volunteers: 3,
+        booked: 0,
+        available: 3,
+        status: 'available',
+        date: '2024-01-20',
+        category_id: 1,
+        category_name: 'Kitchen',
+        is_wednesday_slot: false,
+      },
+    ]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    const nextShift = await screen.findByText(/Greeter/);
+    expect(nextShift).toHaveTextContent('2024');
+
+    const slot = await screen.findByText(/Cook •/);
+    expect(slot).toHaveTextContent('2024');
+
+    jest.useRealTimers();
+  });
+
   it('renders contribution trend and community gauge charts', async () => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
       {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -56,6 +56,7 @@ function formatDateLabel(dateStr: string) {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
+    year: 'numeric',
   });
 }
 


### PR DESCRIPTION
## Summary
- include `year: 'numeric'` when formatting volunteer dashboard date labels
- add test coverage ensuring dates display the year

## Testing
- `npm test` *(fails: VolunteerManagement.test.tsx, others)*
- `npm test src/__tests__/VolunteerDashboard.test.tsx -- -t 'displays year in date labels'`


------
https://chatgpt.com/codex/tasks/task_e_68b3b127f1d0832d8d55aa70187dd699