### PR TITLE
test: convert warning color to rgb

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/__tests__/PantryScheduleCapacity.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/PantryScheduleCapacity.test.tsx
@@ -20,8 +20,9 @@ jest.mock('../../../components/RescheduleDialog', () => () => null);
 
 const { getSlots, getBookings, getHolidays } = jest.requireMock('../../../api/bookings');
 
-function hexToRgb(hex: string) {
-  const sanitized = hex.replace('#', '');
+function hexToRgb(color: string) {
+  if (color.startsWith('rgb')) return color;
+  const sanitized = color.replace('#', '');
   const bigint = parseInt(sanitized, 16);
   const r = (bigint >> 16) & 255;
   const g = (bigint >> 8) & 255;
@@ -126,7 +127,7 @@ describe('PantrySchedule status colors', () => {
     const over = await screen.findByText('Over (2)');
     const cell = over.closest('td') as HTMLElement;
     expect(getComputedStyle(cell).backgroundColor).toBe(
-      theme.palette.warning.light,
+      hexToRgb(theme.palette.warning.light),
     );
     fireEvent.mouseOver(over);
     expect(await screen.findByText(/capacity exceeded/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- use hexToRgb helper to compare warning color against computed style
- allow hexToRgb to handle rgb strings

## Testing
- `npm test src/pages/admin/__tests__/PantryScheduleCapacity.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b65053bc8c832d9562dc8a94207f9b