### PR TITLE
feat: allow staff to book agency client appointments

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ClientHistory from '../pages/agency/ClientHistory';
+
+jest.mock('../api/agencies', () => ({
+  getMyAgencyClients: jest.fn(),
+}));
+
+jest.mock('../api/bookings', () => ({
+  getBookingHistory: jest.fn(),
+  cancelBooking: jest.fn(),
+}));
+
+jest.mock('../components/EntitySearch', () => (props: any) => (
+  <button onClick={() => props.onSelect({ name: 'Client One', client_id: 1 })}>
+    select client
+  </button>
+));
+
+jest.mock('../components/RescheduleDialog', () => () => <div>RescheduleDialog</div>);
+
+describe('Agency ClientHistory', () => {
+  it('cancels a booking', async () => {
+    const { getMyAgencyClients } = require('../api/agencies');
+    const { getBookingHistory, cancelBooking } = require('../api/bookings');
+    (getMyAgencyClients as jest.Mock).mockResolvedValue([
+      { client_id: 1, name: 'Client One' },
+    ]);
+    (getBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 10,
+        status: 'approved',
+        date: '2024-01-01',
+        start_time: '09:00:00',
+        end_time: '10:00:00',
+        created_at: '2024-01-01',
+        slot_id: 1,
+        is_staff_booking: false,
+        reschedule_token: 'tok',
+      },
+    ]);
+    (cancelBooking as jest.Mock).mockResolvedValue(undefined);
+    window.confirm = jest.fn(() => true);
+
+    render(<ClientHistory />);
+
+    fireEvent.click(screen.getByText('select client'));
+    await screen.findByText(/Client One/);
+    await screen.findByText('Cancel');
+    fireEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => expect(cancelBooking).toHaveBeenCalledWith('10'));
+    expect(getBookingHistory).toHaveBeenCalledTimes(2);
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/AgencyClientManager.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyClientManager.test.tsx
@@ -17,6 +17,12 @@ jest.mock('../components/EntitySearch', () =>
   },
 );
 
