### PR TITLE
Fix monthly usage calculation in ManageBookingDialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
@@ -92,5 +92,29 @@ describe('ManageBookingDialog', () => {
       screen.getByText('Visits: 3, Approved bookings: 1'),
     ).toBeInTheDocument();
   });
+  it('calculates monthly usage when counts are strings', () => {
+    render(
+      <MemoryRouter>
+        <ManageBookingDialog
+          open
+          booking={{
+            id: 1,
+            client_id: 5,
+            user_id: 1,
+            visits_this_month: '1' as any,
+            approved_bookings_this_month: '1' as any,
+            date: '2024-02-01',
+            reschedule_token: '',
+            user_name: 'Client',
+            profile_link: 'https://portal.link2feed.ca/org/1605/intake/5',
+          }}
+          onClose={() => {}}
+          onUpdated={() => {}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Monthly usage: 2')).toBeInTheDocument();
+  });
 });
 

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -164,10 +164,13 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
               </MuiLink>
             </Typography>
             <Typography>
-              Monthly usage: {booking.visits_this_month + booking.approved_bookings_this_month}
+              Monthly usage:{' '}
+              {Number(booking.visits_this_month) +
+                Number(booking.approved_bookings_this_month)}
             </Typography>
             <Typography>
-              Visits: {booking.visits_this_month}, Approved bookings: {booking.approved_bookings_this_month}
+              Visits: {Number(booking.visits_this_month)}, Approved bookings:{' '}
+              {Number(booking.approved_bookings_this_month)}
             </Typography>
           </Stack>
           <TextField


### PR DESCRIPTION
## Summary
- ensure monthly usage sums numeric values to avoid string concatenation
- test monthly usage with string counts

## Testing
- `npm test src/__tests__/ManageBookingDialog.test.tsx`
- `npm test` *(fails: environment errors such as missing modules and unwrapped React state updates)*

------
https://chatgpt.com/codex/tasks/task_e_68b3de6b240c832da41fea751bddb398