### PR TITLE
Handle dynamic Regina timezone offset

### DIFF
--- a/MJ_FB_Backend/src/utils/dateUtils.ts
+++ b/MJ_FB_Backend/src/utils/dateUtils.ts
@@ -35,5 +35,13 @@ export function formatReginaDateTime(date: string | Date): string {
 }
 
 export function reginaStartOfDayISO(date: string | Date): string {
-  return `${formatReginaDate(date)}T00:00:00-06:00`;
+  const d = toReginaDate(date);
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: REGINA_TZ,
+    timeZoneName: 'longOffset',
+  }).formatToParts(d);
+  const offset =
+    parts.find(p => p.type === 'timeZoneName')?.value.replace('GMT', '') ||
+    REGINA_OFFSET;
+  return `${formatReginaDate(d)}T00:00:00${offset}`;
 }

--- a/MJ_FB_Backend/tests/dateUtils.test.ts
+++ b/MJ_FB_Backend/tests/dateUtils.test.ts
@@ -8,6 +8,20 @@ describe('formatReginaDate', () => {
 
 describe('reginaStartOfDayISO', () => {
   it('returns midnight in Regina for given date string', () => {
+    const realDTF = Intl.DateTimeFormat;
+    const spy = jest
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation((locale, options) => {
+        if ((options as Intl.DateTimeFormatOptions)?.timeZoneName === 'longOffset') {
+          return {
+            formatToParts: () => [{ type: 'timeZoneName', value: 'GMT-06:00' }],
+          } as unknown as Intl.DateTimeFormat;
+        }
+        return new realDTF(locale, options);
+      });
+
     expect(reginaStartOfDayISO('2024-08-26')).toBe('2024-08-26T00:00:00-06:00');
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- derive Regina start-of-day offsets from Intl.DateTimeFormat instead of hardcoding
- mock dynamic offset in dateUtils test

## Testing
- `npm test` *(fails: 8 failed, 81 passed)*
- `npm test tests/dateUtils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b53b12dc7c832d8dafce42b764c441