### PR TITLE
Fix migration logger

### DIFF
--- a/MJ_FB_Backend/src/runMigrations.ts
+++ b/MJ_FB_Backend/src/runMigrations.ts
@@ -17,7 +17,8 @@ async function runMigrations() {
       migrationsTable: 'pgmigrations',
       tsconfig: 'tsconfig.json',
       logger: {
-        log: msg => logger.info(msg),
+        info: msg => logger.info(msg),
+        warn: msg => logger.warn(msg),
         error: msg => logger.error(msg),
       },
     });


### PR DESCRIPTION
## Summary
- ensure `runMigrations` provides `info`, `warn`, and `error` methods to `node-pg-migrate`

## Testing
- `npm run migrate` *(fails: could not connect to postgres: ECONNREFUSED)*
- `npm test` *(fails: Test Suites: 12 failed, 66 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d3f5b1a8832da5082d06bef31977