### PR TITLE
Limit language selector visibility to key pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@
 - Volunteer Settings provides separate dialogs for creating sub-roles (with an initial shift) and for adding or editing shifts.
 - Deleting sub-roles and shifts prompts confirmation dialogs to prevent accidental removal.
 - Users complete initial password creation at `/set-password` using a token from the setup email.
-- A global language selector in the top navigation bar allows switching between English and Spanish; avoid adding page-specific selectors.
+- A language selector is available on the login, forgot password, set password, client dashboard, book appointment, booking history, profile, and help pages; avoid adding page-specific selectors elsewhere.
 - After setting a password, users are redirected to the login page for their role.
 - Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations.

--- a/MJ_FB_Frontend/src/__tests__/LanguageSelector.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/LanguageSelector.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import App from '../App';
+import { AuthProvider } from '../hooks/useAuth';
+
+describe('Language selector visibility', () => {
+  const originalFetch = (global as any).fetch;
+
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      (global as any).fetch = originalFetch;
+    } else {
+      delete (global as any).fetch;
+    }
+  });
+
+  it('shows language selector on login page', () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+    window.history.pushState({}, '', '/login/user');
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    );
+    expect(screen.getByText(/english/i)).toBeInTheDocument();
+  });
+
+  it('shows language selector on client dashboard', () => {
+    localStorage.setItem('role', 'shopper');
+    localStorage.setItem('name', 'Test User');
+    window.history.pushState({}, '', '/');
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    );
+    expect(screen.getByText(/english/i)).toBeInTheDocument();
+  });
+
+  it('hides language selector on staff dashboard', () => {
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Staff User');
+    localStorage.setItem('access', JSON.stringify(['pantry']));
+    window.history.pushState({}, '', '/pantry');
+    render(
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    );
+    expect(screen.queryByText(/english/i)).not.toBeInTheDocument();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ page and cached on the server:
 ### Frontend features
 
 - Pages are organized into feature-based directories (e.g., booking, staff, volunteer-management, warehouse-management).
-- A global language selector in the top navigation bar lets users switch between English and Spanish on any page, including login and password screens.
+- A language selector lets users switch languages on the login, forgot password, set password, client dashboard, book appointment, booking history, profile, and help pages.
 - A shared dashboard component lives in `src/components/dashboard`.
 - Staff dashboard dates display weekday, month, day, and year (e.g., 'Tue, Jan 2, 2024').
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.


### PR DESCRIPTION
## Summary
- Hide language selector by default and show only on login, password, client booking, profile, and help pages
- Add tests covering language selector visibility
- Update documentation on language selector availability

## Testing
- `npm test` *(fails: VolunteerManagement.test.tsx, VolunteerDashboard.test.tsx, VolunteerBooking.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c38df678832d85c9fb1f0de13992