### PR TITLE
Document volunteer no-show wait period

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -39,3 +39,6 @@ EMAIL_QUEUE_BACKOFF_MS=1000
 PASSWORD_SETUP_TEMPLATE_ID=1
 # Hours until password setup tokens expire (optional, default 24)
 PASSWORD_SETUP_TOKEN_TTL_HOURS=24
+
+# Hours to wait before marking a volunteer shift as no-show
+VOLUNTEER_NO_SHOW_HOURS=24

--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -41,6 +41,8 @@ Authentication cookies are scoped to the `/` path and use the same options when 
 
 `PASSWORD_SETUP_TOKEN_TTL_HOURS` – Hours until password setup tokens expire (default 24).
 
+`VOLUNTEER_NO_SHOW_HOURS` – Hours to wait before marking a volunteer shift as no-show (default 24).
+
 ## Password Policy
 
 Passwords must be at least 8 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character. Requests with weak passwords are rejected before hashing.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ page and cached on the server:
 - `BREAD_WEIGHT_MULTIPLIER` (default `10`)
 - `CANS_WEIGHT_MULTIPLIER` (default `20`)
 
+The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours after a shift before marking it as `no_show`.
+
 ### Frontend features
 
 - Pages are organized into feature-based directories (e.g., booking, staff, volunteer-management, warehouse-management).


### PR DESCRIPTION
## Summary
- add `VOLUNTEER_NO_SHOW_HOURS` to backend `.env.example`
- document volunteer no-show wait period variable in backend README and root README

## Testing
- `npm test` *(fails: Test Suites: 15 failed, 68 passed, 83 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b491f9ea74832d8c6f3aab1f3dd1f7