### PR TITLE
Refactor volunteer availability loading

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -166,17 +166,13 @@ export default function VolunteerDashboard() {
               return d;
             })
           : [today];
-      const all: VolunteerRole[] = [];
-      for (const day of days) {
-        const ds = formatRegina(day, 'yyyy-MM-dd');
-        try {
-          const roles = await getVolunteerRolesForVolunteer(ds);
-          all.push(...roles);
-        } catch {
-          // ignore
-        }
-      }
-      setAvailability(all);
+      const requests = days.map(day =>
+        getVolunteerRolesForVolunteer(formatRegina(day, 'yyyy-MM-dd')).catch(
+          () => [],
+        ),
+      );
+      const results = await Promise.all(requests);
+      setAvailability(results.flat());
     }
     loadAvailability();
   }, [dateMode]);


### PR DESCRIPTION
## Summary
- parallelize volunteer role availability lookups using Promise.all

## Testing
- `npm test` (fails: SyntaxError: Cannot use 'import.meta' outside a module)

------
https://chatgpt.com/codex/tasks/task_e_68b51e951680832d9dc44b12c53cdffc