### PR TITLE
Validate volunteer volunteer shift dates

### DIFF
--- a/MJ_FB_Backend/tests/volunteerBookingInvalidDate.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingInvalidDate.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+import express from 'express';
+
+describe('volunteer booking date validation', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/db', () => ({
+        __esModule: true,
+        default: { query: jest.fn() },
+      }));
+      jest.doMock('../src/utils/emailUtils', () => ({
+        sendEmail: jest.fn(),
+        buildCancelRescheduleButtons: () => '',
+      }));
+      jest.doMock('../src/middleware/authMiddleware', () => ({
+        authMiddleware: (
+          req: any,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => {
+          req.user = { id: 1, email: 'vol@example.com', role: 'volunteer' };
+          next();
+        },
+        authorizeRoles: () => (
+          _req: express.Request,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => next(),
+        optionalAuthMiddleware: (
+          _req: express.Request,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => next(),
+      }));
+      const router = require('../src/routes/volunteer/volunteerBookings').default;
+      app = express();
+      app.use(express.json());
+      app.use('/volunteer-bookings', router);
+    });
+  });
+
+  it('returns 400 for malformed date', async () => {
+    const res = await request(app)
+      .post('/volunteer-bookings')
+      .send({ roleId: 1, date: 'not-a-date' });
+    expect(res.status).toBe(400);
+    const pool = require('../src/db').default;
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for past date', async () => {
+    const res = await request(app)
+      .post('/volunteer-bookings')
+      .send({ roleId: 1, date: '2020-01-01' });
+    expect(res.status).toBe(400);
+    const pool = require('../src/db').default;
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `isValidDateString` to volunteer booking controller
- reject past dates and started shifts in `createVolunteerBooking`
- test invalid and past volunteer booking dates

## Testing
- `npm test` *(fails: clientVisitBookingStatus.test.ts, emailQueue.test.ts, volunteerShopperBooking.test.ts, volunteerBookingStatusEmail.test.ts, volunteerBookingConflict.test.ts, bookingReminderJob.test.ts, noShowCleanupJob.test.ts, volunteerRebookCancelled.test.ts, volunteerNoShowCleanupJob.test.ts, passwordSetupUtils.test.ts, volunteerShiftReminderJob.test.ts, sendTemplatedEmail.test.ts, newClientsMigration.test.ts)*
- `npm test tests/volunteerBookingInvalidDate.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b4901b49dc832d8eb1b9c4a7975f73