### PR TITLE
test: stabilize VolunteerSchedule timing

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -28,11 +28,15 @@ jest.mock('../api/bookings', () => ({ getHolidays: jest.fn() }));
 
 describe('VolunteerSchedule', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-29T19:00:00Z'));
   });
 
   afterEach(() => {
+    jest.useRealTimers();
+    jest.useFakeTimers();
     jest.setSystemTime(new Date());
+    jest.useRealTimers();
   });
 
   it('disables past days and hides past slots', async () => {


### PR DESCRIPTION
## Summary
- stabilize VolunteerSchedule test by mocking time with fake timers

## Testing
- `npm test src/__tests__/VolunteerSchedule.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b5396d2500832d80fd3484b6f0ea8a