### PR TITLE
test: reset auth data in apiFetchRefresh tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/apiFetchRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/apiFetchRefresh.test.tsx
@@ -3,8 +3,10 @@ import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 
 describe('apiFetch refresh handling', () => {
   let fetchMock: jest.Mock;
+  let originalLocation: Location;
 
   beforeEach(() => {
+    originalLocation = window.location;
     document.cookie = 'csrfToken=test';
     localStorage.setItem('role', 'test');
     Object.defineProperty(window, 'location', {
@@ -15,8 +17,11 @@ describe('apiFetch refresh handling', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation });
     restoreFetch();
     jest.resetAllMocks();
+    document.cookie = '';
+    localStorage.clear();
   });
 
   it('redirects when refresh returns unexpected status', async () => {


### PR DESCRIPTION
## Summary
- clear cookies and localStorage after apiFetchRefresh tests to avoid cross-suite auth leakage
- restore window.location after test to prevent jsdom errors

## Testing
- `npm test` *(fails: 19 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b533eba76c832da908a048a4b6a151