### PR TITLE
Add timesheet validation tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -1,4 +1,5 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../../../testUtils/renderWithProviders';
 import Timesheets from '../timesheets';
 
@@ -8,6 +9,43 @@ describe('Timesheets', () => {
     expect(screen.getByText('Date')).toBeInTheDocument();
     expect(screen.getByText('Reg')).toBeInTheDocument();
     expect(screen.getByText('OT')).toBeInTheDocument();
+  });
+
+  it('shows stat day lock icon and tooltip', () => {
+    renderWithProviders(<Timesheets />);
+    const rows = screen.getAllByRole('row');
+    const statRow = rows[1];
+    expect(within(statRow).getByTestId('LockIcon')).toBeInTheDocument();
+    expect(screen.getByText('Stat holiday is locked at 8h')).toBeInTheDocument();
+    const regInput = within(statRow).getAllByRole('spinbutton')[0];
+    expect(regInput).toBeDisabled();
+  });
+
+  it('shows hint when day total exceeds cap', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Timesheets />);
+    const rows = screen.getAllByRole('row');
+    const dayRow = rows[2];
+    const regInput = within(dayRow).getAllByRole('spinbutton')[0];
+    await user.clear(regInput);
+    await user.type(regInput, '9');
+    expect(regInput).toHaveAttribute('aria-invalid', 'true');
+    const cells = within(dayRow).getAllByRole('cell');
+    const paidCell = cells[cells.length - 1];
+    expect(paidCell.style.color).toBe('rgb(211, 47, 47)');
+  });
+
+  it('calculates footer summaries', () => {
+    renderWithProviders(<Timesheets />);
+    const totalsRow = screen.getByText('Totals').closest('tr')!;
+    const cells = within(totalsRow).getAllByRole('cell');
+    expect(cells[1]).toHaveTextContent('16');
+    expect(cells[2]).toHaveTextContent('1');
+    expect(cells[3]).toHaveTextContent('8');
+    expect(cells[7]).toHaveTextContent('25');
+    expect(screen.getByText(/Expected Hours: 24/)).toBeInTheDocument();
+    expect(screen.getByText(/Shortfall: -1/)).toBeInTheDocument();
+    expect(screen.getByText(/OT Bank Remaining: 39/)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- test stat holiday days and daily cap in timesheet controller
- cover locked processed timesheets
- add UI tests for timesheet stat day locks, cap warnings, and footer totals

## Testing
- `npm test` *(fails: Test Suites: 9 failed, 85 passed, 94 total)*
- `npm test` (frontend) *(fails: Test Suites: 6 failed, 20 passed, 26 of 65 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b750595708832da7b7fa5749f6d927