### PR TITLE
Expand timesheet day tracking

### DIFF
--- a/MJ_FB_Backend/src/controllers/timesheetController.ts
+++ b/MJ_FB_Backend/src/controllers/timesheetController.ts
@@ -48,7 +48,14 @@ export async function updateTimesheetDay(req: Request, res: Response, next: Next
     if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
     const timesheetId = Number(req.params.id);
     const workDate = req.params.date;
-    const hours = Number(req.body.hours);
+    const {
+      regHours = 0,
+      otHours = 0,
+      statHours = 0,
+      sickHours = 0,
+      vacHours = 0,
+      note = undefined,
+    } = req.body;
     const ts = await getTimesheetById(timesheetId);
     if (!ts || ts.volunteer_id !== Number(req.user.id)) {
       return next({
@@ -57,7 +64,14 @@ export async function updateTimesheetDay(req: Request, res: Response, next: Next
         message: 'Timesheet not found',
       });
     }
-    await modelUpdateTimesheetDay(timesheetId, workDate, hours);
+    await modelUpdateTimesheetDay(timesheetId, workDate, {
+      regHours: Number(regHours),
+      otHours: Number(otHours),
+      statHours: Number(statHours),
+      sickHours: Number(sickHours),
+      vacHours: Number(vacHours),
+      note,
+    });
     res.json({ message: 'Updated' });
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/src/migrations/1732000000000_timesheet_day_expansion.ts
+++ b/MJ_FB_Backend/src/migrations/1732000000000_timesheet_day_expansion.ts
@@ -1,0 +1,205 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns('timesheet_days', {
+    reg_hours: { type: 'integer', notNull: true, default: 0 },
+    ot_hours: { type: 'integer', notNull: true, default: 0 },
+    stat_hours: { type: 'integer', notNull: true, default: 0 },
+    sick_hours: { type: 'integer', notNull: true, default: 0 },
+    vac_hours: { type: 'integer', notNull: true, default: 0 },
+    note: { type: 'text' },
+    locked_by_rule: { type: 'boolean', notNull: true, default: false },
+    locked_by_leave: { type: 'boolean', notNull: true, default: false },
+  });
+
+  pgm.dropColumn('timesheet_days', 'actual_hours');
+
+  // Replace views
+  pgm.sql('DROP VIEW IF EXISTS v_timesheet_totals;');
+  pgm.sql('DROP VIEW IF EXISTS v_timesheet_expected;');
+  pgm.sql('DROP VIEW IF EXISTS v_timesheet_balance;');
+
+  pgm.sql(`
+    CREATE VIEW v_timesheet_totals AS
+      SELECT t.id AS timesheet_id,
+             COALESCE(SUM(td.reg_hours + td.ot_hours + td.stat_hours + td.sick_hours + td.vac_hours), 0) AS total_hours
+        FROM timesheets t
+        LEFT JOIN timesheet_days td ON td.timesheet_id = t.id
+       GROUP BY t.id;
+  `);
+
+  pgm.sql(`
+    CREATE VIEW v_timesheet_expected AS
+      SELECT t.id AS timesheet_id,
+             COALESCE(SUM(td.expected_hours), 0) AS expected_hours
+        FROM timesheets t
+        LEFT JOIN timesheet_days td ON td.timesheet_id = t.id
+       GROUP BY t.id;
+  `);
+
+  pgm.sql(`
+    CREATE VIEW v_timesheet_balance AS
+      SELECT t.id AS timesheet_id,
+             COALESCE(SUM(td.ot_hours), 0) AS ot_hours,
+             COALESCE(SUM(td.reg_hours + td.stat_hours + td.sick_hours + td.vac_hours - td.expected_hours), 0) AS balance_hours
+        FROM timesheets t
+        LEFT JOIN timesheet_days td ON td.timesheet_id = t.id
+       GROUP BY t.id;
+  `);
+
+  // Replace trigger function
+  pgm.sql('DROP TRIGGER IF EXISTS trg_timesheet_day_rules ON timesheet_days;');
+  pgm.sql('DROP FUNCTION IF EXISTS trg_timesheet_day_rules();');
+
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION trg_timesheet_day_rules()
+    RETURNS trigger AS $$
+    DECLARE
+      is_stat boolean;
+    BEGIN
+      IF TG_OP = 'UPDATE' AND (OLD.locked_by_rule OR OLD.locked_by_leave) THEN
+        RAISE EXCEPTION 'Day is locked';
+      END IF;
+
+      SELECT EXISTS(SELECT 1 FROM holidays WHERE date = NEW.work_date) INTO is_stat;
+      IF is_stat THEN
+        NEW.stat_hours := NEW.expected_hours;
+        NEW.reg_hours := 0;
+        NEW.ot_hours := 0;
+        NEW.sick_hours := 0;
+        NEW.vac_hours := 0;
+        NEW.note := NULL;
+        NEW.locked_by_rule := TRUE;
+      END IF;
+
+      IF NEW.reg_hours + NEW.stat_hours + NEW.sick_hours + NEW.vac_hours > 8 THEN
+        RAISE EXCEPTION 'Daily paid hours cannot exceed 8';
+      END IF;
+
+      IF NEW.reg_hours < 0 OR NEW.ot_hours < 0 OR NEW.stat_hours < 0 OR NEW.sick_hours < 0 OR NEW.vac_hours < 0 THEN
+        RAISE EXCEPTION 'Hours cannot be negative';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+
+  pgm.sql(`
+    CREATE TRIGGER trg_timesheet_day_rules
+    BEFORE INSERT OR UPDATE ON timesheet_days
+    FOR EACH ROW EXECUTE FUNCTION trg_timesheet_day_rules();
+  `);
+
+  // Replace balance validation function
+  pgm.sql('DROP FUNCTION IF EXISTS validate_timesheet_balance(integer);');
+
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION validate_timesheet_balance(p_timesheet_id integer)
+    RETURNS void AS $$
+    DECLARE
+      v_shortfall integer;
+      v_ot integer;
+    BEGIN
+      SELECT COALESCE(SUM(td.reg_hours + td.stat_hours + td.sick_hours + td.vac_hours - td.expected_hours), 0),
+             COALESCE(SUM(td.ot_hours), 0)
+        INTO v_shortfall, v_ot
+        FROM timesheet_days td
+       WHERE td.timesheet_id = p_timesheet_id;
+
+      IF v_shortfall < 0 AND v_ot + v_shortfall < 0 THEN
+        RAISE EXCEPTION 'Shortfall % exceeds OT %', abs(v_shortfall), v_ot;
+      END IF;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('DROP FUNCTION IF EXISTS validate_timesheet_balance(integer);');
+  pgm.sql('DROP TRIGGER IF EXISTS trg_timesheet_day_rules ON timesheet_days;');
+  pgm.sql('DROP FUNCTION IF EXISTS trg_timesheet_day_rules();');
+  pgm.sql('DROP VIEW IF EXISTS v_timesheet_balance;');
+  pgm.sql('DROP VIEW IF EXISTS v_timesheet_expected;');
+  pgm.sql('DROP VIEW IF EXISTS v_timesheet_totals;');
+
+  pgm.addColumn('timesheet_days', { actual_hours: { type: 'integer', notNull: true, default: 0 } });
+  pgm.dropColumns('timesheet_days', [
+    'reg_hours',
+    'ot_hours',
+    'stat_hours',
+    'sick_hours',
+    'vac_hours',
+    'note',
+    'locked_by_rule',
+    'locked_by_leave',
+  ]);
+
+  pgm.sql(`
+    CREATE VIEW v_timesheet_totals AS
+      SELECT t.id AS timesheet_id,
+             COALESCE(SUM(td.actual_hours), 0) AS total_hours
+        FROM timesheets t
+        LEFT JOIN timesheet_days td ON td.timesheet_id = t.id
+       GROUP BY t.id;
+  `);
+
+  pgm.sql(`
+    CREATE VIEW v_timesheet_expected AS
+      SELECT t.id AS timesheet_id,
+             COALESCE(SUM(td.expected_hours), 0) AS expected_hours
+        FROM timesheets t
+        LEFT JOIN timesheet_days td ON td.timesheet_id = t.id
+       GROUP BY t.id;
+  `);
+
+  pgm.sql(`
+    CREATE VIEW v_timesheet_balance AS
+      SELECT t.id AS timesheet_id,
+             COALESCE(SUM(td.actual_hours - td.expected_hours), 0) AS balance_hours
+        FROM timesheets t
+        LEFT JOIN timesheet_days td ON td.timesheet_id = t.id
+       GROUP BY t.id;
+  `);
+
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION trg_timesheet_day_rules()
+    RETURNS trigger AS $$
+    BEGIN
+      IF NEW.actual_hours < 0 THEN
+        RAISE EXCEPTION 'actual_hours cannot be negative';
+      END IF;
+      IF NEW.expected_hours < 0 THEN
+        RAISE EXCEPTION 'expected_hours cannot be negative';
+      END IF;
+      IF NEW.actual_hours > NEW.expected_hours THEN
+        RAISE EXCEPTION 'actual_hours cannot exceed expected_hours';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+
+  pgm.sql(`
+    CREATE TRIGGER trg_timesheet_day_rules
+    BEFORE INSERT OR UPDATE ON timesheet_days
+    FOR EACH ROW EXECUTE FUNCTION trg_timesheet_day_rules();
+  `);
+
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION validate_timesheet_balance(p_timesheet_id integer)
+    RETURNS void AS $$
+    DECLARE v_balance integer;
+    BEGIN
+      SELECT COALESCE(SUM(actual_hours - expected_hours), 0)
+        INTO v_balance
+        FROM timesheet_days
+       WHERE timesheet_id = p_timesheet_id;
+
+      IF v_balance <> 0 THEN
+        RAISE EXCEPTION 'Timesheet % is unbalanced by % hours', p_timesheet_id, v_balance;
+      END IF;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+}

--- a/MJ_FB_Backend/src/utils/timesheetSeeder.ts
+++ b/MJ_FB_Backend/src/utils/timesheetSeeder.ts
@@ -46,8 +46,18 @@ export async function seedTimesheets(staffId?: number): Promise<void> {
 
       // Insert weekday rows with zeroed hours
       await pool.query(
-        `INSERT INTO timesheet_days (timesheet_id, work_date, expected_hours, actual_hours)
-         SELECT $1, gs.day, 0, 0
+        `INSERT INTO timesheet_days (
+            timesheet_id,
+            work_date,
+            expected_hours,
+            reg_hours,
+            ot_hours,
+            stat_hours,
+            sick_hours,
+            vac_hours,
+            note
+         )
+         SELECT $1, gs.day, 0, 0, 0, 0, 0, 0, NULL
            FROM generate_series(GREATEST($2::date, $3::date), $4::date, '1 day') AS gs(day)
           WHERE EXTRACT(ISODOW FROM gs.day) < 6
           ON CONFLICT (timesheet_id, work_date) DO NOTHING`,

--- a/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
+++ b/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
@@ -26,7 +26,20 @@ describe('timesheet controller', () => {
       .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({
         rows: [
-          { id: 2, timesheet_id: 1, work_date: '2024-01-02', expected_hours: 3, actual_hours: 1 },
+          {
+            id: 2,
+            timesheet_id: 1,
+            work_date: '2024-01-02',
+            expected_hours: 3,
+            reg_hours: 1,
+            ot_hours: 0,
+            stat_hours: 0,
+            sick_hours: 0,
+            vac_hours: 0,
+            note: null,
+            locked_by_rule: false,
+            locked_by_leave: false,
+          },
         ],
         rowCount: 1,
       });
@@ -34,7 +47,20 @@ describe('timesheet controller', () => {
     const res: any = { json: jest.fn() };
     await getTimesheetDays(req, res, () => {});
     expect(res.json).toHaveBeenCalledWith([
-      { id: 2, timesheet_id: 1, work_date: '2024-01-02', expected_hours: 3, actual_hours: 1 },
+      {
+        id: 2,
+        timesheet_id: 1,
+        work_date: '2024-01-02',
+        expected_hours: 3,
+        reg_hours: 1,
+        ot_hours: 0,
+        stat_hours: 0,
+        sick_hours: 0,
+        vac_hours: 0,
+        note: null,
+        locked_by_rule: false,
+        locked_by_leave: false,
+      },
     ]);
   });
 
@@ -46,7 +72,20 @@ describe('timesheet controller', () => {
       .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({
         rows: [
-          { id: 1, timesheet_id: 1, work_date: '2024-07-01', expected_hours: 8, actual_hours: 8 },
+          {
+            id: 1,
+            timesheet_id: 1,
+            work_date: '2024-07-01',
+            expected_hours: 8,
+            reg_hours: 0,
+            ot_hours: 0,
+            stat_hours: 8,
+            sick_hours: 0,
+            vac_hours: 0,
+            note: null,
+            locked_by_rule: true,
+            locked_by_leave: false,
+          },
         ],
         rowCount: 1,
       })
@@ -58,13 +97,26 @@ describe('timesheet controller', () => {
     const getRes: any = { json: jest.fn() };
     await getTimesheetDays(getReq, getRes, () => {});
     expect(getRes.json).toHaveBeenCalledWith([
-      { id: 1, timesheet_id: 1, work_date: '2024-07-01', expected_hours: 8, actual_hours: 8 },
+      {
+        id: 1,
+        timesheet_id: 1,
+        work_date: '2024-07-01',
+        expected_hours: 8,
+        reg_hours: 0,
+        ot_hours: 0,
+        stat_hours: 8,
+        sick_hours: 0,
+        vac_hours: 0,
+        note: null,
+        locked_by_rule: true,
+        locked_by_leave: false,
+      },
     ]);
 
     const updReq: any = {
       user: { id: '1', role: 'volunteer' },
       params: { id: '1', date: '2024-07-01' },
-      body: { hours: 4 },
+      body: { regHours: 4 },
     };
     const updRes: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await updateTimesheetDay(updReq, updRes, nextErr(updReq, updRes));
@@ -82,7 +134,7 @@ describe('timesheet controller', () => {
     const req: any = {
       user: { id: '1', role: 'volunteer' },
       params: { id: '1', date: '2024-01-02' },
-      body: { hours: 3 },
+      body: { regHours: 3, otHours: 1, statHours: 0, sickHours: 0, vacHours: 0, note: 'hi' },
     };
     const res: any = { json: jest.fn() };
     await updateTimesheetDay(req, res, () => {});
@@ -97,7 +149,7 @@ describe('timesheet controller', () => {
     const req: any = {
       user: { id: '1', role: 'volunteer' },
       params: { id: '1', date: '2024-01-02' },
-      body: { hours: 2 },
+      body: { regHours: 2 },
     };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await updateTimesheetDay(req, res, nextErr(req, res));
@@ -114,7 +166,7 @@ describe('timesheet controller', () => {
     const req: any = {
       user: { id: '1', role: 'volunteer' },
       params: { id: '1', date: '2024-01-02' },
-      body: { hours: 2 },
+      body: { regHours: 2 },
     };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await updateTimesheetDay(req, res, nextErr(req, res));
@@ -148,7 +200,7 @@ describe('timesheet controller', () => {
     const req: any = {
       user: { id: '1', role: 'volunteer' },
       params: { id: '1', date: '2024-01-02' },
-      body: { hours: 10 },
+      body: { regHours: 10 },
     };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await updateTimesheetDay(req, res, nextErr(req, res));

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -21,7 +21,7 @@ node src/utils/timesheetSeeder.ts
 
 - `GET /timesheets` – list pay periods.
 - `GET /timesheets/:id/days` – list daily entries for a timesheet.
-- `PATCH /timesheets/:id/days/:date` – update hours for a day.
+- `PATCH /timesheets/:id/days/:date` – update hours for a day. Body accepts `regHours`, `otHours`, `statHours`, `sickHours`, `vacHours`, and optional `note`.
 - `POST /timesheets/:id/submit` – submit a pay period.
 - `POST /timesheets/:id/reject` – reject a submitted timesheet.
 - `POST /timesheets/:id/process` – mark a timesheet as processed and exportable.
@@ -46,6 +46,8 @@ After a timesheet is processed, staff can download the period as a CSV using the
 | `vac` | Vacation hours |
 | `note` | Free-form note |
 | `paid_total` | Total paid hours for the day |
+
+Stat holidays are auto-filled with the day's expected hours and locked from editing. Days may also be locked when leave is approved.
 
 ## Localization
 


### PR DESCRIPTION
## Summary
- track regular, overtime, stat, sick, and vacation hours per day and add locking flags
- auto-fill stat holidays, cap paid hours, and validate OT balance in database triggers
- surface new fields in timesheet APIs, seeder, docs, and tests

## Testing
- `npm test` *(fails: 9 failed, 85 passed, 94 total)*
- `npm test tests/timesheets/timesheetController.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b756341da4832dbc9405a02f9a57e6