### PR TITLE
test(frontend): pad volunteer dashboard start_time mock

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -157,7 +157,7 @@ beforeEach(() => {
         id: 1,
         role_id: 1,
         name: 'Greeter',
-        start_time: '9:00:00',
+        start_time: '09:00:00',
         end_time: '12:00:00',
         max_volunteers: 3,
         booked: 0,


### PR DESCRIPTION
## Summary
- pad mocked start_time in VolunteerDashboard tests to use leading zero

## Testing
- `npm test src/__tests__/VolunteerDashboard.test.tsx` *(fails: Unable to find an element with the text: You're in the top 75%!)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b961e2b8832da3917fc1e8252638