### PR TITLE
Translate password dialogs

### DIFF
--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -23,7 +23,7 @@ export default function PasswordResetDialog({
   const { t } = useTranslation();
 
   const label =
-    type === 'staff' ? 'Email' : type === 'volunteer' ? 'Username' : t('client_id');
+    type === 'staff' ? t('email') : type === 'volunteer' ? t('username') : t('client_id');
   const formTitle = t('reset_password');
 
   async function handleSubmit(e: React.FormEvent) {
@@ -37,7 +37,7 @@ export default function PasswordResetDialog({
           : { clientId: identifier };
       await requestPasswordReset(body);
       setSnackbarSeverity('success');
-      setMessage('If the account exists, a reset link has been sent.');
+      setMessage(t('reset_link_sent'));
       setIdentifier('');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));

--- a/MJ_FB_Frontend/src/components/ResendPasswordSetupDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ResendPasswordSetupDialog.tsx
@@ -4,6 +4,7 @@ import { resendPasswordSetup } from '../api/users';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormCard from './FormCard';
 import DialogCloseButton from './DialogCloseButton';
+import { useTranslation } from 'react-i18next';
 
 export default function ResendPasswordSetupDialog({
   open,
@@ -15,6 +16,7 @@ export default function ResendPasswordSetupDialog({
   const [identifier, setIdentifier] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const { t } = useTranslation();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -24,7 +26,7 @@ export default function ResendPasswordSetupDialog({
         ? { clientId: value }
         : { email: value };
       await resendPasswordSetup(body);
-      setMessage('If the account exists, a setup link has been sent.');
+      setMessage(t('setup_link_sent'));
       setIdentifier('');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
@@ -36,19 +38,19 @@ export default function ResendPasswordSetupDialog({
       <Dialog open={open} onClose={onClose} aria-labelledby="resend-setup-dialog-title">
         <DialogCloseButton onClose={onClose} />
         <DialogTitle id="resend-setup-dialog-title" sx={{ display: 'none' }}>
-          Resend Password Setup Link
+          {t('resend_password_setup_link')}
         </DialogTitle>
         <DialogContent sx={{ p: 0 }}>
           <FormCard
-            title="Resend Password Setup Link"
+            title={t('resend_password_setup_link')}
             onSubmit={handleSubmit}
-            actions={<Button type="submit" variant="contained">Submit</Button>}
+            actions={<Button type="submit" variant="contained">{t('submit')}</Button>}
             boxProps={{ minHeight: 'auto', p: 0 }}
           >
             <TextField
               autoFocus
               margin="dense"
-              label="Email or Client ID"
+              label={t('email_or_client_id')}
               name="email"
               autoComplete="email"
               fullWidth

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -60,5 +60,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -60,5 +60,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -58,5 +58,11 @@
   "error_loading_slots": "Error loading slots",
   "selected_on": "Selected: {{slot}} on {{date}}",
   "no_slot_selected": "No slot selected",
-  "select_time_slot": "Select {{start}} to {{end}} time slot"
+  "select_time_slot": "Select {{start}} to {{end}} time slot",
+  "email": "Email",
+  "username": "Username",
+  "resend_password_setup_link": "Resend Password Setup Link",
+  "email_or_client_id": "Email or Client ID",
+  "setup_link_sent": "If the account exists, a setup link has been sent.",
+  "reset_link_sent": "If the account exists, a reset link has been sent."
 }


### PR DESCRIPTION
## Summary
- localize resend password setup dialog labels, title, and success message
- translate password reset dialog email/username labels and success message
- add translation keys for email, username, and reset/setup messages in all locale files

## Testing
- `npm test` *(failed: VolunteerManagement.test.tsx, HelpPage.test.tsx, AgencyAccess.test.tsx, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c4b07c48832daeea4d9184ad05aa