### PR TITLE
test: add renderWithProviders helper

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
 import { loginAgency } from '../api/users';
-import { AuthProvider } from '../hooks/useAuth';
 import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 jest.mock('../api/users', () => ({
   loginAgency: jest.fn(),
@@ -37,11 +37,7 @@ describe('Agency UI access', () => {
       name: 'Agency',
       id: 1,
     });
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    );
+    renderWithProviders(<App />);
 
     const loginLink = await screen.findByText(/agency login/i);
     fireEvent.click(loginLink);
@@ -67,11 +63,7 @@ describe('Agency UI access', () => {
 
   it('redirects unauthenticated users away from agency routes', async () => {
     window.history.pushState({}, '', '/agency/book');
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    );
+    renderWithProviders(<App />);
     await waitFor(() => expect(window.location.pathname).toBe('/login/user'));
     expect(screen.getByText(/client login/i)).toBeInTheDocument();
   });

--- a/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import App from '../App';
-import { AuthProvider } from '../hooks/useAuth';
 import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 describe('AgencyManagement', () => {
   let fetchMock: jest.Mock;
@@ -27,11 +27,7 @@ describe('AgencyManagement', () => {
     localStorage.setItem('name', 'Test Staff');
     localStorage.setItem('access', JSON.stringify(['pantry']));
     window.history.pushState({}, '', '/pantry/agency-management');
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    );
+    renderWithProviders(<App />);
     expect(
       await screen.findByRole('tab', { name: /add agency/i }),
     ).toBeInTheDocument();

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
-import { AuthProvider } from '../hooks/useAuth';
 import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 let fetchMock: jest.Mock;
 
@@ -60,22 +60,14 @@ describe('App authentication persistence', () => {
       json: async () => ({}),
       headers: new Headers(),
     });
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>,
-    );
+    renderWithProviders(<App />);
     expect(await screen.findByText(/client login/i)).toBeInTheDocument();
   });
 
   it('keeps user logged in when role exists', () => {
     localStorage.setItem('role', 'shopper');
     localStorage.setItem('name', 'Test User');
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>,
-    );
+    renderWithProviders(<App />);
     expect(screen.queryByText(/user login/i)).not.toBeInTheDocument();
   });
 
@@ -83,11 +75,7 @@ describe('App authentication persistence', () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');
     window.history.pushState({}, '', '/set-password?token=abc');
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>,
-    );
+    renderWithProviders(<App />);
     const els = await screen.findAllByText(/set password/i);
     expect(els.length).toBeGreaterThan(0);
   });
@@ -96,11 +84,7 @@ describe('App authentication persistence', () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');
     localStorage.setItem('access', JSON.stringify(['pantry']));
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>,
-    );
+    renderWithProviders(<App />);
     await waitFor(() => expect(window.location.pathname).toBe('/pantry'));
   });
 
@@ -109,11 +93,7 @@ describe('App authentication persistence', () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');
     localStorage.setItem('access', JSON.stringify(['volunteer_management']));
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>,
-    );
+    renderWithProviders(<App />);
     await waitFor(() => expect(window.location.pathname).toBe('/volunteer-management'));
   });
 
@@ -121,11 +101,7 @@ describe('App authentication persistence', () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');
     localStorage.setItem('access', JSON.stringify(['warehouse']));
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>,
-    );
+    renderWithProviders(<App />);
     await waitFor(() => expect(window.location.pathname).toBe('/warehouse-management'));
   });
 
@@ -133,11 +109,7 @@ describe('App authentication persistence', () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Admin User');
     localStorage.setItem('access', JSON.stringify(['admin']));
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>,
-    );
+    renderWithProviders(<App />);
     const adminButton = screen.getByRole('button', { name: /admin/i });
     fireEvent.click(adminButton);
     expect(

--- a/MJ_FB_Frontend/src/__tests__/AuthProvider.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AuthProvider.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../hooks/useAuth';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { useAuth } from '../hooks/useAuth';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 jest.mock('../api/client', () => ({
   API_BASE: '',
@@ -39,11 +40,7 @@ describe('AuthProvider cardUrl cleanup', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cardUrl: '/card.pdf' }) });
     (apiLogout as jest.Mock).mockResolvedValue(undefined);
 
