### PR TITLE
test: clear email queue timers

### DIFF
--- a/MJ_FB_Backend/tests/emailLinks.test.ts
+++ b/MJ_FB_Backend/tests/emailLinks.test.ts
@@ -1,8 +1,12 @@
 import { buildCancelRescheduleLinks } from '../src/utils/emailUtils';
 import config from '../src/config';
 import logger from '../src/utils/logger';
+import { shutdownQueue } from '../src/utils/emailQueue';
 
 describe('buildCancelRescheduleLinks', () => {
+  afterEach(() => {
+    shutdownQueue();
+  });
   it('returns cancel and reschedule links', () => {
     const links = buildCancelRescheduleLinks('tok');
     expect(links).toEqual({

--- a/MJ_FB_Backend/tests/emailUtilsFailure.test.ts
+++ b/MJ_FB_Backend/tests/emailUtilsFailure.test.ts
@@ -1,5 +1,6 @@
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import logger from '../src/utils/logger';
+import { shutdownQueue } from '../src/utils/emailQueue';
 
 describe('emailUtils error logging', () => {
   const originalFetch = global.fetch;
@@ -28,6 +29,7 @@ describe('emailUtils error logging', () => {
     process.env.BREVO_API_KEY = originalApiKey;
     process.env.BREVO_FROM_EMAIL = originalFromEmail;
     process.env.BREVO_FROM_NAME = originalFromName;
+    shutdownQueue();
     jest.resetAllMocks();
   });
 

--- a/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
+++ b/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
@@ -1,4 +1,5 @@
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
+import { shutdownQueue } from '../src/utils/emailQueue';
 
 describe('sendTemplatedEmail', () => {
   const originalFetch = global.fetch;
@@ -20,6 +21,7 @@ describe('sendTemplatedEmail', () => {
     process.env.BREVO_API_KEY = originalApiKey;
     process.env.BREVO_FROM_EMAIL = originalFromEmail;
     process.env.BREVO_FROM_NAME = originalFromName;
+    shutdownQueue();
     jest.resetAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- ensure email tests clear queue timers via `shutdownQueue`

## Testing
- `npm test tests/emailLinks.test.ts tests/emailUtilsFailure.test.ts tests/sendTemplatedEmail.test.ts tests/emailQueue.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5d9ff00a4832d9136339f8f6a0a17