### PR TITLE
feat: secure backend with helmet

### DIFF
--- a/MJ_FB_Backend/package-lock.json
+++ b/MJ_FB_Backend/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2",
         "dotenv": "^17",
         "express": "^5",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9",
         "node-cron": "^3",
         "pg": "^8",
@@ -3563,6 +3564,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^17",
     "express": "^5",
     "jsonwebtoken": "^9",
+    "helmet": "^8.1.0",
     "node-cron": "^3",
     "pg": "^8",
     "write-excel-file": "^2",

--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, NextFunction } from 'express';
+import helmet from 'helmet';
 import cors from 'cors';
 import path from 'path';
 import config from './config';
@@ -38,6 +39,8 @@ import logger from './utils/logger';
 import csrfMiddleware from './middleware/csrf';
 
 const app = express();
+
+app.use(helmet());
 
 // ⭐ Add CORS middleware before routes
 // Origins are parsed from FRONTEND_ORIGIN env variable as a comma-separated list.


### PR DESCRIPTION
## Summary
- add helmet to backend dependencies
- enable helmet middleware early in Express app for basic security headers

## Testing
- `npm test` *(fails: 15 failing test suites, 68 passing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4920b0fd0832db04a090970af2d3d