### PR TITLE
test: flush timers in recurring booking tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import VolunteerSchedule from '../pages/volunteer-management/VolunteerSchedule';
 import VolunteerBookingHistory from '../pages/volunteer-management/VolunteerBookingHistory';
 import VolunteerRecurringBookings from '../pages/volunteer-management/VolunteerRecurringBookings';
@@ -35,7 +35,6 @@ jest.mock('../api/bookings', () => ({
 beforeEach(() => {
   jest.useFakeTimers();
   jest.setSystemTime(new Date('2024-04-30T06:00:00Z'));
-  jest.clearAllMocks();
   (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
     {
       id: 1,
@@ -64,8 +63,12 @@ beforeEach(() => {
   (getRoles as jest.Mock).mockResolvedValue([]);
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await act(async () => {
+    jest.runOnlyPendingTimers();
+  });
   jest.useRealTimers();
+  jest.clearAllMocks();
 });
 
 test('submits weekly recurring booking', async () => {


### PR DESCRIPTION
## Summary
- ensure recurring booking tests clear pending timers and mocks

## Testing
- `cd MJ_FB_Frontend && npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68b533e9dda4832da7b0e819d7a0f88f