### PR TITLE
Read password setup TTL at call time

### DIFF
--- a/MJ_FB_Backend/src/utils/passwordSetupUtils.ts
+++ b/MJ_FB_Backend/src/utils/passwordSetupUtils.ts
@@ -10,17 +10,16 @@ export type PasswordTokenRow = {
   used: boolean;
 };
 
-const TOKEN_EXPIRY_MS =
-  Number(process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS ?? '24') *
-  60 * 60 * 1000; // default 24 hours
-
 export async function generatePasswordSetupToken(
   userType: PasswordTokenRow['user_type'],
   userId: number,
 ): Promise<string> {
   const token = randomBytes(32).toString('hex');
   const tokenHash = createHash('sha256').update(token).digest('hex');
-  const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_MS);
+  const tokenExpiryMs =
+    Number(process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS ?? '24') *
+    60 * 60 * 1000; // default 24 hours
+  const expiresAt = new Date(Date.now() + tokenExpiryMs);
   await pool.query(
     `INSERT INTO password_setup_tokens (user_type, user_id, token_hash, expires_at, used)
      VALUES ($1,$2,$3,$4,false)`,


### PR DESCRIPTION
## Summary
- read `PASSWORD_SETUP_TOKEN_TTL_HOURS` when generating password setup tokens
- rework password setup util tests to verify runtime TTL reading

## Testing
- `npm test tests/passwordSetupUtils.test.ts tests/passwordResetFlow.test.ts`
- `npm test tests/clientVisitBookingStatus.test.ts` *(fails: Expected 201 Received 400)*

------
https://chatgpt.com/codex/tasks/task_e_68b536ac40f0832d8407fead798026e0