### PR TITLE
feat: add optional startup trigger for scheduled jobs

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -39,6 +39,7 @@ export async function sendNextDayBookingReminders(): Promise<void> {
 const bookingReminderJob = scheduleDailyJob(
   sendNextDayBookingReminders,
   '0 9 * * *',
+  true,
 );
 
 export const startBookingReminderJob = bookingReminderJob.start;

--- a/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
@@ -21,6 +21,7 @@ export async function cleanupNoShows(): Promise<void> {
 const noShowCleanupJob = scheduleDailyJob(
   cleanupNoShows,
   '0 20 * * *',
+  true,
 );
 
 export const startNoShowCleanupJob = noShowCleanupJob.start;

--- a/MJ_FB_Backend/src/utils/scheduleDailyJob.ts
+++ b/MJ_FB_Backend/src/utils/scheduleDailyJob.ts
@@ -3,12 +3,15 @@ import cron from 'node-cron';
 export default function scheduleDailyJob(
   callback: () => void | Promise<void>,
   schedule: string,
+  runOnStart = true,
 ): { start: () => void; stop: () => void } {
   let task: cron.ScheduledTask | undefined;
 
   const start = (): void => {
     if (process.env.NODE_ENV === 'test') return;
-    void callback();
+    if (runOnStart) {
+      void callback();
+    }
     task = cron.schedule(
       schedule,
       () => {

--- a/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
@@ -59,6 +59,7 @@ export async function cleanupVolunteerNoShows(): Promise<void> {
 const volunteerNoShowCleanupJob = scheduleDailyJob(
   cleanupVolunteerNoShows,
   '0 20 * * *',
+  true,
 );
 
 export const startVolunteerNoShowCleanupJob = volunteerNoShowCleanupJob.start;

--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -45,6 +45,7 @@ export async function sendNextDayVolunteerShiftReminders(): Promise<void> {
 const volunteerShiftReminderJob = scheduleDailyJob(
   sendNextDayVolunteerShiftReminders,
   '0 9 * * *',
+  true,
 );
 
 export const startVolunteerShiftReminderJob = volunteerShiftReminderJob.start;

--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -77,16 +77,14 @@ describe('sendNextDayBookingReminders', () => {
 describe('startBookingReminderJob/stopBookingReminderJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
-  let sendSpy: jest.SpyInstance;
   let originalEnv: string | undefined;
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    sendSpy = jest
-      .spyOn(bookingReminder, 'sendNextDayBookingReminders')
-      .mockResolvedValue(undefined);
+    (fetchBookingsForReminder as jest.Mock).mockResolvedValue([]);
+    (enqueueEmail as jest.Mock).mockResolvedValue(undefined);
     originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
   });
@@ -96,7 +94,8 @@ describe('startBookingReminderJob/stopBookingReminderJob', () => {
     await Promise.resolve();
     jest.useRealTimers();
     scheduleMock.mockReset();
-    sendSpy.mockRestore();
+    (fetchBookingsForReminder as jest.Mock).mockReset();
+    (enqueueEmail as jest.Mock).mockReset();
     process.env.NODE_ENV = originalEnv;
   });
 

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -27,13 +27,11 @@ describe('cleanupNoShows', () => {
 describe('startNoShowCleanupJob/stopNoShowCleanupJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
-  let cleanupSpy: jest.SpyInstance;
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    cleanupSpy = jest.spyOn(noShowJob, 'cleanupNoShows').mockResolvedValue(undefined);
     process.env.NODE_ENV = 'development';
   });
 
@@ -42,7 +40,6 @@ describe('startNoShowCleanupJob/stopNoShowCleanupJob', () => {
     await Promise.resolve();
     jest.useRealTimers();
     scheduleMock.mockReset();
-    cleanupSpy.mockRestore();
     process.env.NODE_ENV = originalEnv;
   });
 

--- a/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
@@ -47,13 +47,13 @@ describe('cleanupVolunteerNoShows', () => {
 describe('startVolunteerNoShowCleanupJob/stopVolunteerNoShowCleanupJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
-  let cleanupSpy: jest.SpyInstance;
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    cleanupSpy = jest.spyOn(job, 'cleanupVolunteerNoShows').mockResolvedValue(undefined);
+    (pool.query as jest.Mock).mockResolvedValue({ rowCount: 0, rows: [] });
+    (sendTemplatedEmail as jest.Mock).mockResolvedValue(undefined);
     process.env.NODE_ENV = 'development';
   });
 
@@ -62,7 +62,8 @@ describe('startVolunteerNoShowCleanupJob/stopVolunteerNoShowCleanupJob', () => {
     await Promise.resolve();
     jest.useRealTimers();
     scheduleMock.mockReset();
-    cleanupSpy.mockRestore();
+    (pool.query as jest.Mock).mockReset();
+    (sendTemplatedEmail as jest.Mock).mockReset();
     process.env.NODE_ENV = originalEnv;
   });
 

--- a/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
@@ -4,20 +4,22 @@ const {
   startVolunteerShiftReminderJob,
   stopVolunteerShiftReminderJob,
 } = volunteerJob;
+import pool from '../src/db';
+jest.mock('../src/db');
+import { enqueueEmail } from '../src/utils/emailQueue';
+jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));
 
 describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
-  let sendSpy: jest.SpyInstance;
   let originalEnv: string | undefined;
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    sendSpy = jest
-      .spyOn(volunteerJob, 'sendNextDayVolunteerShiftReminders')
-      .mockResolvedValue(undefined);
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [] });
+    (enqueueEmail as jest.Mock).mockResolvedValue(undefined);
     originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
   });
@@ -27,7 +29,8 @@ describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
     await Promise.resolve();
     jest.useRealTimers();
     scheduleMock.mockReset();
-    sendSpy.mockRestore();
+    (pool.query as jest.Mock).mockReset();
+    (enqueueEmail as jest.Mock).mockReset();
     process.env.NODE_ENV = originalEnv;
   });
 


### PR DESCRIPTION
## Summary
- allow scheduled jobs to skip running on startup via new `runOnStart` flag
- start reminder and cleanup jobs with explicit `runOnStart: true`
- simplify job tests by mocking dependencies instead of spying on callbacks

## Testing
- `npm test tests/bookingReminderJob.test.ts tests/volunteerShiftReminderJob.test.ts tests/noShowCleanupJob.test.ts tests/volunteerNoShowCleanupJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b53e3ce574832dac3d4423f4dd459b