### PR TITLE
feat: add translations for help page client content

### DIFF
--- a/MJ_FB_Frontend/src/components/Navbar.tsx
+++ b/MJ_FB_Frontend/src/components/Navbar.tsx
@@ -214,7 +214,7 @@ export default function Navbar({
                           disabled={loading}
                           sx={DROPDOWN_ITEM_SX}
                         >
-                          {t('help')}
+                          {t('help.title')}
                         </MenuItem>
                         <MenuItem
                           onClick={() => {
@@ -375,7 +375,7 @@ export default function Navbar({
                     disabled={loading}
                     sx={DROPDOWN_ITEM_SX}
                   >
-                    {t('help')}
+                    {t('help.title')}
                   </MenuItem>
                   <MenuItem
                     onClick={() => {

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -39,7 +39,58 @@
   "booking": "ቀጠሮ",
   "hello_name": "ሰላም {{name}}",
   "profile": "መገለጫ",
-  "help": "እርዳታ",
+  "help": {
+    "title": "እርዳታ",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "ውጣ",
   "breadcrumb": "የመንገድ ምልክት",
   "home": "መነሻ ገጽ"

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -39,7 +39,58 @@
   "booking": "حجز",
   "hello_name": "مرحبًا، {{name}}",
   "profile": "الملف الشخصي",
-  "help": "مساعدة",
+  "help": {
+    "title": "مساعدة",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "تسجيل الخروج",
   "breadcrumb": "مسار التنقل",
   "home": "الصفحة الرئيسية"

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -41,7 +41,58 @@
   "booking": "Booking",
   "hello_name": "Hello, {{name}}",
   "profile": "Profile",
-  "help": "Help",
+  "help": {
+    "title": "Help",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "Logout",
   "breadcrumb": "breadcrumb",
   "home": "Home"

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -41,7 +41,58 @@
   "booking": "Reserva",
   "hello_name": "Hola, {{name}}",
   "profile": "Perfil",
-  "help": "Ayuda",
+  "help": {
+    "title": "Ayuda",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "Cerrar sesión",
   "breadcrumb": "miga de pan",
   "home": "Inicio"

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -39,7 +39,58 @@
   "booking": "رزرو",
   "hello_name": "سلام، {{name}}",
   "profile": "پروفایل",
-  "help": "کمک",
+  "help": {
+    "title": "کمک",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "خروج",
   "breadcrumb": "ردیف راهبری",
   "home": "خانه"

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -39,7 +39,58 @@
   "booking": "Réservation",
   "hello_name": "Bonjour, {{name}}",
   "profile": "Profil",
-  "help": "Aide",
+  "help": {
+    "title": "Aide",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "Déconnexion",
   "breadcrumb": "fil d'Ariane",
   "home": "Accueil"

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -39,7 +39,58 @@
   "booking": "बुकिंग",
   "hello_name": "नमस्ते, {{name}}",
   "profile": "प्रोफ़ाइल",
-  "help": "सहायता",
+  "help": {
+    "title": "सहायता",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "लॉगआउट",
   "breadcrumb": "ब्रेडक्रम्ब",
   "home": "मुखपृष्ठ"

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -39,7 +39,58 @@
   "booking": "ബുക്കിംഗ്",
   "hello_name": "നമസ്കാരം, {{name}}",
   "profile": "പ്രൊഫൈൽ",
-  "help": "സഹായം",
+  "help": {
+    "title": "സഹായം",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "ലോഗ് ഔട്ട്",
   "breadcrumb": "ബ്രെഡ് ക്രംബ്",
   "home": "ഹോം"

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -39,7 +39,58 @@
   "booking": "ਬੁਕਿੰਗ",
   "hello_name": "ਸਤ ਸ੍ਰੀ ਅਕਾਲ, {{name}}",
   "profile": "ਪਰੋਫ਼ਾਈਲ",
-  "help": "ਮਦਦ",
+  "help": {
+    "title": "ਮਦਦ",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "ਲੌਗ ਆਊਟ",
   "breadcrumb": "ਬ੍ਰੇਡਕ੍ਰੰਬ",
   "home": "ਘਰ"

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -39,7 +39,58 @@
   "booking": "ریزرو",
   "hello_name": "سلام، {{name}}",
   "profile": "پروفایل",
-  "help": "مرسته",
+  "help": {
+    "title": "مرسته",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "وتل",
   "breadcrumb": "د لورلارې نښه",
   "home": "کور"

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -39,7 +39,58 @@
   "booking": "Ballan",
   "hello_name": "Salaan, {{name}}",
   "profile": "Profile",
-  "help": "Caawimaad",
+  "help": {
+    "title": "Caawimaad",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "Ka bax",
   "breadcrumb": "raadraac",
   "home": "Bogga hore"

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -39,7 +39,58 @@
   "booking": "Uwekaji miadi",
   "hello_name": "Habari, {{name}}",
   "profile": "Profaili",
-  "help": "Msaada",
+  "help": {
+    "title": "Msaada",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "Toka",
   "breadcrumb": "alama ya njia",
   "home": "Nyumbani"

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -39,7 +39,58 @@
   "booking": "முன்பதிவு",
   "hello_name": "வணக்கம், {{name}}",
   "profile": "சுயவிவரம்",
-  "help": "உதவி",
+  "help": {
+    "title": "உதவி",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "வெளியேறு",
   "breadcrumb": "பிரெட்கிரம்",
   "home": "முகப்பு"

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -39,7 +39,58 @@
   "booking": "ቆርቆሮ",
   "hello_name": "ሰላም {{name}}",
   "profile": "ፕሮፋይል",
-  "help": "ሓገዝ",
+  "help": {
+    "title": "ሓገዝ",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "መውጽእ",
   "breadcrumb": "ትካል መንገዲ",
   "home": "ገዛ"

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -39,7 +39,58 @@
   "booking": "Booking",
   "hello_name": "Kumusta, {{name}}",
   "profile": "Propayl",
-  "help": "Tulong",
+  "help": {
+    "title": "Tulong",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "Mag-logout",
   "breadcrumb": "mga mumo ng tinapay",
   "home": "Bahay"

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -39,7 +39,58 @@
   "booking": "Бронювання",
   "hello_name": "Привіт, {{name}}",
   "profile": "Профіль",
-  "help": "Допомога",
+  "help": {
+    "title": "Допомога",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "Вийти",
   "breadcrumb": "навігаційний ланцюжок",
   "home": "Головна"

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -39,7 +39,58 @@
   "booking": "预约",
   "hello_name": "你好，{{name}}",
   "profile": "个人资料",
-  "help": "帮助",
+  "help": {
+    "title": "帮助",
+    "search": "Search",
+    "print": "Print",
+    "no_matching_topics": "No matching topics.",
+    "client": {
+      "booking_appointments": {
+        "title": "Booking appointments",
+        "description": "Reserve pantry visits from your dashboard.",
+        "steps": [
+          "Open your dashboard.",
+          "Choose an available date.",
+          "Select a time and confirm the booking."
+        ]
+      },
+      "rescheduling_or_canceling": {
+        "title": "Rescheduling or canceling",
+        "description": "Change or cancel an existing booking.",
+        "steps": [
+          "Go to Booking History.",
+          "Find the upcoming visit.",
+          "Click Reschedule or Cancel and follow prompts."
+        ]
+      },
+      "view_booking_history": {
+        "title": "View booking history",
+        "description": "See past and future visits.",
+        "steps": [
+          "Open the Booking History page.",
+          "Browse the list of previous and upcoming bookings."
+        ]
+      },
+      "manage_profile_and_password": {
+        "title": "Manage profile and password",
+        "description": "Update contact information or change your password.",
+        "steps": [
+          "Navigate to the Profile page.",
+          "Edit your information.",
+          "Save changes."
+        ]
+      },
+      "visit_counts_and_reminders": {
+        "title": "Visit counts and reminders",
+        "description": "The dashboard shows monthly totals and upcoming reminders.",
+        "steps": [
+          "Return to the dashboard.",
+          "Review your visit counter.",
+          "Check reminders for upcoming bookings."
+        ]
+      }
+    }
+  },
   "logout": "退出登录",
   "breadcrumb": "面包屑导航",
   "home": "首页"

--- a/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
+++ b/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
@@ -10,9 +10,10 @@ import {
 } from '@mui/material';
 import Page from '../../components/Page';
 import { useAuth } from '../../hooks/useAuth';
-import { helpContent, type HelpSection } from './content';
+import { getHelpContent, type HelpSection } from './content';
 import resetCss from '../../reset.css?url';
 import RoleTabs, { type RoleTabOption } from '../../components/RoleTabs';
+import { useTranslation } from 'react-i18next';
 
 function roleLabel(role: string) {
   return role.charAt(0).toUpperCase() + role.slice(1);
@@ -20,6 +21,7 @@ function roleLabel(role: string) {
 
 export default function HelpPage() {
   const { role, access } = useAuth();
+  const { t, i18n } = useTranslation();
 
   const roles: string[] = [];
   if (role === 'shopper') roles.push('client');
@@ -46,6 +48,7 @@ export default function HelpPage() {
     };
   }, []);
 
+  const helpContent = useMemo(() => getHelpContent(t), [t, i18n.language]);
   const tabs: RoleTabOption[] = useMemo(() => {
     const query = search.toLowerCase();
     return roles.map(r => {
@@ -82,21 +85,23 @@ export default function HelpPage() {
               )}
             </Box>
           ))}
-          {!sections.length && <Typography>No matching topics.</Typography>}
+          {!sections.length && (
+            <Typography>{t('help.no_matching_topics')}</Typography>
+          )}
         </>
       );
       return { label: roleLabel(r), content };
     });
-  }, [roles, search]);
+  }, [roles, search, helpContent, t]);
 
   return (
     <Page
-      title="Help"
+      title={t('help.title')}
       header={
         <Stack spacing={2} sx={{ mb: 2, '@media print': { display: 'none' } }}>
           <Stack direction="row" spacing={1} alignItems="center">
             <TextField
-              label="Search"
+              label={t('help.search')}
               value={search}
               onChange={e => setSearch(e.target.value)}
               size="small"
@@ -107,7 +112,7 @@ export default function HelpPage() {
               onClick={() => window.print()}
               sx={{ '@media print': { display: 'none' } }}
             >
-              Print
+              {t('help.print')}
             </Button>
           </Stack>
         </Stack>

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from 'i18next';
+
 export interface HelpSection {
   title: string;
   body: {
@@ -6,67 +8,67 @@ export interface HelpSection {
   };
 }
 
-export const helpContent: Record<
-  'client' | 'volunteer' | 'agency' | 'pantry' | 'warehouse' | 'admin',
-  HelpSection[]
-> = {
-  client: [
-    {
-      title: 'Booking appointments',
-      body: {
-        description: 'Reserve pantry visits from your dashboard.',
-        steps: [
-          'Open your dashboard.',
-          'Choose an available date.',
-          'Select a time and confirm the booking.',
-        ],
+export function getHelpContent(
+  t: TFunction,
+): Record<'client' | 'volunteer' | 'agency' | 'pantry' | 'warehouse' | 'admin', HelpSection[]> {
+  return {
+    client: [
+      {
+        title: t('help.client.booking_appointments.title'),
+        body: {
+          description: t('help.client.booking_appointments.description'),
+          steps: [
+            t('help.client.booking_appointments.steps.0'),
+            t('help.client.booking_appointments.steps.1'),
+            t('help.client.booking_appointments.steps.2'),
+          ],
+        },
       },
-    },
-    {
-      title: 'Rescheduling or canceling',
-      body: {
-        description: 'Change or cancel an existing booking.',
-        steps: [
-          'Go to Booking History.',
-          'Find the upcoming visit.',
-          'Click Reschedule or Cancel and follow prompts.',
-        ],
+      {
+        title: t('help.client.rescheduling_or_canceling.title'),
+        body: {
+          description: t('help.client.rescheduling_or_canceling.description'),
+          steps: [
+            t('help.client.rescheduling_or_canceling.steps.0'),
+            t('help.client.rescheduling_or_canceling.steps.1'),
+            t('help.client.rescheduling_or_canceling.steps.2'),
+          ],
+        },
       },
-    },
-    {
-      title: 'View booking history',
-      body: {
-        description: 'See past and future visits.',
-        steps: [
-          'Open the Booking History page.',
-          'Browse the list of previous and upcoming bookings.',
-        ],
+      {
+        title: t('help.client.view_booking_history.title'),
+        body: {
+          description: t('help.client.view_booking_history.description'),
+          steps: [
+            t('help.client.view_booking_history.steps.0'),
+            t('help.client.view_booking_history.steps.1'),
+          ],
+        },
       },
-    },
-    {
-      title: 'Manage profile and password',
-      body: {
-        description: 'Update contact information or change your password.',
-        steps: [
-          'Navigate to the Profile page.',
-          'Edit your information.',
-          'Save changes.',
-        ],
+      {
+        title: t('help.client.manage_profile_and_password.title'),
+        body: {
+          description: t('help.client.manage_profile_and_password.description'),
+          steps: [
+            t('help.client.manage_profile_and_password.steps.0'),
+            t('help.client.manage_profile_and_password.steps.1'),
+            t('help.client.manage_profile_and_password.steps.2'),
+          ],
+        },
       },
-    },
-    {
-      title: 'Visit counts and reminders',
-      body: {
-        description: 'The dashboard shows monthly totals and upcoming reminders.',
-        steps: [
-          'Return to the dashboard.',
-          'Review your visit counter.',
-          'Check reminders for upcoming bookings.',
-        ],
+      {
+        title: t('help.client.visit_counts_and_reminders.title'),
+        body: {
+          description: t('help.client.visit_counts_and_reminders.description'),
+          steps: [
+            t('help.client.visit_counts_and_reminders.steps.0'),
+            t('help.client.visit_counts_and_reminders.steps.1'),
+            t('help.client.visit_counts_and_reminders.steps.2'),
+          ],
+        },
       },
-    },
-  ],
-  volunteer: [
+    ],
+    volunteer: [
     {
       title: 'View schedule',
       body: {
@@ -340,5 +342,6 @@ export const helpContent: Record<
       },
     },
   ],
-};
+  };
+}
 


### PR DESCRIPTION
## Summary
- localize help page header, search, print, and empty state strings
- move client help topics into translation resources
- adjust navbar to new help title key

## Testing
- `npm test` *(fails: process hung with ts-jest warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c32464a8832da723b2aca983c983