### PR TITLE
test: restore NODE_ENV after noShowCleanupJob tests

### DIFF
--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -1,3 +1,4 @@
+const originalEnv = process.env.NODE_ENV;
 process.env.NODE_ENV = 'development';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 const noShowJob = require('../src/utils/noShowCleanupJob');
@@ -42,7 +43,7 @@ describe('startNoShowCleanupJob/stopNoShowCleanupJob', () => {
     jest.useRealTimers();
     scheduleMock.mockReset();
     cleanupSpy.mockRestore();
-    process.env.NODE_ENV = 'test';
+    process.env.NODE_ENV = originalEnv;
   });
 
   it('schedules and stops the cron job', async () => {
@@ -75,4 +76,8 @@ describe('countVisitsAndBookingsForMonth', () => {
       [userId, start, end],
     );
   });
+});
+
+afterAll(() => {
+  process.env.NODE_ENV = originalEnv;
 });


### PR DESCRIPTION
## Summary
- capture original NODE_ENV before modifying environment in noShowCleanupJob tests
- reset NODE_ENV after each test and after all tests to prevent leakage

## Testing
- `npm test` *(fails: email queue TS error, booking and volunteer tests failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b531623404832d8659c70c90d96e52