### PR TITLE
Log errors in email utils catch blocks

### DIFF
--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -36,7 +36,11 @@ export async function sendEmail(to: string, subject: string, body: string): Prom
       });
     }
   } catch (error) {
-    logger.warn('Email not sent. Check Brevo configuration or running in local environment.', { to, subject, body });
+    logger.warn(
+      'Email not sent. Check Brevo configuration or running in local environment.',
+      { to, subject, body, error }
+    );
+    throw error;
   }
 }
 
@@ -89,11 +93,11 @@ export async function sendTemplatedEmail({
       });
     }
   } catch (error) {
-    logger.warn('Template email not sent. Check Brevo configuration or running in local environment.', {
-      to,
-      templateId,
-      params,
-    });
+    logger.warn(
+      'Template email not sent. Check Brevo configuration or running in local environment.',
+      { to, templateId, params, error }
+    );
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- include error details in email utility catch blocks
- rethrow errors after logging

## Testing
- `npm test` *(fails: clientVisitBookingStatus.test.ts, volunteerShopperBooking.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b48e4aeb90832d9a5f5c514766abd2