### PR TITLE
refactor error handler to safely inspect unknown errors

### DIFF
--- a/MJ_FB_Backend/src/middleware/errorHandler.ts
+++ b/MJ_FB_Backend/src/middleware/errorHandler.ts
@@ -1,16 +1,47 @@
 import { Request, Response, NextFunction } from 'express';
 import logger from '../utils/logger';
 
-const errorHandler = (err: any, _req: Request, res: Response, _next: NextFunction) => {
-  const status = err.status || err.statusCode || 500;
-  const originalMessage = err.message || 'Unknown error';
+const errorHandler = (
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+) => {
+  const status =
+    typeof err === 'object' &&
+    err !== null &&
+    'status' in err &&
+    typeof (err as any).status === 'number'
+      ? (err as any).status
+      : typeof err === 'object' &&
+        err !== null &&
+        'statusCode' in err &&
+        typeof (err as any).statusCode === 'number'
+      ? (err as any).statusCode
+      : 500;
+
+  const originalMessage =
+    typeof err === 'object' &&
+    err !== null &&
+    'message' in err &&
+    typeof (err as any).message === 'string'
+      ? (err as any).message
+      : 'Unknown error';
+
   logger.error('Unhandled error:', originalMessage, err);
+
   const responseBody: { message: string; stack?: string } = {
     message: status === 500 ? 'Internal Server Error' : originalMessage,
   };
 
-  if (process.env.NODE_ENV !== 'production' && err.stack) {
-    responseBody.stack = err.stack;
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    typeof err === 'object' &&
+    err !== null &&
+    'stack' in err &&
+    typeof (err as any).stack === 'string'
+  ) {
+    responseBody.stack = (err as any).stack;
   }
 
   res.status(status).json(responseBody);

--- a/MJ_FB_Backend/tests/errorHandler.test.ts
+++ b/MJ_FB_Backend/tests/errorHandler.test.ts
@@ -8,7 +8,7 @@ describe('global error handler', () => {
     const app = express();
 
     app.get('/boom', () => {
-      const err: any = new Error('Sensitive internal details');
+      const err = new Error('Sensitive internal details') as Error & { status?: number };
       err.status = 500;
       throw err;
     });

--- a/MJ_FB_Backend/tests/notFoundHandler.test.ts
+++ b/MJ_FB_Backend/tests/notFoundHandler.test.ts
@@ -8,7 +8,7 @@ describe('404 middleware', () => {
     const handlerSpy = jest.fn();
 
     app.use((req, res) => res.status(404).json({ message: 'Not found' }));
-    app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+    app.use((err: unknown, req: express.Request, res: express.Response, next: express.NextFunction) => {
       handlerSpy();
       return errorHandler(err, req, res, next);
     });


### PR DESCRIPTION
## Summary
- type-safe error handler inspects unknown error details
- adjust tests to use unknown errors

## Testing
- `npm test` *(fails: Cannot find module 'morgan' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b52b064b28832daa3c8b0af03cba0f