### PR TITLE
Log unexpected PG pool errors

### DIFF
--- a/MJ_FB_Backend/src/db.ts
+++ b/MJ_FB_Backend/src/db.ts
@@ -1,5 +1,6 @@
 import { Pool } from 'pg';
 import config from './config';
+import logger from './utils/logger';
 
 const pool = new Pool({
   user: config.pgUser,
@@ -8,4 +9,7 @@ const pool = new Pool({
   port: config.pgPort,
   database: config.pgDatabase,
 });
+
+pool.on('error', (err) => logger.error('Unexpected PG pool error', err));
+
 export default pool;

--- a/MJ_FB_Backend/tests/dbPoolErrorHandler.test.ts
+++ b/MJ_FB_Backend/tests/dbPoolErrorHandler.test.ts
@@ -1,0 +1,15 @@
+import pool from '../src/db';
+import logger from '../src/utils/logger';
+
+describe('PG pool error handler', () => {
+  it('logs idle client errors', () => {
+    const err = new Error('idle client error');
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+    // Simulate an idle client error from the pool
+    (pool as any).emit('error', err);
+
+    expect(spy).toHaveBeenCalledWith('Unexpected PG pool error', err);
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- attach a logger for unexpected PG pool errors
- test that the pool error handler logs idle client errors

## Testing
- `npm test tests/dbPoolErrorHandler.test.ts`
- `npm test` *(fails: Test Suites: 15 failed, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b51bf59cf0832dbd4f6648a28acd44