### PR TITLE
test: use process.env in jest setup

### DIFF
--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -12,7 +12,7 @@ import './src/i18n';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { fetch, Headers, Request, Response, FormData, File } = require('undici');
 (Element.prototype as any).scrollIntoView = jest.fn();
-if (!(import.meta as any).env?.VITE_API_BASE) {
+if (!process.env.VITE_API_BASE) {
   (globalThis as any).VITE_API_BASE = 'http://localhost:4000';
 }
 


### PR DESCRIPTION
## Summary
- use `process.env` to set VITE_API_BASE fallback in Jest setup

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b52b985a04832d827765dbbe367d3f