### PR TITLE
feat: make daily jobs optionally skip initial run

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -39,6 +39,7 @@ export async function sendNextDayBookingReminders(): Promise<void> {
 const bookingReminderJob = scheduleDailyJob(
   sendNextDayBookingReminders,
   '0 9 * * *',
+  true,
 );
 
 export const startBookingReminderJob = bookingReminderJob.start;

--- a/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
@@ -21,6 +21,7 @@ export async function cleanupNoShows(): Promise<void> {
 const noShowCleanupJob = scheduleDailyJob(
   cleanupNoShows,
   '0 20 * * *',
+  true,
 );
 
 export const startNoShowCleanupJob = noShowCleanupJob.start;

--- a/MJ_FB_Backend/src/utils/scheduleDailyJob.ts
+++ b/MJ_FB_Backend/src/utils/scheduleDailyJob.ts
@@ -3,12 +3,15 @@ import cron from 'node-cron';
 export default function scheduleDailyJob(
   callback: () => void | Promise<void>,
   schedule: string,
+  runOnStart = true,
 ): { start: () => void; stop: () => void } {
   let task: cron.ScheduledTask | undefined;
 
   const start = (): void => {
     if (process.env.NODE_ENV === 'test') return;
-    void callback();
+    if (runOnStart) {
+      void callback();
+    }
     task = cron.schedule(
       schedule,
       () => {

--- a/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
@@ -59,6 +59,7 @@ export async function cleanupVolunteerNoShows(): Promise<void> {
 const volunteerNoShowCleanupJob = scheduleDailyJob(
   cleanupVolunteerNoShows,
   '0 20 * * *',
+  true,
 );
 
 export const startVolunteerNoShowCleanupJob = volunteerNoShowCleanupJob.start;

--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -45,6 +45,7 @@ export async function sendNextDayVolunteerShiftReminders(): Promise<void> {
 const volunteerShiftReminderJob = scheduleDailyJob(
   sendNextDayVolunteerShiftReminders,
   '0 9 * * *',
+  true,
 );
 
 export const startVolunteerShiftReminderJob = volunteerShiftReminderJob.start;

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -1,6 +1,13 @@
 const originalEnv = process.env.NODE_ENV;
 process.env.NODE_ENV = 'development';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+jest.mock('../src/utils/scheduleDailyJob', () => {
+  const actual = jest.requireActual('../src/utils/scheduleDailyJob');
+  return {
+    __esModule: true,
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false),
+  };
+});
 const noShowJob = require('../src/utils/noShowCleanupJob');
 const {
   cleanupNoShows,
@@ -27,28 +34,23 @@ describe('cleanupNoShows', () => {
 describe('startNoShowCleanupJob/stopNoShowCleanupJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
-  let cleanupSpy: jest.SpyInstance;
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    cleanupSpy = jest.spyOn(noShowJob, 'cleanupNoShows').mockResolvedValue(undefined);
     process.env.NODE_ENV = 'development';
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     stopNoShowCleanupJob();
-    await Promise.resolve();
     jest.useRealTimers();
     scheduleMock.mockReset();
-    cleanupSpy.mockRestore();
     process.env.NODE_ENV = originalEnv;
   });
 
-  it('schedules and stops the cron job', async () => {
+  it('schedules and stops the cron job', () => {
     startNoShowCleanupJob();
-    await Promise.resolve();
     expect(scheduleMock).toHaveBeenCalledWith(
       '0 20 * * *',
       expect.any(Function),

--- a/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
@@ -8,7 +8,11 @@ jest.mock('../src/utils/volunteerShiftReminderJob', () => {
   const scheduleDailyJob = jest.requireActual(
     '../src/utils/scheduleDailyJob',
   ).default;
-  const job = scheduleDailyJob(sendNextDayVolunteerShiftRemindersMock, '0 9 * * *');
+  const job = scheduleDailyJob(
+    sendNextDayVolunteerShiftRemindersMock,
+    '0 9 * * *',
+    false,
+  );
   return {
     __esModule: true,
     sendNextDayVolunteerShiftReminders: sendNextDayVolunteerShiftRemindersMock,
@@ -49,9 +53,8 @@ describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
     process.env.NODE_ENV = originalEnv;
   });
 
-  it('schedules and stops the cron job without querying the database', async () => {
+  it('schedules and stops the cron job without querying the database', () => {
     startVolunteerShiftReminderJob();
-    await Promise.resolve();
     expect(scheduleMock).toHaveBeenCalledWith(
       '0 9 * * *',
       expect.any(Function),


### PR DESCRIPTION
## Summary
- allow scheduleDailyJob to optionally skip running on start
- explicitly enable startup run for reminder and cleanup jobs
- adjust job tests to disable automatic run during testing

## Testing
- `npm test tests/bookingReminderJob.test.ts tests/noShowCleanupJob.test.ts tests/volunteerNoShowCleanupJob.test.ts tests/volunteerShiftReminderJob.test.ts`
- `npm test` *(fails: Email queue scheduling error: Cannot read properties of undefined (reading 'rowCount'))*

------
https://chatgpt.com/codex/tasks/task_e_68b5400388d8832d907b7681cb8a5dda