### PR TITLE
feat: seed staff timesheets

### DIFF
--- a/MJ_FB_Backend/src/controllers/admin/staffController.ts
+++ b/MJ_FB_Backend/src/controllers/admin/staffController.ts
@@ -6,6 +6,7 @@ import { StaffAccess } from '../../models/staff';
 import { generatePasswordSetupToken } from '../../utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../../utils/emailUtils';
 import config from '../../config';
+import seedTimesheets from '../../utils/timesheetSeeder';
 
 export async function checkStaffExists(
   _req: Request,
@@ -61,6 +62,7 @@ export async function createStaff(
         templateId: config.passwordSetupTemplateId,
         params: { link: `${config.frontendOrigins[0]}/set-password?token=${token}` },
       });
+    await seedTimesheets(staffId);
 
     res.status(201).json({ message: 'Staff created' });
   } catch (error) {

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -15,6 +15,7 @@ import {
   stopVolunteerNoShowCleanupJob,
 } from './utils/volunteerNoShowCleanupJob';
 import { initEmailQueue, shutdownQueue } from './utils/emailQueue';
+import seedTimesheets from './utils/timesheetSeeder';
 
 const PORT = config.port;
 
@@ -36,6 +37,7 @@ async function init() {
     startVolunteerShiftReminderJob();
     startNoShowCleanupJob();
     startVolunteerNoShowCleanupJob();
+    await seedTimesheets();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);

--- a/MJ_FB_Backend/src/utils/timesheetSeeder.ts
+++ b/MJ_FB_Backend/src/utils/timesheetSeeder.ts
@@ -1,0 +1,62 @@
+import pool from '../db';
+import logger from './logger';
+
+/**
+ * Seed timesheets for active staff in the current pay period. For each active staff member,
+ * ensure a timesheet exists for the current pay period and insert weekday rows with zeroed
+ * hours. Stat holiday rows are handled via database triggers.
+ *
+ * @param staffId Optional staff ID to seed for a specific staff member. If omitted, seeds for all active staff.
+ */
+export async function seedTimesheets(staffId?: number): Promise<void> {
+  try {
+    // Determine current pay period
+    const payPeriodRes = await pool.query(
+      `SELECT id, start_date, end_date FROM pay_periods WHERE CURRENT_DATE BETWEEN start_date AND end_date`,
+    );
+
+    if (payPeriodRes.rowCount === 0) {
+      return; // No current pay period
+    }
+
+    const period = payPeriodRes.rows[0];
+
+    // Fetch active staff
+    const staffRes = staffId
+      ? await pool.query('SELECT id, starts_on FROM staff WHERE active = true AND id = $1', [staffId])
+      : await pool.query('SELECT id, starts_on FROM staff WHERE active = true');
+
+    for (const staff of staffRes.rows) {
+      // Check for existing timesheet
+      const tsRes = await pool.query(
+        'SELECT id FROM timesheets WHERE staff_id = $1 AND start_date = $2 AND end_date = $3',
+        [staff.id, period.start_date, period.end_date],
+      );
+
+      let timesheetId: number;
+      if (tsRes.rowCount && tsRes.rowCount > 0) {
+        timesheetId = tsRes.rows[0].id;
+      } else {
+        const insertRes = await pool.query(
+          'INSERT INTO timesheets (staff_id, start_date, end_date) VALUES ($1, $2, $3) RETURNING id',
+          [staff.id, period.start_date, period.end_date],
+        );
+        timesheetId = insertRes.rows[0].id;
+      }
+
+      // Insert weekday rows with zeroed hours
+      await pool.query(
+        `INSERT INTO timesheet_days (timesheet_id, work_date, expected_hours, actual_hours)
+         SELECT $1, gs.day, 0, 0
+           FROM generate_series(GREATEST($2::date, $3::date), $4::date, '1 day') AS gs(day)
+          WHERE EXTRACT(ISODOW FROM gs.day) < 6
+          ON CONFLICT (timesheet_id, work_date) DO NOTHING`,
+        [timesheetId, period.start_date, staff.starts_on, period.end_date],
+      );
+    }
+  } catch (err) {
+    logger.error('Error seeding timesheets:', err);
+  }
+}
+
+export default seedTimesheets;

--- a/MJ_FB_Backend/tests/timesheetSeeder.test.ts
+++ b/MJ_FB_Backend/tests/timesheetSeeder.test.ts
@@ -1,0 +1,62 @@
+import pool from '../src/db';
+import { seedTimesheets } from '../src/utils/timesheetSeeder';
+
+describe('seedTimesheets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates timesheet and weekday rows for active staff', async () => {
+    const calls: any[] = [];
+    (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      if (sql.includes('FROM pay_periods')) {
+        return { rows: [{ id: 1, start_date: '2024-06-01', end_date: '2024-06-15' }], rowCount: 1 };
+      }
+      if (sql.includes('FROM staff')) {
+        return { rows: [{ id: 7, starts_on: '2024-05-20' }], rowCount: 1 };
+      }
+      if (sql.startsWith('SELECT id FROM timesheets')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.startsWith('INSERT INTO timesheets')) {
+        return { rows: [{ id: 99 }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    await seedTimesheets();
+
+    const insertTs = calls.find((c) => c.sql.startsWith('INSERT INTO timesheets'));
+    expect(insertTs).toBeDefined();
+    const insertDays = calls.find((c) => c.sql.startsWith('INSERT INTO timesheet_days'));
+    expect(insertDays).toBeDefined();
+    expect(insertDays.sql).toContain('GREATEST($2::date, $3::date)');
+    expect(insertDays.params).toEqual([99, '2024-06-01', '2024-05-20', '2024-06-15']);
+  });
+
+  it('uses staff start date when later than period start', async () => {
+    const calls: any[] = [];
+    (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      if (sql.includes('FROM pay_periods')) {
+        return { rows: [{ id: 2, start_date: '2024-06-01', end_date: '2024-06-15' }], rowCount: 1 };
+      }
+      if (sql.includes('FROM staff')) {
+        return { rows: [{ id: 5, starts_on: '2024-06-05' }], rowCount: 1 };
+      }
+      if (sql.startsWith('SELECT id FROM timesheets')) {
+        return { rows: [{ id: 50 }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    await seedTimesheets();
+
+    const insertTs = calls.find((c) => c.sql.startsWith('INSERT INTO timesheets'));
+    expect(insertTs).toBeUndefined();
+    const insertDays = calls.find((c) => c.sql.startsWith('INSERT INTO timesheet_days'));
+    expect(insertDays).toBeDefined();
+    expect(insertDays.params).toEqual([50, '2024-06-01', '2024-06-05', '2024-06-15']);
+  });
+});


### PR DESCRIPTION
## Summary
- seed staff timesheets for current pay period
- run timesheet seeder on server start and after staff creation
- add timesheetSeeder tests

## Testing
- `npm test` *(fails: clientVisitBookingStatus, volunteerBookingStatusEmail, volunteerShopperBooking, bookingLimit, volunteerBookingConflict, bookingNewClient, volunteerRebookCancelled, bookingCapacity, dbPoolErrorHandler)*
- `npm test tests/timesheetSeeder.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b74bb78564832db36941acbc9d187f