### PR TITLE
Add migration for new clients table and booking reference

### DIFF
--- a/MJ_FB_Backend/src/migrations/1726500000000_new_clients.ts
+++ b/MJ_FB_Backend/src/migrations/1726500000000_new_clients.ts
@@ -1,0 +1,34 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('new_clients', {
+    id: 'id',
+    name: { type: 'text', notNull: true },
+    email: { type: 'text' },
+    phone: { type: 'text' },
+    created_at: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('CURRENT_TIMESTAMP'),
+    },
+  });
+
+  pgm.addColumn('bookings', {
+    new_client_id: {
+      type: 'integer',
+      references: 'new_clients',
+      onDelete: 'SET NULL',
+    },
+  });
+
+  pgm.createIndex('bookings', 'new_client_id');
+  pgm.createIndex('new_clients', 'created_at');
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('bookings', 'new_client_id');
+  pgm.dropIndex('new_clients', 'created_at');
+  pgm.dropColumn('bookings', 'new_client_id');
+  pgm.dropTable('new_clients');
+}
+

--- a/MJ_FB_Backend/src/models/booking.ts
+++ b/MJ_FB_Backend/src/models/booking.ts
@@ -3,6 +3,7 @@ export interface Booking {
   status: string;
   date: string;
   user_id: number | null;
+  new_client_id: number | null;
   user_name: string | null;
   user_email: string | null;
   user_phone: string | null;


### PR DESCRIPTION
## Summary
- add Booking interface support for `new_client_id`
- create `new_clients` table and link `bookings.new_client_id`

## Testing
- `npm test` *(fails: Argument of type 'any' is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68b536af55b0832d8ff2d1655b11a816