### PR TITLE
Include stack trace in non-production error responses

### DIFF
--- a/MJ_FB_Backend/src/middleware/errorHandler.ts
+++ b/MJ_FB_Backend/src/middleware/errorHandler.ts
@@ -5,9 +5,15 @@ const errorHandler = (err: any, _req: Request, res: Response, _next: NextFunctio
   const status = err.status || err.statusCode || 500;
   const originalMessage = err.message || 'Unknown error';
   logger.error('Unhandled error:', originalMessage, err);
-  res.status(status).json({
+  const responseBody: { message: string; stack?: string } = {
     message: status === 500 ? 'Internal Server Error' : originalMessage,
-  });
+  };
+
+  if (process.env.NODE_ENV !== 'production' && err.stack) {
+    responseBody.stack = err.stack;
+  }
+
+  res.status(status).json(responseBody);
 };
 
 export default errorHandler;


### PR DESCRIPTION
## Summary
- Add stack trace to error handler responses when not in production

## Testing
- `npm test` (fails: 14 failed, 73 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b52846d10c832db715ad316b2ea9e1