### PR TITLE
Use translation key for LanguageSelector tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/LanguageSelector.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/LanguageSelector.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
+import i18n from '../i18n';
 
 describe('Language selector visibility', () => {
   const originalFetch = (global as any).fetch;
@@ -36,7 +37,7 @@ describe('Language selector visibility', () => {
         <App />
       </AuthProvider>
     );
-    expect(screen.getByText(/english/i)).toBeInTheDocument();
+    expect(screen.getByText(i18n.t('english'))).toBeInTheDocument();
   });
 
   it('shows language selector on client dashboard', () => {
@@ -48,7 +49,7 @@ describe('Language selector visibility', () => {
         <App />
       </AuthProvider>
     );
-    expect(screen.getByText(/english/i)).toBeInTheDocument();
+    expect(screen.getByText(i18n.t('english'))).toBeInTheDocument();
   });
 
   it('hides language selector on staff dashboard', () => {
@@ -61,6 +62,6 @@ describe('Language selector visibility', () => {
         <App />
       </AuthProvider>
     );
-    expect(screen.queryByText(/english/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(i18n.t('english'))).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Replace English regex checks with translation key lookups in LanguageSelector tests

## Testing
- `npm test src/__tests__/LanguageSelector.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b54015c818832d893c6c90a8422fb5