### PR TITLE
Ensure cancel/reschedule emails have frontend origin

### DIFF
--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -99,6 +99,9 @@ export async function sendTemplatedEmail({
 
 export function buildCancelRescheduleButtons(token: string): string {
   const base = config.frontendOrigins[0];
+  if (!base) {
+    throw new Error('No frontend origin configured; unable to build cancel/reschedule links');
+  }
   const cancelLink = `${base}/cancel/${token}`;
   const rescheduleLink = `${base}/reschedule/${token}`;
   return `<div style="margin-top:16px;">` +

--- a/MJ_FB_Backend/tests/emailButtons.test.ts
+++ b/MJ_FB_Backend/tests/emailButtons.test.ts
@@ -1,9 +1,17 @@
 import { buildCancelRescheduleButtons } from '../src/utils/emailUtils';
+import config from '../src/config';
 
 describe('buildCancelRescheduleButtons', () => {
   it('includes cancel and reschedule links', () => {
     const html = buildCancelRescheduleButtons('tok');
     expect(html).toContain('http://localhost:3000/cancel/tok');
     expect(html).toContain('http://localhost:3000/reschedule/tok');
+  });
+
+  it('throws when no frontend origin is configured', () => {
+    const original = config.frontendOrigins;
+    config.frontendOrigins = [];
+    expect(() => buildCancelRescheduleButtons('tok')).toThrow('No frontend origin configured');
+    config.frontendOrigins = original;
   });
 });


### PR DESCRIPTION
## Summary
- Throw error when no frontend origin is configured for cancel/reschedule links
- Test cancel/reschedule button builder without configured origin

## Testing
- `npm test` *(fails: 10 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b48e515d40832db60213416c3dc47a