### PR TITLE
Include setupEnv in Jest config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 - For changes in `MJ_FB_Backend`, run `npm test` from the `MJ_FB_Backend` directory.
 - For changes in `MJ_FB_Frontend`, run `npm test` from the `MJ_FB_Frontend` directory.
 - Tests polyfill `global.fetch` with `undici` via top-level assignments in `tests/setupFetch.ts`. Ensure this file remains configured in Jest's setup files.
+- Tests load required environment variables from `tests/setupEnv.ts`, which is listed in Jest's `setupFilesAfterEnv`. When running a test file directly, import `'../setupEnv'` so these variables are set, or run the test through Jest.
 - Tests for invitation and password setup flows live in `MJ_FB_Backend/tests/passwordResetFlow.test.ts`; run `npm test tests/passwordResetFlow.test.ts` when working on these features.
 - Mock database access in backend tests by adding `import '../tests/utils/mockDb'`. The helper mocks `../src/db` and exports the mocked `pool` for custom query behavior.
 

--- a/MJ_FB_Backend/jest.config.js
+++ b/MJ_FB_Backend/jest.config.js
@@ -2,7 +2,10 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
-  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts'],
+  setupFilesAfterEnv: [
+    '<rootDir>/tests/setupEnv.ts',
+    '<rootDir>/tests/setupTests.ts',
+  ],
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The backend automatically runs any pending database migrations on startup and lo
 - Update `AGENTS.md` with new repository instructions.
 - Reflect user-facing or setup changes in this `README.md`.
 - Tests polyfill `global.fetch` with `undici` using `tests/setupFetch.ts`, which is included in Jest's setup files.
+- Required environment variables are set in `tests/setupEnv.ts`, also listed in Jest's `setupFilesAfterEnv`. If you run a test file directly instead of through Jest, manually import `'../setupEnv'` so these variables are initialized.
 
 ## Help Page Updates
 


### PR DESCRIPTION
## Summary
- ensure jest runs tests/setupEnv.ts and setupTests.ts
- document environment-variable test setup and guidance for running single tests

## Testing
- `npm test` *(fails: Expected 201 Received 400, 9 failed, 81 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5db3516ac832da5bb9e1cab856926