### PR TITLE
Allow resolving volunteer booking conflicts without new shift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,8 @@ Volunteer management coordinates role-based staffing for the food bank.
 ### Volunteer Bookings
 - `POST /volunteer-bookings` → `{ id, role_id, volunteer_id, date, status, reschedule_token, status_color }` (409 returns `{ attempted, existing }` on overlap)
 - `POST /volunteer-bookings/staff` → `{ id, role_id, volunteer_id, date, status, reschedule_token, status_color }`
-- `POST /volunteer-bookings/resolve-conflict` `{ existingBookingId, roleId, date, keep }` → `{ kept, booking }`
+- `POST /volunteer-bookings/resolve-conflict` `{ existingBookingId, keep, roleId?, date? }` → `{ kept, booking }`
+  - `roleId` and `date` are required only when `keep` is `'new'`.
 - `GET /volunteer-bookings/mine` → `[ { id, role_id, volunteer_id, date, status, reschedule_token, start_time, end_time, role_name, category_name, status_color } ]`
 - `GET /volunteer-bookings/volunteer/:volunteer_id` → `[ { id, role_id, volunteer_id, date, status, reschedule_token, start_time, end_time, role_name, category_name, status_color } ]`
 - `GET /volunteer-bookings` → `[ { id, status, role_id, volunteer_id, date, reschedule_token, start_time, end_time, role_name, category_name, volunteer_name, status_color } ]`

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -86,10 +86,13 @@ export async function resolveVolunteerBookingConflict(
   date: string,
   keep: 'existing' | 'new'
 ): Promise<VolunteerBooking> {
+  const body: any = { existingBookingId, keep };
+  if (roleId !== undefined) body.roleId = roleId;
+  if (date !== undefined) body.date = date;
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/resolve-conflict`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ existingBookingId, roleId, date, keep }),
+    body: JSON.stringify(body),
   });
   const data = await handleResponse(res);
   return normalizeVolunteerBooking(data.booking);

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Before merging a pull request, confirm the following:
 - Volunteers see a random appreciation message on each login with a link to download their card when available.
 - Volunteers also see rotating encouragement messages on the dashboard when no milestone is reached.
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.
-- Conflicting volunteer shift requests return a 409 with both the attempted and existing shift details; resolve conflicts via `POST /volunteer-bookings/resolve-conflict`.
+- Conflicting volunteer shift requests return a 409 with both the attempted and existing shift details; resolve conflicts via `POST /volunteer-bookings/resolve-conflict` (body: `{ existingBookingId, keep, roleId?, date? }`; `roleId` and `date` are required only when keeping the new booking).
 - Volunteer schedule prevents navigating to past dates and hides shifts that have already started.
 - Staff assigning volunteers can override a full role via a confirmation prompt, which increases that slot's `max_volunteers`.
 - Volunteer badges are calculated from activity and manually awardable. Manual awards are issued via `POST /volunteers/me/badges`. `GET /volunteers/me/stats` returns earned badges along with lifetime hours, this month's hours, total completed shifts, and current streak. Only shifts marked as `completed` contribute to hours and shift totals; `approved` or `no_show` shifts are ignored. The endpoint also flags milestones at 5, 10, and 25 shifts so the dashboard can show a celebration banner.


### PR DESCRIPTION
## Summary
- permit volunteers to keep existing booking without providing new role or date
- support optional fields in frontend conflict resolution API
- document resolve-conflict payload

## Testing
- `npm test tests/volunteerBookingConflict.test.ts`
- `npm test` *(failed: VolunteerManagement.test.tsx, VolunteerDashboard.test.tsx, VolunteerBooking.test.tsx, App.test.tsx, ManageVolunteerShiftDialog.test.tsx, StaffRecurringBookings.test.tsx, BookingUI.test.tsx, PasswordSetup.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d74202ac832dbbcec3e072456ad5