### PR TITLE
Add test skip flag to daily job scheduler

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -40,6 +40,7 @@ const bookingReminderJob = scheduleDailyJob(
   sendNextDayBookingReminders,
   '0 9 * * *',
   true,
+  true,
 );
 
 export const startBookingReminderJob = bookingReminderJob.start;

--- a/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
@@ -22,6 +22,7 @@ const noShowCleanupJob = scheduleDailyJob(
   cleanupNoShows,
   '0 20 * * *',
   true,
+  true,
 );
 
 export const startNoShowCleanupJob = noShowCleanupJob.start;

--- a/MJ_FB_Backend/src/utils/scheduleDailyJob.ts
+++ b/MJ_FB_Backend/src/utils/scheduleDailyJob.ts
@@ -4,11 +4,12 @@ export default function scheduleDailyJob(
   callback: () => void | Promise<void>,
   schedule: string,
   runOnStart = true,
+  skipInTest = true,
 ): { start: () => void; stop: () => void } {
   let task: cron.ScheduledTask | undefined;
 
   const start = (): void => {
-    if (process.env.NODE_ENV === 'test') return;
+    if (skipInTest && process.env.NODE_ENV === 'test') return;
     if (runOnStart) {
       void callback();
     }

--- a/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerNoShowCleanupJob.ts
@@ -60,6 +60,7 @@ const volunteerNoShowCleanupJob = scheduleDailyJob(
   cleanupVolunteerNoShows,
   '0 20 * * *',
   true,
+  true,
 );
 
 export const startVolunteerNoShowCleanupJob = volunteerNoShowCleanupJob.start;

--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -46,6 +46,7 @@ const volunteerShiftReminderJob = scheduleDailyJob(
   sendNextDayVolunteerShiftReminders,
   '0 9 * * *',
   true,
+  true,
 );
 
 export const startVolunteerShiftReminderJob = volunteerShiftReminderJob.start;

--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -15,7 +15,7 @@ jest.doMock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
   return {
     __esModule: true,
-    default: (cb: any, schedule: string) => actual.default(cb, schedule, false),
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
   };
 });
 
@@ -34,17 +34,13 @@ test('does not query database on import', () => {
 });
 
 describe('sendNextDayBookingReminders', () => {
-  let originalEnv: string | undefined;
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-01T12:00:00Z'));
-    originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
   });
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
-    process.env.NODE_ENV = originalEnv;
   });
 
   it('fetches next-day bookings and queues reminder emails', async () => {
@@ -94,21 +90,17 @@ describe('sendNextDayBookingReminders', () => {
 describe('startBookingReminderJob/stopBookingReminderJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
-  let originalEnv: string | undefined;
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
   });
 
   afterEach(() => {
     stopBookingReminderJob();
     jest.useRealTimers();
     scheduleMock.mockReset();
-    process.env.NODE_ENV = originalEnv;
   });
 
   it('schedules and stops the cron job', () => {

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -1,11 +1,9 @@
-const originalEnv = process.env.NODE_ENV;
-process.env.NODE_ENV = 'development';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
   return {
     __esModule: true,
-    default: (cb: any, schedule: string) => actual.default(cb, schedule, false),
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
   };
 });
 const noShowJob = require('../src/utils/noShowCleanupJob');
@@ -39,14 +37,12 @@ describe('startNoShowCleanupJob/stopNoShowCleanupJob', () => {
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    process.env.NODE_ENV = 'development';
   });
 
   afterEach(() => {
     stopNoShowCleanupJob();
     jest.useRealTimers();
     scheduleMock.mockReset();
-    process.env.NODE_ENV = originalEnv;
   });
 
   it('schedules and stops the cron job', () => {
@@ -78,8 +74,4 @@ describe('countVisitsAndBookingsForMonth', () => {
       [userId, start, end],
     );
   });
-});
-
-afterAll(() => {
-  process.env.NODE_ENV = originalEnv;
 });

--- a/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
@@ -1,10 +1,9 @@
-const originalEnv = process.env.NODE_ENV;
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
   return {
     __esModule: true,
-    default: (cb: any, schedule: string) => actual.default(cb, schedule, false),
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
   };
 });
 const job = require('../src/utils/volunteerNoShowCleanupJob');
@@ -59,14 +58,12 @@ describe('startVolunteerNoShowCleanupJob/stopVolunteerNoShowCleanupJob', () => {
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    process.env.NODE_ENV = 'development';
   });
 
   afterEach(() => {
     stopVolunteerNoShowCleanupJob();
     jest.useRealTimers();
     scheduleMock.mockReset();
-    process.env.NODE_ENV = originalEnv;
   });
 
   it('schedules and stops the cron job', () => {
@@ -79,8 +76,4 @@ describe('startVolunteerNoShowCleanupJob/stopVolunteerNoShowCleanupJob', () => {
     stopVolunteerNoShowCleanupJob();
     expect(stopMock).toHaveBeenCalled();
   });
-});
-
-afterAll(() => {
-  process.env.NODE_ENV = originalEnv;
 });

--- a/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
@@ -12,6 +12,7 @@ jest.mock('../src/utils/volunteerShiftReminderJob', () => {
     sendNextDayVolunteerShiftRemindersMock,
     '0 9 * * *',
     false,
+    false,
   );
   return {
     __esModule: true,
@@ -32,15 +33,12 @@ describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
   let querySpy: jest.SpyInstance;
-  let originalEnv: string | undefined;
 
   beforeEach(() => {
     jest.useFakeTimers();
     scheduleMock = require('node-cron').schedule as jest.Mock;
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-    originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
     querySpy = jest.spyOn(pool, 'query');
   });
 
@@ -50,7 +48,6 @@ describe('startVolunteerShiftReminderJob/stopVolunteerShiftReminderJob', () => {
     scheduleMock.mockReset();
     querySpy.mockRestore();
     (sendNextDayVolunteerShiftReminders as jest.Mock).mockReset();
-    process.env.NODE_ENV = originalEnv;
   });
 
   it('schedules and stops the cron job without querying the database', () => {


### PR DESCRIPTION
## Summary
- allow scheduled jobs to skip execution in tests via `skipInTest` flag
- update reminder and cleanup jobs to pass skip flag
- adjust related tests to opt into scheduling without mutating `NODE_ENV`

## Testing
- `npm test tests/bookingReminderJob.test.ts tests/noShowCleanupJob.test.ts tests/volunteerNoShowCleanupJob.test.ts tests/volunteerShiftReminderJob.test.ts`
- `npm test` *(fails: Email queue scheduling error: TypeError: Cannot read properties of undefined (reading 'rowCount'))*


------
https://chatgpt.com/codex/tasks/task_e_68b54320160c832dbe42fecac4dc0727