### PR TITLE
fix volunteer slot button overlap

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -379,7 +379,7 @@ export default function VolunteerDashboard() {
                 {availableSlots.map(r => (
                   <ListItem
                     key={`${r.id}-${r.date}`}
-                    disableGutters
+                    sx={{ pl: 0 }}
                     secondaryAction={
                       <Button
                         size="small"


### PR DESCRIPTION
## Summary
- keep padding for volunteer dashboard list items so Request button doesn't overlap text

## Testing
- `CI=true npm test` (fails: 19 failed, 34 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b3e128c024832d8374a546fbadfdff