### PR TITLE
Move events to right dashboard column

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
@@ -26,6 +26,7 @@ describe('StaffDashboard', () => {
     );
 
     await screen.findByText('Today at a Glance');
+    expect(screen.getByText('News & Events')).toBeInTheDocument();
     expect(screen.queryByText('No-Show Rankings')).toBeNull();
   });
 });

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -171,14 +171,6 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
               }
             />
           </Grid>
-          <Grid size={12}>
-            <SectionCard title="Notices & Events" icon={<Announcement color="primary" />}>
-              <EventList
-                events={[...events.today, ...events.upcoming]}
-                limit={5}
-              />
-            </SectionCard>
-          </Grid>
         </Grid>
       </Grid>
       <Grid size={{ xs: 12, md: 6 }}>
@@ -241,6 +233,14 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
                   </Button>
                 </Stack>
               </Stack>
+            </SectionCard>
+          </Grid>
+          <Grid size={12}>
+            <SectionCard title="News & Events" icon={<Announcement color="primary" />}>
+              <EventList
+                events={[...events.today, ...events.upcoming]}
+                limit={5}
+              />
             </SectionCard>
           </Grid>
           <Grid size={12}>


### PR DESCRIPTION
## Summary
- show volunteer news and events in right column
- adjust dashboard test for new section

## Testing
- `npm test` (fails: unable to find module, missing localization, act warnings, etc.)


------
https://chatgpt.com/codex/tasks/task_e_68b3d1cbd080832d87583ad8309aefbb