-    render(
-      <AuthProvider>
-        <TestComponent />
-      </AuthProvider>,
-    );
+    renderWithProviders(<TestComponent />);
 
     fireEvent.click(screen.getByText('login'));
     await waitFor(() =>
@@ -61,11 +58,7 @@ describe('AuthProvider cardUrl cleanup', () => {
       .mockResolvedValueOnce({ ok: true, status: 200 })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cardUrl: '/card.pdf' }) });
 
-    render(
-      <AuthProvider>
-        <TestComponent />
-      </AuthProvider>,
-    );
+    renderWithProviders(<TestComponent />);
 
     fireEvent.click(screen.getByText('login'));
     await waitFor(() =>

--- a/MJ_FB_Frontend/src/__tests__/LanguageSelector.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/LanguageSelector.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import App from '../App';
-import { AuthProvider } from '../hooks/useAuth';
 import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 import i18n from '../i18n';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 describe('Language selector visibility', () => {
   let fetchMock: jest.Mock;
@@ -31,11 +31,7 @@ describe('Language selector visibility', () => {
       headers: new Headers(),
     });
     window.history.pushState({}, '', '/login/user');
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    );
+    renderWithProviders(<App />);
     expect(screen.getByText(i18n.t('english'))).toBeInTheDocument();
   });
 
@@ -43,11 +39,7 @@ describe('Language selector visibility', () => {
     localStorage.setItem('role', 'shopper');
     localStorage.setItem('name', 'Test User');
     window.history.pushState({}, '', '/');
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    );
+    renderWithProviders(<App />);
     expect(screen.getByText(i18n.t('english'))).toBeInTheDocument();
   });
 
