### PR TITLE
chore: centralize test setup

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -41,7 +41,11 @@ Authentication cookies are scoped to the `/` path and use the same options when 
 
 `PASSWORD_SETUP_TOKEN_TTL_HOURS` – Hours until password setup tokens expire (default 24).
 
+`PASSWORD_SETUP_TEMPLATE_ID` – Brevo template ID used for password setup emails.
+
 `VOLUNTEER_NO_SHOW_HOURS` – Hours to wait before marking a volunteer shift as no-show (default 24).
+
+Tests mock these variables via `tests/setupEnv.ts`. Update that file when adding new required environment settings.
 
 ## Password Policy
 

--- a/MJ_FB_Backend/jest.config.js
+++ b/MJ_FB_Backend/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
-  setupFiles: ['<rootDir>/tests/setupEnv.ts', '<rootDir>/tests/setupFetch.ts'],
+  setupFiles: ['<rootDir>/tests/setupTests.ts'],
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/MJ_FB_Backend/tests/setupEnv.ts
+++ b/MJ_FB_Backend/tests/setupEnv.ts
@@ -14,4 +14,25 @@ process.env.BREVO_FROM_NAME = 'MJ Food Bank';
 process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS = '24';
 process.env.PASSWORD_SETUP_TEMPLATE_ID = '1';
 
+const requiredEnvVars = [
+  'JWT_SECRET',
+  'JWT_REFRESH_SECRET',
+  'PG_USER',
+  'PG_PASSWORD',
+  'PG_HOST',
+  'PG_PORT',
+  'PG_DATABASE',
+  'FRONTEND_ORIGIN',
+  'BREVO_API_KEY',
+  'BREVO_FROM_EMAIL',
+  'BREVO_FROM_NAME',
+  'PASSWORD_SETUP_TOKEN_TTL_HOURS',
+  'PASSWORD_SETUP_TEMPLATE_ID',
+];
+
+const missing = requiredEnvVars.filter((key) => !process.env[key]);
+if (missing.length > 0) {
+  console.warn(`Warning: Missing environment variables: ${missing.join(', ')}`);
+}
+
 export {};

--- a/MJ_FB_Backend/tests/setupTests.ts
+++ b/MJ_FB_Backend/tests/setupTests.ts
@@ -1,0 +1,5 @@
+// Unified setup for Jest tests.
+import './setupEnv';
+import './setupFetch';
+
+export {};


### PR DESCRIPTION
## Summary
- consolidate Jest setup into single `tests/setupTests.ts`
- document required env vars for tests in backend README
- warn when critical env vars are missing in test setup

## Testing
- `npm test` *(fails: 8 failed, 81 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c99aec4c832d9dfd2311817b2ad0