### PR TITLE
test: centralize fetch mocking in frontend tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/apiFetchRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/apiFetchRefresh.test.tsx
@@ -1,8 +1,9 @@
 import { apiFetch } from '../api/client';
-
-const realFetch = global.fetch;
+import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 
 describe('apiFetch refresh handling', () => {
+  let fetchMock: jest.Mock;
+
   beforeEach(() => {
     document.cookie = 'csrfToken=test';
     localStorage.setItem('role', 'test');
@@ -10,16 +11,16 @@ describe('apiFetch refresh handling', () => {
       value: { assign: jest.fn(), pathname: '/' },
       writable: true,
     });
-    global.fetch = jest.fn().mockResolvedValue(new Response(null));
+    fetchMock = mockFetch();
   });
 
   afterEach(() => {
-    global.fetch = realFetch;
+    restoreFetch();
     jest.resetAllMocks();
   });
 
   it('redirects when refresh returns unexpected status', async () => {
-    (global.fetch as jest.Mock)
+    fetchMock
       .mockResolvedValueOnce(new Response(null, { status: 401 }))
       .mockResolvedValueOnce(new Response(null, { status: 500 }));
 
@@ -28,7 +29,7 @@ describe('apiFetch refresh handling', () => {
   });
 
   it('redirects when refresh encounters network error', async () => {
-    (global.fetch as jest.Mock)
+    fetchMock
       .mockResolvedValueOnce(new Response(null, { status: 401 }))
       .mockRejectedValueOnce(new Error('network'))
       .mockRejectedValueOnce(new Error('network'));

--- a/MJ_FB_Frontend/src/__tests__/clearAuthRedirect.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/clearAuthRedirect.test.tsx
@@ -1,12 +1,12 @@
 import { apiFetch } from '../api/client';
+import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 
 describe('clearAuthAndRedirect', () => {
-  const realFetch = global.fetch;
   const originalLocation = window.location;
 
   afterEach(() => {
-    global.fetch = realFetch;
     window.location = originalLocation;
+    restoreFetch();
     jest.restoreAllMocks();
     localStorage.clear();
   });
@@ -18,7 +18,7 @@ describe('clearAuthAndRedirect', () => {
       writable: true,
     });
 
-    global.fetch = jest.fn().mockResolvedValue({
+    mockFetch().mockResolvedValue({
       status: 401,
       ok: false,
       headers: new Headers(),
@@ -36,7 +36,7 @@ describe('clearAuthAndRedirect', () => {
       writable: true,
     });
 
-    global.fetch = jest.fn().mockResolvedValue({
+    mockFetch().mockResolvedValue({
       status: 401,
       ok: false,
       headers: new Headers(),

--- a/MJ_FB_Frontend/testUtils/mockFetch.ts
+++ b/MJ_FB_Frontend/testUtils/mockFetch.ts
@@ -1,0 +1,19 @@
+let originalFetch: typeof global.fetch | undefined;
+let isMocked = false;
+
+export function mockFetch() {
+  if (!isMocked) {
+    originalFetch = global.fetch;
+    isMocked = true;
+  }
+  const fetchMock = jest.fn();
+  global.fetch = fetchMock as any;
+  return fetchMock;
+}
+
+export function restoreFetch() {
+  if (isMocked && originalFetch) {
+    global.fetch = originalFetch;
+    isMocked = false;
+  }
+}


### PR DESCRIPTION
## Summary
- add mockFetch and restoreFetch helpers to reuse fetch stubbing
- update apiFetchRefresh and clearAuthRedirect tests to use new helpers

## Testing
- `npm test src/__tests__/apiFetchRefresh.test.tsx`
- `npm test src/__tests__/clearAuthRedirect.test.tsx`
- `npm test` *(fails: 21 failed, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5316676e0832d8d4be53458ef18dd