@@ -56,11 +48,7 @@ describe('Language selector visibility', () => {
     localStorage.setItem('name', 'Staff User');
     localStorage.setItem('access', JSON.stringify(['pantry']));
     window.history.pushState({}, '', '/pantry');
-    render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    );
+    renderWithProviders(<App />);
     expect(screen.queryByText(i18n.t('english'))).not.toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/StaffRecurringLink.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffRecurringLink.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import App from '../App';
-import { AuthProvider } from '../hooks/useAuth';
 import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 let fetchMock: jest.Mock;
 
@@ -35,11 +35,7 @@ test('shows Recurring Shifts link for staff with volunteer-management access', a
   localStorage.setItem('name', 'Test Staff');
   localStorage.setItem('access', JSON.stringify(['volunteer_management']));
 
-  render(
-    <AuthProvider>
-      <App />
-    </AuthProvider>
-  );
+  renderWithProviders(<App />);
 
   const vmButton = await screen.findByRole('button', { name: /volunteer management/i });
   fireEvent.click(vmButton);

--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import VolunteerSchedule from '../pages/volunteer-management/VolunteerSchedule';
 import i18n from '../i18n';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 import {
   getVolunteerRolesForVolunteer,
   getMyVolunteerBookings,
@@ -60,7 +61,7 @@ describe('VolunteerSchedule', () => {
       },
     ]);
 
-    render(<VolunteerSchedule />);
+    renderWithProviders(<VolunteerSchedule />);
 
     fireEvent.mouseDown(screen.getByLabelText(i18n.t('role')));
     fireEvent.click(await screen.findByText('Greeter'));

--- a/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
 import { loginVolunteer } from '../api/volunteers';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 jest.mock('../api/volunteers', () => ({
   loginVolunteer: jest.fn(),
@@ -23,7 +24,7 @@ describe('Volunteer with shopper profile', () => {
       userRole: 'shopper',
     });
 
-    render(<App />);
+    renderWithProviders(<App />);
 
     fireEvent.click(screen.getByText(/volunteer login/i));
 

--- a/MJ_FB_Frontend/src/__tests__/loginAppreciation.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/loginAppreciation.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../hooks/useAuth';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { useAuth } from '../hooks/useAuth';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 import { APPRECIATION_MESSAGES } from '../utils/appreciationMessages';
 import type { Role } from '../types';
 
@@ -30,11 +31,7 @@ describe('appreciation message on login', () => {
   });
 
   it('shows appreciation message and card link for volunteers', async () => {
-    render(
-      <AuthProvider>
-        <Trigger role="volunteer" />
-      </AuthProvider>
-    );
+    renderWithProviders(<Trigger role="volunteer" />);
     fireEvent.click(screen.getByText('Login'));
     await waitFor(() => expect(apiFetch).toHaveBeenCalled());
     expect(
@@ -45,11 +42,7 @@ describe('appreciation message on login', () => {
   });
 
   it('does not show appreciation message for staff', async () => {
-    render(
-      <AuthProvider>
-        <Trigger role="staff" />
-      </AuthProvider>
-    );
+    renderWithProviders(<Trigger role="staff" />);
     fireEvent.click(screen.getByText('Login'));
     await waitFor(() => expect(apiFetch).toHaveBeenCalled());
     expect(

--- a/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '../hooks/useAuth';
+import { screen, waitFor } from '@testing-library/react';
+import { useAuth } from '../hooks/useAuth';
 import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 describe('AuthProvider refresh handling', () => {
   let fetchMock: jest.Mock;
@@ -19,11 +20,7 @@ describe('AuthProvider refresh handling', () => {
   });
 
   it('clears auth and shows message when refresh fails', async () => {
-    render(
-      <AuthProvider>
-        <div />
-      </AuthProvider>,
-    );
+    renderWithProviders(<div />);
 
     await waitFor(() => expect(localStorage.getItem('role')).toBeNull());
     expect(await screen.findByText('Session expired')).toBeInTheDocument();
@@ -37,11 +34,7 @@ describe('AuthProvider refresh handling', () => {
       return <div>{ready ? token : ''}</div>;
     }
 
-    render(
-      <AuthProvider>
-        <Child />
-      </AuthProvider>,
-    );
+    renderWithProviders(<Child />);
 
     await waitFor(() => expect(screen.getByText('cookie')).toBeInTheDocument());
     expect(localStorage.getItem('role')).toBe('staff');
@@ -64,11 +57,7 @@ describe('AuthProvider with no prior session', () => {
   it('does not show session expired when refresh fails without auth', async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 401 });
 
-    render(
-      <AuthProvider>
-        <div />
-      </AuthProvider>,
-    );
+    renderWithProviders(<div />);
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     expect(screen.queryByText('Session expired')).toBeNull();

--- a/MJ_FB_Frontend/testUtils/renderWithProviders.tsx
+++ b/MJ_FB_Frontend/testUtils/renderWithProviders.tsx
@@ -1,0 +1,48 @@
+import { render, type RenderOptions } from '@testing-library/react';
+import { AuthProvider } from '../src/hooks/useAuth';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../src/i18n';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { theme } from '../src/theme';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from '../src/utils/date';
+import type { ReactElement, ReactNode } from 'react';
+
+interface ProvidersProps {
+  children: ReactNode;
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  function Wrapper({ children }: ProvidersProps): JSX.Element {
+    return (
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <LocalizationProvider
+              dateAdapter={AdapterDayjs}
+              dateLibInstance={dayjs}
+            >
+              <ThemeProvider theme={theme}>
+                <CssBaseline />
+                {children}
+              </ThemeProvider>
+            </LocalizationProvider>
+          </AuthProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+  }
+
+  return render(ui, { wrapper: Wrapper, ...options });
+}
+
+export * from '@testing-library/react';


### PR DESCRIPTION
## Summary
- add `renderWithProviders` to wrap tests with app providers
- update various tests to use the new helper

## Testing
- `npm test -- src/__tests__/App.test.tsx src/__tests__/VolunteerSchedule.test.tsx src/__tests__/LanguageSelector.test.tsx src/__tests__/AgencyAccess.test.tsx src/__tests__/loginAppreciation.test.tsx src/__tests__/useAuthRefresh.test.tsx src/__tests__/StaffRecurringLink.test.tsx src/__tests__/AgencyManagement.test.tsx src/__tests__/AuthProvider.test.tsx src/__tests__/VolunteerShopperAccess.test.tsx` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68b6159951b4832d8a42ecfae63a2765