### PR TITLE
feat: translate login errors

### DIFF
--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -24,6 +24,8 @@
   "forgot_password": "¿Olvidó su contraseña?",
   "client_id_required": "Se requiere ID del cliente",
   "password_required": "Se requiere la contraseña",
+  "incorrect_id_password": "ID o contraseña incorrectos",
+  "password_setup_expired": "El enlace de configuración de la contraseña ha expirado",
   "set_password": "Crear contraseña",
   "back_to_login": "Volver al inicio",
   "resend_link": "Reenviar enlace",

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -24,6 +24,8 @@
   "forgot_password": "Forgot password?",
   "client_id_required": "Client ID is required",
   "password_required": "Password is required",
+  "incorrect_id_password": "Incorrect ID or password",
+  "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",
   "resend_link": "Resend link",

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -36,9 +36,9 @@ export default function Login({
     } catch (err: unknown) {
       const apiErr = err as ApiError;
       if (apiErr?.status === 401) {
-        setError('Incorrect ID or password');
+        setError(t('incorrect_id_password'));
       } else if (apiErr?.status === 403) {
-        setError('Password setup link expired');
+        setError(t('password_setup_expired'));
         setResendOpen(true);
       } else {
         setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary
- use i18n keys for login error messages
- add `incorrect_id_password` and `password_setup_expired` translations to all locales

## Testing
- `npm test` *(fails: Test Suites: 18 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bc7693d4832d9b495533a4c7b306