### PR TITLE
Add global 404 handler before error middleware

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -101,6 +101,9 @@ if (process.env.NODE_ENV === 'production') {
   });
 }
 
+// Handle unknown routes
+app.use((req, res) => res.status(404).json({ message: 'Not found' }));
+
 // Global error handler
 app.use(errorHandler);
 

--- a/MJ_FB_Backend/tests/notFoundHandler.test.ts
+++ b/MJ_FB_Backend/tests/notFoundHandler.test.ts
@@ -1,0 +1,22 @@
+import express from 'express';
+import request from 'supertest';
+import errorHandler from '../src/middleware/errorHandler';
+
+describe('404 middleware', () => {
+  it('returns 404 for unknown routes before hitting error handler', async () => {
+    const app = express();
+    const handlerSpy = jest.fn();
+
+    app.use((req, res) => res.status(404).json({ message: 'Not found' }));
+    app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+      handlerSpy();
+      return errorHandler(err, req, res, next);
+    });
+
+    const res = await request(app).get('/missing');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: 'Not found' });
+    expect(handlerSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- return a JSON `Not found` response for unmatched routes
- verify 404 middleware runs before the global error handler

## Testing
- `npm test tests/notFoundHandler.test.ts`
- `npm test` *(fails: Expected 201 Received 400 in clientVisitBookingStatus.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b5283ffbe0832da9a10231ff09a059