### PR TITLE
test: set fixed system time in volunteer tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -19,7 +19,6 @@ const { getSlots, getHolidays } = jest.requireMock('../api/bookings');
 
 describe('BookingUI visible slots', () => {
   beforeAll(() => {
-    jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-01T10:30:00'));
   });
 
@@ -28,7 +27,7 @@ describe('BookingUI visible slots', () => {
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    jest.setSystemTime(new Date());
   });
 
   it('hides past slots when viewing today', async () => {

--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -27,12 +27,11 @@ jest.mock('../api/bookings', () => ({ getHolidays: jest.fn() }));
 
 describe('VolunteerSchedule', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-29T19:00:00Z'));
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    jest.setSystemTime(new Date());
   });
 
   it('disables past days and hides past slots', async () => {


### PR DESCRIPTION
## Summary
- use `jest.setSystemTime` to control date in `VolunteerSchedule.test.tsx`
- switch `BookingUI.test.tsx` to `jest.setSystemTime` while keeping real timers

## Testing
- `npm install @testing-library/user-event@14.6.1`
- `npm test` *(fails: Unable to find element text 'Capacity exceeded', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b531661674832d937df76e7c71602b