### PR TITLE
Mock database before requiring emailQueue in tests

### DIFF
--- a/MJ_FB_Backend/tests/agency.test.ts
+++ b/MJ_FB_Backend/tests/agency.test.ts
@@ -1,38 +1,20 @@
 import request from 'supertest';
 import express from 'express';
-import usersRouter from '../src/routes/users';
-import bookingsRouter from '../src/routes/bookings';
-import agenciesRoutes from '../src/routes/agencies';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import * as bookingRepository from '../src/models/bookingRepository';
-import {
-  getAgencyByEmail,
-  isAgencyClient,
-  addAgencyClient,
-  removeAgencyClient,
-  clientExists,
-  getAgencyForClient,
-  getAgencyEmail,
-  getClientName,
-  getAgencyClientSet,
-} from '../src/models/agency';
-import * as bookingUtils from '../src/utils/bookingUtils';
-import pool from '../src/db';
-import { enqueueEmail } from '../src/utils/emailQueue';
-import { formatReginaDate } from '../src/utils/dateUtils';
 
-jest.mock('../src/db');
-jest.mock('bcrypt');
-jest.mock('jsonwebtoken');
-jest.mock('../src/utils/emailUtils', () => ({
+jest.doMock('../src/db', () => ({
+  __esModule: true,
+  default: { query: jest.fn(), connect: jest.fn() },
+}));
+jest.doMock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
 }));
-jest.mock('../src/utils/emailQueue', () => ({
+jest.doMock('../src/utils/emailQueue', () => ({
   __esModule: true,
   enqueueEmail: jest.fn(),
 }));
-jest.mock('../src/models/bookingRepository', () => ({
+jest.doMock('../src/models/bookingRepository', () => ({
   __esModule: true,
   ...jest.requireActual('../src/models/bookingRepository'),
   checkSlotCapacity: jest.fn(),
@@ -43,7 +25,7 @@ jest.mock('../src/models/bookingRepository', () => ({
   fetchBookingByToken: jest.fn(),
   updateBooking: jest.fn(),
 }));
-jest.mock('../src/models/agency', () => ({
+jest.doMock('../src/models/agency', () => ({
   __esModule: true,
   ...jest.requireActual('../src/models/agency'),
   getAgencyByEmail: jest.fn(),
@@ -56,8 +38,7 @@ jest.mock('../src/models/agency', () => ({
   getClientName: jest.fn(),
   getAgencyClientSet: jest.fn(),
 }));
-
-jest.mock('../src/middleware/authMiddleware', () => ({
+jest.doMock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (
     req: any,
     _res: express.Response,
@@ -85,6 +66,33 @@ jest.mock('../src/middleware/authMiddleware', () => ({
     next();
   },
 }));
+
+jest.mock('bcrypt');
+jest.mock('jsonwebtoken');
+
+const usersRouter = require('../src/routes/users').default;
+const bookingsRouter = require('../src/routes/bookings').default;
+const agenciesRoutes = require('../src/routes/agencies').default;
+const bookingRepository = require('../src/models/bookingRepository');
+const {
+  getAgencyByEmail,
+  isAgencyClient,
+  addAgencyClient,
+  removeAgencyClient,
+  clientExists,
+  getAgencyForClient,
+  getAgencyEmail,
+  getClientName,
+  getAgencyClientSet,
+} = require('../src/models/agency');
+const bookingUtils = require('../src/utils/bookingUtils');
+const pool = require('../src/db').default;
+const { enqueueEmail } = require('../src/utils/emailQueue');
+const { formatReginaDate } = require('../src/utils/dateUtils');
+
+test('does not query database on import', () => {
+  expect(pool.query).not.toHaveBeenCalled();
+});
 
 const app = express();
 app.use(express.json());

--- a/MJ_FB_Backend/tests/badgeUtils.test.ts
+++ b/MJ_FB_Backend/tests/badgeUtils.test.ts
@@ -1,9 +1,18 @@
-import { awardMilestoneBadge } from '../src/utils/badgeUtils';
-import { enqueueEmail } from '../src/utils/emailQueue';
-
-jest.mock('../src/utils/emailQueue', () => ({
+jest.doMock('../src/db', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+jest.doMock('../src/utils/emailQueue', () => ({
   enqueueEmail: jest.fn(),
 }));
+
+const { awardMilestoneBadge } = require('../src/utils/badgeUtils');
+const { enqueueEmail } = require('../src/utils/emailQueue');
+const db = require('../src/db').default;
+
+test('does not query database on import', () => {
+  expect(db.query).not.toHaveBeenCalled();
+});
 
 describe('awardMilestoneBadge', () => {
   it('queues a thank-you email and returns a card url', () => {

--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -1,20 +1,29 @@
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+
+jest.doMock('../src/db', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+jest.doMock('../src/models/bookingRepository', () => ({
+  fetchBookingsForReminder: jest.fn(),
+}));
+jest.doMock('../src/utils/emailQueue', () => ({
+  enqueueEmail: jest.fn(),
+}));
+
+const { fetchBookingsForReminder } = require('../src/models/bookingRepository');
+const { enqueueEmail } = require('../src/utils/emailQueue');
 const bookingReminder = require('../src/utils/bookingReminderJob');
 const {
   sendNextDayBookingReminders,
   startBookingReminderJob,
   stopBookingReminderJob,
 } = bookingReminder;
-import { fetchBookingsForReminder } from '../src/models/bookingRepository';
-import { enqueueEmail } from '../src/utils/emailQueue';
+const db = require('../src/db').default;
 
-jest.mock('../src/models/bookingRepository', () => ({
-  fetchBookingsForReminder: jest.fn(),
-}));
-
-jest.mock('../src/utils/emailQueue', () => ({
-  enqueueEmail: jest.fn(),
-}));
+test('does not query database on import', () => {
+  expect(db.query).not.toHaveBeenCalled();
+});
 
 describe('sendNextDayBookingReminders', () => {
   let originalEnv: string | undefined;


### PR DESCRIPTION
## Summary
- mock database module in tests that import emailQueue
- require modules after mocking and assert no DB queries on import

## Testing
- `npm test` *(fails: Test Suites: 9 failed, 80 passed, 89 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b53e3d7008832d82b0004d4bfd91f9