### PR TITLE
style: align language selector

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -256,7 +256,9 @@ export default function App() {
 
   return (
     <BrowserRouter>
-      <LanguageSelector />
+      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0.5rem' }}>
+        <LanguageSelector />
+      </div>
       <div className="app-container">
         <FeedbackSnackbar
           open={!!error}

--- a/MJ_FB_Frontend/src/components/LanguageSelector.tsx
+++ b/MJ_FB_Frontend/src/components/LanguageSelector.tsx
@@ -34,7 +34,8 @@ export default function LanguageSelector() {
       value={i18n.language}
       onChange={handleChange}
       variant="standard"
-      sx={{ minWidth: 80, color: 'inherit', '&::before, &::after': { borderBottom: 'none' } }}
+      size="small"
+      sx={{ width: 'auto', minWidth: 80, color: 'inherit', '&::before, &::after': { borderBottom: 'none' } }}
       disableUnderline
     >
       {languages.map(lang => (


### PR DESCRIPTION
## Summary
- shrink language selector dropdown and remove full-width styling
- right-align language selector at top of app layout

## Testing
- `npm test` *(fails: multiple frontend tests and worker exit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b93a1334832db1000a22e317724b