### PR TITLE
Handle coordinator email failures individually

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -33,9 +33,17 @@ function mapBookingRow(b: any) {
 const coordinatorEmails: string[] = coordinatorEmailsConfig.coordinatorEmails || [];
 
 async function notifyCoordinators(subject: string, body: string) {
-  await Promise.all(
+  const results = await Promise.allSettled(
     coordinatorEmails.map(email => sendEmail(email, subject, body)),
   );
+  results.forEach((result, idx) => {
+    if (result.status === 'rejected') {
+      logger.error('Failed to send coordinator email', {
+        email: coordinatorEmails[idx],
+        error: result.reason,
+      });
+    }
+  });
 }
 
 export async function createVolunteerBooking(

--- a/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
@@ -29,9 +29,17 @@ export async function cleanupVolunteerNoShows(): Promise<void> {
       logger.info('Marked volunteer bookings as no_show', { ids });
       const subject = 'Volunteer bookings marked as no_show';
       const body = `The following volunteer bookings were automatically marked as no_show: ${ids}`;
-      await Promise.all(
+      const results = await Promise.allSettled(
         coordinatorEmails.map(email => sendEmail(email, subject, body)),
       );
+      results.forEach((result, idx) => {
+        if (result.status === 'rejected') {
+          logger.error('Failed to send coordinator email', {
+            email: coordinatorEmails[idx],
+            error: result.reason,
+          });
+        }
+      });
     } else {
       logger.info('No volunteer bookings to mark as no_show');
     }

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -3,9 +3,12 @@ import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { sendEmail } from '../src/utils/emailUtils';
+import logger from '../src/utils/logger';
 
 jest.mock('../src/db');
-jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
+jest.mock('../src/utils/emailUtils', () => ({
+  sendEmail: jest.fn().mockResolvedValue(undefined),
+}));
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
@@ -47,6 +50,34 @@ describe('updateVolunteerBookingStatus', () => {
     expect((sendEmail as jest.Mock).mock.calls).toHaveLength(2);
     expect((sendEmail as jest.Mock).mock.calls[0][0]).toBe('coordinator1@example.com');
     expect((sendEmail as jest.Mock).mock.calls[1][0]).toBe('coordinator2@example.com');
+  });
+
+  it('logs failure for one coordinator email but continues with others', async () => {
+    const booking = { id: 1, slot_id: 2, volunteer_id: 3, date: '2025-09-01', status: 'approved' };
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          { id: 1, slot_id: 2, volunteer_id: 3, date: '2025-09-01', status: 'cancelled', recurring_id: null, reason: 'sick' },
+        ],
+      });
+
+    const sendEmailMock = sendEmail as jest.Mock;
+    sendEmailMock.mockRejectedValueOnce(new Error('fail')).mockResolvedValue(undefined);
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const res = await request(app)
+      .patch('/volunteer-bookings/1')
+      .send({ status: 'cancelled', reason: 'sick' });
+
+    expect(res.status).toBe(200);
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to send coordinator email',
+      expect.objectContaining({ email: 'coordinator1@example.com' }),
+    );
+    errorSpy.mockRestore();
   });
 
   it('requires reason when cancelling', async () => {


### PR DESCRIPTION
## Summary
- log per-email errors when notifying coordinators
- ensure volunteer no-show job continues after individual email failures
- test coordinator notification continues after one send fails

## Testing
- `npm test` *(fails: clientVisitBookingStatus.test.ts and others)*
- `npm test -- tests/volunteerBookingStatusEmail.test.ts -t "logs failure for one coordinator email but continues with others"`


------
https://chatgpt.com/codex/tasks/task_e_68b4903c04c0832dbb68a5a8c1bd5158