### PR TITLE
Fix duplicate keys in booking history rows

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -181,7 +181,7 @@ export default function ClientHistory() {
                         ? formatDate(b.date, 'MMM D, YYYY')
                         : 'N/A';
                     return (
-                      <TableRow key={b.id}>
+                      <TableRow key={`${b.id}-${b.created_at}`}>
                         <TableCell sx={cellSx}>{formattedDate}</TableCell>
                         <TableCell sx={cellSx}>
                           {startTime !== 'N/A' && endTime !== 'N/A'

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -251,7 +251,7 @@ export default function UserHistory({
                         ? formatDate(b.date, 'MMM D, YYYY')
                         : 'N/A';
                     return (
-                      <TableRow key={b.id}>
+                      <TableRow key={`${b.id}-${b.created_at}`}>
                         <TableCell sx={cellSx}>{formattedDate}</TableCell>
                         <TableCell sx={cellSx}>
                           {startTime !== 'N/A' && endTime !== 'N/A'


### PR DESCRIPTION
## Summary
- ensure unique React keys in staff user history rows
- ensure unique React keys in agency client history rows

## Testing
- `npm test` *(fails: 19 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ca054d70832d872b27f0e6ee29a6