### PR TITLE
Add notes to client visit records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@
 - The Manage Booking dialog shows the client's name, profile link, and current-month visit count.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
+- Staff and agency users may append `includeVisitNotes=true` to `/bookings/history` to retrieve notes recorded on client visits.
 - Agencies can filter booking history for multiple clients and paginate results via `/bookings/history?clientIds=1,2&limit=10&offset=0`.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
 - `PUT /slots/capacity` updates the `max_capacity` for all slots.

--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -292,14 +292,15 @@ export async function markBookingVisited(req: Request, res: Response, next: Next
   const weightWithCart = req.body?.weightWithCart as number | undefined;
   const weightWithoutCart = req.body?.weightWithoutCart as number | undefined;
   const petItem = req.body?.petItem as number | undefined;
+  const note = req.body?.note as string | undefined;
   try {
     const insertRes = await pool.query(
-      `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous)
-       SELECT b.date, b.user_id, $1, $2, COALESCE($3,0), false
+      `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous, note)
+       SELECT b.date, b.user_id, $1, $2, COALESCE($3,0), false, $4
        FROM bookings b
-       WHERE b.id = $4
+       WHERE b.id = $5
        RETURNING client_id`,
-      [weightWithCart ?? null, weightWithoutCart ?? null, petItem ?? 0, bookingId],
+      [weightWithCart ?? null, weightWithoutCart ?? null, petItem ?? 0, note ?? null, bookingId],
     );
     await updateBooking(bookingId, { status: 'visited', request_data: requestData });
     const clientId: number | null = insertRes.rows[0]?.client_id ?? null;
@@ -710,6 +711,16 @@ export async function getBookingHistory(
     const status = (req.query.status as string)?.toLowerCase();
     const past = req.query.past === 'true';
     const includeVisits = req.query.includeVisits === 'true';
+    const includeVisitNotes = req.query.includeVisitNotes === 'true';
+    if (
+      includeVisitNotes &&
+      requester.role !== 'staff' &&
+      requester.role !== 'agency'
+    ) {
+      return res
+        .status(403)
+        .json({ message: 'Not authorized to include visit notes' });
+    }
     const limitParam = req.query.limit as string | undefined;
     const offsetParam = req.query.offset as string | undefined;
     const limit = limitParam ? Number(limitParam) : undefined;
@@ -730,6 +741,11 @@ export async function getBookingHistory(
       limit,
       offset,
     );
+    if (!includeVisitNotes) {
+      for (const row of rows as any[]) {
+        if ('note' in row) delete (row as any).note;
+      }
+    }
     res.json(rows);
   } catch (error) {
     logger.error('Error fetching booking history:', error);

--- a/MJ_FB_Backend/src/migrations/1730500000000_client_visit_note.ts
+++ b/MJ_FB_Backend/src/migrations/1730500000000_client_visit_note.ts
@@ -1,0 +1,12 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('client_visits', {
+    note: { type: 'text' },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('client_visits', 'note');
+}
+

--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -216,7 +216,7 @@ export async function fetchBookingHistory(
       visitWhere.push('v.date < CURRENT_DATE');
     }
     const visitRes = await client.query(
-      `SELECT v.id, 'visited' AS status, v.date, NULL AS slot_id, NULL AS reason, NULL AS start_time, NULL AS end_time, v.date AS created_at, false AS is_staff_booking, NULL AS reschedule_token
+      `SELECT v.id, 'visited' AS status, v.date, NULL AS slot_id, NULL AS reason, NULL AS start_time, NULL AS end_time, v.date AS created_at, false AS is_staff_booking, NULL AS reschedule_token, v.note
          FROM client_visits v
          INNER JOIN clients c ON c.client_id = v.client_id
          LEFT JOIN bookings b ON b.user_id = c.client_id AND b.date = v.date

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -48,7 +48,7 @@ router.get(
 );
 
 // Booking history for user or staff lookup
-// Optional query params: status, past=true, userId (staff/agency), includeVisits=true
+// Optional query params: status, past=true, userId (staff/agency), includeVisits=true, includeVisitNotes=true
 router.get('/history', authMiddleware, getBookingHistory);
 
 // Cancel booking (staff or user)

--- a/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
@@ -7,6 +7,7 @@ export const clientVisitSchema = z.object({
   weightWithCart: z.number().int(),
   weightWithoutCart: z.number().int(),
   petItem: z.number().int().optional(),
+  note: z.string().optional(),
 });
 
 export const addVisitSchema = clientVisitSchema;

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -168,7 +168,8 @@ CREATE TABLE IF NOT EXISTS client_visits (
     is_anonymous boolean NOT NULL DEFAULT false,
     weight_with_cart integer NOT NULL,
     weight_without_cart integer NOT NULL,
-    pet_item integer NOT NULL DEFAULT 0
+    pet_item integer NOT NULL DEFAULT 0,
+    note text
 );
 
 CREATE TABLE IF NOT EXISTS surplus_log (

--- a/MJ_FB_Backend/tests/includeVisitNotesAuth.test.ts
+++ b/MJ_FB_Backend/tests/includeVisitNotesAuth.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest';
+import express from 'express';
+import bookingsRouter from '../src/routes/bookings';
+
+jest.mock('../src/models/bookingRepository', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/models/bookingRepository'),
+  fetchBookingHistory: jest.fn().mockResolvedValue([]),
+}));
+const { fetchBookingHistory } = require('../src/models/bookingRepository');
+
+let currentUser: any = { id: 1, role: 'shopper' };
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = currentUser;
+    next();
+  },
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  optionalAuthMiddleware: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  authorizeAccess: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+const app = express();
+app.use('/bookings', bookingsRouter);
+app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  res.status(err.status || 500).json({ message: err.message });
+});
+
+describe('includeVisitNotes authorization', () => {
+  it('rejects shoppers requesting visit notes', async () => {
+    currentUser = { id: 1, role: 'shopper' };
+    const res = await request(app).get('/bookings/history?includeVisitNotes=true');
+    expect(res.status).toBe(403);
+  });
+
+  it('allows staff to request visit notes', async () => {
+    currentUser = { id: 2, role: 'staff' };
+    const res = await request(app).get('/bookings/history?userId=1&includeVisitNotes=true');
+    expect(res.status).not.toBe(403);
+    expect(fetchBookingHistory).toHaveBeenCalled();
+  });
+});
+

--- a/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
@@ -25,11 +25,11 @@ describe('bookings api', () => {
     }));
   });
 
-  it('calls visited endpoint', async () => {
-    await markBookingVisited(7, 'notes');
+  it('calls visited endpoint with note', async () => {
+    await markBookingVisited(7, 'notes', 'visit');
     expect(apiFetch).toHaveBeenCalledWith('/api/bookings/7/visited', expect.objectContaining({
       method: 'POST',
-      body: JSON.stringify({ requestData: 'notes' }),
+      body: JSON.stringify({ requestData: 'notes', note: 'visit' }),
     }));
   });
 

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -131,6 +131,7 @@ export async function getBookingHistory(
     past?: boolean;
     userId?: number;
     includeVisits?: boolean;
+    includeVisitNotes?: boolean;
     clientIds?: number[];
     limit?: number;
     offset?: number;
@@ -141,6 +142,7 @@ export async function getBookingHistory(
   if (opts.past) params.append('past', 'true');
   if (opts.userId) params.append('userId', String(opts.userId));
   if (opts.includeVisits) params.append('includeVisits', 'true');
+  if (opts.includeVisitNotes) params.append('includeVisitNotes', 'true');
   if (opts.clientIds && opts.clientIds.length)
     params.append('clientIds', opts.clientIds.join(','));
   if (typeof opts.limit === 'number')
@@ -291,11 +293,15 @@ export async function markBookingNoShow(
 export async function markBookingVisited(
   bookingId: number,
   requestData?: string,
+  note?: string,
 ): Promise<void> {
+  const body: Record<string, unknown> = {};
+  if (requestData) body.requestData = requestData;
+  if (note) body.note = note;
   const res = await apiFetch(`${API_BASE}/bookings/${bookingId}/visited`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(requestData ? { requestData } : {}),
+    body: JSON.stringify(body),
   });
   await handleResponse<void>(res);
 }

--- a/MJ_FB_Frontend/src/api/clientVisits.ts
+++ b/MJ_FB_Frontend/src/api/clientVisits.ts
@@ -1,15 +1,5 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
-
-export interface ClientVisit {
-  id: number;
-  date: string;
-  clientId: number | null;
-  clientName: string | null;
-  anonymous: boolean;
-  weightWithCart: number;
-  weightWithoutCart: number;
-  petItem: number;
-}
+import type { ClientVisit } from '../types';
 
 export async function getClientVisits(date: string): Promise<ClientVisit[]> {
   const res = await apiFetch(

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -260,3 +260,15 @@ export interface VolunteerBookingConflict {
   attempted: VolunteerBookingInfo;
   existing: VolunteerBookingInfo;
 }
+
+export interface ClientVisit {
+  id: number;
+  date: string;
+  clientId: number | null;
+  clientName: string | null;
+  anonymous: boolean;
+  weightWithCart: number;
+  weightWithoutCart: number;
+  petItem: number;
+  note?: string | null;
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Before merging a pull request, confirm the following:
 
 - Appointment booking workflow for clients with automatic approval and rescheduling.
 - Bookings support an optional **note** field stored and returned via `/bookings` endpoints.
+- Client visit records include an optional **note** field. Staff and agency users can retrieve these notes through `/bookings/history?includeVisitNotes=true`.
  - Help page offers role-specific guidance with real-time search and a printable view. Admins can view all help topics, including client and volunteer guidance.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas; volunteers can only book shifts in roles they are trained for.


### PR DESCRIPTION
## Summary
- allow optional note on client visit records
- gate `includeVisitNotes` query flag for booking history to staff and agencies
- extend booking visit API to send visit notes

## Testing
- `npm test tests/includeVisitNotesAuth.test.ts`
- `npm test src/api/__tests__/bookingsApi.test.ts`
- `npm test` *(fails: expect received 400 for client visit integration, volunteer booking tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b73be6cd40832dac363aca34ee0bf6