### PR TITLE
feat: add email template env vars

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -40,5 +40,14 @@ PASSWORD_SETUP_TEMPLATE_ID=1
 # Hours until password setup tokens expire (optional, default 24)
 PASSWORD_SETUP_TOKEN_TTL_HOURS=24
 
+# Brevo template ID used for booking confirmation emails
+BOOKING_CONFIRMATION_TEMPLATE_ID=2
+# Brevo template ID used for booking reminder emails
+BOOKING_REMINDER_TEMPLATE_ID=3
+# Brevo template ID used for volunteer booking confirmation emails
+VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID=4
+# Brevo template ID used for volunteer booking reminder emails
+VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID=5
+
 # Hours to wait before marking a volunteer shift as no-show
 VOLUNTEER_NO_SHOW_HOURS=24

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -22,6 +22,10 @@ const envSchema = z.object({
   EMAIL_QUEUE_MAX_RETRIES: z.coerce.number().default(5),
   EMAIL_QUEUE_BACKOFF_MS: z.coerce.number().default(1000),
   PASSWORD_SETUP_TEMPLATE_ID: z.coerce.number(),
+  BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
+  BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
+  VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
+  VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
 
@@ -55,5 +59,9 @@ export default {
   emailQueueMaxRetries: env.EMAIL_QUEUE_MAX_RETRIES,
   emailQueueBackoffMs: env.EMAIL_QUEUE_BACKOFF_MS,
   passwordSetupTemplateId: env.PASSWORD_SETUP_TEMPLATE_ID,
+  bookingConfirmationTemplateId: env.BOOKING_CONFIRMATION_TEMPLATE_ID,
+  bookingReminderTemplateId: env.BOOKING_REMINDER_TEMPLATE_ID,
+  volunteerBookingConfirmationTemplateId: env.VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID,
+  volunteerBookingReminderTemplateId: env.VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID,
   volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `EMAIL_QUEUE_MAX_RETRIES` | Max retry attempts for failed email jobs (default 5) |
 | `EMAIL_QUEUE_BACKOFF_MS` | Initial backoff delay in ms for email retries (default 1000) |
 | `PASSWORD_SETUP_TEMPLATE_ID` | Brevo template ID for invitation and password setup emails |
+| `BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for booking confirmation emails |
+| `BOOKING_REMINDER_TEMPLATE_ID` | Brevo template ID for booking reminder emails |
+| `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations |
+| `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Brevo template ID for volunteer shift reminder emails |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS` | Hours until password setup tokens expire (default 24) |
 
 ### Invitation flow

--- a/docs/release.md
+++ b/docs/release.md
@@ -36,6 +36,14 @@ Define these variables (Settings → Secrets and variables → Actions → Varia
 | `BACKEND_APP_NAME` | Name of the backend Container App |
 | `FRONTEND_APP_NAME` | Name of the frontend Container App |
 
+## Backend Environment Variables
+Set the following variables in the backend deployment environment:
+
+- `BOOKING_CONFIRMATION_TEMPLATE_ID`
+- `BOOKING_REMINDER_TEMPLATE_ID`
+- `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID`
+- `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`
+
 ## Deployment Notes
 - Images are tagged with the branch or tag name that triggered the workflow.
 - Ensure backend and frontend environment variables are configured in the Azure portal before deploying.


### PR DESCRIPTION
## Summary
- expose Brevo template ID env vars for booking confirmations and reminders
- document new template variables in example env file and release guide
- list booking-related template env vars in README

## Testing
- `npm test` *(backend)*

------
https://chatgpt.com/codex/tasks/task_e_68b51f32889c832dbfcf4de75a0d07de