### PR TITLE
test: isolate NODE_ENV in reminder job tests

### DIFF
--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -1,4 +1,3 @@
-process.env.NODE_ENV = 'development';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 const bookingReminder = require('../src/utils/bookingReminderJob');
 const {
@@ -18,15 +17,17 @@ jest.mock('../src/utils/emailQueue', () => ({
 }));
 
 describe('sendNextDayBookingReminders', () => {
+  let originalEnv: string | undefined;
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+    originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
   });
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
-    process.env.NODE_ENV = 'test';
+    process.env.NODE_ENV = originalEnv;
   });
 
   it('fetches next-day bookings and queues reminder emails', async () => {
@@ -56,6 +57,7 @@ describe('startBookingReminderJob/stopBookingReminderJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
   let sendSpy: jest.SpyInstance;
+  let originalEnv: string | undefined;
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
@@ -63,7 +65,8 @@ describe('startBookingReminderJob/stopBookingReminderJob', () => {
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
     sendSpy = jest
       .spyOn(bookingReminder, 'sendNextDayBookingReminders')
-      .mockResolvedValue();
+      .mockResolvedValue(undefined);
+    originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
   });
 
@@ -73,7 +76,7 @@ describe('startBookingReminderJob/stopBookingReminderJob', () => {
     jest.useRealTimers();
     scheduleMock.mockReset();
     sendSpy.mockRestore();
-    process.env.NODE_ENV = 'test';
+    process.env.NODE_ENV = originalEnv;
   });
 
   it('schedules and stops the cron job', async () => {

--- a/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
@@ -1,4 +1,3 @@
-process.env.NODE_ENV = 'development';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 const volunteerJob = require('../src/utils/volunteerShiftReminderJob');
 const {
@@ -10,6 +9,7 @@ describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
   let sendSpy: jest.SpyInstance;
+  let originalEnv: string | undefined;
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
@@ -18,6 +18,7 @@ describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
     sendSpy = jest
       .spyOn(volunteerJob, 'sendNextDayVolunteerShiftReminders')
       .mockResolvedValue(undefined);
+    originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
   });
 
@@ -27,7 +28,7 @@ describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
     jest.useRealTimers();
     scheduleMock.mockReset();
     sendSpy.mockRestore();
-    process.env.NODE_ENV = 'test';
+    process.env.NODE_ENV = originalEnv;
   });
 
   it('schedules and stops the cron job', async () => {


### PR DESCRIPTION
## Summary
- remove global NODE_ENV mutations in booking and volunteer reminder job tests
- set NODE_ENV in beforeEach and restore in afterEach to avoid leakage

## Testing
- `npm test tests/volunteerShiftReminderJob.test.ts`
- `npm test tests/bookingReminderJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b52e1f2b28832d95a1d3110d340bd5