### PR TITLE
test: centralize db mocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
 - For changes in `MJ_FB_Backend`, run `npm test` from the `MJ_FB_Backend` directory.
 - For changes in `MJ_FB_Frontend`, run `npm test` from the `MJ_FB_Frontend` directory.
 - Tests polyfill `global.fetch` with `undici` in a `beforeAll`; keep this setup for compatibility.
+- In backend tests, mock the database by importing `../tests/utils/mockDb` instead of calling `jest.mock('../src/db')` directly.
 - Tests for invitation and password setup flows live in `MJ_FB_Backend/tests/passwordResetFlow.test.ts`; run `npm test tests/passwordResetFlow.test.ts` when working on these features.
 
 - Volunteers can earn badges. Use `GET /volunteers/me/stats` to retrieve badges and

--- a/MJ_FB_Backend/tests/adminStaff.test.ts
+++ b/MJ_FB_Backend/tests/adminStaff.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import adminStaffRouter from '../src/routes/admin/adminStaff';
@@ -6,7 +7,6 @@ import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import config from '../src/config';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),

--- a/MJ_FB_Backend/tests/agencyProfile.test.ts
+++ b/MJ_FB_Backend/tests/agencyProfile.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (req: any, _res: any, next: any) => {

--- a/MJ_FB_Backend/tests/authMiddleware.test.ts
+++ b/MJ_FB_Backend/tests/authMiddleware.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import { authMiddleware, optionalAuthMiddleware } from '../src/middleware/authMiddleware';
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db');
 jest.mock('jsonwebtoken', () => ({
   ...jest.requireActual('jsonwebtoken'),
   verify: jest.fn(),

--- a/MJ_FB_Backend/tests/authorization.test.ts
+++ b/MJ_FB_Backend/tests/authorization.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import blockedSlotsRouter from '../src/routes/blockedSlots';
@@ -6,7 +7,6 @@ import { authMiddleware, authorizeRoles, authorizeAccess } from '../src/middlewa
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db');
 jest.mock('jsonwebtoken');
 jest.mock('../src/controllers/slotController', () => ({
   __esModule: true,

--- a/MJ_FB_Backend/tests/blockedSlots.test.ts
+++ b/MJ_FB_Backend/tests/blockedSlots.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import blockedSlotsRouter from '../src/routes/blockedSlots';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/bookingCapacity.test.ts
+++ b/MJ_FB_Backend/tests/bookingCapacity.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';
@@ -5,7 +6,6 @@ import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 import * as bookingRepository from '../src/models/bookingRepository';
 
-jest.mock('../src/db');
 jest.mock('../src/models/bookingRepository', () => ({
   __esModule: true,
   ...jest.requireActual('../src/models/bookingRepository'),

--- a/MJ_FB_Backend/tests/bookingHistoryVisits.test.ts
+++ b/MJ_FB_Backend/tests/bookingHistoryVisits.test.ts
@@ -1,7 +1,7 @@
+import '../tests/utils/mockDb';
 import pool from '../src/db';
 import { fetchBookingHistory } from '../src/models/bookingRepository';
 
-jest.mock('../src/db');
 
 describe('fetchBookingHistory includeVisits', () => {
   beforeEach(() => {

--- a/MJ_FB_Backend/tests/bookingNewClient.test.ts
+++ b/MJ_FB_Backend/tests/bookingNewClient.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';
@@ -6,7 +7,6 @@ import * as bookingRepository from '../src/models/bookingRepository';
 import * as newClientModel from '../src/models/newClient';
 import { formatReginaDate } from '../src/utils/dateUtils';
 
-jest.mock('../src/db');
 jest.mock('../src/models/bookingRepository', () => ({
   __esModule: true,
   ...jest.requireActual('../src/models/bookingRepository'),

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import pool from '../src/db';
 import {
   checkSlotCapacity,
@@ -9,7 +10,6 @@ import {
   fetchBookingHistory,
 } from '../src/models/bookingRepository';
 
-jest.mock('../src/db');
 
 describe('bookingRepository', () => {
   beforeEach(() => {

--- a/MJ_FB_Backend/tests/bookingSlotIdValidation.test.ts
+++ b/MJ_FB_Backend/tests/bookingSlotIdValidation.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';
 import pool from '../src/db';
 import { formatReginaDate } from '../src/utils/dateUtils';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/bookingUtils', () => ({
   isDateWithinCurrentOrNextMonth: jest.fn(),
   countVisitsAndBookingsForMonth: jest.fn(),

--- a/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
+++ b/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';
@@ -10,10 +11,6 @@ jest.mock('../src/models/bookingRepository', () => ({
   updateBooking: jest.fn(),
 }));
 
-jest.mock('../src/db', () => ({
-  __esModule: true,
-  default: { query: jest.fn() },
-}));
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (req: any, _res: express.Response, next: express.NextFunction) => {

--- a/MJ_FB_Backend/tests/clientCancelBooking.test.ts
+++ b/MJ_FB_Backend/tests/clientCancelBooking.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';
@@ -5,7 +6,6 @@ import * as bookingRepository from '../src/models/bookingRepository';
 import pool from '../src/db';
 import { formatReginaDate } from '../src/utils/dateUtils';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));
 jest.mock('../src/models/bookingRepository', () => ({
   __esModule: true,

--- a/MJ_FB_Backend/tests/clientProfileVisitCount.test.ts
+++ b/MJ_FB_Backend/tests/clientProfileVisitCount.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (req: any, _res: any, next: any) => {

--- a/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import clientVisitsRouter from '../src/routes/clientVisits';
@@ -5,7 +6,6 @@ import bookingsRouter from '../src/routes/bookings';
 import pool from '../src/db';
 import * as bookingRepository from '../src/models/bookingRepository';
 
-jest.mock('../src/db');
 jest.mock('../src/models/bookingRepository', () => ({
   __esModule: true,
   ...jest.requireActual('../src/models/bookingRepository'),

--- a/MJ_FB_Backend/tests/createAgency.test.ts
+++ b/MJ_FB_Backend/tests/createAgency.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import agenciesRoutes from '../src/routes/agencies';
@@ -6,7 +7,6 @@ import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import config from '../src/config';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),

--- a/MJ_FB_Backend/tests/createUser.test.ts
+++ b/MJ_FB_Backend/tests/createUser.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';
@@ -6,7 +7,6 @@ import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import config from '../src/config';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),

--- a/MJ_FB_Backend/tests/donationAggregations.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregations.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import donationsRoutes from '../src/routes/warehouse/donations';
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db');
 jest.mock('jsonwebtoken');
 
 const app = express();

--- a/MJ_FB_Backend/tests/donorDonations.test.ts
+++ b/MJ_FB_Backend/tests/donorDonations.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import donorsRoutes from '../src/routes/donors';
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db');
 jest.mock('jsonwebtoken');
 
 const app = express();

--- a/MJ_FB_Backend/tests/events.test.ts
+++ b/MJ_FB_Backend/tests/events.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import eventsRouter from '../src/routes/events';
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db');
 jest.mock('jsonwebtoken');
 
 const app = express();

--- a/MJ_FB_Backend/tests/findUpcomingBooking.test.ts
+++ b/MJ_FB_Backend/tests/findUpcomingBooking.test.ts
@@ -1,8 +1,8 @@
+import '../tests/utils/mockDb';
 import { describe, it, expect, jest } from '@jest/globals';
 import pool from '../src/db';
 import { findUpcomingBooking } from '../src/utils/bookingUtils';
 
-jest.mock('../src/db');
 
 describe('findUpcomingBooking', () => {
   it('ignores bookings with recorded visits', async () => {

--- a/MJ_FB_Backend/tests/holidaysAccess.test.ts
+++ b/MJ_FB_Backend/tests/holidaysAccess.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import holidaysRouter from '../src/routes/holidays';
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db');
 jest.mock('jsonwebtoken');
 
 const app = express();

--- a/MJ_FB_Backend/tests/insertWalkinUser.test.ts
+++ b/MJ_FB_Backend/tests/insertWalkinUser.test.ts
@@ -1,7 +1,7 @@
+import '../tests/utils/mockDb';
 import pool from '../src/db';
 import { insertWalkinUser } from '../src/models/bookingRepository';
 
-jest.mock('../src/db');
 
 describe('insertWalkinUser', () => {
   beforeEach(() => {

--- a/MJ_FB_Backend/tests/login.test.ts
+++ b/MJ_FB_Backend/tests/login.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';
@@ -5,7 +6,6 @@ import pool from '../src/db';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db');
 jest.mock('bcrypt');
 jest.mock('jsonwebtoken');
 jest.mock('../src/utils/bookingUtils', () => ({

--- a/MJ_FB_Backend/tests/logout.test.ts
+++ b/MJ_FB_Backend/tests/logout.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import authRouter from '../src/routes/auth';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 
 const app = express();
 app.use('/auth', authRouter);

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 const originalEnv = process.env.NODE_ENV;
 process.env.NODE_ENV = 'development';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
@@ -15,7 +16,6 @@ const {
   stopNoShowCleanupJob,
 } = noShowJob;
 import pool from '../src/db';
-jest.mock('../src/db');
 
 describe('cleanupNoShows', () => {
   beforeEach(() => {

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import authRouter from '../src/routes/auth';
@@ -11,7 +12,6 @@ import {
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import config from '../src/config';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),

--- a/MJ_FB_Backend/tests/passwordSetupUtils.test.ts
+++ b/MJ_FB_Backend/tests/passwordSetupUtils.test.ts
@@ -1,6 +1,6 @@
+import '../tests/utils/mockDb';
 import { createHash } from 'crypto';
 
-jest.mock('../src/db');
 
 let pool: any;
 

--- a/MJ_FB_Backend/tests/recurringBlockedSlots.test.ts
+++ b/MJ_FB_Backend/tests/recurringBlockedSlots.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import recurringBlockedSlotsRouter from '../src/routes/recurringBlockedSlots';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
+++ b/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import authRouter from '../src/routes/auth';
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db');
 
 const app = express();
 app.use('/auth', authRouter);

--- a/MJ_FB_Backend/tests/slotCrud.test.ts
+++ b/MJ_FB_Backend/tests/slotCrud.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import slotsRouter from '../src/routes/slots';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/slots.test.ts
+++ b/MJ_FB_Backend/tests/slots.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import app from '../src/app';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/slotsCurrentDay.test.ts
+++ b/MJ_FB_Backend/tests/slotsCurrentDay.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import app from '../src/app';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/staffCreation.test.ts
+++ b/MJ_FB_Backend/tests/staffCreation.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import staffRoutes from '../src/routes/admin/staff';
@@ -6,7 +7,6 @@ import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import config from '../src/config';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/passwordSetupUtils');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),

--- a/MJ_FB_Backend/tests/topLists.test.ts
+++ b/MJ_FB_Backend/tests/topLists.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import donorsRoutes from '../src/routes/donors';
 import outgoingReceiversRoutes from '../src/routes/warehouse/outgoingReceivers';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 
 const app = express();
 app.use('/donors', donorsRoutes);

--- a/MJ_FB_Backend/tests/utils/mockDb.ts
+++ b/MJ_FB_Backend/tests/utils/mockDb.ts
@@ -1,0 +1,14 @@
+import { Pool } from 'pg';
+
+const pool = {
+  query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  connect: jest.fn().mockResolvedValue({
+    query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    release: jest.fn(),
+  }),
+  end: jest.fn(),
+} as unknown as Pool;
+
+jest.mock('../../src/db', () => ({ __esModule: true, default: pool }));
+
+export default pool;

--- a/MJ_FB_Backend/tests/volunteerBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBooking.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (
     _req: express.Request,

--- a/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
@@ -5,7 +6,6 @@ import pool from '../src/db';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import logger from '../src/utils/logger';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn().mockResolvedValue(undefined),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerBookingsUnmarked.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsUnmarked.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerGroupStats.test.ts
+++ b/MJ_FB_Backend/tests/volunteerGroupStats.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerStatsRouter from '../src/routes/volunteerStats';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
+++ b/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerStatsRouter from '../src/routes/volunteerStats';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerMasterRoleCascade.test.ts
+++ b/MJ_FB_Backend/tests/volunteerMasterRoleCascade.test.ts
@@ -1,5 +1,7 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
+import pool from '../src/db';
 
 // In-memory mock data to simulate cascading deletes
 const masterRoles = [{ id: 1, name: 'Master' }];
@@ -39,10 +41,8 @@ const mockQuery = jest.fn(async (sql: string, params?: any[]) => {
   return { rows: [], rowCount: 0 };
 });
 
-jest.mock('../src/db', () => ({
-  __esModule: true,
-  default: { query: mockQuery },
-}));
+(pool.query as jest.Mock).mockImplementation(mockQuery);
+
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerMasterRoles.test.ts
+++ b/MJ_FB_Backend/tests/volunteerMasterRoles.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerMasterRolesRouter from '../src/routes/volunteer/volunteerMasterRoles';
 import volunteerRolesRouter from '../src/routes/volunteer/volunteerRoles';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 const originalEnv = process.env.NODE_ENV;
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 jest.mock('../src/utils/scheduleDailyJob', () => {
@@ -14,7 +15,6 @@ const {
   stopVolunteerNoShowCleanupJob,
 } = job;
 import pool from '../src/db';
-jest.mock('../src/db');
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import { VOLUNTEER_NO_SHOW_NOTIFICATION_TEMPLATE_ID } from '../src/config/emailTemplates';
 jest.mock('../src/utils/emailUtils');

--- a/MJ_FB_Backend/tests/volunteerNoShowRanking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowRanking.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerStatsRouter from '../src/routes/volunteerStats';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerRanking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRanking.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerStatsRouter from '../src/routes/volunteerStats';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerRebookCancelled.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRebookCancelled.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import express from 'express';
 import request from 'supertest';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteerRoles.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRoles.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerRolesRouter from '../src/routes/volunteer/volunteerRoles';
 import volunteerMasterRolesRouter from '../src/routes/volunteer/volunteerMasterRoles';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerRolesActive.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesActive.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerRolesRouter from '../src/routes/volunteer/volunteerRoles';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerRolesRouter from '../src/routes/volunteer/volunteerRoles';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerRolesRestore.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesRestore.test.ts
@@ -1,5 +1,7 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
+import pool from '../src/db';
 
 const DEFAULT_MASTER_ROLES = [
   { id: 1, name: 'Pantry' },
@@ -104,10 +106,8 @@ const mockQuery = jest.fn(async (sql: string) => {
 
 const mockConnect = jest.fn(async () => ({ query: mockQuery, release: jest.fn() }));
 
-jest.mock('../src/db', () => ({
-  __esModule: true,
-  default: { query: (sql: string) => mockQuery(sql), connect: mockConnect },
-}));
+(pool.query as jest.Mock).mockImplementation((sql: string) => mockQuery(sql));
+(pool.connect as jest.Mock).mockImplementation(mockConnect);
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';
@@ -6,7 +7,6 @@ import * as bookingRepository from '../src/models/bookingRepository';
 import pool from '../src/db';
 import { formatReginaDate } from '../src/utils/dateUtils';
 
-jest.mock('../src/db');
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteersRouter from '../src/routes/volunteer/volunteers';
@@ -8,7 +9,6 @@ import { generatePasswordSetupToken } from '../src/utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import config from '../src/config';
 
-jest.mock('../src/db');
 jest.mock('bcrypt');
 jest.mock('jsonwebtoken');
 jest.mock('../src/utils/passwordSetupUtils');

--- a/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
@@ -1,10 +1,10 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';
 import pool from '../src/db';
 import writeXlsxFile from 'write-excel-file/node';
 
-jest.mock('../src/db');
 jest.mock('write-excel-file/node', () => jest.fn().mockResolvedValue(Buffer.from('test')));
 
 const app = express();

--- a/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
@@ -1,9 +1,9 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';
 import pool from '../src/db';
 
-jest.mock('../src/db');
 
 const app = express();
 app.use('/warehouse-overall', warehouseOverallRoutes);

--- a/MJ_FB_Backend/tests/warehouseSettings.test.ts
+++ b/MJ_FB_Backend/tests/warehouseSettings.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import warehouseSettingsRouter from '../src/routes/admin/warehouseSettings';
@@ -8,7 +9,6 @@ import {
   clearWarehouseSettingsCache,
 } from '../src/utils/warehouseSettings';
 
-jest.mock('../src/db');
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),


### PR DESCRIPTION
## Summary
- add reusable mockDb helper for tests
- replace ad-hoc `jest.mock('../src/db')` calls with helper import
- document database mocking convention in AGENTS.md

## Testing
- `npm test` *(fails: 8 failing test suites, 13 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b543217838832d951702d8e204a632