### PR TITLE
Handle volunteer dashboard events fetch errors

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -103,6 +103,22 @@ beforeEach(() => {
     expect(await screen.findByText(/Volunteer Event/)).toBeInTheDocument();
   });
 
+  it('shows an error message if events cannot be fetched', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockRejectedValue(new Error('fail'));
+    (getVolunteerStats as jest.Mock).mockResolvedValue(makeStats());
+
+    render(
+      <MemoryRouter>
+        <VolunteerDashboard />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getEvents).toHaveBeenCalled());
+    expect(await screen.findByText('Failed to load events')).toBeInTheDocument();
+  });
+
   it('hides slots already booked by volunteer', async () => {
     const today = new Date().toISOString().split('T')[0];
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -125,7 +125,13 @@ export default function VolunteerDashboard() {
   }, []);
 
   useEffect(() => {
-    getEvents().then(setEvents).catch(() => {});
+    getEvents()
+      .then(setEvents)
+      .catch(err => {
+        console.error('Failed to load events', err);
+        setSnackbarSeverity('error');
+        setMessage('Failed to load events');
+      });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- log failures when loading events on the volunteer dashboard and show snackbar
- cover events fetch failure with a new test

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b51eb2f150832d8efea109f94a4a39