### PR TITLE
test: refactor volunteer management tests

### DIFF
--- a/MJ_FB_Frontend/package-lock.json
+++ b/MJ_FB_Frontend/package-lock.json
@@ -30,6 +30,7 @@
         "@eslint/js": "^9",
         "@testing-library/jest-dom": "^6",
         "@testing-library/react": "^16",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2794,6 +2795,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/MJ_FB_Frontend/package.json
+++ b/MJ_FB_Frontend/package.json
@@ -40,6 +40,7 @@
     "@eslint/js": "^9",
     "@testing-library/jest-dom": "^6",
     "@testing-library/react": "^16",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
## Summary
- import `act` from React and use `userEvent` for volunteer management tests
- switch client ID field to `userEvent.type` and await navigation actions
- add `@testing-library/user-event` dev dependency

## Testing
- `npm test src/__tests__/VolunteerManagement.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b52e2b7630832dac151738a1b0296d