### PR TITLE
Normalize volunteer role dates to show volunteer availability

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.tsx
@@ -154,4 +154,27 @@ describe('volunteers api', () => {
     );
   });
 
+  it('normalizes ISO dates for volunteer role availability', async () => {
+    (handleResponse as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 1,
+        role_id: 1,
+        name: 'Greeter',
+        start_time: '09:00:00',
+        end_time: '10:00:00',
+        max_volunteers: 3,
+        booked: 0,
+        available: 3,
+        status: 'available',
+        date: '2024-01-29T00:00:00.000Z',
+        category_id: 1,
+        category_name: 'Front',
+        is_wednesday_slot: false,
+      },
+    ]);
+    const { getVolunteerRolesForVolunteer } = await import('../api/volunteers');
+    const roles = await getVolunteerRolesForVolunteer('2024-01-29');
+    expect(roles[0].date).toBe('2024-01-29');
+  });
+
 });

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -62,7 +62,11 @@ export async function getVolunteerRolesForVolunteer(
   date: string,
 ): Promise<VolunteerRole[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-roles/mine?date=${date}`);
-  return handleResponse(res);
+  const data = await handleResponse(res);
+  return data.map((r: any) => ({
+    ...r,
+    date: r.date?.split('T')[0] ?? r.date,
+  }));
 }
 
 export async function requestVolunteerBooking(


### PR DESCRIPTION
## Summary
- Normalize `date` field from volunteer role API to remove time portion so upcoming shifts display
- Add regression test for volunteer role date normalization

## Testing
- `npm test`
- `npm test src/__tests__/volunteersApi.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b3dcbe31d0832d82fc530f429d7a50