### PR TITLE
docs: describe visit notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,13 @@
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
 - The database schema is managed via TypeScript migrations in `src/migrations`. The backend runs pending migrations automatically on startup and logs each applied migration name. You can also run them manually with `npm run migrate`.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
-- The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights to create a client visit.
+ - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights and notes to create a client visit.
 - The Manage Booking dialog shows the client's name, profile link, and current-month visit count.
 - Bookings accept optional notes; clients may include a message during booking, and staff see it in Manage Booking and Manage Volunteer Shift dialogs.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
-- Staff and agency users may append `includeVisitNotes=true` to `/bookings/history` to retrieve notes recorded on client visits.
+ - Staff and agency users may append `includeVisitNotes=true` to `/bookings/history` to retrieve notes recorded on client visits.
+ - Visit history can be filtered by note text using the `notes` query parameter on `/bookings/history`.
 - Agencies can filter booking history for multiple clients and paginate results via `/bookings/history?clientIds=1,2&limit=10&offset=0`.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
 - `PUT /slots/capacity` updates the `max_capacity` for all slots.

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -219,11 +219,22 @@ export function getHelpContent(
     {
       title: 'Record visits and handle no-shows',
       body: {
-        description: 'Mark bookings as visited while logging weights, notes, or record no-shows.',
+        description: 'Mark bookings as visited while logging weights and adding visit notes, or record no-shows.',
         steps: [
           'Open the schedule.',
           'Select a booking.',
-          'Mark visited or no-show, enter weight, and add a note if needed.',
+          'Mark visited or no-show, enter weight, and add a visit note if needed.',
+        ],
+      },
+    },
+    {
+      title: 'Filter visits by notes',
+      body: {
+        description: 'Show only visits that contain notes.',
+        steps: [
+          'Open Booking History.',
+          'Enable the notes-only filter.',
+          'Review the matching visits.',
         ],
       },
     },

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Before merging a pull request, confirm the following:
 
 - Appointment booking workflow for clients with automatic approval and rescheduling.
 - Bookings support an optional **note** field. Clients can add notes during booking, and staff see them in booking dialogs. Notes are stored and returned via `/bookings` endpoints.
-- Client visit records include an optional **note** field. Staff and agency users can retrieve these notes through `/bookings/history?includeVisitNotes=true`.
+ - Client visit records include an optional **note** field. Staff and agency users can record notes for each visit and retrieve them through `/bookings/history?includeVisitNotes=true`.
  - Help page offers role-specific guidance with real-time search and a printable view. Admins can view all help topics, including client and volunteer guidance.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas; volunteers can only book shifts in roles they are trained for.

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -2,7 +2,9 @@
 
 Clients can include an optional note when booking an appointment. The note is stored with the booking and appears in staff dialogs when managing client bookings or volunteer shifts.
 
-Staff and agency users can include visit notes in booking history responses by adding `includeVisitNotes=true` to `/bookings/history`.
+Staff can add notes when recording client visits in the pantry schedule. These notes are stored with the visit.
+
+Staff and agency users can include visit notes in booking history responses by adding `includeVisitNotes=true` to `/bookings/history` and filter visit history by note text using the `notes` query parameter.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary
- mention adding visit notes and filtering by notes on staff help page
- document visit notes in repository docs and AGENTS instructions

## Testing
- `CI=true npm test` *(fails: NoShowWeek.test.tsx, PasswordSetup.test.tsx, fetchWithRetry.test.ts, AgencyAccess.test.tsx, Profile.test.tsx, ClientDashboard.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b74098aad8832d8845c122a886d3d6