### PR TITLE
feat: enable warehouse aggregation export

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -12,11 +12,13 @@ import {
   MenuItem,
   Stack,
   CircularProgress,
+  Button,
 } from '@mui/material';
 import Page from '../../components/Page';
 import {
   getWarehouseOverall,
   getWarehouseOverallYears,
+  exportWarehouseOverall,
   type WarehouseOverall,
 } from '../../api/warehouseOverall';
 import { getDonorAggregations, type DonorAggregation } from '../../api/donations';
@@ -36,6 +38,7 @@ export default function Aggregations() {
   const [tab, setTab] = useState(0);
   const [donorRows, setDonorRows] = useState<DonorAggregation[]>([]);
   const [donorLoading, setDonorLoading] = useState(false);
+  const [exportLoading, setExportLoading] = useState(false);
 
   useEffect(() => {
     async function loadYears() {
@@ -117,6 +120,26 @@ export default function Aggregations() {
     }),
     { donations: 0, surplus: 0, pigPound: 0, outgoingDonations: 0 },
   );
+
+  async function handleExportOverall() {
+    setExportLoading(true);
+    try {
+      const blob = await exportWarehouseOverall(overallYear);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${overallYear}_warehouse_overall_stats.xlsx`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      setSnackbar({ open: true, message: 'Export ready', severity: 'success' });
+    } catch {
+      setSnackbar({ open: true, message: 'Failed to export', severity: 'error' });
+    } finally {
+      setExportLoading(false);
+    }
+  }
 
   const donorContent = (
     <>
@@ -293,6 +316,14 @@ export default function Aggregations() {
             ))}
           </Select>
         </FormControl>
+        <Button
+          size="small"
+          variant="contained"
+          onClick={handleExportOverall}
+          disabled={exportLoading}
+        >
+          {exportLoading ? <CircularProgress size={20} /> : 'Export'}
+        </Button>
       </Stack>
       <TableContainer sx={{ overflowX: 'auto' }}>
         <Table size="small">

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Staff dashboard dates display weekday, month, day, and year (e.g., 'Tue, Jan 2, 2024').
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.
+- Warehouse Aggregations page provides yearly totals and supports exporting them via `/warehouse-overall/export`.
 - Page and form titles render in uppercase with a lighter font weight for clarity.
 - Admin staff creation page provides a link back to the staff list for easier navigation.
 - Admin navigation includes Pantry Settings and Volunteer Settings pages.


### PR DESCRIPTION
## Summary
- allow exporting yearly warehouse aggregates from Aggregations page
- test aggregation export and donor reload
- document export feature in README

## Testing
- `CI=true npx jest --runTestsByPath src/__tests__/Aggregations.test.tsx`
- `CI=true npm test` *(fails: Cannot find module 'helmet', and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b494e688c8832dabd9e3efa843c8c3