### PR TITLE
refactor: add booking and conflict types

### DIFF
--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -6,6 +6,8 @@ import type {
   BlockedSlot,
   Break,
   Holiday,
+  Booking,
+  BookingResponse,
 } from '../types';
 
 interface SlotResponse {
@@ -90,29 +92,22 @@ export async function createBooking(
   return handleResponse(res);
 }
 
-interface BookingResponse {
-  [key: string]: unknown;
-  start_time?: string;
-  end_time?: string;
-  startTime?: string;
-  endTime?: string;
-}
-
-function normalizeBooking(b: BookingResponse) {
-  const newClientId = (b as any).newClientId ?? (b as any).new_client_id ?? null;
+function normalizeBooking(b: BookingResponse): Booking {
+  const { new_client_id, ...rest } = b;
+  const newClientId = b.newClientId ?? new_client_id ?? null;
   return {
-    ...b,
-    start_time: b.start_time ?? b.startTime,
-    end_time: b.end_time ?? b.endTime,
-    startTime: b.startTime ?? b.start_time,
-    endTime: b.endTime ?? b.end_time,
+    ...rest,
+    start_time: b.start_time ?? b.startTime ?? '',
+    end_time: b.end_time ?? b.endTime ?? '',
+    startTime: b.startTime ?? b.start_time ?? '',
+    endTime: b.endTime ?? b.end_time ?? '',
     newClientId,
-  } as BookingResponse & { newClientId: number | null };
+  };
 }
 
 export async function getBookings(
   opts: { status?: string; date?: string; clientIds?: number[] } = {},
-) {
+): Promise<Booking[] | Booking> {
   const params = new URLSearchParams();
   if (opts.status) params.append('status', opts.status);
   if (opts.date) params.append('date', opts.date);
@@ -134,7 +129,7 @@ export async function getBookingHistory(
     limit?: number;
     offset?: number;
   } = {},
-) {
+): Promise<Booking[] | Booking> {
   const params = new URLSearchParams();
   if (opts.status) params.append('status', opts.status);
   if (opts.past) params.append('past', 'true');

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -14,24 +14,17 @@ import {
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
 import FeedbackSnackbar from './FeedbackSnackbar';
-import { getSlots, rescheduleBookingByToken, cancelBooking, markBookingNoShow } from '../api/bookings';
+import {
+  getSlots,
+  rescheduleBookingByToken,
+  cancelBooking,
+  markBookingNoShow,
+} from '../api/bookings';
 import { createClientVisit } from '../api/clientVisits';
 import { formatTime } from '../utils/time';
-import type { Slot } from '../types';
+import type { Slot, Booking } from '../types';
 
 const CART_TARE = 27;
-
-interface Booking {
-  id: number;
-  reschedule_token: string;
-  client_id: number;
-  user_id: number;
-  user_name: string;
-  visits_this_month: number;
-  approved_bookings_this_month: number;
-  date: string;
-  profile_link: string;
-}
 
 interface ManageBookingDialogProps {
   open: boolean;

--- a/MJ_FB_Frontend/src/components/OverlapBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/OverlapBookingDialog.tsx
@@ -9,20 +9,12 @@ import {
 } from '@mui/material';
 import { formatTime } from '../utils/time';
 import { formatReginaDate } from '../utils/date';
-
-interface BookingInfo {
-  id?: number;
-  role_id: number;
-  role_name: string;
-  date: string;
-  start_time: string;
-  end_time: string;
-}
+import type { VolunteerBookingInfo } from '../types';
 
 interface Props {
   open: boolean;
-  attempted: BookingInfo;
-  existing: BookingInfo;
+  attempted: VolunteerBookingInfo;
+  existing: VolunteerBookingInfo;
   onClose: () => void;
   onResolve: (choice: 'existing' | 'new') => void;
 }

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -16,7 +16,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import EventAvailable from '@mui/icons-material/EventAvailable';
 import Announcement from '@mui/icons-material/Announcement';
 import { getBookings, getSlotsRange } from '../../api/bookings';
-import type { Role } from '../../types';
+import type { Role, Booking } from '../../types';
 import { formatTime } from '../../utils/time';
 import EntitySearch from '../EntitySearch';
 import { getEvents, type EventGroups } from '../../api/events';
@@ -47,15 +47,6 @@ const Stat = ({ icon, label, value }: StatProps) => (
     </Stack>
   </Stack>
 );
-
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  user_name?: string;
-  start_time?: string;
-  end_time?: string;
-}
 
 function parseLocalDate(dateStr: string) {
   const [year, month, day] = dateStr.split('-').map(Number);

--- a/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
@@ -27,7 +27,7 @@ import {
   cancelBooking,
 } from '../../api/bookings';
 import { getEvents, type EventGroups } from '../../api/events';
-import type { Slot, Holiday } from '../../types';
+import type { Slot, Holiday, Booking } from '../../types';
 import { formatTime, formatReginaDate, formatRegina } from '../../utils/time';
 import type { AlertColor } from '@mui/material';
 import SectionCard from '../../components/dashboard/SectionCard';
@@ -35,16 +35,6 @@ import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 import Page from '../../components/Page';
 import { useTranslation } from 'react-i18next';
-
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  start_time?: string;
-  end_time?: string;
-  reschedule_token?: string;
-  user_name?: string;
-}
 
 interface NextSlot {
   date: string;

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -26,25 +26,13 @@ import { formatDate } from '../../utils/date';
 import Page from '../../components/Page';
 import { useTranslation } from 'react-i18next';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import type { Booking } from '../../types';
 
 const TIMEZONE = 'America/Regina';
 
 interface User {
   name: string;
   client_id: number;
-}
-
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  start_time: string;
-  end_time: string;
-  created_at: string;
-  slot_id: number;
-  is_staff_booking: boolean;
-  reason?: string;
-  reschedule_token: string;
 }
 
 export default function ClientHistory() {

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -21,7 +21,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../../api/bookings';
 import { getEvents, type EventGroups } from '../../api/events';
-import type { Slot, Holiday } from '../../types';
+import type { Slot, Holiday, Booking } from '../../types';
 import { formatTime, formatReginaDate, formatRegina } from '../../utils/time';
 import type { AlertColor } from '@mui/material';
 import SectionCard from '../../components/dashboard/SectionCard';
@@ -29,15 +29,6 @@ import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 import Page from '../../components/Page';
 import { useTranslation } from 'react-i18next';
-
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  start_time?: string;
-  end_time?: string;
-  reschedule_token?: string;
-}
 
 interface NextSlot {
   date: string;

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -7,7 +7,7 @@ import {
   createBookingForNewClient,
 } from '../../api/bookings';
 import { searchUsers } from '../../api/users';
-import type { Slot, Holiday } from '../../types';
+import type { Slot, Holiday, Booking } from '../../types';
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 import { formatTime } from '../../utils/time';
 import { formatDate, addDays } from '../../utils/date';
@@ -26,22 +26,6 @@ import { useTranslation } from 'react-i18next';
 import RescheduleDialog from '../../components/RescheduleDialog';
 import ManageBookingDialog from '../../components/ManageBookingDialog';
 import Page from '../../components/Page';
-
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  slot_id: number;
-  user_name: string;
-  user_id: number | null;
-  client_id: number | null;
-  newClientId?: number | null;
-  visits_this_month: number;
-  approved_bookings_this_month: number;
-  is_staff_booking: boolean;
-  reschedule_token: string;
-  profile_link: string;
-}
 
 interface User {
   client_id: number;

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
@@ -20,22 +20,7 @@ import {
 import type { AlertColor } from '@mui/material';
 import ManageBookingDialog from '../../../components/ManageBookingDialog';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
-
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  slot_id: number;
-  user_name: string;
-  user_id: number | null;
-  client_id: number | null;
-  newClientId?: number | null;
-  visits_this_month: number;
-  approved_bookings_this_month: number;
-  is_staff_booking: boolean;
-  reschedule_token: string;
-  profile_link: string;
-}
+import type { Booking } from '../../../types';
 
 export default function NoShowWeek() {
   const [start] = useState(() => toDayjs().startOf('week'));

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -36,25 +36,13 @@ import DialogCloseButton from '../../../components/DialogCloseButton';
 import { useTranslation } from 'react-i18next';
 import { toDate, formatDate } from '../../../utils/date';
 import Page from '../../../components/Page';
+import type { Booking } from '../../../types';
 
 const TIMEZONE = 'America/Regina';
 
 interface User {
   name: string;
   client_id: number;
-}
-
-interface Booking {
-  id: number;
-  status: string;
-  date: string;
-  start_time: string;
-  end_time: string;
-  created_at: string;
-  slot_id: number;
-  is_staff_booking: boolean;
-  reason?: string;
-  reschedule_token: string;
 }
 
 export default function UserHistory({

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -30,6 +30,7 @@ import { formatTime } from '../../utils/time';
 import Page from '../../components/Page';
 import OverlapBookingDialog from '../../components/OverlapBookingDialog';
 import useHolidays from '../../hooks/useHolidays';
+import type { VolunteerBookingConflict } from '../../types';
 
 function useVolunteerSlots(
   date: Dayjs,
@@ -71,10 +72,7 @@ export default function VolunteerBooking() {
     message: string;
     severity: 'success' | 'error';
   }>({ open: false, message: '', severity: 'success' });
-  const [conflict, setConflict] = useState<{
-    attempted: any;
-    existing: any;
-  } | null>(null);
+  const [conflict, setConflict] = useState<VolunteerBookingConflict | null>(null);
   const slotsRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
@@ -102,9 +100,9 @@ export default function VolunteerBooking() {
       refetch();
     } catch (e) {
       const err = e as ApiError;
-      const details = err.details as any;
+      const details = err.details as VolunteerBookingConflict | undefined;
       if (err.status === 409 && details?.attempted && details?.existing) {
-        setConflict({ attempted: details.attempted, existing: details.existing });
+        setConflict(details);
       } else {
         setSnackbar({
           open: true,

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -50,6 +50,7 @@ import PersonalContributionChart, {
 } from '../../components/dashboard/PersonalContributionChart';
 import OverlapBookingDialog from '../../components/OverlapBookingDialog';
 import type { ApiError } from '../../api/client';
+import type { VolunteerBookingConflict } from '../../types';
 
 function formatDateLabel(dateStr: string) {
   const d = toDate(dateStr);
@@ -74,9 +75,7 @@ export default function VolunteerDashboard() {
   const [leaderboard, setLeaderboard] = useState<{ rank: number; percentile: number }>();
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
-  const [conflict, setConflict] = useState<{ attempted: any; existing: any } | null>(
-    null,
-  );
+  const [conflict, setConflict] = useState<VolunteerBookingConflict | null>(null);
   const navigate = useNavigate();
   const { t } = useTranslation();
 
@@ -238,9 +237,9 @@ export default function VolunteerDashboard() {
       ]);
     } catch (e: unknown) {
       const err = e as ApiError;
-      const details = err.details as any;
+      const details = err.details as VolunteerBookingConflict | undefined;
       if (err.status === 409 && details?.attempted && details?.existing) {
-        setConflict({ attempted: details.attempted, existing: details.existing });
+        setConflict(details);
       } else {
         setSnackbarSeverity('error');
         setMessage(err.message ?? 'Failed to request shift');

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -26,6 +26,7 @@ import RescheduleDialog from '../../components/VolunteerRescheduleDialog';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import OverlapBookingDialog from '../../components/OverlapBookingDialog';
 import type { ApiError } from '../../api/client';
+import type { VolunteerBookingConflict } from '../../types';
 import {
   Box,
   FormControl,
@@ -65,9 +66,7 @@ export default function VolunteerSchedule() {
   const [decisionReason, setDecisionReason] = useState('');
   const [rescheduleBooking, setRescheduleBooking] =
     useState<VolunteerBooking | null>(null);
-  const [conflict, setConflict] = useState<{ attempted: any; existing: any } | null>(
-    null,
-  );
+  const [conflict, setConflict] = useState<VolunteerBookingConflict | null>(null);
   const [frequency, setFrequency] =
     useState<'one-time' | 'daily' | 'weekly'>('one-time');
   const [weekdays, setWeekdays] = useState<number[]>([]);
@@ -174,9 +173,9 @@ export default function VolunteerSchedule() {
       await loadData();
     } catch (err) {
       const apiErr = err as ApiError;
-      const details = apiErr.details as any;
+      const details = apiErr.details as VolunteerBookingConflict | undefined;
       if (apiErr.status === 409 && details?.attempted && details?.existing) {
-        setConflict({ attempted: details.attempted, existing: details.existing });
+        setConflict(details);
       } else {
         setSnackbarSeverity('error');
         setMessage(apiErr.message);

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -206,3 +206,50 @@ export interface EditableSlot {
   is_wednesday_slot: boolean;
   is_active: boolean;
 }
+
+export interface BookingResponse {
+  id: number;
+  status: string;
+  date: string;
+  slot_id: number;
+  user_id?: number | null;
+  new_client_id?: number | null;
+  newClientId?: number | null;
+  is_staff_booking?: boolean;
+  reschedule_token?: string;
+  user_name?: string;
+  user_email?: string;
+  user_phone?: string;
+  client_id?: number | null;
+  profile_link?: string;
+  visits_this_month?: number;
+  approved_bookings_this_month?: number;
+  start_time?: string;
+  end_time?: string;
+  startTime?: string;
+  endTime?: string;
+  reason?: string;
+}
+
+export interface Booking
+  extends Omit<BookingResponse, 'new_client_id' | 'startTime' | 'endTime'> {
+  start_time: string;
+  end_time: string;
+  startTime: string;
+  endTime: string;
+  newClientId: number | null;
+}
+
+export interface VolunteerBookingInfo {
+  id?: number;
+  role_id: number;
+  role_name: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+}
+
+export interface VolunteerBookingConflict {
+  attempted: VolunteerBookingInfo;
+  existing: VolunteerBookingInfo;
+}


### PR DESCRIPTION
## Summary
- add explicit Booking and VolunteerBookingConflict types
- use new booking type in normalizeBooking
- apply conflict type across volunteer booking pages and dialog

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b51eaafdc8832db04e781b5f5585b7