### PR TITLE
Document timesheet workflow and payroll export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Keep recurring-booking tests current in both the backend and frontend whenever this feature changes.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Document translation strings for localization in `docs/` and update `src/locales` when user-facing text is added.
+- Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes.
 - A GitHub Actions workflow in `.github/workflows/release.yml` builds, tests, and deploys container images to Azure Container Apps. Configure repository secrets `AZURE_CREDENTIALS`, `REGISTRY_LOGIN_SERVER`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD` and variables `AZURE_RESOURCE_GROUP`, `BACKEND_APP_NAME`, and `FRONTEND_APP_NAME`; see `docs/release.md` for details.
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 22+ for native `fetch`; earlier versions are not supported.

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -99,7 +99,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -224,6 +225,10 @@
     "note": "Note",
     "paid_total": "Paid Total",
     "lock_stat_tooltip": "Stat holiday is locked at 8h",
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -99,7 +99,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -222,6 +223,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -225,6 +226,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -97,7 +97,8 @@
         "steps": [
           "Open the Timesheets page.",
           "Fill in your hours for each day.",
-          "Review totals and submit."
+          "Review totals and submit.",
+          "Export a CSV for payroll."
         ]
       }
     }
@@ -220,6 +221,10 @@
       "expected": "Expected Hours",
       "shortfall": "Shortfall",
       "ot_bank_remaining": "OT Bank Remaining"
-    }
+    },
+    "add_row": "Add row",
+    "remove_row": "Remove row",
+    "export_csv": "Export CSV",
+    "payroll_export": "Payroll export"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # MJ FoodBank Booking
 
-This repository uses Git submodules for the backend and frontend components. After cloning, make sure to pull in the submodules and install their dependencies.
+Booking and volunteer management for the Moose Jaw Food Bank. This monorepo includes:
+
+- [MJ_FB_Backend](MJ_FB_Backend) – Node.js/Express API.
+- [MJ_FB_Frontend](MJ_FB_Frontend) – React single-page app.
+- [docs](docs/) with setup notes and a [Timesheets guide](docs/timesheets.md).
+
+This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 
 ## Node Version
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -2,6 +2,51 @@
 
 Staff can record daily hours and submit pay periods.
 
+## Setup
+
+1. Run database migrations to create the `timesheets` tables:
+
+```bash
+cd MJ_FB_Backend
+npm run migrate
+```
+
+2. Seed current pay periods for active staff (optional):
+
+```bash
+node src/utils/timesheetSeeder.ts
+```
+
+## API usage
+
+- `GET /timesheets` – list pay periods.
+- `GET /timesheets/:id/days` – list daily entries for a timesheet.
+- `PATCH /timesheets/:id/days/:date` – update hours for a day.
+- `POST /timesheets/:id/submit` – submit a pay period.
+- `POST /timesheets/:id/reject` – reject a submitted timesheet.
+- `POST /timesheets/:id/process` – mark a timesheet as processed and exportable.
+
+## UI walkthrough
+
+![Timesheet entry form](https://via.placeholder.com/600x400?text=Timesheet+Entry+Form)
+
+![Timesheet summary](https://via.placeholder.com/600x400?text=Timesheet+Summary)
+
+## Payroll export
+
+After a timesheet is processed, staff can download the period as a CSV using the **Export CSV** action. The file lists one row per day with the following columns:
+
+| Column | Description |
+| --- | --- |
+| `date` | Work date |
+| `reg` | Regular hours |
+| `ot` | Overtime hours |
+| `stat` | Stat holiday hours |
+| `sick` | Sick hours |
+| `vac` | Vacation hours |
+| `note` | Free-form note |
+| `paid_total` | Total paid hours for the day |
+
 ## Localization
 
 Add the following translation strings to locale files:
@@ -20,8 +65,13 @@ Add the following translation strings to locale files:
 - `timesheets.summary.expected`
 - `timesheets.summary.shortfall`
 - `timesheets.summary.ot_bank_remaining`
+- `timesheets.add_row`
+- `timesheets.remove_row`
+- `timesheets.export_csv`
+- `timesheets.payroll_export`
 - `help.pantry.timesheets.title`
 - `help.pantry.timesheets.description`
 - `help.pantry.timesheets.steps.0`
 - `help.pantry.timesheets.steps.1`
 - `help.pantry.timesheets.steps.2`
+- `help.pantry.timesheets.steps.3`


### PR DESCRIPTION
## Summary
- outline project structure and link to docs and timesheet guide in README
- add comprehensive `docs/timesheets.md` with setup, API usage, payroll CSV details, UI placeholders, and localization keys
- note timesheet doc maintenance in `AGENTS.md` and add translation strings across locales
- drop local screenshot binaries to keep repository text-only

## Testing
- `npm test` (backend) *(fails: client visit booking integration, volunteer booking status email, booking limits, and others)*
- `npm test` (frontend) *(fails: AgencyAccess, PasswordSetup, NoShowWeek, StaffRecurringBookings, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7520245f8832dbb8c71184ddb299b