### PR TITLE
Specify JWT algorithm for auth tokens

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -263,7 +263,9 @@ export async function refreshToken(req: Request, res: Response, next: NextFuncti
     if (!token) {
       return res.status(401).json({ message: 'Missing refresh token' });
     }
-    const payload = jwt.verify(token, config.jwtRefreshSecret) as {
+    const payload = jwt.verify(token, config.jwtRefreshSecret, {
+      algorithms: ['HS256'],
+    }) as {
       id: number | string;
       role: string;
       type: string;
@@ -301,11 +303,12 @@ export async function refreshToken(req: Request, res: Response, next: NextFuncti
 
     const accessToken = jwt.sign(basePayload, config.jwtSecret, {
       expiresIn: '1h',
+      algorithm: 'HS256',
     });
     const newRefreshToken = jwt.sign(
       { ...basePayload, jti: newJti },
       config.jwtRefreshSecret,
-      { expiresIn: '7d' },
+      { expiresIn: '7d', algorithm: 'HS256' },
     );
     const refreshExpiry = 7 * 24 * 60 * 60 * 1000; // 7 days
     res.cookie('token', accessToken, {
@@ -331,7 +334,9 @@ export async function logout(req: Request, res: Response, next: NextFunction) {
     const token = getRefreshTokenFromCookies(req);
     if (token) {
       try {
-        const payload = jwt.verify(token, config.jwtRefreshSecret) as {
+        const payload = jwt.verify(token, config.jwtRefreshSecret, {
+          algorithms: ['HS256'],
+        }) as {
           id: number | string;
           type: string;
         };

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -35,7 +35,9 @@ async function authenticate(req: Request): Promise<AuthResult> {
   }
 
   try {
-    const decoded = jwt.verify(token, config.jwtSecret) as {
+    const decoded = jwt.verify(token, config.jwtSecret, {
+      algorithms: ['HS256'],
+    }) as {
       id: number | string;
       role: string;
       type: string;

--- a/MJ_FB_Backend/src/utils/authUtils.ts
+++ b/MJ_FB_Backend/src/utils/authUtils.ts
@@ -42,9 +42,13 @@ export async function issueAuthTokens(
   subject: string,
 ) {
   const jti = randomUUID();
-  const token = jwt.sign(payload, config.jwtSecret, { expiresIn: '1h' });
+  const token = jwt.sign(payload, config.jwtSecret, {
+    expiresIn: '1h',
+    algorithm: 'HS256',
+  });
   const refreshToken = jwt.sign({ ...payload, jti }, config.jwtRefreshSecret, {
     expiresIn: '7d',
+    algorithm: 'HS256',
   });
 
   await pool.query(

--- a/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
+++ b/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
@@ -19,7 +19,9 @@ describe('POST /auth/refresh', () => {
       userRole: 'shopper',
       jti: 'oldjti',
     };
-    const refreshToken = jwt.sign(payload, process.env.JWT_REFRESH_SECRET!);
+    const refreshToken = jwt.sign(payload, process.env.JWT_REFRESH_SECRET!, {
+      algorithm: 'HS256',
+    });
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ token_id: 'oldjti' }] })
       .mockResolvedValueOnce({});


### PR DESCRIPTION
## Summary
- enforce HS256 when verifying JWTs in auth middleware and refresh/logout flows
- sign access and refresh tokens explicitly with HS256
- update refresh token test to mirror algorithm choice

## Testing
- `npm test` *(fails: 10 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b48e8a44d0832da9d4176ba70ea47f