### PR TITLE
Allow agencies to cancel new client bookings

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -191,11 +191,13 @@ export async function cancelBooking(req: Request, res: Response, next: NextFunct
 
     const requesterId = Number((requester as any).userId ?? requester.id);
     if (requester.role === 'agency') {
-      const associated = await isAgencyClient(requesterId, booking.user_id);
-      if (!associated) {
-        return res.status(403).json({
-          message: 'Client not associated with agency',
-        });
+      if (booking.user_id) {
+        const associated = await isAgencyClient(requesterId, booking.user_id);
+        if (!associated) {
+          return res.status(403).json({
+            message: 'Client not associated with agency',
+          });
+        }
       }
     } else if (requester.role !== 'staff' && booking.user_id !== requesterId) {
       return res.status(403).json({ message: 'Forbidden' });

--- a/MJ_FB_Backend/tests/agency.test.ts
+++ b/MJ_FB_Backend/tests/agency.test.ts
@@ -240,6 +240,23 @@ describe('Agency booking modifications', () => {
     expect(res.body).toHaveProperty('message', 'Booking cancelled');
   });
 
+  it('cancels new client booking without association', async () => {
+    (bookingRepository.fetchBookingById as jest.Mock).mockResolvedValue({
+      id: 1,
+      user_id: null,
+      new_client_id: 7,
+      status: 'approved',
+      date: futureDate,
+    });
+    (bookingRepository.updateBooking as jest.Mock).mockResolvedValue(undefined);
+
+    const res = await request(app).post('/api/bookings/1/cancel');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('message', 'Booking cancelled');
+    expect(isAgencyClient).not.toHaveBeenCalled();
+  });
+
   it('rejects cancellation for unassociated client', async () => {
     (isAgencyClient as jest.Mock).mockResolvedValue(false);
     (bookingRepository.fetchBookingById as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Summary
- allow agency users to cancel bookings that were made for unregistered clients
- add regression test for agency cancelling a new client booking

## Testing
- `npm test tests/agency.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3d916c7ac832d963d2aaaf7ecbbff