### PR TITLE
Use i18n keys in volunteer schedule tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import VolunteerSchedule from '../pages/volunteer-management/VolunteerSchedule';
+import i18n from '../i18n';
 import {
   getVolunteerRolesForVolunteer,
   getMyVolunteerBookings,
@@ -58,12 +59,12 @@ describe('VolunteerSchedule', () => {
 
     render(<VolunteerSchedule />);
 
-    fireEvent.mouseDown(screen.getByLabelText('Role'));
+    fireEvent.mouseDown(screen.getByLabelText(i18n.t('role')));
     fireEvent.click(await screen.findByText('Greeter'));
 
-    const prev = await screen.findByRole('button', { name: /Previous/i });
+    const prev = await screen.findByRole('button', { name: i18n.t('previous') });
     expect(prev).toBeDisabled();
 
-    expect(await screen.findByText('No bookings.')).toBeInTheDocument();
+    expect(await screen.findByText(i18n.t('no_bookings'))).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/VolunteerScheduleTable.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerScheduleTable.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import VolunteerScheduleTable from '../components/VolunteerScheduleTable';
+import i18n from '../i18n';
 
 describe('VolunteerScheduleTable', () => {
   it('handles maxSlots=0 gracefully', () => {
     render(<VolunteerScheduleTable maxSlots={0} rows={[]} />);
     expect(screen.getByText('Slot 1')).toBeInTheDocument();
-    expect(screen.getByText(/No bookings\./i)).toBeInTheDocument();
+    expect(screen.getByText(i18n.t('no_bookings'))).toBeInTheDocument();
   });
 
 });


### PR DESCRIPTION
## Summary
- import i18n and use translation keys for volunteer schedule tests
- use translation for "no bookings" in volunteer schedule table tests

## Testing
- `npm test` *(fails: 19 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b53167c78c832dbe77e0bc867f3734