### PR TITLE
test: isolate import meta env

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/registerServiceWorker.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/registerServiceWorker.test.ts
@@ -4,8 +4,10 @@ describe('registerServiceWorker', () => {
   const originalNodeEnv = process.env.NODE_ENV;
   let registerMock: jest.Mock;
   let originalSecure: boolean;
+  let originalImportMetaEnv: any;
 
   beforeEach(() => {
+    originalImportMetaEnv = (import.meta as any).env;
     originalSecure = window.isSecureContext;
     registerMock = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(window, 'isSecureContext', {
@@ -24,6 +26,7 @@ describe('registerServiceWorker', () => {
     process.env.NODE_ENV = originalNodeEnv;
     // @ts-ignore
     delete navigator.serviceWorker;
+    (import.meta as any).env = originalImportMetaEnv;
   });
 
   it('registers the service worker in production mode', () => {


### PR DESCRIPTION
## Summary
- prevent registerServiceWorker test from leaking import.meta.env between tests

## Testing
- `CI=1 npm test` *(fails: 23 failed, 40 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5430f6adc832dab59e24d853f47ed