### PR TITLE
Auto-schedule email queue on import

### DIFF
--- a/MJ_FB_Backend/src/utils/emailQueue.ts
+++ b/MJ_FB_Backend/src/utils/emailQueue.ts
@@ -95,3 +95,6 @@ export function shutdownQueue(): void {
   scheduled = false;
 }
 
+// Kick off the queue on module load so any pending jobs are scheduled
+scheduleNextRun().catch((err) => logger.error('Email queue scheduling error:', err));
+

--- a/MJ_FB_Backend/tests/emailQueue.test.ts
+++ b/MJ_FB_Backend/tests/emailQueue.test.ts
@@ -97,6 +97,7 @@ describe('persistent email queue', () => {
 
     enqueueEmail({ to: 'user@example.com', templateId: 1, params: { body: 'Body' } });
     await Promise.resolve();
+    await Promise.resolve();
     expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1);
     expect(sendTemplatedEmailMock.mock.calls[0][0]).toEqual({
       to: 'user@example.com',
@@ -126,6 +127,7 @@ describe('persistent email queue', () => {
 
     enqueueEmail({ to: 'user@example.com', templateId: 1, params: { body: 'Body' } });
     await Promise.resolve();
+    await Promise.resolve();
     expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1);
     expect(sendTemplatedEmailMock.mock.calls[0][0]).toEqual({
       to: 'user@example.com',
@@ -149,6 +151,7 @@ describe('persistent email queue', () => {
     process.env.EMAIL_QUEUE_BACKOFF_MS = '1';
     const sendTemplatedEmailMock: jest.Mock = jest
       .fn()
+      // @ts-ignore
       .mockRejectedValue(new Error('fail') as any);
     jest.doMock('../src/utils/emailUtils', () => ({ sendTemplatedEmail: sendTemplatedEmailMock }));
     const logger = require('../src/utils/logger').default;
@@ -157,6 +160,7 @@ describe('persistent email queue', () => {
     const { enqueueEmail } = require('../src/utils/emailQueue');
 
     enqueueEmail({ to: 'user@example.com', templateId: 1, params: { body: 'Body' } });
+    await Promise.resolve();
     await Promise.resolve();
     expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Summary
- Schedule pending email jobs automatically when the email queue module loads
- Adjust email queue tests to ensure timers restart after module resets

## Testing
- `npm test tests/emailQueue.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b536aa0650832db9c6b7087a68f702