### PR TITLE
Await email enqueue in booking reminders

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -21,7 +21,7 @@ export async function sendNextDayBookingReminders(): Promise<void> {
         b.reschedule_token,
       );
       const body = `This is a reminder for your booking on ${nextDate}${time}.`;
-      enqueueEmail({
+      await enqueueEmail({
         to: b.user_email,
         templateId: 1,
         params: { body, cancelLink, rescheduleLink },
@@ -29,6 +29,7 @@ export async function sendNextDayBookingReminders(): Promise<void> {
     }
   } catch (err) {
     logger.error('Failed to send booking reminders', err);
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary
- await email queue sends in booking reminder job and propagate errors
- test booking reminder job surfacing enqueueEmail failures

## Testing
- `NODE_OPTIONS=--unhandled-rejections=warn npm test tests/bookingReminderJob.test.ts`
- `NODE_OPTIONS=--unhandled-rejections=warn npm test` *(fails: Cannot read properties of undefined (reading 'rowCount'))*

------
https://chatgpt.com/codex/tasks/task_e_68b53b11d744832db839257024446182