### PR TITLE
Add guidance tooltips to agency pages

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
@@ -34,6 +34,7 @@ import SectionCard from '../../components/dashboard/SectionCard';
 import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 import Page from '../../components/Page';
+import InfoTooltip from '../../components/InfoTooltip';
 
 interface Booking {
   id: number;
@@ -163,7 +164,7 @@ export default function AgencyDashboard() {
                       primary={`${formatDate(next.date)} ${formatTime(next.start_time || '')}`}
                       secondary={next.user_name}
                     />
-                    <Stack direction="row" spacing={1}>
+                    <Stack direction="row" spacing={1} alignItems="center">
                       <Button
                         size="small"
                         variant="outlined"
@@ -172,6 +173,10 @@ export default function AgencyDashboard() {
                       >
                         Cancel
                       </Button>
+                      <InfoTooltip
+                        title="Cancel at least 24 hours before the booking to avoid a no-show."
+                        placement="top"
+                      />
                       {next.reschedule_token && (
                         <Button
                           size="small"
@@ -218,14 +223,17 @@ export default function AgencyDashboard() {
                     <ListItem
                       key={`${s.date}-${s.slot.id}`}
                       secondaryAction={
-                        <Button
-                          size="small"
-                          variant="contained"
-                          sx={{ textTransform: 'none' }}
-                          onClick={() => navigate('/agency/book')}
-                        >
-                          Book
-                        </Button>
+                        <Stack direction="row" spacing={0.5} alignItems="center">
+                          <Button
+                            size="small"
+                            variant="contained"
+                            sx={{ textTransform: 'none' }}
+                            onClick={() => navigate('/agency/book')}
+                          >
+                            Book
+                          </Button>
+                          <InfoTooltip title="Slot has remaining capacity" />
+                        </Stack>
                       }
                     >
                       <ListItemText

--- a/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState, useCallback } from 'react';
 import PantrySchedule from '../staff/PantrySchedule';
 import Page from '../../components/Page';
 import { getMyAgencyClients } from '../../api/agencies';
-import type { Role } from '../../types';
+import { Stack, Typography } from '@mui/material';
+import InfoTooltip from '../../components/InfoTooltip';
 import { useAuth } from '../../hooks/useAuth';
 
 interface AgencyClient {
@@ -51,6 +52,10 @@ export default function AgencySchedule() {
 
   return (
     <Page title="Agency Schedule">
+      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 1 }}>
+        <Typography variant="body2">Select a green slot to book; gray slots are full.</Typography>
+        <InfoTooltip title="Green cells show available spots. Gray cells are full or unavailable." />
+      </Stack>
       <PantrySchedule
         token={token}
         clientIds={clientIds}

--- a/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
@@ -8,6 +8,7 @@ import {
   IconButton,
   TextField,
   Button,
+  Stack,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -18,6 +19,7 @@ import {
 } from '../../api/agencies';
 import { useAuth } from '../../hooks/useAuth';
 import Page from '../../components/Page';
+import InfoTooltip from '../../components/InfoTooltip';
 
 interface AgencyClient {
   id: number;
@@ -90,9 +92,10 @@ export default function ClientList() {
     <Page title="Agency Clients">
     <Grid container spacing={2}>
       <Grid item xs={12} md={6}>
-        <Typography variant="h5" gutterBottom>
-          Clients
-        </Typography>
+        <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 1 }}>
+          <Typography variant="h5">Clients</Typography>
+          <InfoTooltip title="Shows assigned clients and their public IDs." />
+        </Stack>
         <List dense>
           {clients.map(c => (
             <ListItem


### PR DESCRIPTION
## Summary
- add tooltip for cancellation rules on agency dashboard
- clarify slot availability with tooltips in dashboard and schedule
- explain client list columns with tooltip

## Testing
- `npm test` (fails: VolunteerManagement.test.tsx, VolunteerDashboard.test.tsx, others)

------
https://chatgpt.com/codex/tasks/task_e_68b3b5f301ac832dbdf76b3e1dace98a