### PR TITLE
Handle volunteer booking conflict cancellation reason

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -434,10 +434,10 @@ export async function resolveVolunteerBookingConflict(
       return res.status(400).json({ message: 'Role is full' });
     }
 
-    await pool.query('UPDATE volunteer_bookings SET status=$1 WHERE id=$2', [
-      'cancelled',
-      existingBookingId,
-    ]);
+    await pool.query(
+      'UPDATE volunteer_bookings SET status=$1, reason=$2 WHERE id=$3',
+      ['cancelled', 'conflict', existingBookingId],
+    );
 
     const token = randomUUID();
     const insertRes = await pool.query(

--- a/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
@@ -74,6 +74,10 @@ describe('volunteer booking conflict', () => {
 
     expect(res.status).toBe(201);
     expect(res.body.booking).toMatchObject({ id: 9, role_id: 1, date: '2024-01-02' });
+    expect(pool.query).toHaveBeenCalledWith(
+      'UPDATE volunteer_bookings SET status=$1, reason=$2 WHERE id=$3',
+      ['cancelled', 'conflict', 5],
+    );
   });
 
   it('keeps existing booking when resolving conflict', async () => {


### PR DESCRIPTION
## Summary
- Ensure existing booking cancellations include a reason when resolving volunteer booking conflicts
- Test that conflict resolution records the cancellation reason

## Testing
- `npm test` *(fails: 10 failed, 68 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3da7e3cb4832db6902a2a789b374c