### PR TITLE
feat: add helper to set mock DB results

### DIFF
--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -1,4 +1,4 @@
-import mockPool from './utils/mockDb';
+import mockPool, { setQueryResults } from './utils/mockDb';
 import {
   checkSlotCapacity,
   insertBooking,
@@ -41,7 +41,7 @@ describe('bookingRepository', () => {
   });
 
   it('insertBooking calls query with correct params', async () => {
-    (mockPool.query as jest.Mock).mockResolvedValueOnce({});
+    setQueryResults({});
     await insertBooking(1, 2, 'approved', '', '2024-01-01', false, 'token', null);
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/INSERT INTO bookings/);
@@ -61,7 +61,7 @@ describe('bookingRepository', () => {
   });
 
   it('updateBooking ignores disallowed keys', async () => {
-    (mockPool.query as jest.Mock).mockResolvedValueOnce({});
+    setQueryResults({});
     await updateBooking(1, {
       status: 'cancelled',
       request_data: 'reason',
@@ -83,7 +83,7 @@ describe('bookingRepository', () => {
   });
 
   it('fetchBookings applies optional filters', async () => {
-    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    setQueryResults({ rows: [] });
     await fetchBookings('approved', '2024-01-01', [1, 2]);
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/SELECT/);
@@ -102,7 +102,7 @@ describe('bookingRepository', () => {
   });
 
   it('fetchBookingsForReminder selects only necessary fields', async () => {
-    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    setQueryResults({ rows: [] });
     await fetchBookingsForReminder('2024-01-01');
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/SELECT/);
@@ -117,7 +117,7 @@ describe('bookingRepository', () => {
   });
 
   it('fetchBookingHistory supports arrays and pagination', async () => {
-    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    setQueryResults({ rows: [] });
     await fetchBookingHistory([1, 2], false, undefined, false, 5, 10);
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/SELECT/);
@@ -137,7 +137,7 @@ describe('bookingRepository', () => {
   });
 
   it('fetchBookingHistory uses LEFT JOIN on slots', async () => {
-    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    setQueryResults({ rows: [] });
     await fetchBookingHistory([1], false, undefined, false);
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/LEFT JOIN\s+slots\s+s\s+ON b.slot_id = s.id/);

--- a/MJ_FB_Backend/tests/findUpcomingBooking.test.ts
+++ b/MJ_FB_Backend/tests/findUpcomingBooking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import mockPool from './utils/mockDb';
+import mockPool, { setQueryResults } from './utils/mockDb';
 import { findUpcomingBooking } from '../src/utils/bookingUtils';
 
 
@@ -9,8 +9,8 @@ describe('findUpcomingBooking', () => {
   });
 
   it('ignores bookings with recorded visits', async () => {
-    const mockQuery = mockPool.query as unknown as jest.Mock<any>;
-    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const mockQuery = mockPool.query as jest.Mock;
+    setQueryResults({ rowCount: 0, rows: [] });
     const result = await findUpcomingBooking(1);
     expect(mockQuery).toHaveBeenCalled();
     const query = mockQuery.mock.calls[0][0] as string;

--- a/MJ_FB_Backend/tests/insertWalkinUser.test.ts
+++ b/MJ_FB_Backend/tests/insertWalkinUser.test.ts
@@ -1,4 +1,4 @@
-import mockPool from './utils/mockDb';
+import mockPool, { setQueryResults } from './utils/mockDb';
 import { insertWalkinUser } from '../src/models/bookingRepository';
 
 
@@ -8,7 +8,7 @@ describe('insertWalkinUser', () => {
   });
 
   it('issues INSERT with clients.client_id and profile link', async () => {
-    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ client_id: 123 }] });
+    setQueryResults({ rows: [{ client_id: 123 }] });
 
     const first = 'Test';
     const last = 'User';

--- a/MJ_FB_Backend/tests/setupTests.ts
+++ b/MJ_FB_Backend/tests/setupTests.ts
@@ -1,6 +1,11 @@
 // Unified setup for Jest tests.
 import './setupEnv';
 import './setupFetch';
-import './utils/mockDb';
+import mockPool, { setQueryResults } from './utils/mockDb';
+
+beforeEach(() => {
+  (mockPool.query as jest.Mock).mockReset();
+  setQueryResults({ rows: [], rowCount: 0 });
+});
 
 export {};

--- a/MJ_FB_Backend/tests/utils/mockDb.ts
+++ b/MJ_FB_Backend/tests/utils/mockDb.ts
@@ -11,6 +11,10 @@ const mockPool = new EventEmitter() as unknown as Pool & EventEmitter;
   release: jest.fn(),
 });
 
+export const setQueryResults = (result: any) => {
+  (mockPool.query as jest.Mock).mockResolvedValue(result);
+};
+
 jest.mock('../../src/db', () => ({
   __esModule: true,
   default: mockPool,

--- a/MJ_FB_Backend/tests/volunteerMasterRoleCascade.test.ts
+++ b/MJ_FB_Backend/tests/volunteerMasterRoleCascade.test.ts
@@ -40,9 +40,6 @@ const mockQuery = jest.fn(async (sql: string, params?: any[]) => {
   return { rows: [], rowCount: 0 };
 });
 
-(mockDb.query as jest.Mock).mockImplementation(mockQuery);
-
-
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
@@ -56,6 +53,8 @@ app.use('/volunteer-master-roles', volunteerMasterRolesRouter);
 
 describe('DELETE /volunteer-master-roles/:id', () => {
   beforeEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (mockDb.query as jest.Mock).mockImplementation(mockQuery);
     mockQuery.mockClear();
     masterRoles.splice(0, masterRoles.length, { id: 1, name: 'Master' });
     roles.splice(0, roles.length, { id: 10, name: 'Role', category_id: 1 });
@@ -68,6 +67,10 @@ describe('DELETE /volunteer-master-roles/:id', () => {
       is_wednesday_slot: false,
       is_active: true,
     });
+  });
+
+  afterEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
   });
 
   it('removes associated roles and slots', async () => {

--- a/MJ_FB_Backend/tests/volunteerRolesRestore.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesRestore.test.ts
@@ -105,9 +105,6 @@ const mockQuery = jest.fn(async (sql: string) => {
 
 const mockConnect = jest.fn(async () => ({ query: mockQuery, release: jest.fn() }));
 
-(mockDb.query as jest.Mock).mockImplementation((sql: string) => mockQuery(sql));
-(mockDb.connect as jest.Mock).mockImplementation(mockConnect);
-
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
   authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
@@ -121,6 +118,10 @@ app.use('/volunteer-roles', volunteerRolesRouter);
 
 describe('POST /volunteer-roles/restore', () => {
   beforeEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (mockDb.connect as jest.Mock).mockReset();
+    (mockDb.query as jest.Mock).mockImplementation((sql: string) => mockQuery(sql));
+    (mockDb.connect as jest.Mock).mockImplementation(mockConnect);
     masterRoles = [{ id: 1, name: 'Old' }, { id: 99, name: 'Temp' }];
     roles = [
       { id: 1, name: 'Old Role', category_id: 1 },
@@ -135,6 +136,11 @@ describe('POST /volunteer-roles/restore', () => {
     ];
     tempTrained = [];
     mockQuery.mockClear();
+  });
+
+  afterEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (mockDb.connect as jest.Mock).mockReset();
   });
 
   it('restores defaults and preserves training for existing roles', async () => {


### PR DESCRIPTION
## Summary
- add `setQueryResults` helper for mocked PG pool
- reset mock DB before each test and adjust tests to set query results

## Testing
- `npm test` *(fails: 9 failed, 81 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b65056eec8832d8f41d57a7b7020be