### PR TITLE
Gracefully terminate server on SIGINT/SIGTERM

### DIFF
--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -4,13 +4,21 @@ import { setupDatabase } from './setupDatabase';
 import { runMigrations } from './runMigrations';
 import logger from './utils/logger';
 import app from './app';
-import { startBookingReminderJob } from './utils/bookingReminderJob';
-import { startVolunteerShiftReminderJob } from './utils/volunteerShiftReminderJob';
-import { startNoShowCleanupJob } from './utils/noShowCleanupJob';
-import { startVolunteerNoShowCleanupJob } from './utils/volunteerNoShowCleanupJob';
-import { initEmailQueue } from './utils/emailQueue';
+import { startBookingReminderJob, stopBookingReminderJob } from './utils/bookingReminderJob';
+import {
+  startVolunteerShiftReminderJob,
+  stopVolunteerShiftReminderJob,
+} from './utils/volunteerShiftReminderJob';
+import { startNoShowCleanupJob, stopNoShowCleanupJob } from './utils/noShowCleanupJob';
+import {
+  startVolunteerNoShowCleanupJob,
+  stopVolunteerNoShowCleanupJob,
+} from './utils/volunteerNoShowCleanupJob';
+import { initEmailQueue, shutdownQueue } from './utils/emailQueue';
 
 const PORT = config.port;
+
+let server: ReturnType<typeof app.listen> | undefined;
 
 async function init() {
   try {
@@ -21,7 +29,7 @@ async function init() {
     client.release();
 
     initEmailQueue();
-    app.listen(PORT, () => {
+    server = app.listen(PORT, () => {
       logger.info(`Server running at http://localhost:${PORT}`);
     });
     startBookingReminderJob();
@@ -33,5 +41,37 @@ async function init() {
     process.exit(1);
   }
 }
+
+async function shutdown(signal: NodeJS.Signals): Promise<void> {
+  logger.info(`Received ${signal}. Shutting down gracefully...`);
+  stopBookingReminderJob();
+  stopVolunteerShiftReminderJob();
+  stopNoShowCleanupJob();
+  stopVolunteerNoShowCleanupJob();
+  shutdownQueue();
+  if (server) {
+    server.close();
+  }
+  try {
+    await pool.end();
+  } catch (err) {
+    logger.error('Error while closing database pool', err);
+  }
+  process.exit(0);
+}
+
+process.on('SIGINT', (sig) => {
+  shutdown(sig).catch((err) => {
+    logger.error('Error during shutdown', err);
+    process.exit(1);
+  });
+});
+
+process.on('SIGTERM', (sig) => {
+  shutdown(sig).catch((err) => {
+    logger.error('Error during shutdown', err);
+    process.exit(1);
+  });
+});
 
 init();


### PR DESCRIPTION
## Summary
- Stop cron jobs and clear email queue when the server receives SIGINT or SIGTERM
- Close the database pool and exit the process after cleanup

## Testing
- `npm test` *(fails: tests/emailQueue.test.ts, client visit booking integration, cancelVolunteerBookingOccurrence, booking monthly limits, volunteer booking conflict, bookingReminderJob, bookingCapacity, bookingNewClient, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b51bee4908832daa2a399cceb4aa69