### PR TITLE
Add note support to client visits and booking history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@
 - The Manage Booking dialog shows the client's name, profile link, and current-month visit count.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
+- Staff or agency users may append `includeVisitNotes=true` to `/bookings/history` to include visit notes.
 - Agencies can filter booking history for multiple clients and paginate results via `/bookings/history?clientIds=1,2&limit=10&offset=0`.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
 - `PUT /slots/capacity` updates the `max_capacity` for all slots.
@@ -240,7 +241,7 @@ The booking flow uses the following PostgreSQL tables. **PK** denotes a primary 
 - **users** – PK `id`; unique `email` and `client_id` (1–9,999,999); `role` is `shopper` or `delivery`; referenced by `bookings.user_id`.
 - **client_email_verifications** – PK `id`; unique `client_id`; FK `client_id` → `clients.id`; stores `email`, `otp_hash`, and `expires_at` for verifying client emails.
 - **bookings** – PK `id`; FK `user_id` → `users.id`; FK `slot_id` → `slots.id`; `status` in `approved|cancelled|no_show|visited`; includes `reschedule_token`.
-- **client_visits** – PK `id`; FK `client_id` → `clients.client_id`; records `date`, `is_anonymous` (default `false`), `weight_with_cart`, `weight_without_cart`, and `pet_item` counts.
+- **client_visits** – PK `id`; FK `client_id` → `clients.client_id`; records `date`, `is_anonymous` (default `false`), `weight_with_cart`, `weight_without_cart`, `pet_item`, and optional `note`.
 - **breaks** – PK `id`; unique `(day_of_week, slot_id)`; FK `slot_id` → `slots.id`.
 - **blocked_slots** – PK `id`; unique `(date, slot_id)`; FK `slot_id` → `slots.id`.
 - **recurring_blocked_slots** – PK `id`; unique `(day_of_week, week_of_month, slot_id)`; FK `slot_id` → `slots.id`; defines weekly/monthly slot blocks with a `reason`.

