### PR TITLE
refactor tests for templated emails

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import pool from '../../db';
-import { sendEmail, buildCancelRescheduleLinks } from '../../utils/emailUtils';
+import { sendTemplatedEmail, buildCancelRescheduleLinks } from '../../utils/emailUtils';
 import { enqueueEmail } from '../../utils/emailQueue';
 import logger from '../../utils/logger';
 import {
@@ -42,7 +42,9 @@ const coordinatorEmails: string[] = coordinatorEmailsConfig.coordinatorEmails ||
 
 async function notifyCoordinators(subject: string, body: string) {
   const results = await Promise.allSettled(
-    coordinatorEmails.map(email => sendEmail(email, subject, body)),
+    coordinatorEmails.map(email =>
+      sendTemplatedEmail({ to: email, templateId: 0, params: { subject, body } }),
+    ),
   );
   results.forEach((result, idx) => {
     if (result.status === 'rejected') {
@@ -1053,7 +1055,11 @@ export async function createRecurringVolunteerBooking(
       const subject = `Volunteer booking confirmed for ${date} ${slot.start_time}-${slot.end_time}`;
       const body = `Your volunteer booking on ${date} from ${slot.start_time} to ${slot.end_time} has been confirmed.`;
       if (user.email) {
-        await sendEmail(user.email, subject, body);
+        await sendTemplatedEmail({
+          to: user.email,
+          templateId: 0,
+          params: { subject, body },
+        });
       } else {
         logger.warn(
           'Volunteer booking confirmation email not sent. Volunteer %s has no email.',
@@ -1218,7 +1224,11 @@ export async function createRecurringVolunteerBookingForVolunteer(
       const subject = `Volunteer booking confirmed for ${date} ${slot.start_time}-${slot.end_time}`;
       const body = `Your volunteer booking on ${date} from ${slot.start_time} to ${slot.end_time} has been confirmed.`;
       if (volunteerEmail) {
-        await sendEmail(volunteerEmail, subject, body);
+        await sendTemplatedEmail({
+          to: volunteerEmail,
+          templateId: 0,
+          params: { subject, body },
+        });
       } else {
         logger.warn(
           'Volunteer booking confirmation email not sent. Volunteer %s has no email.',
@@ -1329,7 +1339,11 @@ export async function cancelVolunteerBookingOccurrence(
     const subject = `Volunteer booking cancelled for ${dateStr} ${slot.start_time}-${slot.end_time}`;
     const body = `Your volunteer booking on ${dateStr} from ${slot.start_time} to ${slot.end_time} has been cancelled.`;
     if (volunteerEmail) {
-      await sendEmail(volunteerEmail, subject, body);
+      await sendTemplatedEmail({
+        to: volunteerEmail,
+        templateId: 0,
+        params: { subject, body },
+      });
     } else {
       logger.warn(
         'Volunteer booking cancellation email not sent. Volunteer %s has no email.',
@@ -1389,7 +1403,11 @@ export async function cancelRecurringVolunteerBooking(
     const subject = `Recurring volunteer bookings cancelled starting ${from} ${info.start_time}-${info.end_time}`;
     const body = `Your recurring volunteer bookings starting ${from} from ${info.start_time} to ${info.end_time} have been cancelled.`;
     if (info.email) {
-      await sendEmail(info.email, subject, body);
+      await sendTemplatedEmail({
+        to: info.email,
+        templateId: 0,
+        params: { subject, body },
+      });
     } else {
       logger.warn(
         'Volunteer booking cancellation email not sent. Volunteer %s has no email.',

--- a/MJ_FB_Backend/tests/agency.test.ts
+++ b/MJ_FB_Backend/tests/agency.test.ts
@@ -24,7 +24,9 @@ import { enqueueEmail } from '../src/utils/emailQueue';
 jest.mock('../src/db');
 jest.mock('bcrypt');
 jest.mock('jsonwebtoken');
-jest.mock('../src/utils/emailUtils', () => ({ sendEmail: jest.fn() }));
+jest.mock('../src/utils/emailUtils', () => ({
+  sendTemplatedEmail: jest.fn(),
+}));
 jest.mock('../src/utils/emailQueue', () => ({
   __esModule: true,
   enqueueEmail: jest.fn(),

--- a/MJ_FB_Backend/tests/emailQueue.test.ts
+++ b/MJ_FB_Backend/tests/emailQueue.test.ts
@@ -98,6 +98,11 @@ describe('persistent email queue', () => {
     enqueueEmail({ to: 'user@example.com', templateId: 1, params: { body: 'Body' } });
     await Promise.resolve();
     expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendTemplatedEmailMock.mock.calls[0][0]).toEqual({
+      to: 'user@example.com',
+      templateId: 1,
+      params: { body: 'Body' },
+    });
 
     await jest.advanceTimersByTimeAsync(1);
     expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(2);
@@ -122,6 +127,11 @@ describe('persistent email queue', () => {
     enqueueEmail({ to: 'user@example.com', templateId: 1, params: { body: 'Body' } });
     await Promise.resolve();
     expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendTemplatedEmailMock.mock.calls[0][0]).toEqual({
+      to: 'user@example.com',
+      templateId: 1,
+      params: { body: 'Body' },
+    });
 
     // simulate restart before retry
     jest.clearAllTimers();
@@ -139,7 +149,7 @@ describe('persistent email queue', () => {
     process.env.EMAIL_QUEUE_BACKOFF_MS = '1';
     const sendTemplatedEmailMock: jest.Mock = jest
       .fn()
-      .mockRejectedValue(new Error('fail'));
+      .mockRejectedValue(new Error('fail') as any);
     jest.doMock('../src/utils/emailUtils', () => ({ sendTemplatedEmail: sendTemplatedEmailMock }));
     const logger = require('../src/utils/logger').default;
     const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});

--- a/MJ_FB_Backend/tests/emailUtilsFailure.test.ts
+++ b/MJ_FB_Backend/tests/emailUtilsFailure.test.ts
@@ -1,4 +1,4 @@
-import { sendEmail, sendTemplatedEmail } from '../src/utils/emailUtils';
+import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import logger from '../src/utils/logger';
 
 describe('emailUtils error logging', () => {
@@ -29,18 +29,6 @@ describe('emailUtils error logging', () => {
     process.env.BREVO_FROM_EMAIL = originalFromEmail;
     process.env.BREVO_FROM_NAME = originalFromName;
     jest.resetAllMocks();
-  });
-
-  it('logs error when sendEmail receives non-2xx response', async () => {
-    await sendEmail('user@example.com', 'Subject', '<p>Hello</p>');
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Failed to send email via Brevo',
-      expect.objectContaining({
-        status: 500,
-        to: 'user@example.com',
-        subject: 'Subject',
-      })
-    );
   });
 
   it('logs error when sendTemplatedEmail receives non-2xx response', async () => {

--- a/MJ_FB_Backend/tests/volunteerBookingConcurrency.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingConcurrency.test.ts
@@ -42,7 +42,7 @@ afterAll(async () => {
 
 // Mock db module after pool initialized
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));

--- a/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
@@ -5,7 +5,7 @@ import pool from '../src/db';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));

--- a/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
@@ -5,7 +5,7 @@ import pool from '../src/db';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));

--- a/MJ_FB_Backend/tests/volunteerBookingInvalidDate.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingInvalidDate.test.ts
@@ -11,8 +11,9 @@ describe('volunteer booking date validation', () => {
         __esModule: true,
         default: { query: jest.fn() },
       }));
+      const sendTemplatedEmail = jest.fn();
       jest.doMock('../src/utils/emailUtils', () => ({
-        sendEmail: jest.fn(),
+        sendTemplatedEmail,
         buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
       }));
       jest.doMock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));

--- a/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
@@ -5,7 +5,7 @@ import pool from '../src/db';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
@@ -5,7 +5,7 @@ import pool from '../src/db';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerBookingsUnmarked.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsUnmarked.test.ts
@@ -5,7 +5,7 @@ import pool from '../src/db';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerRebookCancelled.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRebookCancelled.test.ts
@@ -5,7 +5,7 @@ import pool from '../src/db';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));

--- a/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
@@ -2,13 +2,14 @@ import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
-import { sendEmail } from '../src/utils/emailUtils';
+import { sendTemplatedEmail } from '../src/utils/emailUtils';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
+const sendTemplatedEmailMock = sendTemplatedEmail as jest.Mock;
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (req: any, _res: express.Response, next: express.NextFunction) => {
     req.user = { id: 1, role: 'volunteer', email: 'test@example.com' };
@@ -50,7 +51,12 @@ describe('recurring volunteer bookings', () => {
       '2025-01-03',
     ]);
     expect(res.body.skipped).toEqual([]);
-    expect((sendEmail as jest.Mock).mock.calls).toHaveLength(9);
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(9);
+    expect(sendTemplatedEmailMock.mock.calls[0][0]).toMatchObject({
+      to: 'test@example.com',
+      templateId: 0,
+      params: expect.any(Object),
+    });
   });
 
   it('skips dates that fail validation', async () => {
@@ -79,7 +85,7 @@ describe('recurring volunteer bookings', () => {
       { date: '2025-01-04', reason: 'Role not bookable on holidays or weekends' },
       { date: '2025-01-05', reason: 'Role not bookable on holidays or weekends' },
     ]);
-    expect((sendEmail as jest.Mock).mock.calls).toHaveLength(3);
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(3);
   });
 
   it('cancels future recurring bookings', async () => {
@@ -101,7 +107,7 @@ describe('recurring volunteer bookings', () => {
       '/volunteer-bookings/recurring/10?from=2025-01-02',
     );
     expect(res.status).toBe(200);
-    expect((sendEmail as jest.Mock).mock.calls).toHaveLength(3);
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(3);
   });
 
   it('lists recurring bookings', async () => {

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -2,13 +2,14 @@ import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
-import { sendEmail } from '../src/utils/emailUtils';
+import { sendTemplatedEmail } from '../src/utils/emailUtils';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
+const sendTemplatedEmailMock = sendTemplatedEmail as jest.Mock;
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
@@ -48,8 +49,14 @@ describe('rescheduleVolunteerBooking', () => {
     expect(res.status).toBe(200);
     const updateCall = (pool.query as jest.Mock).mock.calls[6];
     expect(updateCall[0]).toContain("status='approved'");
-    expect((sendEmail as jest.Mock).mock.calls).toHaveLength(2);
-    expect((sendEmail as jest.Mock).mock.calls[0][0]).toBe('coordinator1@example.com');
-    expect((sendEmail as jest.Mock).mock.calls[1][0]).toBe('coordinator2@example.com');
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(2);
+    expect(sendTemplatedEmailMock.mock.calls[0][0]).toMatchObject({
+      to: 'coordinator1@example.com',
+      templateId: 0,
+    });
+    expect(sendTemplatedEmailMock.mock.calls[1][0]).toMatchObject({
+      to: 'coordinator2@example.com',
+      templateId: 0,
+    });
   });
 });

--- a/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
@@ -7,7 +7,7 @@ import pool from '../src/db';
 
 jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
-  sendEmail: jest.fn(),
+  sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));


### PR DESCRIPTION
## Summary
- replace legacy email mocks with `sendTemplatedEmail`
- queue coordinator notifications through templates
- add template assertions across volunteer booking tests

## Testing
- `npm test` *(fails: 16 failed, 214 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b522eab208832d92a52ddc69dfce33