### PR TITLE
test: restore secure context in service worker test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/registerServiceWorker.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/registerServiceWorker.test.ts
@@ -3,8 +3,10 @@ import { registerServiceWorker } from '../registerServiceWorker';
 describe('registerServiceWorker', () => {
   const originalNodeEnv = process.env.NODE_ENV;
   let registerMock: jest.Mock;
+  let originalSecure: boolean;
 
   beforeEach(() => {
+    originalSecure = window.isSecureContext;
     registerMock = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(window, 'isSecureContext', {
       value: true,
@@ -18,6 +20,7 @@ describe('registerServiceWorker', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(window, 'isSecureContext', { value: originalSecure, configurable: true });
     process.env.NODE_ENV = originalNodeEnv;
     // @ts-ignore
     delete navigator.serviceWorker;


### PR DESCRIPTION
## Summary
- capture original `window.isSecureContext` in the service worker test setup and restore it afterward

## Testing
- `npm test` *(fails: PantryScheduleCapacity and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b533ee3f1c832da0a6dc1c9f97410d