### PR TITLE
Mock CSS url imports in Jest

### DIFF
--- a/MJ_FB_Frontend/jest.config.cjs
+++ b/MJ_FB_Frontend/jest.config.cjs
@@ -10,6 +10,7 @@ module.exports = {
   ],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
+    '\\.css\\?url$': '<rootDir>/testUtils/fileMock.ts',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },
   transform: {

--- a/MJ_FB_Frontend/testUtils/fileMock.ts
+++ b/MJ_FB_Frontend/testUtils/fileMock.ts
@@ -1,0 +1,1 @@
+export default 'test-file-stub';


### PR DESCRIPTION
## Summary
- add file mock returning a stub string
- map `.css?url` imports to the mock in Jest config

## Testing
- `npm test` *(fails: App authentication persistence and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fad9ee8c832d8049bb9adbbdb360