--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -55,6 +55,7 @@ export async function listVisits(req: Request, res: Response, next: NextFunction
     const result = await pool.query(
       `SELECT v.id, v.date, v.client_id as "clientId", v.weight_with_cart as "weightWithCart",
               v.weight_without_cart as "weightWithoutCart", v.pet_item as "petItem", v.is_anonymous as "anonymous",
+              v.note as "note",
               COALESCE(c.first_name || ' ' || c.last_name, '') as "clientName"
        FROM client_visits v
        LEFT JOIN clients c ON v.client_id = c.client_id
@@ -72,14 +73,22 @@ export async function listVisits(req: Request, res: Response, next: NextFunction
 export async function addVisit(req: Request, res: Response, next: NextFunction) {
   const client = await pool.connect();
   try {
-    const { date, clientId, weightWithCart, weightWithoutCart, petItem, anonymous } = req.body;
+    const { date, clientId, weightWithCart, weightWithoutCart, petItem, anonymous, note } = req.body;
     await client.query('BEGIN');
     const insertRes = await client.query(
-      `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous)
-       VALUES ($1, $2, $3, $4, COALESCE($5,0), $6)
+      `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous, note)
+       VALUES ($1, $2, $3, $4, COALESCE($5,0), $6, $7)
        RETURNING id, date, client_id as "clientId", weight_with_cart as "weightWithCart",
-                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous"`,
-      [date, clientId ?? null, weightWithCart, weightWithoutCart, petItem ?? 0, anonymous ?? false]
+                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous", note as "note"`,
+      [
+        date,
+        clientId ?? null,
+        weightWithCart,
+        weightWithoutCart,
+        petItem ?? 0,
+        anonymous ?? false,
+        note ?? null,
+      ]
     );
     let clientName: string | null = null;
     if (clientId) {
@@ -143,16 +152,25 @@ export async function addVisit(req: Request, res: Response, next: NextFunction) 
 export async function updateVisit(req: Request, res: Response, next: NextFunction) {
   try {
     const { id } = req.params;
-    const { date, clientId, weightWithCart, weightWithoutCart, petItem, anonymous } = req.body;
+    const { date, clientId, weightWithCart, weightWithoutCart, petItem, anonymous, note } = req.body;
     const existing = await pool.query('SELECT client_id FROM client_visits WHERE id = $1', [id]);
     const prevClientId: number | null = existing.rows[0]?.client_id ?? null;
     const result = await pool.query(
       `UPDATE client_visits
-       SET date = $1, client_id = $2, weight_with_cart = $3, weight_without_cart = $4, pet_item = COALESCE($5,0), is_anonymous = $6
-       WHERE id = $7
+       SET date = $1, client_id = $2, weight_with_cart = $3, weight_without_cart = $4, pet_item = COALESCE($5,0), is_anonymous = $6, note = $7
+       WHERE id = $8
        RETURNING id, date, client_id as "clientId", weight_with_cart as "weightWithCart",
-                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous"`,
-      [date, clientId ?? null, weightWithCart, weightWithoutCart, petItem ?? 0, anonymous ?? false, id]
+                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous", note as "note"`,
+      [
+        date,
+        clientId ?? null,
+        weightWithCart,
+        weightWithoutCart,
+        petItem ?? 0,
+        anonymous ?? false,
+        note ?? null,
+        id,
+      ]
     );
     let clientName: string | null = null;
     if (clientId) {

--- a/MJ_FB_Backend/src/migrations/1730100000000_client_visit_note.ts
+++ b/MJ_FB_Backend/src/migrations/1730100000000_client_visit_note.ts
@@ -1,0 +1,11 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('client_visits', {
+    note: { type: 'text' },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('client_visits', 'note');
+}

--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -199,7 +199,7 @@ export async function fetchBookingHistory(
     limitOffset += ` OFFSET $${params.length}`;
   }
   const res = await client.query(
-    `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason,
+    `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason, b.note,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.start_time END AS start_time,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.end_time END AS end_time,
             b.created_at, b.is_staff_booking, b.reschedule_token
@@ -216,7 +216,7 @@ export async function fetchBookingHistory(
       visitWhere.push('v.date < CURRENT_DATE');
     }
     const visitRes = await client.query(
-      `SELECT v.id, 'visited' AS status, v.date, NULL AS slot_id, NULL AS reason, NULL AS start_time, NULL AS end_time, v.date AS created_at, false AS is_staff_booking, NULL AS reschedule_token
+      `SELECT v.id, 'visited' AS status, v.date, NULL AS slot_id, NULL AS reason, v.note, NULL AS start_time, NULL AS end_time, v.date AS created_at, false AS is_staff_booking, NULL AS reschedule_token
          FROM client_visits v
          INNER JOIN clients c ON c.client_id = v.client_id
          LEFT JOIN bookings b ON b.user_id = c.client_id AND b.date = v.date

--- a/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
@@ -7,6 +7,7 @@ export const clientVisitSchema = z.object({
   weightWithCart: z.number().int(),
   weightWithoutCart: z.number().int(),
   petItem: z.number().int().optional(),
+  note: z.string().optional(),
 });
 
 export const addVisitSchema = clientVisitSchema;

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -168,7 +168,8 @@ CREATE TABLE IF NOT EXISTS client_visits (
     is_anonymous boolean NOT NULL DEFAULT false,
     weight_with_cart integer NOT NULL,
     weight_without_cart integer NOT NULL,
-    pet_item integer NOT NULL DEFAULT 0
+    pet_item integer NOT NULL DEFAULT 0,
+    note text
 );
 
 CREATE TABLE IF NOT EXISTS surplus_log (

--- a/MJ_FB_Backend/tests/bookingHistoryVisitNotes.test.ts
+++ b/MJ_FB_Backend/tests/bookingHistoryVisitNotes.test.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction } from 'express';
+
+describe('getBookingHistory includeVisitNotes', () => {
+  let getBookingHistory: any;
+  let fetchBookingHistory: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/utils/emailQueue', () => ({
+        __esModule: true,
+        enqueueEmail: jest.fn(),
+      }));
+      jest.doMock('../src/models/bookingRepository', () => ({
+        __esModule: true,
+        fetchBookingHistory: jest
+          .fn()
+          .mockResolvedValue([{ id: 1, status: 'visited', slot_id: null, note: 'hello' }]),
+      }));
+      getBookingHistory = require('../src/controllers/bookingController').getBookingHistory;
+      fetchBookingHistory = require('../src/models/bookingRepository').fetchBookingHistory;
+    });
+  });
+
+  function makeReq(role: string, query: any = {}): Request {
+    return { user: { id: '1', role, userId: '1' }, query } as unknown as Request;
+  }
+
+  it('forbids notes for non staff/agency', async () => {
+    const req = makeReq('shopper', { includeVisitNotes: 'true' });
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+    await getBookingHistory(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Forbidden' });
+    expect(fetchBookingHistory).not.toHaveBeenCalled();
+  });
+
+  it('allows notes for staff', async () => {
+    const req = makeReq('staff', { userId: '1', includeVisitNotes: 'true' });
+    const res = { json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+    await getBookingHistory(req, res, next);
+    expect(fetchBookingHistory).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ note: 'hello' })]),
+    );
+  });
+});

