### PR TITLE
test: centralize DB mock utility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@
 - For changes in `MJ_FB_Frontend`, run `npm test` from the `MJ_FB_Frontend` directory.
 - Tests polyfill `global.fetch` with `undici` via top-level assignments in `tests/setupFetch.ts`. Ensure this file remains configured in Jest's setup files.
 - Tests for invitation and password setup flows live in `MJ_FB_Backend/tests/passwordResetFlow.test.ts`; run `npm test tests/passwordResetFlow.test.ts` when working on these features.
-- Mock database access in backend tests by importing `../tests/utils/mockDb` instead of calling `jest.mock('../src/db')` directly.
+- Mock database access in backend tests by adding `import '../tests/utils/mockDb'`. The helper mocks `../src/db` and exports the mocked `pool` for custom query behavior.
 
 - Volunteers can earn badges. Use `GET /volunteers/me/stats` to retrieve badges and
   `POST /volunteers/me/badges` to manually award one. The stats endpoint also returns

--- a/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
+++ b/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
@@ -1,3 +1,4 @@
+import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';
@@ -10,10 +11,6 @@ jest.mock('../src/models/bookingRepository', () => ({
   updateBooking: jest.fn(),
 }));
 
-jest.mock('../src/db', () => ({
-  __esModule: true,
-  default: { query: jest.fn() },
-}));
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (req: any, _res: express.Response, next: express.NextFunction) => {

--- a/MJ_FB_Backend/tests/utils/mockDb.ts
+++ b/MJ_FB_Backend/tests/utils/mockDb.ts
@@ -1,5 +1,7 @@
 import { Pool } from 'pg';
 
+// Shared mocked pg Pool for tests that access the database.
+
 const mockPool = {
   query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
   connect: jest.fn().mockResolvedValue({

--- a/MJ_FB_Backend/tests/volunteerMasterRoleCascade.test.ts
+++ b/MJ_FB_Backend/tests/volunteerMasterRoleCascade.test.ts
@@ -1,5 +1,6 @@
 import request from 'supertest';
 import express from 'express';
+import mockDb from '../tests/utils/mockDb';
 
 // In-memory mock data to simulate cascading deletes
 const masterRoles = [{ id: 1, name: 'Master' }];
@@ -39,10 +40,8 @@ const mockQuery = jest.fn(async (sql: string, params?: any[]) => {
   return { rows: [], rowCount: 0 };
 });
 
-jest.mock('../src/db', () => ({
-  __esModule: true,
-  default: { query: mockQuery },
-}));
+(mockDb.query as jest.Mock).mockImplementation(mockQuery);
+
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),

--- a/MJ_FB_Backend/tests/volunteerRolesRestore.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesRestore.test.ts
@@ -1,5 +1,6 @@
 import request from 'supertest';
 import express from 'express';
+import mockDb from '../tests/utils/mockDb';
 
 const DEFAULT_MASTER_ROLES = [
   { id: 1, name: 'Pantry' },
@@ -104,10 +105,8 @@ const mockQuery = jest.fn(async (sql: string) => {
 
 const mockConnect = jest.fn(async () => ({ query: mockQuery, release: jest.fn() }));
 
-jest.mock('../src/db', () => ({
-  __esModule: true,
-  default: { query: (sql: string) => mockQuery(sql), connect: mockConnect },
-}));
+(mockDb.query as jest.Mock).mockImplementation((sql: string) => mockQuery(sql));
+(mockDb.connect as jest.Mock).mockImplementation(mockConnect);
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),


### PR DESCRIPTION
## Summary
- add shared mock database helper
- use shared mock in booking and volunteer role tests
- document mock helper in AGENTS guidelines

## Testing
- `npm test tests/bookingStatusUpdate.test.ts`
- `npm test tests/volunteerMasterRoleCascade.test.ts`
- `npm test tests/volunteerRolesRestore.test.ts`
- `npm test` *(fails: database connection and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bf9e2538832db84591607593d361