### PR TITLE
fix: avoid duplicate React root on hot reload

### DIFF
--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -28,11 +28,19 @@ function Main() {
   );
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const container = document.getElementById('root')!;
+const root = ReactDOM.createRoot(container);
+
+root.render(
   <React.StrictMode>
     <Main />
   </React.StrictMode>,
 );
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+  import.meta.hot.dispose(() => root.unmount());
+}
 
 registerServiceWorker();
 


### PR DESCRIPTION
## Summary
- ensure React root is unmounted on module hot replacement to prevent NotFoundError in browser

## Testing
- `npm test src/__tests__/VolunteerScheduleTable.test.tsx` *(fails: Cannot find module '@testing-library/user-event')*


------
https://chatgpt.com/codex/tasks/task_e_68b3ca2e75f0832d9cb518eb41c16790