### PR TITLE
refactor: extract fetchWithRetry helper

### DIFF
--- a/MJ_FB_Frontend/src/api/fetchWithRetry.ts
+++ b/MJ_FB_Frontend/src/api/fetchWithRetry.ts
@@ -1,0 +1,16 @@
+export async function fetchWithRetry(
+  resource: RequestInfo | URL,
+  options: RequestInit,
+  retries = 1,
+  backoff = 300,
+): Promise<Response> {
+  for (let i = 0; i <= retries; i++) {
+    try {
+      return await fetch(resource, options);
+    } catch (e) {
+      if (i === retries) throw e;
+      await new Promise(res => setTimeout(res, backoff * 2 ** i));
+    }
+  }
+  throw new Error('Unreachable');
+}


### PR DESCRIPTION
## Summary
- move fetchWithRetry into its own module
- refactor apiFetch to use shared fetchWithRetry with configurable retries/backoff

## Testing
- `npm test` *(fails: 19 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b51c118078832d854d1658d5d415fe