### PR TITLE
feat: parameterize password setup email template

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -35,7 +35,7 @@ BREVO_FROM_NAME=MJ Food Bank
 EMAIL_QUEUE_MAX_RETRIES=5
 # Initial backoff delay in ms for email retries (optional, default 1000)
 EMAIL_QUEUE_BACKOFF_MS=1000
-# Brevo template ID used for invitation and password reset emails
+# Brevo template ID used for invitation and password setup emails
 PASSWORD_SETUP_TEMPLATE_ID=1
 # Hours until password setup tokens expire (optional, default 24)
 PASSWORD_SETUP_TOKEN_TTL_HOURS=24

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -21,6 +21,7 @@ const envSchema = z.object({
   BREVO_FROM_NAME: z.string().optional(),
   EMAIL_QUEUE_MAX_RETRIES: z.coerce.number().default(5),
   EMAIL_QUEUE_BACKOFF_MS: z.coerce.number().default(1000),
+  PASSWORD_SETUP_TEMPLATE_ID: z.coerce.number(),
   VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
 
@@ -53,5 +54,6 @@ export default {
   brevoFromName: env.BREVO_FROM_NAME ?? '',
   emailQueueMaxRetries: env.EMAIL_QUEUE_MAX_RETRIES,
   emailQueueBackoffMs: env.EMAIL_QUEUE_BACKOFF_MS,
+  passwordSetupTemplateId: env.PASSWORD_SETUP_TEMPLATE_ID,
   volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/MJ_FB_Backend/src/controllers/admin/adminStaffController.ts
+++ b/MJ_FB_Backend/src/controllers/admin/adminStaffController.ts
@@ -69,11 +69,11 @@ export async function createStaff(req: Request, res: Response, next: NextFunctio
     );
     const staffId = result.rows[0].id;
     const token = await generatePasswordSetupToken('staff', staffId);
-    await sendTemplatedEmail({
-      to: email,
-      templateId: 1,
-      params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
-    });
+      await sendTemplatedEmail({
+        to: email,
+        templateId: config.passwordSetupTemplateId,
+        params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
+      });
     res.status(201).json({ message: 'Staff created' });
   } catch (error) {
     logger.error('Error creating staff:', error);

--- a/MJ_FB_Backend/src/controllers/admin/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/admin/staffController.ts
@@ -56,11 +56,11 @@ export async function createStaff(
     );
     const staffId = result.rows[0].id;
     const token = await generatePasswordSetupToken('staff', staffId);
-    await sendTemplatedEmail({
-      to: email,
-      templateId: 1,
-      params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
-    });
+      await sendTemplatedEmail({
+        to: email,
+        templateId: config.passwordSetupTemplateId,
+        params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
+      });
 
     res.status(201).json({ message: 'Staff created' });
   } catch (error) {

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -37,11 +37,11 @@ export async function createAgency(
     }
     const agency = await insertAgency(name, email, contactInfo);
     const token = await generatePasswordSetupToken('agencies', agency.id);
-    await sendTemplatedEmail({
-      to: email,
-      templateId: 1,
-      params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
-    });
+      await sendTemplatedEmail({
+        to: email,
+        templateId: config.passwordSetupTemplateId,
+        params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
+      });
     res.status(201).json({ id: agency.id });
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -75,13 +75,13 @@ export async function requestPasswordReset(
 
     if (user) {
       const token = await generatePasswordSetupToken(user.table, user.id);
-      await sendTemplatedEmail({
-        to: user.email,
-        templateId: 1,
-        params: {
-          link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
-        },
-      });
+        await sendTemplatedEmail({
+          to: user.email,
+          templateId: config.passwordSetupTemplateId,
+          params: {
+            link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
+          },
+        });
       logger.info(`Password reset requested for ${user.email}`);
     }
     res.status(204).send();
@@ -147,13 +147,13 @@ export async function resendPasswordSetup(
 
     if (user) {
       const token = await generatePasswordSetupToken(user.table, user.id);
-      await sendTemplatedEmail({
-        to: user.email,
-        templateId: 1,
-        params: {
-          link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
-        },
-      });
+        await sendTemplatedEmail({
+          to: user.email,
+          templateId: config.passwordSetupTemplateId,
+          params: {
+            link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
+          },
+        });
       logger.info(`Password setup link resent for ${user.email}`);
     }
     res.status(204).send();

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -178,11 +178,11 @@ export async function createUser(req: Request, res: Response, next: NextFunction
 
     const token = await generatePasswordSetupToken('clients', clientId);
     if (email) {
-      await sendTemplatedEmail({
-        to: email,
-        templateId: 1,
-        params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
-      });
+        await sendTemplatedEmail({
+          to: email,
+          templateId: config.passwordSetupTemplateId,
+          params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
+        });
     }
 
     res.status(201).json({ message: 'User created' });

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -214,11 +214,11 @@ export async function createVolunteer(
     );
     const token = await generatePasswordSetupToken('volunteers', volunteerId);
     if (email) {
-      await sendTemplatedEmail({
-        to: email,
-        templateId: 1,
-        params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
-      });
+        await sendTemplatedEmail({
+          to: email,
+          templateId: config.passwordSetupTemplateId,
+          params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
+        });
     }
     res.status(201).json({ id: volunteerId });
   } catch (error) {
@@ -274,11 +274,11 @@ export async function createVolunteerShopperProfile(
     ]);
     const token = await generatePasswordSetupToken('clients', clientId);
     if (volRes.rows[0].email) {
-      await sendTemplatedEmail({
-        to: volRes.rows[0].email,
-        templateId: 1,
-        params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
-      });
+        await sendTemplatedEmail({
+          to: volRes.rows[0].email,
+          templateId: config.passwordSetupTemplateId,
+          params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
+        });
     }
     res.status(201).json({ userId });
   } catch (error) {

--- a/MJ_FB_Backend/tests/adminStaff.test.ts
+++ b/MJ_FB_Backend/tests/adminStaff.test.ts
@@ -4,6 +4,7 @@ import adminStaffRouter from '../src/routes/admin/adminStaff';
 import pool from '../src/db';
 import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
+import config from '../src/config';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
@@ -54,6 +55,8 @@ describe('POST /admin/staff', () => {
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ message: 'Staff created' });
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('staff', 8);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 });

--- a/MJ_FB_Backend/tests/createAgency.test.ts
+++ b/MJ_FB_Backend/tests/createAgency.test.ts
@@ -4,6 +4,7 @@ import agenciesRoutes from '../src/routes/agencies';
 import pool from '../src/db';
 import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
+import config from '../src/config';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
@@ -58,7 +59,9 @@ describe('POST /agencies', () => {
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id', 5);
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('agencies', 5);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 
   it('rejects non-staff user', async () => {

--- a/MJ_FB_Backend/tests/createUser.test.ts
+++ b/MJ_FB_Backend/tests/createUser.test.ts
@@ -4,6 +4,7 @@ import usersRouter from '../src/routes/users';
 import pool from '../src/db';
 import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
+import config from '../src/config';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
@@ -59,6 +60,8 @@ describe('POST /users/add-client', () => {
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ message: 'User created' });
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('clients', 123);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 });

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -9,6 +9,7 @@ import {
   markPasswordTokenUsed,
 } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
+import config from '../src/config';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
@@ -39,7 +40,9 @@ describe('requestPasswordReset', () => {
     expect(pool.query).toHaveBeenCalledTimes(1);
     expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/UNION ALL/);
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('staff', 7);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 
   it('handles username lookup for volunteers', async () => {
@@ -53,7 +56,9 @@ describe('requestPasswordReset', () => {
       .send({ username: 'vol' });
     expect(res.status).toBe(204);
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('volunteers', 5);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 
   it('handles clientId lookup for clients', async () => {
@@ -67,7 +72,9 @@ describe('requestPasswordReset', () => {
       .send({ clientId: 3 });
     expect(res.status).toBe(204);
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('clients', 3);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 });
 
@@ -122,7 +129,9 @@ describe('resendPasswordSetup', () => {
       .send({ email: 'resend@example.com' });
     expect(res.status).toBe(204);
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('staff', 9);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 
   it('requires an identifier', async () => {

--- a/MJ_FB_Backend/tests/setupEnv.ts
+++ b/MJ_FB_Backend/tests/setupEnv.ts
@@ -12,5 +12,6 @@ process.env.BREVO_API_KEY = 'test-api-key';
 process.env.BREVO_FROM_EMAIL = 'noreply@example.com';
 process.env.BREVO_FROM_NAME = 'MJ Food Bank';
 process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS = '24';
+process.env.PASSWORD_SETUP_TEMPLATE_ID = '1';
 
 export {};

--- a/MJ_FB_Backend/tests/staffCreation.test.ts
+++ b/MJ_FB_Backend/tests/staffCreation.test.ts
@@ -4,6 +4,7 @@ import staffRoutes from '../src/routes/admin/staff';
 import pool from '../src/db';
 import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
+import config from '../src/config';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
@@ -40,7 +41,9 @@ describe('POST /staff (first staff member)', () => {
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ message: 'Staff created' });
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('staff', 7);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 });
 

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -6,6 +6,7 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
+import config from '../src/config';
 
 jest.mock('../src/db');
 jest.mock('bcrypt');
@@ -55,7 +56,9 @@ describe('Volunteer routes role ID validation', () => {
     expect(res.body).toEqual({ id: 5 });
     expect((pool.query as jest.Mock).mock.calls[2][0]).toMatch(/SELECT id FROM volunteer_roles/);
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('volunteers', 5);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 
   it('updates trained areas when role IDs are valid', async () => {
@@ -120,7 +123,9 @@ describe('Volunteer shopper profile', () => {
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ userId: 9 });
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('clients', 123);
-    expect(sendTemplatedEmail).toHaveBeenCalled();
+    expect(sendTemplatedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+    );
   });
 
   it('removes a shopper profile for a volunteer', async () => {

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `BREVO_FROM_NAME` | Optional sender name displayed in emails |
 | `EMAIL_QUEUE_MAX_RETRIES` | Max retry attempts for failed email jobs (default 5) |
 | `EMAIL_QUEUE_BACKOFF_MS` | Initial backoff delay in ms for email retries (default 1000) |
-| `PASSWORD_SETUP_TEMPLATE_ID` | Brevo template ID for invitation and password reset emails |
+| `PASSWORD_SETUP_TEMPLATE_ID` | Brevo template ID for invitation and password setup emails |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS` | Hours until password setup tokens expire (default 24) |
 
 ### Invitation flow


### PR DESCRIPTION
## Summary
- expose PASSWORD_SETUP_TEMPLATE_ID in backend config
- use config-driven template ID for password setup/invite emails
- reference template ID via config in related tests

## Testing
- `npm test` *(fails: clientVisitBookingStatus.test.ts, emailQueue.test.ts, noShowCleanupJob.test.ts, bookingCapacity.test.ts, volunteerRebookCancelled.test.ts, passwordSetupUtils.test.ts, volunteerShiftReminderJob.test.ts, sendTemplatedEmail.test.ts, newClientsMigration.test.ts)*
- `npm test tests/passwordResetFlow.test.ts`
- `npm test tests/clientVisitBookingStatus.test.ts` *(fails: marks future booking visited and frees slot, marks past booking no_show)*

------
https://chatgpt.com/codex/tasks/task_e_68b491e7cf68832d81ab993ed7195021