### PR TITLE
Add email queue shutdown utility

### DIFF
--- a/MJ_FB_Backend/tests/emailQueue.test.ts
+++ b/MJ_FB_Backend/tests/emailQueue.test.ts
@@ -68,6 +68,8 @@ describe('persistent email queue', () => {
   });
 
   afterEach(() => {
+    const { shutdownQueue } = require('../src/utils/emailQueue');
+    shutdownQueue();
     jest.useRealTimers();
     jest.clearAllTimers();
     jest.resetModules();


### PR DESCRIPTION
## Summary
- expose shutdownQueue to clear any pending email queue timers
- cleanup timers in emailQueue tests

## Testing
- `node node_modules/jest/bin/jest.js tests/emailQueue.test.ts` *(fails: Cannot find name 'process' - missing @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b95ee704832dab1f6beffd214394