### PR TITLE
docs: expand admin staff help

### DIFF
--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -300,11 +300,12 @@ export function getHelpContent(
     {
       title: 'Staff users and permissions',
       body: {
-        description: 'Admins can add new staff accounts, edit existing users, and manage permissions.',
+        description:
+          'Admins can add new staff accounts, edit existing users, resend password setup links, and manage permissions.',
         steps: [
-          'Open Staff Settings.',
-          'Add or edit users.',
-          'Assign permissions and save.',
+          'Go to Admin > Staff.',
+          'Use Add Staff or Edit to modify a user.',
+          'Assign permissions, save changes, or resend setup links.',
         ],
       },
     },


### PR DESCRIPTION
## Summary
- clarify admin staff management steps and mention resending password setup links

## Testing
- `npm test` (MJ_FB_Frontend) *(fails: Unable to find role="button" and name `/^Request$/`, etc.)*
- `npm test` (MJ_FB_Backend) *(fails: Cannot find module 'helmet', etc.)*
- `npm test tests/passwordResetFlow.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b494e78610832db701ed6f2c6c492e