--- a/MJ_FB_Backend/tests/bookingHistoryVisits.test.ts
+++ b/MJ_FB_Backend/tests/bookingHistoryVisits.test.ts
@@ -33,6 +33,7 @@ describe('fetchBookingHistory includeVisits', () => {
             date: '2024-01-02',
             slot_id: null,
             reason: null,
+            note: null,
             start_time: null,
             end_time: null,
             created_at: '2024-01-02',
@@ -49,6 +50,7 @@ describe('fetchBookingHistory includeVisits', () => {
     const visitQuery = (mockPool.query as jest.Mock).mock.calls[1][0];
     expect(visitQuery).toMatch(/LEFT JOIN bookings b/);
     expect(visitQuery).toMatch(/b\.id IS NULL/);
+    expect(visitQuery).toMatch(/v\.note/);
   });
 
   it('omits visits that already have a booking', async () => {
@@ -76,6 +78,7 @@ describe('fetchBookingHistory includeVisits', () => {
     const visitQuery = (mockPool.query as jest.Mock).mock.calls[1][0];
     expect(visitQuery).toMatch(/LEFT JOIN bookings b/);
     expect(visitQuery).toMatch(/b\.id IS NULL/);
+    expect(visitQuery).toMatch(/v\.note/);
   });
 });
 

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -126,6 +126,7 @@ describe('bookingRepository', () => {
     expect(call[0]).toMatch(/WHERE/);
     expect(call[0]).toMatch(/b.user_id = ANY\(\$1\)/);
     expect(call[0]).toMatch(/ORDER BY b.created_at DESC/);
+    expect(call[0]).toMatch(/b\.note/);
     expect(call[0]).toMatch(/LIMIT \$2/);
     expect(call[0]).toMatch(/OFFSET \$3/);
     expect(call[1]).toEqual(

--- a/MJ_FB_Frontend/src/__tests__/bookingsApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/bookingsApi.test.ts
@@ -31,4 +31,12 @@ describe('bookings api', () => {
       body: JSON.stringify({ requestData: 'notes' }),
     }));
   });
+
+  it('includes note when provided', async () => {
+    await markBookingVisited(8, undefined, 'memo');
+    expect(apiFetch).toHaveBeenCalledWith('/api/bookings/8/visited', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ note: 'memo' }),
+    }));
+  });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -125,6 +125,7 @@ export async function getBookingHistory(
     past?: boolean;
     userId?: number;
     includeVisits?: boolean;
+    includeVisitNotes?: boolean;
     clientIds?: number[];
     limit?: number;
     offset?: number;
@@ -135,6 +136,7 @@ export async function getBookingHistory(
   if (opts.past) params.append('past', 'true');
   if (opts.userId) params.append('userId', String(opts.userId));
   if (opts.includeVisits) params.append('includeVisits', 'true');
+  if (opts.includeVisitNotes) params.append('includeVisitNotes', 'true');
   if (opts.clientIds && opts.clientIds.length)
     params.append('clientIds', opts.clientIds.join(','));
   if (typeof opts.limit === 'number')
@@ -285,11 +287,15 @@ export async function markBookingNoShow(
 export async function markBookingVisited(
   bookingId: number,
   requestData?: string,
+  note?: string,
 ): Promise<void> {
+  const body: any = {};
+  if (requestData) body.requestData = requestData;
+  if (note) body.note = note;
   const res = await apiFetch(`${API_BASE}/bookings/${bookingId}/visited`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(requestData ? { requestData } : {}),
+    body: JSON.stringify(body),
   });
   await handleResponse<void>(res);
 }

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -229,6 +229,7 @@ export interface BookingResponse {
   startTime?: string | null;
   endTime?: string | null;
   reason?: string;
+  note?: string | null;
 }
 
 export interface Booking

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Before merging a pull request, confirm the following:
 ## Features
 
 - Appointment booking workflow for clients with automatic approval and rescheduling.
-- Bookings support an optional **note** field stored and returned via `/bookings` endpoints.
+- Bookings support an optional **note** field stored and returned via `/bookings` endpoints. Client visits also allow an optional note.
  - Help page offers role-specific guidance with real-time search and a printable view. Admins can view all help topics, including client and volunteer guidance.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas; volunteers can only book shifts in roles they are trained for.
@@ -100,6 +100,7 @@ Before merging a pull request, confirm the following:
  - Booking requests are automatically approved; the submitted state has been removed.
  - Booking confirmations display "Shift booked"; the volunteer dashboard shows only approved bookings.
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
+- Staff and agency users can add `includeVisitNotes=true` to `/bookings/history` to receive visit notes.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.
 - **Volunteer Recurring Bookings** let volunteers schedule repeating shifts with start and end dates, choose daily, weekly, or weekday patterns, and cancel individual occurrences or the remaining series.


### PR DESCRIPTION
## Summary
- add note column to client_visits and database setup
- surface visit notes through controllers, booking history, and frontend types
- allow staff or agencies to request visit notes via includeVisitNotes flag

## Testing
- `npm test` (backend) *(fails: 9 failed, 82 passed)*
- `npm test` (frontend) *(fails: see TypeError in jsdom and test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68b7393c4da8832d993b8a15e9d5ea1b