### PR TITLE
feat: add staff timesheets page

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -101,6 +101,7 @@ const VolunteerSettings = React.lazy(() =>
 );
 const Events = React.lazy(() => import('./pages/events/Events'));
 const PantryVisits = React.lazy(() => import('./pages/staff/PantryVisits'));
+const Timesheets = React.lazy(() => import('./pages/staff/timesheets'));
 const AgencyLogin = React.lazy(() => import('./pages/agency/Login'));
 const AgencyBookAppointment = React.lazy(() =>
   import('./pages/agency/AgencyBookAppointment')
@@ -166,6 +167,7 @@ export default function App() {
       { label: 'Manage Availability', to: '/pantry/manage-availability' },
       { label: 'Pantry Schedule', to: '/pantry/schedule' },
       { label: 'Pantry Visits', to: '/pantry/visits' },
+      { label: t('timesheets.title'), to: '/pantry/timesheets' },
       { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Agency Management', to: '/pantry/agency-management' },
     ];
@@ -329,6 +331,9 @@ export default function App() {
                   )}
                   {showStaff && (
                     <Route path="/pantry/visits" element={<PantryVisits />} />
+                  )}
+                  {showStaff && (
+                    <Route path="/pantry/timesheets" element={<Timesheets />} />
                   )}
                   {showWarehouse && (
                     <Route path="/warehouse-management" element={<WarehouseDashboard />} />

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "ውጣ",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "تسجيل الخروج",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -91,6 +91,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "Logout",
@@ -201,5 +212,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -91,6 +91,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "Cerrar sesión",
@@ -194,5 +205,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "خروج",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "Déconnexion",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "लॉगआउट",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "ലോഗ് ഔട്ട്",
@@ -197,5 +208,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "ਲੌਗ ਆਊਟ",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "وتل",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "Ka bax",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "Toka",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "வெளியேறு",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "መውጽእ",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "Mag-logout",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "Вийти",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -89,6 +89,17 @@
           "Check reminders for upcoming bookings."
         ]
       }
+    },
+    "pantry": {
+      "timesheets": {
+        "title": "Timesheets",
+        "description": "Record hours and submit pay periods.",
+        "steps": [
+          "Open the Timesheets page.",
+          "Fill in your hours for each day.",
+          "Review totals and submit."
+        ]
+      }
     }
   },
   "logout": "退出登录",
@@ -192,5 +203,23 @@
   "timesheet_already_submitted": "Timesheet already submitted",
   "timesheet_not_submitted": "Timesheet not submitted",
   "timesheet_already_processed": "Timesheet already processed",
-  "timesheet_unbalanced": "Timesheet must balance"
+  "timesheet_unbalanced": "Timesheet must balance",
+  "timesheets": {
+    "title": "Timesheets",
+    "date": "Date",
+    "reg": "Reg",
+    "ot": "OT",
+    "stat": "Stat",
+    "sick": "Sick",
+    "vac": "Vac",
+    "note": "Note",
+    "paid_total": "Paid Total",
+    "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "summary": {
+      "totals": "Totals",
+      "expected": "Expected Hours",
+      "shortfall": "Shortfall",
+      "ot_bank_remaining": "OT Bank Remaining"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -282,6 +282,17 @@ export function getHelpContent(
         ],
       },
     },
