### PR TITLE
Handle missing frontend origin in email links

### DIFF
--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -106,10 +106,15 @@ export async function sendTemplatedEmail({
 export function buildCancelRescheduleLinks(
   token: string,
 ): { cancelLink: string; rescheduleLink: string } {
-  const base = config.frontendOrigins[0];
-  if (!base) {
-    throw new Error('No frontend origin configured; unable to build cancel/reschedule links');
+  if (!config.frontendOrigins.length) {
+    logger.error('No frontend origin configured; returning placeholder links', { token });
+    return {
+      cancelLink: '#',
+      rescheduleLink: '#',
+    };
   }
+
+  const base = config.frontendOrigins[0];
   return {
     cancelLink: `${base}/cancel/${token}`,
     rescheduleLink: `${base}/reschedule/${token}`,

--- a/MJ_FB_Backend/tests/emailLinks.test.ts
+++ b/MJ_FB_Backend/tests/emailLinks.test.ts
@@ -1,5 +1,6 @@
 import { buildCancelRescheduleLinks } from '../src/utils/emailUtils';
 import config from '../src/config';
+import logger from '../src/utils/logger';
 
 describe('buildCancelRescheduleLinks', () => {
   it('returns cancel and reschedule links', () => {
@@ -10,12 +11,16 @@ describe('buildCancelRescheduleLinks', () => {
     });
   });
 
-  it('throws when no frontend origin is configured', () => {
+  it('returns placeholder links when no frontend origin is configured', () => {
     const original = config.frontendOrigins;
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
     config.frontendOrigins = [];
-    expect(() => buildCancelRescheduleLinks('tok')).toThrow(
-      'No frontend origin configured',
-    );
+
+    const links = buildCancelRescheduleLinks('tok');
+    expect(links).toEqual({ cancelLink: '#', rescheduleLink: '#' });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
     config.frontendOrigins = original;
   });
 });


### PR DESCRIPTION
## Summary
- avoid throwing when no frontend origin is configured for cancel/reschedule links
- return placeholder `#` links and log an error
- test email link builder without `FRONTEND_ORIGIN`

## Testing
- `npm test tests/emailLinks.test.ts`
- `npm test` *(fails: 8 failed, 81 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b53b144320832d8adc16c348e1e000