### PR TITLE
Display booking history beside volunteer roles

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -43,8 +43,8 @@ import {
   TableContainer,
   Typography,
   useTheme,
-  Grid,
   Stack,
+  Box,
   Chip,
   CircularProgress,
 } from '@mui/material';
@@ -660,11 +660,12 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
             onSelect={selectVolunteer}
           />
           {selectedVolunteer && (
-            <Grid container spacing={2} mt={2}>
-              <Grid
-                size={{ xs: 12, md: 4, lg: 4 }}
-                sx={{ flexBasis: { md: '33.333%' }, maxWidth: { md: '33.333%' } }}
-              >
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              mt={2}
+            >
+              <Box sx={{ width: { xs: 1, md: '33%' } }}>
                 <Stack spacing={2} sx={{ width: 1 }}>
                   <PageCard sx={{ width: 1 }}>
                     <Typography variant="h6" gutterBottom>
@@ -737,8 +738,8 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                     )}
                   </PageCard>
                 </Stack>
-              </Grid>
-              <Grid size={{ xs: 12, md: 8, lg: 8 }} sx={{ flexGrow: 1 }}>
+              </Box>
+              <Box sx={{ width: { xs: 1, md: '67%' } }}>
                 <PageCard sx={{ width: 1 }}>
                   <Typography variant="h6" gutterBottom>
                     {t('booking_history')}
@@ -804,8 +805,8 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                     </Table>
                   </TableContainer>
                 </PageCard>
-              </Grid>
-            </Grid>
+              </Box>
+            </Stack>
           )}
         </>
       )}


### PR DESCRIPTION
## Summary
- Lay out volunteer profile and role management next to booking history using a responsive two-column Stack.

## Testing
- `npm test` *(fails: The given element does not have a value setter; unable to find expected elements in various tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d2e67920832dad13ebd84076f702