### PR TITLE
feat: add timesheet API

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -35,6 +35,7 @@ import agenciesRoutes from './routes/agencies';
 import badgesRoutes from './routes/badges';
 import statsRoutes from './routes/stats';
 import volunteerStatsRoutes from './routes/volunteerStats';
+import timesheetsRoutes from './routes/timesheets';
 import { initializeSlots } from './data';
 import csrfMiddleware from './middleware/csrf';
 import errorHandler from './middleware/errorHandler';
@@ -87,6 +88,7 @@ app.use('/warehouse-overall', warehouseOverallRoutes);
 app.use('/events', eventsRoutes);
 app.use('/badges', badgesRoutes);
 app.use('/stats', statsRoutes);
+app.use('/timesheets', timesheetsRoutes);
 
 // Serve the frontend in production
 if (process.env.NODE_ENV === 'production') {

--- a/MJ_FB_Backend/src/controllers/timesheetController.ts
+++ b/MJ_FB_Backend/src/controllers/timesheetController.ts
@@ -1,0 +1,104 @@
+import { Request, Response, NextFunction } from 'express';
+import {
+  getTimesheetsForVolunteer,
+  getTimesheetDays as modelGetTimesheetDays,
+  getTimesheetById,
+  updateTimesheetDay as modelUpdateTimesheetDay,
+  submitTimesheet as modelSubmitTimesheet,
+  rejectTimesheet as modelRejectTimesheet,
+  processTimesheet as modelProcessTimesheet,
+} from '../models/timesheet';
+
+export async function listMyTimesheets(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
+    const rows = await getTimesheetsForVolunteer(Number(req.user.id));
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getTimesheetDays(req: Request, res: Response, next: NextFunction) {
+  try {
+    if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
+    const timesheetId = Number(req.params.id);
+    const ts = await getTimesheetById(timesheetId);
+    if (!ts || ts.volunteer_id !== Number(req.user.id)) {
+      return next({
+        status: 404,
+        code: 'TIMESHEET_NOT_FOUND',
+        message: 'Timesheet not found',
+      });
+    }
+    const days = await modelGetTimesheetDays(timesheetId);
+    res.json(days);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateTimesheetDay(req: Request, res: Response, next: NextFunction) {
+  try {
+    if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
+    const timesheetId = Number(req.params.id);
+    const workDate = req.params.date;
+    const hours = Number(req.body.hours);
+    const ts = await getTimesheetById(timesheetId);
+    if (!ts || ts.volunteer_id !== Number(req.user.id)) {
+      return next({
+        status: 404,
+        code: 'TIMESHEET_NOT_FOUND',
+        message: 'Timesheet not found',
+      });
+    }
+    await modelUpdateTimesheetDay(timesheetId, workDate, hours);
+    res.json({ message: 'Updated' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function submitTimesheet(req: Request, res: Response, next: NextFunction) {
+  try {
+    if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
+    const timesheetId = Number(req.params.id);
+    const ts = await getTimesheetById(timesheetId);
+    if (!ts || ts.volunteer_id !== Number(req.user.id)) {
+      return next({
+        status: 404,
+        code: 'TIMESHEET_NOT_FOUND',
+        message: 'Timesheet not found',
+      });
+    }
+    await modelSubmitTimesheet(timesheetId);
+    res.json({ message: 'Submitted' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function rejectTimesheet(req: Request, res: Response, next: NextFunction) {
+  try {
+    const timesheetId = Number(req.params.id);
+    await modelRejectTimesheet(timesheetId);
+    res.json({ message: 'Rejected' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function processTimesheet(req: Request, res: Response, next: NextFunction) {
+  try {
+    const timesheetId = Number(req.params.id);
+    await modelProcessTimesheet(timesheetId);
+    res.json({ message: 'Processed' });
+  } catch (err) {
+    next(err);
+  }
+}
+

--- a/MJ_FB_Backend/src/middleware/errorHandler.ts
+++ b/MJ_FB_Backend/src/middleware/errorHandler.ts
@@ -30,8 +30,23 @@ const errorHandler = (
 
   logger.error('Unhandled error:', originalMessage, err);
 
-  const responseBody: { message: string; stack?: string } = {
-    message: status === 500 ? 'Internal Server Error' : originalMessage,
+  const code =
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    typeof (err as any).code === 'string'
+      ? (err as any).code
+      : 'UNKNOWN';
+
+  const safeMessage = status === 500 ? 'Internal Server Error' : originalMessage;
+
+  const responseBody: {
+    message: string;
+    error: { code: string; message: string };
+    stack?: string;
+  } = {
+    message: safeMessage,
+    error: { code, message: safeMessage },
   };
 
   if (

--- a/MJ_FB_Backend/src/models/timesheet.ts
+++ b/MJ_FB_Backend/src/models/timesheet.ts
@@ -1,0 +1,144 @@
+import pool from '../db';
+
+export interface Timesheet {
+  id: number;
+  volunteer_id: number;
+  start_date: string;
+  end_date: string;
+  submitted_at: string | null;
+  approved_at: string | null;
+}
+
+export interface TimesheetDay {
+  id: number;
+  timesheet_id: number;
+  work_date: string;
+  expected_hours: number;
+  actual_hours: number;
+}
+
+export interface TimesheetSummary extends Timesheet {
+  total_hours: number;
+  expected_hours: number;
+  balance_hours: number;
+}
+
+export async function getTimesheetsForVolunteer(volunteerId: number): Promise<TimesheetSummary[]> {
+  const res = await pool.query(
+    `SELECT t.id, t.volunteer_id, t.start_date, t.end_date, t.submitted_at, t.approved_at,
+            COALESCE(tot.total_hours, 0) AS total_hours,
+            COALESCE(exp.expected_hours, 0) AS expected_hours,
+            COALESCE(bal.balance_hours, 0) AS balance_hours
+       FROM timesheets t
+       LEFT JOIN v_timesheet_totals tot ON tot.timesheet_id = t.id
+       LEFT JOIN v_timesheet_expected exp ON exp.timesheet_id = t.id
+       LEFT JOIN v_timesheet_balance bal ON bal.timesheet_id = t.id
+      WHERE t.volunteer_id = $1
+      ORDER BY t.start_date DESC`,
+    [volunteerId],
+  );
+  return res.rows;
+}
+
+export async function getTimesheetById(id: number): Promise<Timesheet | undefined> {
+  const res = await pool.query('SELECT * FROM timesheets WHERE id = $1', [id]);
+  return res.rows[0];
+}
+
+export async function getTimesheetDays(timesheetId: number): Promise<TimesheetDay[]> {
+  const res = await pool.query(
+    'SELECT id, timesheet_id, work_date, expected_hours, actual_hours FROM timesheet_days WHERE timesheet_id = $1 ORDER BY work_date',
+    [timesheetId],
+  );
+  return res.rows;
+}
+
+export async function updateTimesheetDay(
+  timesheetId: number,
+  workDate: string,
+  hours: number,
+): Promise<void> {
+  const tsRes = await pool.query(
+    'SELECT submitted_at, approved_at FROM timesheets WHERE id = $1',
+    [timesheetId],
+  );
+  if ((tsRes.rowCount ?? 0) === 0) {
+    const err: any = new Error('Timesheet not found');
+    err.status = 404;
+    err.code = 'TIMESHEET_NOT_FOUND';
+    throw err;
+  }
+  const { submitted_at, approved_at } = tsRes.rows[0];
+  if (submitted_at || approved_at) {
+    const err: any = new Error('Timesheet is locked');
+    err.status = 400;
+    err.code = 'TIMESHEET_LOCKED';
+    throw err;
+  }
+  const res = await pool.query(
+    'UPDATE timesheet_days SET actual_hours = $3 WHERE timesheet_id = $1 AND work_date = $2 RETURNING id',
+    [timesheetId, workDate, hours],
+  );
+  if ((res.rowCount ?? 0) === 0) {
+    const err: any = new Error('Day not found');
+    err.status = 404;
+    err.code = 'DAY_NOT_FOUND';
+    throw err;
+  }
+}
+
+export async function submitTimesheet(id: number): Promise<void> {
+  try {
+    await pool.query('SELECT validate_timesheet_balance($1)', [id]);
+  } catch (e) {
+    const err: any = new Error('Timesheet must balance');
+    err.status = 400;
+    err.code = 'TIMESHEET_UNBALANCED';
+    throw err;
+  }
+  const res = await pool.query(
+    'UPDATE timesheets SET submitted_at = NOW() WHERE id = $1 AND submitted_at IS NULL RETURNING id',
+    [id],
+  );
+  if ((res.rowCount ?? 0) === 0) {
+    const err: any = new Error('Timesheet already submitted');
+    err.status = 400;
+    err.code = 'ALREADY_SUBMITTED';
+    throw err;
+  }
+}
+
+export async function rejectTimesheet(id: number): Promise<void> {
+  const res = await pool.query(
+    'UPDATE timesheets SET submitted_at = NULL WHERE id = $1 AND approved_at IS NULL RETURNING id',
+    [id],
+  );
+  if ((res.rowCount ?? 0) === 0) {
+    const err: any = new Error('Timesheet already processed');
+    err.status = 400;
+    err.code = 'ALREADY_PROCESSED';
+    throw err;
+  }
+}
+
+export async function processTimesheet(id: number): Promise<void> {
+  try {
+    await pool.query('SELECT validate_timesheet_balance($1)', [id]);
+  } catch (e) {
+    const err: any = new Error('Timesheet must balance');
+    err.status = 400;
+    err.code = 'TIMESHEET_UNBALANCED';
+    throw err;
+  }
+  const res = await pool.query(
+    'UPDATE timesheets SET approved_at = NOW() WHERE id = $1 AND submitted_at IS NOT NULL AND approved_at IS NULL RETURNING id',
+    [id],
+  );
+  if ((res.rowCount ?? 0) === 0) {
+    const err: any = new Error('Timesheet not submitted');
+    err.status = 400;
+    err.code = 'NOT_SUBMITTED';
+    throw err;
+  }
+}
+

--- a/MJ_FB_Backend/src/routes/timesheets.ts
+++ b/MJ_FB_Backend/src/routes/timesheets.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
+import {
+  listMyTimesheets,
+  getTimesheetDays,
+  updateTimesheetDay,
+  submitTimesheet,
+  rejectTimesheet,
+  processTimesheet,
+} from '../controllers/timesheetController';
+
+const router = express.Router();
+
+router.get('/', authMiddleware, listMyTimesheets);
+router.get('/:id/days', authMiddleware, getTimesheetDays);
+router.patch('/:id/days/:date', authMiddleware, updateTimesheetDay);
+router.post('/:id/submit', authMiddleware, submitTimesheet);
+router.post('/:id/reject', authMiddleware, authorizeRoles('staff'), rejectTimesheet);
+router.post('/:id/process', authMiddleware, authorizeRoles('staff'), processTimesheet);
+
+export default router;

--- a/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
+++ b/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
@@ -1,0 +1,102 @@
+import '../setupTests';
+import {
+  listMyTimesheets,
+  getTimesheetDays,
+  updateTimesheetDay,
+  submitTimesheet,
+  rejectTimesheet,
+  processTimesheet,
+} from '../../src/controllers/timesheetController';
+import errorHandler from '../../src/middleware/errorHandler';
+import mockPool from '../utils/mockDb';
+
+const nextErr = (req: any, res: any) => (err: any) => errorHandler(err, req, res, () => {});
+
+describe('timesheet controller', () => {
+  it('lists volunteer timesheets', async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
+    const req: any = { user: { id: '1', role: 'volunteer' } };
+    const res: any = { json: jest.fn() };
+    await listMyTimesheets(req, res, () => {});
+    expect(res.json).toHaveBeenCalledWith([{ id: 1 }]);
+  });
+
+  it('gets timesheet days', async () => {
+    (mockPool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 2, timesheet_id: 1, work_date: '2024-01-02', expected_hours: 3, actual_hours: 1 },
+        ],
+        rowCount: 1,
+      });
+    const req: any = { user: { id: '1', role: 'volunteer' }, params: { id: '1' } };
+    const res: any = { json: jest.fn() };
+    await getTimesheetDays(req, res, () => {});
+    expect(res.json).toHaveBeenCalledWith([
+      { id: 2, timesheet_id: 1, work_date: '2024-01-02', expected_hours: 3, actual_hours: 1 },
+    ]);
+  });
+
+  it('updates a timesheet day', async () => {
+    (mockPool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ submitted_at: null, approved_at: null }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 });
+    const req: any = {
+      user: { id: '1', role: 'volunteer' },
+      params: { id: '1', date: '2024-01-02' },
+      body: { hours: 3 },
+    };
+    const res: any = { json: jest.fn() };
+    await updateTimesheetDay(req, res, () => {});
+    expect(res.json).toHaveBeenCalledWith({ message: 'Updated' });
+    expect((mockPool.query as jest.Mock).mock.calls[2][0]).toContain('UPDATE timesheet_days');
+  });
+
+  it('prevents editing a submitted timesheet', async () => {
+    (mockPool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ submitted_at: '2024-01-10', approved_at: null }], rowCount: 1 });
+    const req: any = {
+      user: { id: '1', role: 'volunteer' },
+      params: { id: '1', date: '2024-01-02' },
+      body: { hours: 2 },
+    };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await updateTimesheetDay(req, res, nextErr(req, res));
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: { code: 'TIMESHEET_LOCKED', message: 'Timesheet is locked' } }),
+    );
+  });
+
+  it('rejects unbalanced timesheet on submit', async () => {
+    (mockPool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockRejectedValueOnce(new Error('Timesheet unbalanced'));
+    const req: any = { user: { id: '1', role: 'volunteer' }, params: { id: '1' } };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await submitTimesheet(req, res, nextErr(req, res));
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: { code: 'TIMESHEET_UNBALANCED', message: 'Timesheet must balance' } }),
+    );
+  });
+
+  it('rejects and processes timesheet', async () => {
+    (mockPool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
+    const req1: any = { params: { id: '1' } };
+    const res1: any = { json: jest.fn() };
+    await rejectTimesheet(req1, res1, () => {});
+    expect(res1.json).toHaveBeenCalledWith({ message: 'Rejected' });
+
+    const req2: any = { params: { id: '1' } };
+    const res2: any = { json: jest.fn() };
+    await processTimesheet(req2, res2, () => {});
+    expect(res2.json).toHaveBeenCalledWith({ message: 'Processed' });
+  });
+});

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -194,5 +194,12 @@
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
   "extra_info_label": "Extra info (optional)",
   "note_label": "Note",
-  "note_prefix": "Note:"
+  "note_prefix": "Note:",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -187,5 +187,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -190,5 +190,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -185,5 +185,12 @@
   "cancelled": "Cancelled",
   "confirm_booking": "Confirm booking",
   "booking_summary": "Date: {{date}} • Time: {{time}} • Visits this month: {{count}}",
-  "extra_info_label": "Extra info (optional)"
+  "extra_info_label": "Extra info (optional)",
+  "timesheet_not_found": "Timesheet not found",
+  "timesheet_day_not_found": "Day not found",
+  "timesheet_locked": "Timesheet is locked",
+  "timesheet_already_submitted": "Timesheet already submitted",
+  "timesheet_not_submitted": "Timesheet not submitted",
+  "timesheet_already_processed": "Timesheet already processed",
+  "timesheet_unbalanced": "Timesheet must balance"
 }


### PR DESCRIPTION
## Summary
- add Timesheet models and controller to manage volunteer hours
- expose new `/timesheets` routes and hook into app with auth protection
- extend error handler with `{ error: { code, message } }` payload
- add timesheet translations and tests

## Testing
- `npm test --ignore-scripts tests/timesheets/timesheetController.test.ts`
- `npm test --ignore-scripts` *(fails: clientVisitBookingStatus.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b74bbe8ffc832d91c2fa409a589748