+    {
+      title: t('help.pantry.timesheets.title'),
+      body: {
+        description: t('help.pantry.timesheets.description'),
+        steps: [
+          t('help.pantry.timesheets.steps.0'),
+          t('help.pantry.timesheets.steps.1'),
+          t('help.pantry.timesheets.steps.2'),
+        ],
+      },
+    },
   ],
   warehouse: [
     {

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -1,0 +1,13 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../testUtils/renderWithProviders';
+import Timesheets from '../timesheets';
+
+describe('Timesheets', () => {
+  it('renders table headers', () => {
+    renderWithProviders(<Timesheets />);
+    expect(screen.getByText('Date')).toBeInTheDocument();
+    expect(screen.getByText('Reg')).toBeInTheDocument();
+    expect(screen.getByText('OT')).toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react';
+import {
+  Box,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TableFooter,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import LockIcon from '@mui/icons-material/Lock';
+import Page from '../../components/Page';
+import StyledTabs, { type TabItem } from '../../components/StyledTabs';
+import { useTranslation } from 'react-i18next';
+import { formatLocaleDate } from '../../utils/date';
+
+type Day = {
+  date: string;
+  reg: number;
+  ot: number;
+  stat: number;
+  sick: number;
+  vac: number;
+  note: string;
+  expected: number;
+};
+
+type PayPeriod = {
+  id: number;
+  start: string;
+  end: string;
+  submitted: boolean;
+  processed: boolean;
+  days: Day[];
+};
+
+const mockPeriods: PayPeriod[] = [
+  {
+    id: 2,
+    start: '2023-12-15',
+    end: '2023-12-31',
+    submitted: true,
+    processed: true,
+    days: [
+      { date: '2023-12-15', reg: 8, ot: 0, stat: 0, sick: 0, vac: 0, note: '', expected: 8 },
+      { date: '2023-12-16', reg: 4, ot: 4, stat: 0, sick: 0, vac: 0, note: '', expected: 8 },
+    ],
+  },
+  {
+    id: 1,
+    start: '2024-01-01',
+    end: '2024-01-07',
+    submitted: false,
+    processed: false,
+    days: [
+      { date: '2024-01-01', reg: 0, ot: 0, stat: 8, sick: 0, vac: 0, note: '', expected: 8 },
+      { date: '2024-01-02', reg: 8, ot: 0, stat: 0, sick: 0, vac: 0, note: '', expected: 8 },
+      { date: '2024-01-03', reg: 8, ot: 1, stat: 0, sick: 0, vac: 0, note: '', expected: 8 },
+    ],
+  },
+];
+
+export default function Timesheets() {
+  const { t } = useTranslation();
+  const [periods, setPeriods] = useState<PayPeriod[]>(mockPeriods);
+  const [tab, setTab] = useState(() => {
+    const idx = mockPeriods.findIndex(p => !p.processed);
+    return idx === -1 ? mockPeriods.length - 1 : idx;
+  });
+
+  const current = periods[tab];
+  const inputsDisabled = current.submitted || current.processed;
+
+  const tabs: TabItem[] = periods.map(p => ({
+    label: `${formatLocaleDate(p.start)} - ${formatLocaleDate(p.end)}`,
+    content: renderTable(p),
+  }));
+
+  function renderTable(period: PayPeriod) {
+    const handleChange = (index: number, field: keyof Day, value: string) => {
+      setPeriods(prev => {
+        const copy = [...prev];
+        const days = [...copy[tab].days];
+        days[index] = { ...days[index], [field]: field === 'note' ? value : Number(value) };
+        copy[tab] = { ...copy[tab], days };
+        return copy;
+      });
+    };
+
+    const totals = period.days.reduce(
+      (acc, d) => {
+        const paid = d.reg + d.ot + d.stat + d.sick + d.vac;
+        acc.reg += d.reg;
+        acc.ot += d.ot;
+        acc.stat += d.stat;
+        acc.sick += d.sick;
+        acc.vac += d.vac;
+        acc.paid += paid;
+        acc.expected += d.expected;
+        return acc;
+      },
+      { reg: 0, ot: 0, stat: 0, sick: 0, vac: 0, paid: 0, expected: 0 },
+    );
+    const shortfall = totals.expected - totals.paid;
+    const otBankRemaining = 40 - totals.ot;
+
+    return (
+      <Box>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('timesheets.date')}</TableCell>
+              <TableCell>{t('timesheets.reg')}</TableCell>
+              <TableCell>{t('timesheets.ot')}</TableCell>
+              <TableCell>{t('timesheets.stat')}</TableCell>
+              <TableCell>{t('timesheets.sick')}</TableCell>
+              <TableCell>{t('timesheets.vac')}</TableCell>
+              <TableCell>{t('timesheets.note')}</TableCell>
+              <TableCell>{t('timesheets.paid_total')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {period.days.map((d, i) => {
+              const paid = d.reg + d.ot + d.stat + d.sick + d.vac;
+              const over = paid > 8;
+              const disabled = inputsDisabled || d.stat === 8;
+              return (
+                <TableRow key={d.date}>
+                  <TableCell>
+                    {formatLocaleDate(d.date)}
+                    {d.stat === 8 && (
+                      <Tooltip title={t('timesheets.lock_stat_tooltip')}>
+                        <LockIcon sx={{ ml: 1, fontSize: 16 }} />
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      type="number"
+                      value={d.reg}
+                      size="small"
+                      disabled={disabled}
+                      error={over}
+                      onChange={e => handleChange(i, 'reg', e.target.value)}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      type="number"
+                      value={d.ot}
+                      size="small"
+                      disabled={disabled}
+                      error={over}
+                      onChange={e => handleChange(i, 'ot', e.target.value)}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      type="number"
+                      value={d.stat}
+                      size="small"
+                      disabled
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      type="number"
+                      value={d.sick}
+                      size="small"
+                      disabled={disabled}
+                      error={over}
+                      onChange={e => handleChange(i, 'sick', e.target.value)}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      type="number"
+                      value={d.vac}
+                      size="small"
+                      disabled={disabled}
+                      error={over}
+                      onChange={e => handleChange(i, 'vac', e.target.value)}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      value={d.note}
+                      size="small"
+                      disabled={disabled}
+                      onChange={e => handleChange(i, 'note', e.target.value)}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ color: over ? 'error.main' : undefined }}>
+                    {paid}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TableCell>{t('timesheets.summary.totals')}</TableCell>
+              <TableCell>{totals.reg}</TableCell>
+              <TableCell>{totals.ot}</TableCell>
+              <TableCell>{totals.stat}</TableCell>
+              <TableCell>{totals.sick}</TableCell>
+              <TableCell>{totals.vac}</TableCell>
+              <TableCell />
+              <TableCell>{totals.paid}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell colSpan={8}>
+                <Typography variant="body2">
+                  {t('timesheets.summary.expected')}: {totals.expected} •{' '}
+                  {t('timesheets.summary.shortfall')}: {shortfall} •{' '}
+                  {t('timesheets.summary.ot_bank_remaining')}: {otBankRemaining}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </Box>
+    );
+  }
+
+  return (
+    <Page title={t('timesheets.title')}>
+      <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />
+    </Page>
+  );
+}
+

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Agency profile page shows the agency's name, email, and contact info with editable fields and sends password reset links via email.
 - Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.
 - Staff can add agencies, assign clients, and book appointments for those clients through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list with Book buttons for scheduling on their behalf.
+- Staff can enter pay period timesheets with daily hour categories and summary totals.
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 
 ## Deploying to Azure

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -1,0 +1,27 @@
+# Timesheets
+
+Staff can record daily hours and submit pay periods.
+
+## Localization
+
+Add the following translation strings to locale files:
+
+- `timesheets.title`
+- `timesheets.date`
+- `timesheets.reg`
+- `timesheets.ot`
+- `timesheets.stat`
+- `timesheets.sick`
+- `timesheets.vac`
+- `timesheets.note`
+- `timesheets.paid_total`
+- `timesheets.lock_stat_tooltip`
+- `timesheets.summary.totals`
+- `timesheets.summary.expected`
+- `timesheets.summary.shortfall`
+- `timesheets.summary.ot_bank_remaining`
+- `help.pantry.timesheets.title`
+- `help.pantry.timesheets.description`
+- `help.pantry.timesheets.steps.0`
+- `help.pantry.timesheets.steps.1`
+- `help.pantry.timesheets.steps.2`


### PR DESCRIPTION
## Summary
- add staff timesheets route with pay-period tabs and daily hour grid
- localize new timesheet strings and help content
- document timesheet translations and update README

## Testing
- `npm test` *(fails: NoShowWeek, ClientManagement, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b74de7f008832dae9397d429d25b9a