### PR TITLE
feat: add tooltips to volunteer views

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/SectionCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/SectionCard.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import PageCard from '../layout/PageCard';
 
 interface SectionCardProps {
-  title: string;
+  title: ReactNode;
   icon?: ReactNode;
   children: ReactNode;
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Skeleton,
 } from '@mui/material';
+import InfoTooltip from '../../components/InfoTooltip';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import dayjs, { Dayjs } from 'dayjs';
 import { useQuery } from '@tanstack/react-query';
@@ -227,11 +228,14 @@ export default function VolunteerBooking() {
         }}
       >
         <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Typography>
-            {selected
-              ? `${selected.name} • ${formatTime(selected.start_time)}–${formatTime(selected.end_time)} on ${date.format('ddd, MMM D, YYYY')}`
-              : 'No slot selected'}
-          </Typography>
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            <Typography>
+              {selected
+                ? `${selected.name} • ${formatTime(selected.start_time)}–${formatTime(selected.end_time)} on ${date.format('ddd, MMM D, YYYY')}`
+                : 'No slot selected'}
+            </Typography>
+            <InfoTooltip title="Select a slot above, then click Request shift to book it." />
+          </Stack>
           <Button
             variant="contained"
             size="small"

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -15,6 +15,7 @@ import {
   Select,
   MenuItem,
 } from '@mui/material';
+import InfoTooltip from '../../components/InfoTooltip';
 import Announcement from '@mui/icons-material/Announcement';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -446,7 +447,16 @@ export default function VolunteerDashboard() {
               </Stack>
             </SectionCard>
 
-            <SectionCard title="My Stats">
+            <SectionCard
+              title={
+                <Stack direction="row" spacing={0.5} alignItems="center">
+                  My Stats
+                  <InfoTooltip
+                    title="Hours and shifts count only completed shifts. Streak shows consecutive weeks volunteering."
+                  />
+                </Stack>
+              }
+            >
               <Stack spacing={2}>
                 {badges.length > 0 ? (
                   <Stack direction="row" spacing={1} flexWrap="wrap">

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -46,6 +46,7 @@ import {
 } from '@mui/material';
 import { lighten } from '@mui/material/styles';
 import type { AlertColor } from '@mui/material';
+import InfoTooltip from '../../components/InfoTooltip';
 
 const reginaTimeZone = 'America/Regina';
 
@@ -392,14 +393,20 @@ export default function VolunteerSchedule() {
             >
               Previous
             </Button>
-            <Typography variant="h6" component="h3">
-              {dateStr} - {dayName}
-              {isHoliday
-                ? ` (Holiday${holidayObj?.reason ? ': ' + holidayObj.reason : ''})`
-                : isWeekend
-                  ? ' (Weekend)'
-                  : ''}
-            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Typography variant="h6" component="h3">
+                {dateStr} - {dayName}
+                {isHoliday
+                  ? ` (Holiday${holidayObj?.reason ? ': ' + holidayObj.reason : ''})`
+                  : isWeekend
+                    ? ' (Weekend)'
+                    : ''}
+              </Typography>
+              <InfoTooltip
+                title="Green cells show your bookings, gray cells are filled. Click 'Volunteer Needed' to book."
+                sx={{ ml: 0.5 }}
+              />
+            </Box>
             <Button onClick={() => changeDay(1)} variant="outlined" color="primary">Next</Button>
           </Box>
           <FeedbackSnackbar


### PR DESCRIPTION
## Summary
- add InfoTooltip to volunteer dashboard stats, booking, and schedule
- allow SectionCard titles to include ReactNode

## Testing
- `npm test` *(fails: Test Suites: 18 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b5f3b930832da9c5d8b7032100be