### PR TITLE
refactor: centralize mock DB setup

### DIFF
--- a/MJ_FB_Backend/jest.config.js
+++ b/MJ_FB_Backend/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
-  setupFiles: ['<rootDir>/tests/setupTests.ts'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts'],
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/MJ_FB_Backend/tests/adminStaff.test.ts
+++ b/MJ_FB_Backend/tests/adminStaff.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import adminStaffRouter from '../src/routes/admin/adminStaff';

--- a/MJ_FB_Backend/tests/agencyProfile.test.ts
+++ b/MJ_FB_Backend/tests/agencyProfile.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';

--- a/MJ_FB_Backend/tests/authMiddleware.test.ts
+++ b/MJ_FB_Backend/tests/authMiddleware.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import { authMiddleware, optionalAuthMiddleware } from '../src/middleware/authMiddleware';

--- a/MJ_FB_Backend/tests/authorization.test.ts
+++ b/MJ_FB_Backend/tests/authorization.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import blockedSlotsRouter from '../src/routes/blockedSlots';

--- a/MJ_FB_Backend/tests/badgeUtils.test.ts
+++ b/MJ_FB_Backend/tests/badgeUtils.test.ts
@@ -30,3 +30,5 @@ describe('awardMilestoneBadge', () => {
     expect(cardUrl).toContain('gold');
   });
 });
+
+export {};

--- a/MJ_FB_Backend/tests/blockedSlots.test.ts
+++ b/MJ_FB_Backend/tests/blockedSlots.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import blockedSlotsRouter from '../src/routes/blockedSlots';

--- a/MJ_FB_Backend/tests/bookingCapacity.test.ts
+++ b/MJ_FB_Backend/tests/bookingCapacity.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';

--- a/MJ_FB_Backend/tests/bookingHistoryVisits.test.ts
+++ b/MJ_FB_Backend/tests/bookingHistoryVisits.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import pool from '../src/db';
 import { fetchBookingHistory } from '../src/models/bookingRepository';
 

