### PR TITLE
chore: type volunteer shift dialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageVolunteerShiftDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageVolunteerShiftDialog.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ManageVolunteerShiftDialog from '../components/ManageVolunteerShiftDialog';
+import type { VolunteerBookingDetail } from '../types';
 
 jest.mock('../api/volunteers', () => ({
   getRoleShifts: jest.fn(),
@@ -18,7 +19,7 @@ const {
 } = jest.requireMock('../api/volunteers');
 
 describe('ManageVolunteerShiftDialog', () => {
-  const booking = {
+  const booking: VolunteerBookingDetail = {
     id: 1,
     role_id: 1,
     volunteer_id: 2,
@@ -29,16 +30,21 @@ describe('ManageVolunteerShiftDialog', () => {
     end_time: '12:00:00',
     status: 'approved',
     reschedule_token: 'abc',
-  } as any;
+  };
 
   beforeAll(() => {
     window.matchMedia =
       window.matchMedia ||
-      ((() => ({
+      ((query: string): MediaQueryList => ({
         matches: false,
+        media: query,
+        onchange: null,
         addListener: () => {},
         removeListener: () => {},
-      })) as any);
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }));
   });
 
   beforeEach(() => {

--- a/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
@@ -19,7 +19,7 @@ import {
   rescheduleVolunteerBookingByToken,
   updateVolunteerBookingStatus,
 } from '../api/volunteers';
-import type { VolunteerBookingDetail, Shift } from '../types';
+import type { VolunteerBookingDetail, Shift, VolunteerBookingStatus } from '../types';
 import type { ApiError } from '../api/client';
 import { formatTime } from '../utils/time';
 import { formatReginaDate } from '../utils/date';
@@ -37,11 +37,12 @@ export default function ManageVolunteerShiftDialog({
   onClose,
   onUpdated,
 }: ManageVolunteerShiftDialogProps) {
-  const [status, setStatus] = useState('');
+  type ManageStatus = 'reschedule' | 'cancel' | VolunteerBookingStatus;
+  const [status, setStatus] = useState<ManageStatus | ''>('');
   const [date, setDate] = useState('');
   const [shiftId, setShiftId] = useState('');
   const [shifts, setShifts] = useState<Shift[]>([]);
-  const [bookings, setBookings] = useState<any[]>([]);
+  const [bookings, setBookings] = useState<VolunteerBookingDetail[]>([]);
   const [reason, setReason] = useState('');
   const [message, setMessage] = useState('');
   const [severity, setSeverity] = useState<AlertColor>('success');
@@ -142,7 +143,7 @@ export default function ManageVolunteerShiftDialog({
           return;
         case 'completed':
         case 'no_show':
-          await updateVolunteerBookingStatus(booking.id, status as any);
+          await updateVolunteerBookingStatus(booking.id, status);
           onUpdated('Status updated', 'success');
           onClose();
           return;


### PR DESCRIPTION
## Summary
- type status options in ManageVolunteerShiftDialog
- remove any casts from volunteer shift management and tests

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b525bc0b00832da90e40bf7e9b140b