### PR TITLE
Expand Jest test discovery for page tests

### DIFF
--- a/MJ_FB_Frontend/jest.config.cjs
+++ b/MJ_FB_Frontend/jest.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   testMatch: [
     '<rootDir>/src/pages/admin/__tests__/**/*.test.tsx',
+    '<rootDir>/src/pages/**/__tests__/**/*.test.tsx',
     '<rootDir>/src/__tests__/**/*.test.tsx',
     '<rootDir>/src/api/__tests__/**/*.test.ts',
   ],


### PR DESCRIPTION
## Summary
- include `src/pages/**/__tests__/**/*.test.tsx` in Jest `testMatch`

## Testing
- `npm test` *(fails: NoShowWeek, PantryVisits, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b54011ff74832da73c7024b84002b3