### PR TITLE
Use staff IDs for timesheets

### DIFF
--- a/MJ_FB_Backend/src/controllers/timesheetController.ts
+++ b/MJ_FB_Backend/src/controllers/timesheetController.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import {
-  getTimesheetsForVolunteer,
+  getTimesheetsForStaff,
   getTimesheetDays as modelGetTimesheetDays,
   getTimesheetById,
   updateTimesheetDay as modelUpdateTimesheetDay,
@@ -16,8 +16,9 @@ export async function listMyTimesheets(
   next: NextFunction,
 ) {
   try {
-    if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
-    const rows = await getTimesheetsForVolunteer(Number(req.user.id));
+    if (!req.user || req.user.type !== 'staff')
+      return res.status(401).json({ message: 'Unauthorized' });
+    const rows = await getTimesheetsForStaff(Number(req.user.id));
     res.json(rows);
   } catch (err) {
     next(err);
@@ -26,10 +27,11 @@ export async function listMyTimesheets(
 
 export async function getTimesheetDays(req: Request, res: Response, next: NextFunction) {
   try {
-    if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
+    if (!req.user || req.user.type !== 'staff')
+      return res.status(401).json({ message: 'Unauthorized' });
     const timesheetId = Number(req.params.id);
     const ts = await getTimesheetById(timesheetId);
-    if (!ts || ts.volunteer_id !== Number(req.user.id)) {
+    if (!ts || ts.staff_id !== Number(req.user.id)) {
       return next({
         status: 404,
         code: 'TIMESHEET_NOT_FOUND',
@@ -45,12 +47,13 @@ export async function getTimesheetDays(req: Request, res: Response, next: NextFu
 
 export async function updateTimesheetDay(req: Request, res: Response, next: NextFunction) {
   try {
-    if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
+    if (!req.user || req.user.type !== 'staff')
+      return res.status(401).json({ message: 'Unauthorized' });
     const timesheetId = Number(req.params.id);
     const workDate = req.params.date;
     const hours = Number(req.body.hours);
     const ts = await getTimesheetById(timesheetId);
-    if (!ts || ts.volunteer_id !== Number(req.user.id)) {
+    if (!ts || ts.staff_id !== Number(req.user.id)) {
       return next({
         status: 404,
         code: 'TIMESHEET_NOT_FOUND',
@@ -66,10 +69,11 @@ export async function updateTimesheetDay(req: Request, res: Response, next: Next
 
 export async function submitTimesheet(req: Request, res: Response, next: NextFunction) {
   try {
-    if (!req.user) return res.status(401).json({ message: 'Unauthorized' });
+    if (!req.user || req.user.type !== 'staff')
+      return res.status(401).json({ message: 'Unauthorized' });
     const timesheetId = Number(req.params.id);
     const ts = await getTimesheetById(timesheetId);
-    if (!ts || ts.volunteer_id !== Number(req.user.id)) {
+    if (!ts || ts.staff_id !== Number(req.user.id)) {
       return next({
         status: 404,
         code: 'TIMESHEET_NOT_FOUND',

--- a/MJ_FB_Backend/src/migrations/1731000000000_timesheets.ts
+++ b/MJ_FB_Backend/src/migrations/1731000000000_timesheets.ts
@@ -3,10 +3,10 @@ import { MigrationBuilder } from 'node-pg-migrate';
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createTable('timesheets', {
     id: 'id',
-    volunteer_id: {
+    staff_id: {
       type: 'integer',
       notNull: true,
-      references: 'volunteers',
+      references: 'staff',
       onDelete: 'CASCADE',
     },
     start_date: { type: 'date', notNull: true },
@@ -17,8 +17,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.addConstraint(
     'timesheets',
-    'timesheets_volunteer_period_unique',
-    'UNIQUE(volunteer_id, start_date, end_date)',
+    'timesheets_staff_period_unique',
+    'UNIQUE(staff_id, start_date, end_date)',
   );
 
   pgm.createTable('timesheet_days', {

--- a/MJ_FB_Backend/src/models/timesheet.ts
+++ b/MJ_FB_Backend/src/models/timesheet.ts
@@ -2,7 +2,7 @@ import pool from '../db';
 
 export interface Timesheet {
   id: number;
-  volunteer_id: number;
+  staff_id: number;
   start_date: string;
   end_date: string;
   submitted_at: string | null;
@@ -23,9 +23,9 @@ export interface TimesheetSummary extends Timesheet {
   balance_hours: number;
 }
 
-export async function getTimesheetsForVolunteer(volunteerId: number): Promise<TimesheetSummary[]> {
+export async function getTimesheetsForStaff(staffId: number): Promise<TimesheetSummary[]> {
   const res = await pool.query(
-    `SELECT t.id, t.volunteer_id, t.start_date, t.end_date, t.submitted_at, t.approved_at,
+    `SELECT t.id, t.staff_id, t.start_date, t.end_date, t.submitted_at, t.approved_at,
             COALESCE(tot.total_hours, 0) AS total_hours,
             COALESCE(exp.expected_hours, 0) AS expected_hours,
             COALESCE(bal.balance_hours, 0) AS balance_hours
@@ -33,9 +33,9 @@ export async function getTimesheetsForVolunteer(volunteerId: number): Promise<Ti
        LEFT JOIN v_timesheet_totals tot ON tot.timesheet_id = t.id
        LEFT JOIN v_timesheet_expected exp ON exp.timesheet_id = t.id
        LEFT JOIN v_timesheet_balance bal ON bal.timesheet_id = t.id
-      WHERE t.volunteer_id = $1
+      WHERE t.staff_id = $1
       ORDER BY t.start_date DESC`,
-    [volunteerId],
+    [staffId],
   );
   return res.rows;
 }

--- a/MJ_FB_Backend/src/routes/timesheets.ts
+++ b/MJ_FB_Backend/src/routes/timesheets.ts
@@ -11,10 +11,10 @@ import {
 
 const router = express.Router();
 
-router.get('/', authMiddleware, listMyTimesheets);
-router.get('/:id/days', authMiddleware, getTimesheetDays);
-router.patch('/:id/days/:date', authMiddleware, updateTimesheetDay);
-router.post('/:id/submit', authMiddleware, submitTimesheet);
+router.get('/', authMiddleware, authorizeRoles('staff'), listMyTimesheets);
+router.get('/:id/days', authMiddleware, authorizeRoles('staff'), getTimesheetDays);
+router.patch('/:id/days/:date', authMiddleware, authorizeRoles('staff'), updateTimesheetDay);
+router.post('/:id/submit', authMiddleware, authorizeRoles('staff'), submitTimesheet);
 router.post('/:id/reject', authMiddleware, authorizeRoles('staff'), rejectTimesheet);
 router.post('/:id/process', authMiddleware, authorizeRoles('staff'), processTimesheet);
 

--- a/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
+++ b/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
@@ -13,9 +13,9 @@ import mockPool from '../utils/mockDb';
 const nextErr = (req: any, res: any) => (err: any) => errorHandler(err, req, res, () => {});
 
 describe('timesheet controller', () => {
-  it('lists volunteer timesheets', async () => {
+  it('lists staff timesheets', async () => {
     (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
-    const req: any = { user: { id: '1', role: 'volunteer' } };
+    const req: any = { user: { id: '1', role: 'staff', type: 'staff' } };
     const res: any = { json: jest.fn() };
     await listMyTimesheets(req, res, () => {});
     expect(res.json).toHaveBeenCalledWith([{ id: 1 }]);
@@ -23,14 +23,14 @@ describe('timesheet controller', () => {
 
   it('gets timesheet days', async () => {
     (mockPool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({
         rows: [
           { id: 2, timesheet_id: 1, work_date: '2024-01-02', expected_hours: 3, actual_hours: 1 },
         ],
         rowCount: 1,
       });
-    const req: any = { user: { id: '1', role: 'volunteer' }, params: { id: '1' } };
+    const req: any = { user: { id: '1', role: 'staff', type: 'staff' }, params: { id: '1' } };
     const res: any = { json: jest.fn() };
     await getTimesheetDays(req, res, () => {});
     expect(res.json).toHaveBeenCalledWith([
@@ -43,18 +43,18 @@ describe('timesheet controller', () => {
     lockErr.status = 400;
     lockErr.code = 'STAT_DAY_LOCKED';
     (mockPool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({
         rows: [
           { id: 1, timesheet_id: 1, work_date: '2024-07-01', expected_hours: 8, actual_hours: 8 },
         ],
         rowCount: 1,
       })
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ submitted_at: null, approved_at: null }], rowCount: 1 })
       .mockRejectedValueOnce(lockErr);
 
-    const getReq: any = { user: { id: '1', role: 'volunteer' }, params: { id: '1' } };
+    const getReq: any = { user: { id: '1', role: 'staff', type: 'staff' }, params: { id: '1' } };
     const getRes: any = { json: jest.fn() };
     await getTimesheetDays(getReq, getRes, () => {});
     expect(getRes.json).toHaveBeenCalledWith([
@@ -62,7 +62,7 @@ describe('timesheet controller', () => {
     ]);
 
     const updReq: any = {
-      user: { id: '1', role: 'volunteer' },
+      user: { id: '1', role: 'staff', type: 'staff' },
       params: { id: '1', date: '2024-07-01' },
       body: { hours: 4 },
     };
@@ -76,11 +76,11 @@ describe('timesheet controller', () => {
 
   it('updates a timesheet day', async () => {
     (mockPool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ submitted_at: null, approved_at: null }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 });
     const req: any = {
-      user: { id: '1', role: 'volunteer' },
+      user: { id: '1', role: 'staff', type: 'staff' },
       params: { id: '1', date: '2024-01-02' },
       body: { hours: 3 },
     };
@@ -92,10 +92,10 @@ describe('timesheet controller', () => {
 
   it('prevents editing a submitted timesheet', async () => {
     (mockPool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ submitted_at: '2024-01-10', approved_at: null }], rowCount: 1 });
     const req: any = {
-      user: { id: '1', role: 'volunteer' },
+      user: { id: '1', role: 'staff', type: 'staff' },
       params: { id: '1', date: '2024-01-02' },
       body: { hours: 2 },
     };
@@ -109,10 +109,10 @@ describe('timesheet controller', () => {
 
   it('prevents editing a processed timesheet', async () => {
     (mockPool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ submitted_at: '2024-01-10', approved_at: '2024-01-11' }], rowCount: 1 });
     const req: any = {
-      user: { id: '1', role: 'volunteer' },
+      user: { id: '1', role: 'staff', type: 'staff' },
       params: { id: '1', date: '2024-01-02' },
       body: { hours: 2 },
     };
@@ -126,9 +126,9 @@ describe('timesheet controller', () => {
 
   it('returns validation error when shortfall exceeds OT', async () => {
     (mockPool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockRejectedValueOnce(new Error('Shortfall 2 exceeds OT 1'));
-    const req: any = { user: { id: '1', role: 'volunteer' }, params: { id: '1' } };
+    const req: any = { user: { id: '1', role: 'staff', type: 'staff' }, params: { id: '1' } };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await submitTimesheet(req, res, nextErr(req, res));
     expect(res.status).toHaveBeenCalledWith(400);
@@ -142,11 +142,11 @@ describe('timesheet controller', () => {
     capErr.status = 400;
     capErr.code = 'DAILY_CAP_EXCEEDED';
     (mockPool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ submitted_at: null, approved_at: null }], rowCount: 1 })
       .mockRejectedValueOnce(capErr);
     const req: any = {
-      user: { id: '1', role: 'volunteer' },
+      user: { id: '1', role: 'staff', type: 'staff' },
       params: { id: '1', date: '2024-01-02' },
       body: { hours: 10 },
     };
@@ -160,10 +160,10 @@ describe('timesheet controller', () => {
 
   it('submits timesheet when shortfall is covered by OT', async () => {
     (mockPool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ volunteer_id: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ staff_id: 1 }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ result: null }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
-    const req: any = { user: { id: '1', role: 'volunteer' }, params: { id: '1' } };
+    const req: any = { user: { id: '1', role: 'staff', type: 'staff' }, params: { id: '1' } };
     const res: any = { json: jest.fn() };
     await submitTimesheet(req, res, nextErr(req, res));
     expect(res.json).toHaveBeenCalledWith({ message: 'Submitted' });


### PR DESCRIPTION
## Summary
- Replace volunteer_id with staff_id in timesheets migration and schema
- Update timesheet model, controller and routes for staff access
- Adjust tests for staff-based timesheets

## Testing
- `npm run migrate` *(fails: could not connect to postgres)*
- `npm test` *(fails: 9 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b7561f3064832da70b9e0cd7ffbfcf