--- a/MJ_FB_Backend/tests/bookingNewClient.test.ts
+++ b/MJ_FB_Backend/tests/bookingNewClient.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import pool from '../src/db';
 import {
   checkSlotCapacity,

--- a/MJ_FB_Backend/tests/bookingSlotIdValidation.test.ts
+++ b/MJ_FB_Backend/tests/bookingSlotIdValidation.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';

--- a/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
+++ b/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';

--- a/MJ_FB_Backend/tests/clientCancelBooking.test.ts
+++ b/MJ_FB_Backend/tests/clientCancelBooking.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';

--- a/MJ_FB_Backend/tests/clientProfileVisitCount.test.ts
+++ b/MJ_FB_Backend/tests/clientProfileVisitCount.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';

--- a/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import clientVisitsRouter from '../src/routes/clientVisits';

--- a/MJ_FB_Backend/tests/createAgency.test.ts
+++ b/MJ_FB_Backend/tests/createAgency.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import agenciesRoutes from '../src/routes/agencies';

--- a/MJ_FB_Backend/tests/createUser.test.ts
+++ b/MJ_FB_Backend/tests/createUser.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';

--- a/MJ_FB_Backend/tests/donationAggregations.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregations.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import donationsRoutes from '../src/routes/warehouse/donations';

--- a/MJ_FB_Backend/tests/donorDonations.test.ts
+++ b/MJ_FB_Backend/tests/donorDonations.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import donorsRoutes from '../src/routes/donors';

--- a/MJ_FB_Backend/tests/events.test.ts
+++ b/MJ_FB_Backend/tests/events.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import eventsRouter from '../src/routes/events';

--- a/MJ_FB_Backend/tests/findUpcomingBooking.test.ts
+++ b/MJ_FB_Backend/tests/findUpcomingBooking.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import { describe, it, expect, jest } from '@jest/globals';
 import pool from '../src/db';
 import { findUpcomingBooking } from '../src/utils/bookingUtils';

--- a/MJ_FB_Backend/tests/holidaysAccess.test.ts
+++ b/MJ_FB_Backend/tests/holidaysAccess.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import holidaysRouter from '../src/routes/holidays';

--- a/MJ_FB_Backend/tests/insertWalkinUser.test.ts
+++ b/MJ_FB_Backend/tests/insertWalkinUser.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import pool from '../src/db';
 import { insertWalkinUser } from '../src/models/bookingRepository';
 

--- a/MJ_FB_Backend/tests/login.test.ts
+++ b/MJ_FB_Backend/tests/login.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';

--- a/MJ_FB_Backend/tests/logout.test.ts
+++ b/MJ_FB_Backend/tests/logout.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import authRouter from '../src/routes/auth';

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import authRouter from '../src/routes/auth';

--- a/MJ_FB_Backend/tests/passwordSetupUtils.test.ts
+++ b/MJ_FB_Backend/tests/passwordSetupUtils.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import { createHash } from 'crypto';
 
 

--- a/MJ_FB_Backend/tests/recurringBlockedSlots.test.ts
+++ b/MJ_FB_Backend/tests/recurringBlockedSlots.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import recurringBlockedSlotsRouter from '../src/routes/recurringBlockedSlots';

--- a/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
+++ b/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import authRouter from '../src/routes/auth';

--- a/MJ_FB_Backend/tests/setupTests.ts
+++ b/MJ_FB_Backend/tests/setupTests.ts
@@ -1,5 +1,6 @@
 // Unified setup for Jest tests.
 import './setupEnv';
 import './setupFetch';
+import './utils/mockDb';
 
 export {};

--- a/MJ_FB_Backend/tests/slotCrud.test.ts
+++ b/MJ_FB_Backend/tests/slotCrud.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import slotsRouter from '../src/routes/slots';

--- a/MJ_FB_Backend/tests/slots.test.ts
+++ b/MJ_FB_Backend/tests/slots.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import app from '../src/app';

--- a/MJ_FB_Backend/tests/slotsCurrentDay.test.ts
+++ b/MJ_FB_Backend/tests/slotsCurrentDay.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import app from '../src/app';

--- a/MJ_FB_Backend/tests/staffCreation.test.ts
+++ b/MJ_FB_Backend/tests/staffCreation.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import staffRoutes from '../src/routes/admin/staff';

--- a/MJ_FB_Backend/tests/topLists.test.ts
+++ b/MJ_FB_Backend/tests/topLists.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import donorsRoutes from '../src/routes/donors';

--- a/MJ_FB_Backend/tests/utils/mockDb.ts
+++ b/MJ_FB_Backend/tests/utils/mockDb.ts
@@ -1,14 +1,15 @@
 import { Pool } from 'pg';
+import { EventEmitter } from 'events';
 
 // Shared mocked pg Pool for tests that access the database.
 
-const mockPool = {
+const mockPool = new EventEmitter() as unknown as Pool & EventEmitter;
+
+(mockPool as any).query = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+(mockPool as any).connect = jest.fn().mockResolvedValue({
   query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
-  connect: jest.fn().mockResolvedValue({
-    query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
-    release: jest.fn(),
-  }),
-} as unknown as Pool;
+  release: jest.fn(),
+});
 
 jest.mock('../../src/db', () => ({
   __esModule: true,

--- a/MJ_FB_Backend/tests/volunteerBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBooking.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerBookingsUnmarked.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsUnmarked.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerGroupStats.test.ts
+++ b/MJ_FB_Backend/tests/volunteerGroupStats.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerStatsRouter from '../src/routes/volunteerStats';

--- a/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
+++ b/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerStatsRouter from '../src/routes/volunteerStats';

--- a/MJ_FB_Backend/tests/volunteerMasterRoles.test.ts
+++ b/MJ_FB_Backend/tests/volunteerMasterRoles.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerMasterRolesRouter from '../src/routes/volunteer/volunteerMasterRoles';

--- a/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');

--- a/MJ_FB_Backend/tests/volunteerNoShowRanking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowRanking.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerStatsRouter from '../src/routes/volunteerStats';

--- a/MJ_FB_Backend/tests/volunteerRanking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRanking.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerStatsRouter from '../src/routes/volunteerStats';

--- a/MJ_FB_Backend/tests/volunteerRebookCancelled.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRebookCancelled.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import express from 'express';
 import request from 'supertest';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';

--- a/MJ_FB_Backend/tests/volunteerRoles.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRoles.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerRolesRouter from '../src/routes/volunteer/volunteerRoles';

--- a/MJ_FB_Backend/tests/volunteerRolesActive.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesActive.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerRolesRouter from '../src/routes/volunteer/volunteerRoles';

--- a/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesAdd.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteerRolesRouter from '../src/routes/volunteer/volunteerRoles';

--- a/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import bookingsRouter from '../src/routes/bookings';

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import volunteersRouter from '../src/routes/volunteer/volunteers';

--- a/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';

--- a/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';

--- a/MJ_FB_Backend/tests/warehouseSettings.test.ts
+++ b/MJ_FB_Backend/tests/warehouseSettings.test.ts
@@ -1,4 +1,3 @@
-import '../tests/utils/mockDb';
 import request from 'supertest';
 import express from 'express';
 import warehouseSettingsRouter from '../src/routes/admin/warehouseSettings';


### PR DESCRIPTION
## Summary
- centralize jest setup to load env, fetch polyfill, and shared DB mock
- switch jest config to setupFilesAfterEnv and extend mock pool with EventEmitter
- drop manual mockDb imports across backend tests

## Testing
- `npm test` *(fails: 9 failed, 80 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cda0622c832d920ffc8018b7d509