### PR TITLE
refactor: use mockFetch helper in tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
-
-const realFetch = global.fetch;
+import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 
 describe('AgencyManagement', () => {
+  let fetchMock: jest.Mock;
+
   beforeEach(() => {
-    (global as any).fetch = jest.fn().mockResolvedValue({
+    fetchMock = mockFetch();
+    fetchMock.mockResolvedValue({
       ok: true,
       status: 204,
       json: async () => ({}),
@@ -16,7 +18,8 @@ describe('AgencyManagement', () => {
   });
 
   afterEach(() => {
-    global.fetch = realFetch;
+    restoreFetch();
+    jest.resetAllMocks();
   });
 
   it('shows tabs for adding agencies and managing clients', async () => {

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
+import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 
-const originalFetch = (global as any).fetch;
+let fetchMock: jest.Mock;
 
 jest.mock('../pages/volunteer-management/VolunteerManagement', () => () => (
   <div>VolunteerManagement</div>
@@ -25,7 +26,8 @@ jest.mock('../api/volunteers', () => ({
 
 describe('App authentication persistence', () => {
   beforeEach(() => {
-    (global as any).fetch = jest.fn().mockResolvedValue({
+    fetchMock = mockFetch();
+    fetchMock.mockResolvedValue({
       ok: true,
       status: 204,
       json: async () => ({}),
@@ -36,15 +38,12 @@ describe('App authentication persistence', () => {
   });
 
   afterEach(() => {
-    if (originalFetch) {
-      (global as any).fetch = originalFetch;
-    } else {
-      delete (global as any).fetch;
-    }
+    restoreFetch();
+    jest.resetAllMocks();
   });
 
   it('shows login when not authenticated', async () => {
-    (global as any).fetch = jest.fn().mockResolvedValue({
+    fetchMock.mockResolvedValue({
       ok: false,
       status: 401,
       json: async () => ({}),

--- a/MJ_FB_Frontend/src/__tests__/LanguageSelector.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/LanguageSelector.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
+import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 
 describe('Language selector visibility', () => {
-  const originalFetch = (global as any).fetch;
+  let fetchMock: jest.Mock;
 
   beforeEach(() => {
-    (global as any).fetch = jest.fn().mockResolvedValue({
+    fetchMock = mockFetch();
+    fetchMock.mockResolvedValue({
       ok: true,
       status: 204,
       json: async () => ({}),
@@ -16,15 +18,12 @@ describe('Language selector visibility', () => {
   });
 
   afterEach(() => {
-    if (originalFetch) {
-      (global as any).fetch = originalFetch;
-    } else {
-      delete (global as any).fetch;
-    }
+    restoreFetch();
+    jest.resetAllMocks();
   });
 
   it('shows language selector on login page', () => {
-    (global as any).fetch = jest.fn().mockResolvedValue({
+    fetchMock.mockResolvedValue({
       ok: false,
       status: 401,
       json: async () => ({}),

--- a/MJ_FB_Frontend/src/__tests__/StaffRecurringLink.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffRecurringLink.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import App from '../App';
 import { AuthProvider } from '../hooks/useAuth';
+import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 
-const originalFetch = (global as any).fetch;
+let fetchMock: jest.Mock;
 
 beforeEach(() => {
-  (global as any).fetch = jest.fn().mockResolvedValue({
+  fetchMock = mockFetch();
+  fetchMock.mockResolvedValue({
     ok: true,
     status: 204,
     json: async () => ({}),
@@ -16,11 +18,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (originalFetch) {
-    (global as any).fetch = originalFetch;
-  } else {
-    delete (global as any).fetch;
-  }
+  restoreFetch();
+  jest.resetAllMocks();
 });
 
 jest.mock('../pages/volunteer-management/VolunteerManagement', () => () => <div>VolunteerManagement</div>);

--- a/MJ_FB_Frontend/src/api/__tests__/fetchWithRetry.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/fetchWithRetry.test.ts
@@ -1,61 +1,65 @@
 import { fetchWithRetry } from '../fetchWithRetry';
+import { mockFetch, restoreFetch } from '../../../testUtils/mockFetch';
 
-const realFetch = global.fetch;
+let fetchMock: jest.Mock;
 
 describe('fetchWithRetry', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    global.fetch = jest.fn();
+    fetchMock = mockFetch();
   });
 
   afterEach(() => {
     jest.useRealTimers();
-    global.fetch = realFetch;
+    restoreFetch();
     jest.resetAllMocks();
   });
 
   it('returns immediately on success', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue(new Response('ok', { status: 200 }));
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+    fetchMock.mockResolvedValue(new Response('ok', { status: 200 }));
     const res = await fetchWithRetry('/test', {}, 2, 100);
     expect(res.status).toBe(200);
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(setTimeout).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).not.toHaveBeenCalled();
   });
 
   it('retries on network failure with exponential backoff', async () => {
     const timeoutSpy = jest.spyOn(global, 'setTimeout');
-    (global.fetch as jest.Mock)
+    fetchMock
       .mockRejectedValueOnce(new Error('net1'))
       .mockRejectedValueOnce(new Error('net2'))
       .mockResolvedValueOnce(new Response('ok'));
 
     const promise = fetchWithRetry('/test', {}, 2, 100);
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(timeoutSpy).not.toHaveBeenCalled();
 
     await Promise.resolve();
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
     jest.runOnlyPendingTimers();
     await Promise.resolve();
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
+    await Promise.resolve();
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 200);
     jest.runOnlyPendingTimers();
     const res = await promise;
     expect(res.status).toBe(200);
-    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     const delays = timeoutSpy.mock.calls.map(([, ms]) => ms);
     expect(delays).toEqual([100, 200]);
   });
 
   it('does not retry on 5xx response', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue(new Response(null, { status: 500 }));
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+    fetchMock.mockResolvedValue(new Response(null, { status: 500 }));
     const res = await fetchWithRetry('/test', {}, 2, 100);
     expect(res.status).toBe(500);
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(setTimeout).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- replace manual global.fetch stubs with mockFetch/restoreFetch
- ensure fetch mocking cleaned up via beforeEach/afterEach in tests

## Testing
- `npm test src/api/__tests__/fetchWithRetry.test.ts` *(fails: fetchWithRetry › does not retry on 5xx response)*


------
https://chatgpt.com/codex/tasks/task_e_68b54013d1ec832da2fe01cfeeb162af