### PR TITLE
feat: conditionally register service worker

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/registerServiceWorker.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/registerServiceWorker.test.ts
@@ -1,0 +1,39 @@
+import { registerServiceWorker } from '../registerServiceWorker';
+
+describe('registerServiceWorker', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let registerMock: jest.Mock;
+
+  beforeEach(() => {
+    registerMock = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: { register: registerMock },
+      configurable: true,
+    });
+    (import.meta as any).env = {};
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    // @ts-ignore
+    delete navigator.serviceWorker;
+  });
+
+  it('registers the service worker in production mode', () => {
+    process.env.NODE_ENV = 'production';
+    registerServiceWorker();
+    window.dispatchEvent(new Event('load'));
+    expect(registerMock).toHaveBeenCalledWith('/sw.js');
+  });
+
+  it('skips registration when not in production mode', () => {
+    process.env.NODE_ENV = 'development';
+    registerServiceWorker();
+    window.dispatchEvent(new Event('load'));
+    expect(registerMock).not.toHaveBeenCalled();
+  });
+});

--- a/MJ_FB_Frontend/src/registerServiceWorker.ts
+++ b/MJ_FB_Frontend/src/registerServiceWorker.ts
@@ -1,4 +1,8 @@
 export function registerServiceWorker() {
+  const mode = (import.meta as any).env?.MODE ?? process.env.NODE_ENV;
+  if (mode !== 'production') {
+    return;
+  }
   if ('serviceWorker' in navigator && window.isSecureContext) {
     window.addEventListener('load', () => {
       navigator.serviceWorker


### PR DESCRIPTION
## Summary
- skip service worker registration unless in production
- test service worker registration logic

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b525b06400832d8f4593610e064066