### PR TITLE
Guard response.text in email utilities

### DIFF
--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -25,8 +25,9 @@ export async function sendEmail(to: string, subject: string, body: string): Prom
       }),
     });
 
-    if (!response.ok) {
-      const responseText = await response.text();
+    if (response.ok !== true) {
+      const responseText =
+        typeof response.text === 'function' ? await response.text() : undefined;
       logger.error('Failed to send email via Brevo', {
         status: response.status,
         responseText,
@@ -82,8 +83,9 @@ export async function sendTemplatedEmail({
       }),
     });
 
-    if (!response.ok) {
-      const responseText = await response.text();
+    if (response.ok !== true) {
+      const responseText =
+        typeof response.text === 'function' ? await response.text() : undefined;
       logger.error('Failed to send template email via Brevo', {
         status: response.status,
         responseText,

--- a/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
+++ b/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
@@ -9,7 +9,7 @@ describe('sendTemplatedEmail', () => {
   } = process.env;
 
   beforeEach(() => {
-    global.fetch = jest.fn().mockResolvedValue({});
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, text: jest.fn() });
     process.env.BREVO_API_KEY = 'test-key';
     process.env.BREVO_FROM_EMAIL = 'from@example.com';
     process.env.BREVO_FROM_NAME = 'Test Sender';


### PR DESCRIPTION
## Summary
- Safely handle Brevo API responses by checking `response.ok` and ensuring `response.text` exists before reading the body
- Update email tests to mock `fetch` with `ok` and `text` for compatibility with new guards

## Testing
- `npm test` *(fails: 11 failed, 78 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68b536ada204832dab27e99d7a3ffa29