### PR TITLE
Expose booking notes in frontend

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
@@ -77,7 +77,7 @@ describe('ManageBookingDialog', () => {
       <MemoryRouter>
         <ManageBookingDialog
           open
-          booking={{ id: 1, client_id: 5, user_id: 1, visits_this_month: 3, approved_bookings_this_month: 1, date: '2024-02-01', reschedule_token: '', user_name: 'Client', profile_link: 'https://portal.link2feed.ca/org/1605/intake/5' }}
+          booking={{ id: 1, client_id: 5, user_id: 1, visits_this_month: 3, approved_bookings_this_month: 1, date: '2024-02-01', reschedule_token: '', user_name: 'Client', profile_link: 'https://portal.link2feed.ca/org/1605/intake/5', note: 'remember ID' }}
           onClose={() => {}}
           onUpdated={() => {}}
         />
@@ -91,6 +91,20 @@ describe('ManageBookingDialog', () => {
     expect(
       screen.getByText('Visits: 3, Approved bookings: 1'),
     ).toBeInTheDocument();
+    expect(screen.getByText('Note: remember ID')).toBeInTheDocument();
+  });
+  it('renders note when provided', () => {
+    render(
+      <MemoryRouter>
+        <ManageBookingDialog
+          open
+          booking={{ id: 2, client_id: 6, user_id: 1, visits_this_month: 0, approved_bookings_this_month: 0, date: '2024-02-02', reschedule_token: '', user_name: 'Another', profile_link: 'https://portal.link2feed.ca/org/1605/intake/6', note: 'bring cart' }}
+          onClose={() => {}}
+          onUpdated={() => {}}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Note: bring cart')).toBeInTheDocument();
   });
   it('calculates monthly usage when counts are strings', () => {
     render(

--- a/MJ_FB_Frontend/src/__tests__/ManageVolunteerShiftDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageVolunteerShiftDialog.test.tsx
@@ -30,6 +30,7 @@ describe('ManageVolunteerShiftDialog', () => {
     end_time: '12:00:00',
     status: 'approved',
     reschedule_token: 'abc',
+    note: 'bring gloves',
   };
 
   beforeAll(() => {
@@ -88,7 +89,7 @@ describe('ManageVolunteerShiftDialog', () => {
       target: { value: '2024-02-02' },
     });
 
-    fireEvent.mouseDown(screen.getByLabelText(/shift/i));
+    fireEvent.mouseDown(await screen.findByLabelText('Shift'));
     fireEvent.click(await screen.findByRole('option', { name: /9:00/i }));
 
     fireEvent.click(screen.getByText(/submit/i));
@@ -104,6 +105,11 @@ describe('ManageVolunteerShiftDialog', () => {
       <ManageVolunteerShiftDialog open booking={null} onClose={() => {}} onUpdated={() => {}} />,
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it('shows note when provided', () => {
+    render(<ManageVolunteerShiftDialog open booking={booking} onClose={() => {}} onUpdated={() => {}} />);
+    expect(screen.getByText('Note: bring gloves')).toBeInTheDocument();
   });
 });
 

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -93,10 +93,11 @@ export async function createBooking(
 }
 
 function normalizeBooking(b: BookingResponse): Booking {
-  const { new_client_id, ...rest } = b;
+  const { new_client_id, note, ...rest } = b;
   const newClientId = b.newClientId ?? new_client_id ?? null;
   return {
     ...rest,
+    note: note ?? null,
     start_time: b.start_time ?? b.startTime ?? null,
     end_time: b.end_time ?? b.endTime ?? null,
     startTime: b.startTime ?? b.start_time ?? null,

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -15,6 +15,7 @@ import type { LoginResponse } from './users';
 function normalizeVolunteerBooking(b: any): VolunteerBooking {
   return {
     ...b,
+    note: b.note ?? null,
     date: b.date?.split('T')[0] ?? b.date,
     start_time: b.start_time ?? b.startTime,
     end_time: b.end_time ?? b.endTime,

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -167,6 +167,7 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
               {Number(booking.approved_bookings_this_month)}
             </Typography>
           </Stack>
+          {booking.note && <Typography>Note: {booking.note}</Typography>}
           <TextField
             select
             label="Status"

--- a/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
@@ -169,6 +169,7 @@ export default function ManageVolunteerShiftDialog({
           <Typography>
             {booking.role_name} on {booking.date} {formatTime(booking.start_time)} - {formatTime(booking.end_time)}
           </Typography>
+          {booking.note && <Typography>Note: {booking.note}</Typography>}
           <TextField
             select
             label="Status"

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -125,6 +125,7 @@ export interface VolunteerBooking {
   status_color?: string;
   reschedule_token?: string;
   recurring_id?: number;
+  note?: string | null;
 }
 
 export interface VolunteerRecurringBooking {
@@ -150,6 +151,7 @@ export interface VolunteerBookingDetail {
   can_book?: boolean;
   reschedule_token?: string;
   recurring_id?: number;
+  note?: string | null;
 }
 
 export interface RecurringVolunteerBooking {
@@ -229,15 +231,20 @@ export interface BookingResponse {
   startTime?: string | null;
   endTime?: string | null;
   reason?: string;
+  note?: string | null;
 }
 
 export interface Booking
-  extends Omit<BookingResponse, 'new_client_id' | 'startTime' | 'endTime'> {
+  extends Omit<
+    BookingResponse,
+    'new_client_id' | 'startTime' | 'endTime' | 'note'
+  > {
   start_time: string | null;
   end_time: string | null;
   startTime: string | null;
   endTime: string | null;
   newClientId: number | null;
+  note?: string | null;
 }
 
 export interface VolunteerBookingInfo {


### PR DESCRIPTION
## Summary
- support optional note on Booking and VolunteerBookingDetail types
- surface booking note in bookings and volunteer API mappers
- display notes in ManageBookingDialog and ManageVolunteerShiftDialog

## Testing
- `npm test` (fails: 18 failed, 45 passed)
- `npm test src/__tests__/ManageBookingDialog.test.tsx src/__tests__/ManageVolunteerShiftDialog.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b738ee0418832d9cae32ec30fe239b