### PR TITLE
feat: add timesheet api and hooks

### DIFF
--- a/MJ_FB_Frontend/src/api/__tests__/timesheets.api.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/timesheets.api.test.ts
@@ -1,0 +1,65 @@
+import { apiFetch, handleResponse } from '../client';
+import {
+  listTimesheets,
+  getTimesheetDays,
+  updateTimesheetDay,
+  submitTimesheet,
+  rejectTimesheet,
+  processTimesheet,
+} from '../timesheets';
+
+jest.mock('../client', () => ({
+  API_BASE: '/api',
+  apiFetch: jest.fn(),
+  handleResponse: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('timesheets api', () => {
+  beforeEach(() => {
+    (apiFetch as jest.Mock).mockResolvedValue(new Response(null));
+    jest.clearAllMocks();
+  });
+
+  it('lists my timesheets', async () => {
+    await listTimesheets();
+    expect(apiFetch).toHaveBeenCalledWith('/api/timesheets');
+  });
+
+  it('gets timesheet days', async () => {
+    await getTimesheetDays(5);
+    expect(apiFetch).toHaveBeenCalledWith('/api/timesheets/5/days');
+  });
+
+  it('updates timesheet day', async () => {
+    await updateTimesheetDay(3, '2024-01-02', 7.5);
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/timesheets/3/days/2024-01-02',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ hours: 7.5 }),
+      }),
+    );
+  });
+
+  it('submits timesheet', async () => {
+    await submitTimesheet(9);
+    expect(apiFetch).toHaveBeenCalledWith('/api/timesheets/9/submit', {
+      method: 'POST',
+    });
+  });
+
+  it('rejects timesheet', async () => {
+    await rejectTimesheet(4);
+    expect(apiFetch).toHaveBeenCalledWith('/api/timesheets/4/reject', {
+      method: 'POST',
+    });
+  });
+
+  it('processes timesheet', async () => {
+    await processTimesheet(6);
+    expect(apiFetch).toHaveBeenCalledWith('/api/timesheets/6/process', {
+      method: 'POST',
+    });
+  });
+});
+

--- a/MJ_FB_Frontend/src/api/timesheets.ts
+++ b/MJ_FB_Frontend/src/api/timesheets.ts
@@ -1,0 +1,131 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ApiError } from './client';
+
+export interface TimesheetSummary {
+  id: number;
+  volunteer_id: number;
+  start_date: string;
+  end_date: string;
+  submitted_at: string | null;
+  approved_at: string | null;
+  total_hours: number;
+  expected_hours: number;
+  balance_hours: number;
+}
+
+export interface TimesheetDay {
+  id: number;
+  timesheet_id: number;
+  work_date: string;
+  expected_hours: number;
+  actual_hours: number;
+}
+
+export async function listTimesheets(): Promise<TimesheetSummary[]> {
+  const res = await apiFetch(`${API_BASE}/timesheets`);
+  return handleResponse(res);
+}
+
+export async function getTimesheetDays(timesheetId: number): Promise<TimesheetDay[]> {
+  const res = await apiFetch(`${API_BASE}/timesheets/${timesheetId}/days`);
+  return handleResponse(res);
+}
+
+export async function updateTimesheetDay(
+  timesheetId: number,
+  date: string,
+  hours: number,
+): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/timesheets/${timesheetId}/days/${date}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ hours }),
+  });
+  await handleResponse(res);
+}
+
+export async function submitTimesheet(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/timesheets/${id}/submit`, {
+    method: 'POST',
+  });
+  await handleResponse(res);
+}
+
+export async function rejectTimesheet(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/timesheets/${id}/reject`, {
+    method: 'POST',
+  });
+  await handleResponse(res);
+}
+
+export async function processTimesheet(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/timesheets/${id}/process`, {
+    method: 'POST',
+  });
+  await handleResponse(res);
+}
+
+export function useTimesheets() {
+  const { data, isFetching, error } = useQuery<TimesheetSummary[]>({
+    queryKey: ['timesheets'],
+    queryFn: listTimesheets,
+  });
+  return { timesheets: data ?? [], isLoading: isFetching, error };
+}
+
+export function useTimesheetDays(timesheetId?: number) {
+  const { data, isFetching, error } = useQuery<TimesheetDay[]>({
+    queryKey: ['timesheets', timesheetId, 'days'],
+    queryFn: () => getTimesheetDays(timesheetId!),
+    enabled: !!timesheetId,
+  });
+  return { days: data ?? [], isLoading: isFetching, error };
+}
+
+export function useUpdateTimesheetDay(timesheetId: number) {
+  const qc = useQueryClient();
+  return useMutation<
+    void,
+    ApiError,
+    { date: string; hours: number }
+  >({
+    mutationFn: ({ date, hours }) => updateTimesheetDay(timesheetId, date, hours),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['timesheets', timesheetId, 'days'] });
+      qc.invalidateQueries({ queryKey: ['timesheets'] });
+    },
+  });
+}
+
+export function useSubmitTimesheet() {
+  const qc = useQueryClient();
+  return useMutation<void, ApiError, number>({
+    mutationFn: submitTimesheet,
+    onSuccess: (_, id) => {
+      qc.invalidateQueries({ queryKey: ['timesheets'] });
+      qc.invalidateQueries({ queryKey: ['timesheets', id, 'days'] });
+    },
+  });
+}
+
+export function useRejectTimesheet() {
+  const qc = useQueryClient();
+  return useMutation<void, ApiError, number>({
+    mutationFn: rejectTimesheet,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['timesheets'] });
+    },
+  });
+}
+
+export function useProcessTimesheet() {
+  const qc = useQueryClient();
+  return useMutation<void, ApiError, number>({
+    mutationFn: processTimesheet,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['timesheets'] });
+    },
+  });
+}
+

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -2,6 +2,39 @@ import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../../testUtils/renderWithProviders';
 import Timesheets from '../timesheets';
 
+jest.mock('../../../api/timesheets', () => ({
+  useTimesheets: () => ({
+    timesheets: [
+      {
+        id: 1,
+        start_date: '2024-01-01',
+        end_date: '2024-01-07',
+        submitted_at: null,
+        approved_at: null,
+        total_hours: 0,
+        expected_hours: 0,
+        balance_hours: 0,
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+  useTimesheetDays: () => ({
+    days: [
+      {
+        id: 1,
+        timesheet_id: 1,
+        work_date: '2024-01-01',
+        expected_hours: 8,
+        actual_hours: 0,
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+  useUpdateTimesheetDay: () => ({ mutate: jest.fn() }),
+}));
+
 describe('Timesheets', () => {
   it('renders table headers', () => {
     renderWithProviders(<Timesheets />);


### PR DESCRIPTION
## Summary
- add API client and hooks for timesheet routes
- integrate timesheet page with React Query and error handling
- cover timesheet API calls with unit tests

## Testing
- `npm test` *(fails: NoShowWeek.test.tsx cannot find Approved Past)*
- `npm test src/api/__tests__/timesheets.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b75053cd94832da0e97f1c65d2b05a