### PR TITLE
Align volunteer no-show cleanup test with parameterized query

### DIFF
--- a/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
@@ -25,8 +25,9 @@ describe('cleanupVolunteerNoShows', () => {
 
   it('marks past approved volunteer bookings as no_show and notifies coordinators', async () => {
     await cleanupVolunteerNoShows();
-    const query = (pool.query as jest.Mock).mock.calls[0][0];
-    expect(query).toContain("NOW() - INTERVAL '24 hours'");
+    const [query, params] = (pool.query as jest.Mock).mock.calls[0];
+    expect(query).toContain("NOW() - $1::int * INTERVAL '1 hour'");
+    expect(params).toEqual([24]);
     expect(query).toContain('FROM volunteer_slots');
     expect(query).toContain('vb.date + vs.end_time');
     expect(sendTemplatedEmail).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary
- update volunteer no-show cleanup job test to assert parameterized query and hours value

## Testing
- `npm test` *(fails: Test Suites: 13 failed, 75 passed, 88 total)*
- `npx jest tests/volunteerNoShowCleanupJob.test.ts --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68b52c308b54832d9eb74e060bf519dc