### PR TITLE
refactor: add authenticated request typing

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import type { AuthRequest } from '../types/AuthRequest';
 import { randomUUID } from 'crypto';
 import pool from '../db';
 import config from '../config';
@@ -182,7 +183,7 @@ export async function listBookings(req: Request, res: Response, next: NextFuncti
 }
 
 // --- Cancel booking (staff or user) ---
-export async function cancelBooking(req: Request, res: Response, next: NextFunction) {
+export async function cancelBooking(req: AuthRequest, res: Response, next: NextFunction) {
   const bookingId = req.params.id;
   const requester = req.user;
   if (!requester) return res.status(401).json({ message: 'Unauthorized' });
@@ -193,7 +194,7 @@ export async function cancelBooking(req: Request, res: Response, next: NextFunct
     const booking = await fetchBookingById(Number(bookingId));
     if (!booking) return res.status(404).json({ message: 'Booking not found' });
 
-    const requesterId = Number((requester as any).userId ?? requester.id);
+    const requesterId = Number(requester.userId ?? requester.id);
     const bookingUserId = booking.user_id ? Number(booking.user_id) : undefined;
     if (requester.role === 'agency') {
       if (bookingUserId !== undefined) {
@@ -632,7 +633,7 @@ export async function createBookingForNewClient(
 
 // --- Get booking history ---
 export async function getBookingHistory(
-  req: Request,
+  req: AuthRequest,
   res: Response,
   next: NextFunction,
 ) {
@@ -691,7 +692,7 @@ export async function getBookingHistory(
         userIds = [parsed];
       }
     } else {
-      const parsed = Number((requester as any).userId ?? requester.id);
+      const parsed = Number(requester.userId ?? requester.id);
       if (Number.isNaN(parsed)) {
         return res.status(400).json({ message: 'Invalid user' });
       }

--- a/MJ_FB_Backend/src/types/AuthRequest.ts
+++ b/MJ_FB_Backend/src/types/AuthRequest.ts
@@ -1,0 +1,6 @@
+import type { Request } from 'express';
+import type { AuthenticatedUser } from './AuthenticatedUser';
+
+export interface AuthRequest extends Request {
+  user?: AuthenticatedUser;
+}

--- a/MJ_FB_Backend/src/types/AuthenticatedUser.ts
+++ b/MJ_FB_Backend/src/types/AuthenticatedUser.ts
@@ -1,0 +1,5 @@
+export interface AuthenticatedUser {
+  id: string;
+  role: string;
+  userId?: string;
+}

--- a/MJ_FB_Backend/src/types/RequestUser.ts
+++ b/MJ_FB_Backend/src/types/RequestUser.ts
@@ -1,11 +1,10 @@
-export interface RequestUser {
-  id: string;
-  role: string;
+import type { AuthenticatedUser } from './AuthenticatedUser';
+
+export interface RequestUser extends AuthenticatedUser {
   type: 'user' | 'staff' | 'volunteer' | 'agency';
   email?: string;
   phone?: string;
   name?: string;
-  userId?: string;
   userRole?: 'shopper' | 'delivery';
   access?: string[];
 }


### PR DESCRIPTION
## Summary
- define `AuthenticatedUser` interface and `AuthRequest` for typed authenticated requests
- extend existing `RequestUser` and use typed user in booking cancellation and history handlers

## Testing
- `npm test` *(fails: missing dependencies and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b52b0ad1e8832d9032f24d12e0a25b