### PR TITLE
Replace deprecated MUI Grid props

### DIFF
--- a/MJ_FB_Frontend/src/components/OverlapBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/OverlapBookingDialog.tsx
@@ -42,7 +42,7 @@ export default function OverlapBookingDialog({
           You already have a shift at this time. Which one would you like to keep?
         </Typography>
         <Grid container spacing={2}>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Typography variant="subtitle2">Existing Shift</Typography>
             <Typography>{existing.role_name}</Typography>
             <Typography>
@@ -50,7 +50,7 @@ export default function OverlapBookingDialog({
               {formatTime(existing.end_time)}
             </Typography>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Typography variant="subtitle2">New Shift</Typography>
             <Typography>{attempted.role_name}</Typography>
             <Typography>

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -289,7 +289,7 @@ export default function BookingUI({
         {t('available_slots_for', { date: date.format('ddd, MMM D, YYYY') })}
       </Typography>
       <Grid container spacing={2}>
-        <Grid item xs={12} md="auto">
+        <Grid size={{ xs: 12, md: 'auto' }}>
           <Paper sx={{ p: 2, borderRadius: 2 }}>
             {!holidaysReady ? (
               <Skeleton variant="rectangular" height={296} />
@@ -324,7 +324,7 @@ export default function BookingUI({
             )}
           </Paper>
         </Grid>
-        <Grid item xs={12} md sx={{ flexGrow: 1 }}>
+        <Grid size={{ xs: 12, md: 'grow' }} sx={{ flexGrow: 1 }}>
           <Paper
             ref={slotsRef}
             sx={{

--- a/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/PantrySettings.tsx
@@ -68,7 +68,7 @@ export default function PantrySettings() {
   return (
     <Page title="Pantry Settings">
       <Grid container spacing={2} p={2}>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Card>
             <CardHeader title="Pantry max booking capacity" />
             <CardContent>
@@ -90,7 +90,7 @@ export default function PantrySettings() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Card>
             <CardHeader title="Cart Tare (lbs)" />
             <CardContent>

--- a/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/VolunteerSettings.tsx
@@ -430,12 +430,12 @@ export default function VolunteerSettings() {
                 {(rolesByCategory.get(master.id) || []).map(role => (
                   <Box key={role.id} mb={2}>
                     <Grid container alignItems="center" spacing={1}>
-                      <Grid item xs>
+                      <Grid size="grow">
                         <Typography variant="subtitle1" fontWeight="bold">
                           {role.name}
                         </Typography>
                       </Grid>
-                      <Grid item>
+                      <Grid>
                         <Button
                           size="small"
                           variant="outlined"
@@ -451,7 +451,7 @@ export default function VolunteerSettings() {
                           Add Shift
                         </Button>
                       </Grid>
-                      <Grid item>
+                      <Grid>
                         <IconButton aria-label="delete" onClick={() => removeRole(role)}>
                           <DeleteIcon />
                         </IconButton>

--- a/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
@@ -93,7 +93,7 @@ export default function ClientList() {
   return (
     <Page title="Agency Clients">
     <Grid container spacing={2}>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 1 }}>
           <Typography variant="h5">Clients</Typography>
           <InfoTooltip title={t('tooltip_assigned_clients')} />
@@ -120,7 +120,7 @@ export default function ClientList() {
           )}
         </List>
       </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid size={{ xs: 12, md: 6 }}>
         <Typography variant="h5" gutterBottom>
           Add Client
         </Typography>

--- a/MJ_FB_Frontend/src/pages/staff/AddAgency.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AddAgency.tsx
@@ -31,7 +31,7 @@ export default function AddAgency() {
   return (
     <>
       <Grid container justifyContent="center" alignItems="center" spacing={2}>
-        <Grid item xs={12} md={6} lg={4}>
+        <Grid size={{ xs: 12, md: 6, lg: 4 }}>
           <Box component="form" onSubmit={handleSubmit}>
             <TextField
               label="Name"

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -120,7 +120,7 @@ export default function AgencyClientManager() {
       </Card>
       {agency && (
         <Grid container spacing={2}>
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
                 <Typography variant="h5" gutterBottom>
@@ -150,7 +150,7 @@ export default function AgencyClientManager() {
               </CardContent>
             </Card>
           </Grid>
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
                 <Typography variant="h6" gutterBottom>

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -290,7 +290,7 @@ export default function ManageAvailability() {
           <CardHeader title="Add Holiday" />
           <CardContent>
             <Grid container spacing={2}>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <DatePicker
                   label="Date"
                   value={holidayDate}
@@ -298,7 +298,7 @@ export default function ManageAvailability() {
                   slotProps={{ textField: { fullWidth: true, size: 'medium' } }}
                 />
               </Grid>
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <TextField
                   label="Reason"
                   value={holidayReason}
@@ -307,7 +307,7 @@ export default function ManageAvailability() {
                   size="medium"
                 />
               </Grid>
-              <Grid item xs={12} sm={2}>
+              <Grid size={{ xs: 12, sm: 2 }}>
                 <Button
                   fullWidth
                   variant="contained"
@@ -365,7 +365,7 @@ export default function ManageAvailability() {
               />
               {isRecurring ? (
                 <Grid container spacing={2}>
-                  <Grid item xs={12} sm={6}>
+                  <Grid size={{ xs: 12, sm: 6 }}>
                     <FormControl fullWidth sx={{ minWidth: 200 }}>
                       <InputLabel id="blocked-day-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                         Day
@@ -386,7 +386,7 @@ export default function ManageAvailability() {
                       </Select>
                     </FormControl>
                   </Grid>
-                  <Grid item xs={12} sm={6}>
+                  <Grid size={{ xs: 12, sm: 6 }}>
                     <FormControl fullWidth sx={{ minWidth: 200 }}>
                       <InputLabel id="blocked-week-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                         Week
@@ -498,7 +498,7 @@ export default function ManageAvailability() {
           <CardHeader title="Staff Breaks" />
           <CardContent>
             <Grid container spacing={2}>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <FormControl fullWidth sx={{ minWidth: 200 }}>
                   <InputLabel id="break-day-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     Day
@@ -519,7 +519,7 @@ export default function ManageAvailability() {
                   </Select>
                 </FormControl>
               </Grid>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <FormControl fullWidth sx={{ minWidth: 200 }}>
                   <InputLabel id="break-slot-label" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     Slot
@@ -540,7 +540,7 @@ export default function ManageAvailability() {
                   </Select>
                 </FormControl>
               </Grid>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <TextField
                   label="Reason"
                   value={breakReason}
@@ -548,7 +548,7 @@ export default function ManageAvailability() {
                   fullWidth
                 />
               </Grid>
-              <Grid item xs={12}>
+              <Grid size={12}>
                 <Button
                   variant="contained"
                   size="small"

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -170,7 +170,7 @@ export default function VolunteerBooking() {
     <Page title="Volunteer Booking">
       <Container sx={{ pb: 8 }}>
         <Grid container spacing={2} alignItems="stretch">
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Paper
             sx={{ p: 2, borderRadius: 2, height: '100%', display: 'flex', flexDirection: 'column' }}
           >
@@ -182,7 +182,7 @@ export default function VolunteerBooking() {
             />
           </Paper>
         </Grid>
-        <Grid item xs={12} md sx={{ flexGrow: 1 }}>
+        <Grid size={{ xs: 12, md: 'grow' }} sx={{ flexGrow: 1 }}>
           <Paper
             ref={slotsRef}
             sx={{ p: 2, borderRadius: 2, maxHeight: { xs: 420, md: 560 }, overflow: 'auto' }}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -662,10 +662,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
           {selectedVolunteer && (
             <Grid container spacing={2} mt={2}>
               <Grid
-                item
-                xs={12}
-                md={4}
-                lg={4}
+                size={{ xs: 12, md: 4, lg: 4 }}
                 sx={{ flexBasis: { md: '33.333%' }, maxWidth: { md: '33.333%' } }}
               >
                 <Stack spacing={2} sx={{ width: 1 }}>
@@ -741,7 +738,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                   </PageCard>
                 </Stack>
               </Grid>
-              <Grid item xs={12} md={8} lg={8} sx={{ flexGrow: 1 }}>
+              <Grid size={{ xs: 12, md: 8, lg: 8 }} sx={{ flexGrow: 1 }}>
                 <PageCard sx={{ width: 1 }}>
                   <Typography variant="h6" gutterBottom>
                     {t('booking_history')}


### PR DESCRIPTION
## Summary
- Replace removed MUI Grid v1 props with new `size` API to eliminate MUI warnings
- Update booking and admin pages to use Grid v2

## Testing
- `npm test` *(fails: e.g., RescheduleDialog.test.tsx unable to find element)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cbdf0138832d81a73c7f1230b5c6