### PR TITLE
Strongly type warehouse settings updates

### DIFF
--- a/MJ_FB_Backend/src/utils/warehouseSettings.ts
+++ b/MJ_FB_Backend/src/utils/warehouseSettings.ts
@@ -29,11 +29,11 @@ export async function getWarehouseSettings(): Promise<WarehouseSettings> {
 }
 
 export async function updateWarehouseSettings(settings: WarehouseSettings): Promise<void> {
-  const entries = [
+  const entries: [string, number][] = [
     ['bread_weight_multiplier', settings.breadWeightMultiplier],
     ['cans_weight_multiplier', settings.cansWeightMultiplier],
   ];
-  const values: any[] = [];
+  const values: string[] = [];
   const placeholders = entries
     .map(([k, v], i) => {
       values.push(k, String(v));


### PR DESCRIPTION
## Summary
- use `string[]` for warehouse config query values
- coerce numeric settings to strings before DB write

## Testing
- `npm test tests/warehouseSettings.test.ts`
- `npm test` *(fails: clientVisitBookingStatus.test.ts expected 201 received 400)*

------
https://chatgpt.com/codex/tasks/task_e_68b525a60ef8832dbab81b2a9b96d2c7