### PR TITLE
test: add matchMedia event listener polyfill

### DIFF
--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -16,6 +16,20 @@ if (!process.env.VITE_API_BASE) {
   (globalThis as any).VITE_API_BASE = 'http://localhost:4000';
 }
 
+// Polyfill matchMedia for testing environment with modern and legacy listeners
+if (!window.matchMedia) {
+  (window as any).matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  });
+}
+
 beforeAll(() => {
   (global as any).fetch = fetch;
   (global as any).Headers = Headers as any;

--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -21,11 +21,6 @@ describe('BookingUI visible slots', () => {
   beforeAll(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-01T10:30:00'));
-    window.matchMedia = window.matchMedia || ((() => ({
-      matches: false,
-      addListener: () => {},
-      removeListener: () => {},
-    })) as any);
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- move matchMedia polyfill to global jest setup
- include addEventListener/removeEventListener alongside legacy listeners
- clean up BookingUI test matchMedia stub

## Testing
- `npm test` (fails: VolunteerDashboard.test.tsx, App.test.tsx and others)

------
https://chatgpt.com/codex/tasks/task_e_68b52e2a6970832da2bd450f3eac2b1c