### PR TITLE
Handle Excel export failures gracefully

### DIFF
--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -287,7 +287,8 @@ export function getHelpContent(
     {
       title: 'Export or review aggregate reports',
       body: {
-        description: 'Use the Aggregations page to review monthly totals or export yearly spreadsheets.',
+        description:
+          'Use the Aggregations page to review monthly totals or export donor and overall yearly spreadsheets.',
         steps: [
           'Open the Aggregations page.',
           'Select the year or month.',

--- a/MJ_FB_Frontend/src/utils/exportTableToExcel.ts
+++ b/MJ_FB_Frontend/src/utils/exportTableToExcel.ts
@@ -1,9 +1,18 @@
 import writeXlsxFile from 'write-excel-file';
 
-export function exportTableToExcel(table: HTMLTableElement, filename: string) {
-  const data = Array.from(table.rows).map((row) =>
-    Array.from(row.cells).map((cell) => ({ value: cell.textContent || '' }))
+export async function exportTableToExcel(
+  table: HTMLTableElement,
+  filename: string,
+): Promise<boolean> {
+  const data = Array.from(table.rows).map(row =>
+    Array.from(row.cells).map(cell => ({ value: cell.textContent || '' })),
   );
 
-  void writeXlsxFile(data, { fileName: `${filename}.xlsx` });
+  try {
+    await writeXlsxFile(data, { fileName: `${filename}.xlsx` });
+    return true;
+  } catch (err) {
+    console.error('Failed to export table to Excel', err);
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- Make `exportTableToExcel` asynchronous and return success status
- Allow donor aggregations export via new utility with snackbar error handling
- Note donor and overall export options on the Help page

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b52b0e5200832dae5de74dd6942888