### PR TITLE
refactor: centralize daily job scheduling

### DIFF
--- a/MJ_FB_Backend/src/utils/scheduleDailyJob.ts
+++ b/MJ_FB_Backend/src/utils/scheduleDailyJob.ts
@@ -1,0 +1,30 @@
+import cron from 'node-cron';
+
+export default function scheduleDailyJob(
+  callback: () => void | Promise<void>,
+  schedule: string,
+): { start: () => void; stop: () => void } {
+  let task: cron.ScheduledTask | undefined;
+
+  const start = (): void => {
+    if (process.env.NODE_ENV === 'test') return;
+    void callback();
+    task = cron.schedule(
+      schedule,
+      () => {
+        void callback();
+      },
+      { timezone: 'America/Regina' },
+    );
+  };
+
+  const stop = (): void => {
+    if (task) {
+      task.stop();
+      task = undefined;
+    }
+  };
+
+  return { start, stop };
+}
+

--- a/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
@@ -1,6 +1,6 @@
 import pool from '../db';
 import logger from './logger';
-import cron from 'node-cron';
+import scheduleDailyJob from './scheduleDailyJob';
 import config from '../config';
 import coordinatorEmailsConfig from '../config/coordinatorEmails.json';
 import { sendTemplatedEmail } from './emailUtils';
@@ -55,28 +55,10 @@ export async function cleanupVolunteerNoShows(): Promise<void> {
 /**
  * Schedule the volunteer no-show cleanup job to run nightly at 8:00 PM Regina time.
  */
-let volunteerNoShowCleanupTask: cron.ScheduledTask | undefined;
+const volunteerNoShowCleanupJob = scheduleDailyJob(
+  cleanupVolunteerNoShows,
+  '0 20 * * *',
+);
 
-export function startVolunteerNoShowCleanupJob(): void {
-  if (process.env.NODE_ENV === 'test') return;
-  // Run immediately and then on the scheduled interval.
-  cleanupVolunteerNoShows().catch(err =>
-    logger.error('Initial volunteer no-show cleanup failed', err),
-  );
-  volunteerNoShowCleanupTask = cron.schedule(
-    '0 20 * * *',
-    () => {
-      cleanupVolunteerNoShows().catch(err =>
-        logger.error('Scheduled volunteer no-show cleanup failed', err),
-      );
-    },
-    { timezone: 'America/Regina' },
-  );
-}
-
-export function stopVolunteerNoShowCleanupJob(): void {
-  if (volunteerNoShowCleanupTask) {
-    volunteerNoShowCleanupTask.stop();
-    volunteerNoShowCleanupTask = undefined;
-  }
-}
+export const startVolunteerNoShowCleanupJob = volunteerNoShowCleanupJob.start;
+export const stopVolunteerNoShowCleanupJob = volunteerNoShowCleanupJob.stop;


### PR DESCRIPTION
## Summary
- add reusable `scheduleDailyJob` helper to manage cron jobs with start/stop
- refactor booking and volunteer reminder/cleanup jobs to use new helper

## Testing
- `npm test` *(fails: 13 failed, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5230c95a4832daf00d6e08e2dc44d