### PR TITLE
feat: remove tooltip logic

### DIFF
--- a/MJ_FB_Frontend/src/components/InfoTooltip.tsx
+++ b/MJ_FB_Frontend/src/components/InfoTooltip.tsx
@@ -1,5 +1,5 @@
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
-import { Tooltip, type TooltipProps, type SxProps, type Theme } from '@mui/material';
+import { type TooltipProps, type SxProps, type Theme } from '@mui/material';
 
 interface InfoTooltipProps {
   title?: TooltipProps['title'];
@@ -7,10 +7,6 @@ interface InfoTooltipProps {
   sx?: SxProps<Theme>;
 }
 
-export default function InfoTooltip({ title, placement = 'top', sx }: InfoTooltipProps) {
-  return (
-    <Tooltip title={title ?? ''} placement={placement}>
-      <HelpOutlineIcon fontSize="small" color="action" sx={sx} />
-    </Tooltip>
-  );
+export default function InfoTooltip({ sx }: InfoTooltipProps) {
+  return <HelpOutlineIcon fontSize="small" color="action" sx={sx} />;
 }

--- a/MJ_FB_Frontend/src/components/README.md
+++ b/MJ_FB_Frontend/src/components/README.md
@@ -2,14 +2,12 @@
 
 ## InfoTooltip
 
-Displays a small `HelpOutline` question mark icon with a tooltip.
+Displays a small `HelpOutline` question mark icon. Tooltip support has been removed; `title` and `placement` props are ignored.
 
 ```tsx
 import InfoTooltip from './InfoTooltip'; // adjust path as needed
 
-<InfoTooltip title="Explain this field" placement="right" sx={{ ml: 0.5 }} />
+<InfoTooltip sx={{ ml: 0.5 }} />
 ```
 
-- `title` – tooltip content.
-- `placement` – optional tooltip placement.
 - `sx` – optional style overrides for the icon.


### PR DESCRIPTION
## Summary
- drop Tooltip wrapper from InfoTooltip
- document InfoTooltip no longer showing tooltip

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/user-event', among others)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e0e1ea44832da4940f1b9fd34cd7