### PR TITLE
Handle bookings without slots

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -196,9 +196,12 @@ export async function fetchBookingHistory(
     limitOffset += ` OFFSET $${params.length}`;
   }
   const res = await client.query(
-    `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason, s.start_time, s.end_time, b.created_at, b.is_staff_booking, b.reschedule_token
+    `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason,
+            CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.start_time END AS start_time,
+            CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.end_time END AS end_time,
+            b.created_at, b.is_staff_booking, b.reschedule_token
        FROM bookings b
-       INNER JOIN slots s ON b.slot_id = s.id
+       LEFT JOIN slots s ON b.slot_id = s.id
        WHERE ${where}
        ORDER BY b.created_at DESC${limitOffset}`,
     params,

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -136,4 +136,11 @@ describe('bookingRepository', () => {
     );
     expect(call[1]).toHaveLength(3);
   });
+
+  it('fetchBookingHistory uses LEFT JOIN on slots', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    await fetchBookingHistory([1], false, undefined, false);
+    const call = (pool.query as jest.Mock).mock.calls[0];
+    expect(call[0]).toMatch(/LEFT JOIN\s+slots\s+s\s+ON b.slot_id = s.id/);
+  });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -97,10 +97,10 @@ function normalizeBooking(b: BookingResponse): Booking {
   const newClientId = b.newClientId ?? new_client_id ?? null;
   return {
     ...rest,
-    start_time: b.start_time ?? b.startTime ?? '',
-    end_time: b.end_time ?? b.endTime ?? '',
-    startTime: b.startTime ?? b.start_time ?? '',
-    endTime: b.endTime ?? b.end_time ?? '',
+    start_time: b.start_time ?? b.startTime ?? null,
+    end_time: b.end_time ?? b.endTime ?? null,
+    startTime: b.startTime ?? b.start_time ?? null,
+    endTime: b.endTime ?? b.end_time ?? null,
     newClientId,
   };
 }

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -171,14 +171,17 @@ export default function BookingUI({
         const existing = (apiErr.details as any)?.existingBooking;
         if (existing) {
           const dateStr = dayjs(existing.date).format('ddd, MMM D, YYYY');
-          const timeStr = dayjs(existing.start_time, 'HH:mm:ss').format('h:mm A');
+          const timeStr = existing.start_time
+            ? dayjs(existing.start_time, 'HH:mm:ss').format('h:mm A')
+            : '';
           const status = existing.status;
           setModal({
             open: true,
             message: (
               <Stack spacing={2}>
                 <Typography>
-                  You already have an {status} appointment on {dateStr} at {timeStr}.
+                  You already have an {status} appointment on {dateStr}
+                  {timeStr ? ` at ${timeStr}` : ''}.
                 </Typography>
                 <Typography>
                   If you need to reschedule, please do so from your bookings{' '}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
@@ -57,6 +57,7 @@ export default function NoShowWeek() {
     const approvedPast = list.filter(
       b =>
         b.status === 'approved' &&
+        b.start_time &&
         toDayjs(`${dateStr}T${b.start_time}`).isBefore(now),
     );
     const noShows = list.filter(b => b.status === 'no_show');

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -211,7 +211,7 @@ export interface BookingResponse {
   id: number;
   status: string;
   date: string;
-  slot_id: number;
+  slot_id: number | null;
   user_id?: number | null;
   new_client_id?: number | null;
   newClientId?: number | null;
@@ -224,19 +224,19 @@ export interface BookingResponse {
   profile_link?: string;
   visits_this_month?: number;
   approved_bookings_this_month?: number;
-  start_time?: string;
-  end_time?: string;
-  startTime?: string;
-  endTime?: string;
+  start_time?: string | null;
+  end_time?: string | null;
+  startTime?: string | null;
+  endTime?: string | null;
   reason?: string;
 }
 
 export interface Booking
   extends Omit<BookingResponse, 'new_client_id' | 'startTime' | 'endTime'> {
-  start_time: string;
-  end_time: string;
-  startTime: string;
-  endTime: string;
+  start_time: string | null;
+  end_time: string | null;
+  startTime: string | null;
+  endTime: string | null;
   newClientId: number | null;
 }
 


### PR DESCRIPTION
## Summary
- Expand booking history to include entries lacking slots with nullable times
- Permit null start/end times across booking types on the frontend
- Guard components against missing slot times

## Testing
- `npm test` (backend) *(fails: Argument of type 'any' is not assignable to parameter of type 'never'; booking and volunteer booking tests fail)*
- `npm test` (frontend)
- `npm test tests/bookingRepository.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b536aecf9c832dafcc9e5f5ae4fdc5