### PR TITLE
chore: align Node.js 22 across CI and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: '.nvmrc'
 
       - name: Install backend dependencies
         working-directory: MJ_FB_Backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 22+ for native `fetch`; earlier versions are not supported.
 - Development is pinned to Node 22 via `.nvmrc`, and `.npmrc` sets `engine-strict=true` to prevent using other Node versions.
+- GitHub Actions reads the Node version from `.nvmrc` to keep CI builds and tests on the same runtime.
 - Booking emails are sent through Brevo; configure `BREVO_API_KEY`, `BREVO_FROM_EMAIL`, and `BREVO_FROM_NAME` in the backend environment.
 - Booking confirmation and reminder emails include Cancel and Reschedule buttons with links generated from each booking's reschedule token.
 - Email queue retries failed sends with exponential backoff and persists jobs in the `email_queue` table so retries survive restarts. Configure `EMAIL_QUEUE_MAX_RETRIES` and `EMAIL_QUEUE_BACKOFF_MS` to adjust retry behavior.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ nvm install   # installs the version listed in .nvmrc
 nvm use
 ```
 
+GitHub Actions reads the same `.nvmrc` to run CI on Node 22. Run all backend and frontend tests on this runtime to match CI results.
+
 Individuals who use the food bank are referred to as clients throughout the application.
 
 The `clients` table uses `client_id` as its primary key. Do not reference an `id` column for clients; always use `client_id` in database queries and API responses.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # Release Workflow
 
-The `Release` GitHub Actions workflow builds, tests, and deploys the backend and frontend.
+The `Release` GitHub Actions workflow builds, tests, and deploys the backend and frontend. It reads the Node.js version from `.nvmrc` (Node 22) so CI runs with the same runtime as local development.
 
 ## Triggers
 - Pushes to the `main` branch


### PR DESCRIPTION
## Summary
- have GitHub Actions load Node version from `.nvmrc`
- document Node.js 22 requirement in README and release guide
- note in AGENTS that CI mirrors `.nvmrc` version

## Testing
- `npm test` *(MJ_FB_Backend - failed: 9 failed, 81 passed)*
- `npm test` *(MJ_FB_Frontend - failed with jsdom errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b61940e15c832dbf6a71f06adcad7e