### PR TITLE
Fix persistent session expiration warning

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
@@ -47,3 +47,26 @@ describe('AuthProvider refresh handling', () => {
     expect(localStorage.getItem('role')).toBe('staff');
   });
 });
+
+describe('AuthProvider with no prior session', () => {
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('does not show session expired when refresh fails without auth', async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 401 });
+
+    render(
+      <AuthProvider>
+        <div />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect((global as any).fetch).toHaveBeenCalled());
+    expect(screen.queryByText('Session expired')).toBeNull();
+  });
+});

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -86,6 +86,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     let active = true;
+    const hadAuth = !!localStorage.getItem('role');
+    const handleExpired = () => {
+      clearAuth();
+      if (hadAuth) setSessionMessage('Session expired');
+    };
     const attemptRefresh = async (tries = 0): Promise<void> => {
       try {
         const res = await apiFetch(`${API_BASE}/auth/refresh`, {
@@ -97,22 +102,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           // Another tab already refreshed; token cookie is still valid
           if (active) setToken('cookie');
         } else if (res.status === 401) {
-          if (active) {
-            clearAuth();
-            setSessionMessage('Session expired');
-          }
+          if (active) handleExpired();
         } else if (tries < 1) {
           await attemptRefresh(tries + 1);
         } else if (active) {
-          clearAuth();
-          setSessionMessage('Session expired');
+          handleExpired();
         }
       } catch {
         if (tries < 1) {
           await attemptRefresh(tries + 1);
         } else if (active) {
-          clearAuth();
-          setSessionMessage('Session expired');
+          handleExpired();
         }
       }
     };


### PR DESCRIPTION
## Summary
- avoid showing session expired message when no previous auth exists
- cover refresh behavior with new test case

## Testing
- `npm test` *(fails: Test Suites: 18 failed, 33 passed, 51 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1f9a970832db3a00bf0dac4a832