### PR TITLE
Ensure card URL clears on logout

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AuthProvider.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AuthProvider.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AuthProvider, useAuth } from '../hooks/useAuth';
+
+jest.mock('../api/client', () => ({
+  API_BASE: '',
+  apiFetch: jest.fn(),
+}));
+
+jest.mock('../api/users', () => ({
+  logout: jest.fn(),
+}));
+
+const { apiFetch } = require('../api/client');
+const { logout: apiLogout } = require('../api/users');
+
+function TestComponent() {
+  const { login, logout, cardUrl } = useAuth();
+  return (
+    <div>
+      <button onClick={() => login({ role: 'volunteer', name: 'Test', access: [] })}>
+        login
+      </button>
+      <button onClick={() => logout()}>logout</button>
+      <div data-testid="card">{cardUrl}</div>
+    </div>
+  );
+}
+
+describe('AuthProvider cardUrl cleanup', () => {
+  afterEach(() => {
+    (apiFetch as jest.Mock).mockReset();
+    (apiLogout as jest.Mock).mockReset();
+    localStorage.clear();
+  });
+
+  it('clears cardUrl on logout', async () => {
+    (apiFetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ cardUrl: '/card.pdf' }) });
+    (apiLogout as jest.Mock).mockResolvedValue(undefined);
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText('login'));
+    await waitFor(() =>
+      expect(screen.getByTestId('card')).toHaveTextContent('/card.pdf'),
+    );
+
+    fireEvent.click(screen.getByText('logout'));
+    await waitFor(() =>
+      expect(screen.getByTestId('card')).toHaveTextContent(''),
+    );
+  });
+
+  it('clears cardUrl when session ends in another tab', async () => {
+    (apiFetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ cardUrl: '/card.pdf' }) });
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText('login'));
+    await waitFor(() =>
+      expect(screen.getByTestId('card')).toHaveTextContent('/card.pdf'),
+    );
+
+    localStorage.removeItem('role');
+    window.dispatchEvent(new StorageEvent('storage', { key: 'role' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('card')).toHaveTextContent(''),
+    );
+  });
+});
+

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -51,6 +51,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUserRole('');
     setAccess([]);
     setId(null);
+    setCardUrl('');
     localStorage.removeItem('role');
     localStorage.removeItem('name');
     localStorage.removeItem('userRole');


### PR DESCRIPTION
## Summary
- Clear `cardUrl` in `clearAuth` so download link disappears on logout or session end
- Test that `cardUrl` is removed on logout and when auth is cleared from another tab

## Testing
- `npm test` *(fails: Unable to find an element with the text "You're in the top 75%!" etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b51c1bfe58832db86fa55491dcde12