+const mockBookingUI = jest.fn();
+jest.mock('../pages/BookingUI', () => (props: any) => {
+  mockBookingUI(props);
+  return <div>BookingUI {props.shopperName}</div>;
+});
+
 describe('AgencyClientManager', () => {
   it('shows modal when client already associated with another agency', async () => {
     const { addAgencyClient } = require('../api/agencies');
@@ -35,6 +41,26 @@ describe('AgencyClientManager', () => {
           /This client is already associated with Other Agency/i,
         ),
       ).toBeInTheDocument(),
+    );
+  });
+
+  it('opens booking dialog for a client', async () => {
+    const { getAgencyClients } = require('../api/agencies');
+    (getAgencyClients as jest.Mock).mockResolvedValue([
+      {
+        client_id: 5,
+        first_name: 'Client',
+        last_name: 'One',
+        email: 'c@example.com',
+      },
+    ]);
+    render(<AgencyClientManager />);
+    fireEvent.click(screen.getByText('select agency'));
+    await screen.findByText('Clients for Agency A');
+    fireEvent.click(screen.getByText('Book'));
+    expect(await screen.findByText('BookingUI Client One')).toBeInTheDocument();
+    expect(mockBookingUI).toHaveBeenCalledWith(
+      expect.objectContaining({ shopperName: 'Client One', userId: 5 }),
     );
   });
 });

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -245,7 +245,7 @@ export function getHelpContent(
         steps: [
           'Open agency management pages.',
           'Search for the agency or client.',
-          'Link, unlink, or book as needed.',
+          'Link, unlink, or use the Book button to schedule for a client.',
         ],
       },
     },

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -13,6 +13,9 @@ import {
   DialogActions,
   Card,
   CardContent,
+  Box,
+  Stack,
+  CircularProgress,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EntitySearch from '../../components/EntitySearch';
@@ -22,6 +25,7 @@ import {
   removeAgencyClient,
   getAgencyClients,
 } from '../../api/agencies';
+import BookingUI from '../BookingUI';
 
 interface AgencyClient {
   clientId: number;
@@ -36,6 +40,8 @@ export default function AgencyClientManager() {
     { message: string; severity: 'success' | 'error' } | null
   >(null);
   const [conflictAgency, setConflictAgency] = useState<string | null>(null);
+  const [bookingClient, setBookingClient] = useState<AgencyClient | null>(null);
+  const [bookingLoading, setBookingLoading] = useState(false);
 
   const load = async (id: number) => {
     try {
@@ -104,6 +110,10 @@ export default function AgencyClientManager() {
       });
     }
   };
+  const handleBook = (client: AgencyClient) => {
+    setBookingClient(client);
+    setBookingLoading(true);
+  };
   return (
     <>
       <Card sx={{ mb: 2 }}>
@@ -161,13 +171,22 @@ export default function AgencyClientManager() {
                     <ListItem
                       key={c.clientId}
                       secondaryAction={
-                        <IconButton
-                          edge="end"
-                          aria-label="remove"
-                          onClick={() => handleRemove(c.clientId)}
-                        >
-                          <DeleteIcon />
-                        </IconButton>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <Button
+                            size="small"
+                            variant="contained"
+                            onClick={() => handleBook(c)}
+                          >
+                            Book
+                          </Button>
+                          <IconButton
+                            edge="end"
+                            aria-label="remove"
+                            onClick={() => handleRemove(c.clientId)}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </Stack>
                       }
                     >
                       <ListItemText primary={c.name} secondary={`ID: ${c.clientId}`} />
@@ -196,6 +215,43 @@ export default function AgencyClientManager() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setConflictAgency(null)}>OK</Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        open={!!bookingClient}
+        onClose={() => setBookingClient(null)}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle>
+          {bookingClient ? `Book for ${bookingClient.name}` : 'Book Appointment'}
+        </DialogTitle>
+        <DialogContent>
+          {bookingLoading && (
+            <Box
+              sx={{
+                minHeight: 200,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <CircularProgress size={24} />
+            </Box>
+          )}
+          {bookingClient && (
+            <Box sx={{ display: bookingLoading ? 'none' : 'block' }}>
+              <BookingUI
+                shopperName={bookingClient.name}
+                userId={bookingClient.clientId}
+                embedded
+                onLoadingChange={setBookingLoading}
+              />
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setBookingClient(null)}>Close</Button>
         </DialogActions>
       </Dialog>
     </>

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/AgencyClientManager.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/AgencyClientManager.test.tsx
@@ -13,6 +13,12 @@ jest.mock('../../../api/agencies', () => ({
   getAgencyClients: jest.fn().mockResolvedValue([]),
 }));
 
+const mockBookingUI = jest.fn();
+jest.mock('../../BookingUI', () => (props: any) => {
+  mockBookingUI(props);
+  return <div>BookingUI {props.shopperName}</div>;
+});
+
 describe('AgencyClientManager', () => {
   it('shows agency search before selection then shows client search', async () => {
     render(<AgencyClientManager />);
@@ -26,5 +32,24 @@ describe('AgencyClientManager', () => {
     expect(
       await screen.findByText('Clients for Test Agency'),
     ).toBeInTheDocument();
+  });
+
+  it('opens booking dialog for a client', async () => {
+    const { getAgencyClients } = require('../../../api/agencies');
+    (getAgencyClients as jest.Mock).mockResolvedValue([
+      { client_id: 5, first_name: 'Client', last_name: 'One', email: 'c@example.com' },
+    ]);
+
+    render(<AgencyClientManager />);
+
+    fireEvent.click(screen.getByText('Select Agency'));
+    await screen.findByText('Clients for Test Agency');
+    expect(await screen.findByText('Client One')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Book'));
+    expect(await screen.findByText('BookingUI Client One')).toBeInTheDocument();
+    expect(mockBookingUI).toHaveBeenCalledWith(
+      expect.objectContaining({ shopperName: 'Client One', userId: 5 }),
+    );
   });
 });

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Agency navigation offers Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all behind an `AgencyGuard`.
 - Agency profile page shows the agency's name, email, and contact info with editable fields and sends password reset links via email.
 - Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.
-- Staff can add agencies and assign clients to them through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list for managing associations.
+- Staff can add agencies, assign clients, and book appointments for those clients through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list with Book buttons for scheduling on their behalf.
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 
 ## Deploying to Azure


### PR DESCRIPTION
## Summary
- enable staff to book appointments for agency-linked clients
- support cancelling client bookings from agency history
- document new agency client booking workflow

## Testing
- `npm test src/__tests__/AgencyClientManager.test.tsx src/__tests__/AgencyClientHistory.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b494e3a53c832db6b589adf6bc4d02