### PR TITLE
Refresh client visit count on profile

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -25,7 +25,7 @@ import {
 } from '../models/bookingRepository';
 import { insertNewClient } from '../models/newClient';
 import { isAgencyClient, getAgencyClientSet } from '../models/agency';
-import { refreshClientVisitCount } from './clientVisitController';
+import { refreshClientVisitCount, getClientBookingsThisMonth } from './clientVisitController';
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 function isValidDateString(date: string): boolean {
@@ -124,8 +124,7 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
         userId,
       );
     }
-    const countRes = await pool.query('SELECT bookings_this_month FROM clients WHERE client_id=$1', [userId]);
-    const bookingsThisMonth = countRes.rows[0]?.bookings_this_month ?? 0;
+    const bookingsThisMonth = await getClientBookingsThisMonth(userId);
     res.status(201).json({
       message: 'Booking automatically approved',
       bookingsThisMonth,

--- a/MJ_FB_Backend/tests/clientProfileVisitCount.test.ts
+++ b/MJ_FB_Backend/tests/clientProfileVisitCount.test.ts
@@ -1,0 +1,58 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.user = { id: 1, type: 'user', role: 'shopper' };
+    next();
+  },
+  authorizeRoles: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../src/middleware/validate', () => ({
+  validate: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/users', usersRouter);
+
+afterEach(() => {
+  (pool.query as jest.Mock).mockReset();
+});
+
+describe('client profile visit count', () => {
+  it('refreshes visit count when outdated', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{
+          client_id: 1,
+          first_name: 'John',
+          last_name: 'Doe',
+          email: null,
+          phone: null,
+          role: 'shopper',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ bookings_this_month: 2, current: false }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ bookings_this_month: 0 }],
+      });
+
+    const res = await request(app).get('/api/users/me');
+
+    expect(res.status).toBe(200);
+    expect(res.body.bookingsThisMonth).toBe(0);
+    expect((pool.query as jest.Mock).mock.calls[2][0]).toMatch(/UPDATE clients c/);
+  });
+});


### PR DESCRIPTION
## Summary
- recalc client visit counts when profile or booking is fetched so new months are accurate
- ensure login and profile endpoints refresh monthly visit counts
- add regression test for stale client visit counters

## Testing
- `npm test`
- `npm test tests/clientProfileVisitCount.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3de27aa70832db5b12ac50328019b