### PR TITLE
Use parameterized volunteer no-show cleanup query

### DIFF
--- a/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
@@ -20,8 +20,9 @@ export async function cleanupVolunteerNoShows(): Promise<void> {
        FROM volunteer_slots vs
        WHERE vb.slot_id = vs.slot_id
          AND vb.status='approved'
-         AND (vb.date + vs.end_time) < NOW() - INTERVAL '${hours} hours'
+         AND (vb.date + vs.end_time) < NOW() - $1::int * INTERVAL '1 hour'
        RETURNING vb.id`,
+      [hours],
     );
     if (res.rowCount && res.rowCount > 0) {
       const ids = res.rows.map((r: any) => r.id).join(', ');


### PR DESCRIPTION
## Summary
- use parameterized SQL query for volunteer no-show cleanup to avoid string interpolation

## Testing
- `npm test` *(fails: Test Suites: 14 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b52306f7c4832da034cac4045a8353