### PR TITLE
chore: document Node 22 requirement

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - A GitHub Actions workflow in `.github/workflows/release.yml` builds, tests, and deploys container images to Azure Container Apps. Configure repository secrets `AZURE_CREDENTIALS`, `REGISTRY_LOGIN_SERVER`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD` and variables `AZURE_RESOURCE_GROUP`, `BACKEND_APP_NAME`, and `FRONTEND_APP_NAME`; see `docs/release.md` for details.
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 22+ for native `fetch`; earlier versions are not supported.
+- Development is pinned to Node 22 via `.nvmrc`, and `.npmrc` sets `engine-strict=true` to prevent using other Node versions.
 - Booking emails are sent through Brevo; configure `BREVO_API_KEY`, `BREVO_FROM_EMAIL`, and `BREVO_FROM_NAME` in the backend environment.
 - Booking confirmation and reminder emails include Cancel and Reschedule buttons with links generated from each booking's reschedule token.
 - Email queue retries failed sends with exponential backoff and persists jobs in the `email_queue` table so retries survive restarts. Configure `EMAIL_QUEUE_MAX_RETRIES` and `EMAIL_QUEUE_BACKOFF_MS` to adjust retry behavior.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repository uses Git submodules for the backend and frontend components. After cloning, make sure to pull in the submodules and install their dependencies.
 
+## Node Version
+
+Requires **Node.js 22+**. The repo includes a `.nvmrc` file and installation is engine‑strict, so use the pinned version:
+
+```bash
+nvm install   # installs the version listed in .nvmrc
+nvm use
+```
+
 Individuals who use the food bank are referred to as clients throughout the application.
 
 The `clients` table uses `client_id` as its primary key. Do not reference an `id` column for clients; always use `client_id` in database queries and API responses.


### PR DESCRIPTION
## Summary
- enforce Node 22 via `.npmrc` and add engine strict
- document using Node 22 with nvm in README
- mention Node version pin in AGENTS guidance

## Testing
- `npm test` (MJ_FB_Backend) *(fails: client visit booking integration, volunteer booking conflict, etc.)*
- `npm test` (MJ_FB_Frontend) *(fails: multiple test suites such as App authentication persistence, NoShowWeek, HelpPage, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cbe21018832d98097944552d4e8e