### PR TITLE
refactor(frontend): configure ts-jest via transform

### DIFF
--- a/MJ_FB_Frontend/jest.config.cjs
+++ b/MJ_FB_Frontend/jest.config.cjs
@@ -2,11 +2,6 @@ module.exports = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  globals: {
-    'ts-jest': {
-      useESM: true,
-    },
-  },
   testMatch: [
     '<rootDir>/src/pages/admin/__tests__/**/*.test.tsx',
     '<rootDir>/src/__tests__/**/*.test.tsx',
@@ -21,6 +16,7 @@ module.exports = {
       'ts-jest',
       {
         tsconfig: '<rootDir>/tsconfig.test.json',
+        useESM: true,
         diagnostics: false,
       },
     ],


### PR DESCRIPTION
## Summary
- move ts-jest options from deprecated globals block to transform config
- drop ts-jest globals usage

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b52ba83218832d9e21190b77233b2a