### PR TITLE
docs: add booking note guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Ensure tests are added or updated for any code changes and run the relevant test suites after each task.
 - Keep recurring-booking tests current in both the backend and frontend whenever this feature changes.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
+- Document translation strings for localization in `docs/` and update `src/locales` when user-facing text is added.
 - A GitHub Actions workflow in `.github/workflows/release.yml` builds, tests, and deploys container images to Azure Container Apps. Configure repository secrets `AZURE_CREDENTIALS`, `REGISTRY_LOGIN_SERVER`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD` and variables `AZURE_RESOURCE_GROUP`, `BACKEND_APP_NAME`, and `FRONTEND_APP_NAME`; see `docs/release.md` for details.
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 22+ for native `fetch`; earlier versions are not supported.
@@ -88,6 +89,7 @@
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
 - The Manage Booking dialog shows the client's name, profile link, and current-month visit count.
+- Bookings accept optional notes; clients may include a message during booking, and staff see it in Manage Booking and Manage Volunteer Shift dialogs.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
 - Staff and agency users may append `includeVisitNotes=true` to `/bookings/history` to retrieve notes recorded on client visits.

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -53,7 +53,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add extra info if needed, and confirm the booking."
+          "Select a time, add a note for staff if needed, and confirm the booking."
         ]
       },
       "rescheduling_or_canceling": {
@@ -192,5 +192,7 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "note_label": "Note",
+  "note_prefix": "Note:"
 }

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -228,6 +228,17 @@ export function getHelpContent(
       },
     },
     {
+      title: 'View booking notes',
+      body: {
+        description: 'Staff dialogs display any note submitted with a booking.',
+        steps: [
+          'Open the schedule.',
+          'Select a booking.',
+          'Read the note in the dialog.',
+        ],
+      },
+    },
+    {
       title: 'Book new clients from the schedule',
       body: {
         description: 'Use the Assign User modal to book a slot for an unregistered individual.',

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Before merging a pull request, confirm the following:
 ## Features
 
 - Appointment booking workflow for clients with automatic approval and rescheduling.
-- Bookings support an optional **note** field stored and returned via `/bookings` endpoints.
+- Bookings support an optional **note** field. Clients can add notes during booking, and staff see them in booking dialogs. Notes are stored and returned via `/bookings` endpoints.
 - Client visit records include an optional **note** field. Staff and agency users can retrieve these notes through `/bookings/history?includeVisitNotes=true`.
  - Help page offers role-specific guidance with real-time search and a printable view. Admins can view all help topics, including client and volunteer guidance.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,0 +1,19 @@
+# Booking notes
+
+Clients can include an optional note when booking an appointment. The note is stored with the booking and appears in staff dialogs when managing client bookings or volunteer shifts.
+
+Staff and agency users can include visit notes in booking history responses by adding `includeVisitNotes=true` to `/bookings/history`.
+
+## Environment variables
+
+This feature does not require any additional environment variables.
+
+## Localization
+
+Add the following translation strings to locale files:
+
+- `help.client.booking_appointments.steps.2`
+- `note_label`
+- `note_prefix`
+
+Document any new translation keys here when extending note functionality.


### PR DESCRIPTION
## Summary
- document optional booking notes across README, AGENTS, and docs
- add staff help entry for viewing booking notes
- mention note and translation keys in locales

## Testing
- `CI=true npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*


------
https://chatgpt.com/codex/tasks/task_e_68b73e84d7c4832db71cb21ee3292a29