### PR TITLE
feat: scaffold leave request API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Document translation strings for localization in `docs/` and update `src/locales` when user-facing text is added.
 - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes.
- - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes. Timesheets now support vacation leave requests via `/timesheets/:id/leave-requests`; ensure related translations are added.
+- Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes. Timesheets now support vacation leave requests via `/timesheets/:id/leave-requests`; ensure related translations are added.
+- Global review endpoints exist under `/api/leave/requests` for leave submissions; document changes and translations when updating leave features.
 - A GitHub Actions workflow in `.github/workflows/release.yml` builds, tests, and deploys container images to Azure Container Apps. Configure repository secrets `AZURE_CREDENTIALS`, `REGISTRY_LOGIN_SERVER`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD` and variables `AZURE_RESOURCE_GROUP`, `BACKEND_APP_NAME`, and `FRONTEND_APP_NAME`; see `docs/release.md` for details.
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 22+ for native `fetch`; earlier versions are not supported.
@@ -81,6 +82,7 @@
 ## Project Layout
 
 ### Backend (`MJ_FB_Backend`)
+
 - Node.js + Express API written in TypeScript.
 - `controllers/` – business logic for each resource, grouped by domain (e.g., volunteer, warehouse, admin).
 - `routes/` – REST endpoints wiring, organized by matching domain directories.
@@ -89,18 +91,19 @@
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
 - The database schema is managed via TypeScript migrations in `src/migrations`. The backend runs pending migrations automatically on startup and logs each applied migration name. You can also run them manually with `npm run migrate`.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
- - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights and notes to create a client visit.
+- The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights and notes to create a client visit.
 - The Manage Booking dialog shows the client's name, profile link, and current-month visit count.
 - Bookings accept optional notes; clients may include a message during booking, and staff see it in Manage Booking and Manage Volunteer Shift dialogs.
 - Creating a client visit will automatically mark the client's approved booking on that date as visited.
 - `/bookings/history?includeVisits=true` merges walk-in visits (`client_visits`) with booking history.
- - Staff and agency users may append `includeVisitNotes=true` to `/bookings/history` to retrieve notes recorded on client visits.
- - Visit history can be filtered by note text using the `notes` query parameter on `/bookings/history`.
+- Staff and agency users may append `includeVisitNotes=true` to `/bookings/history` to retrieve notes recorded on client visits.
+- Visit history can be filtered by note text using the `notes` query parameter on `/bookings/history`.
 - Agencies can filter booking history for multiple clients and paginate results via `/bookings/history?clientIds=1,2&limit=10&offset=0`.
 - Staff can create, update, or delete slots and adjust their capacities via `/slots` routes.
 - `PUT /slots/capacity` updates the `max_capacity` for all slots.
 
 ### Frontend (`MJ_FB_Frontend`)
+
 - React app built with Vite.
 - Build requires `VITE_API_BASE` to be set in `MJ_FB_Frontend/.env`.
 - `pages/` define top-level views and are organized into feature-based directories (booking, staff, volunteer-management, warehouse-management, etc.).
@@ -135,17 +138,20 @@
 ## UI Rules & Design System (Global)
 
 ### Tech & Theme
+
 - Library: Material UI v5 only (no Tailwind).
 - Theme: Use the app’s `ThemeProvider` theme (primary `#941818`, Golos font, rounded corners). Never hard-code colors, spacing, or fonts—pull from the theme.
 - Typography: Default to theme typography. Section titles use `subtitle1`/`h5` with bold as defined in theme.
- - Typography: Default to theme typography. Page and form titles use uppercase `h4`/`h5` variants with a slightly lighter font weight.
+- Typography: Default to theme typography. Page and form titles use uppercase `h4`/`h5` variants with a slightly lighter font weight.
 
 ### Layout
+
 - Grid: Use `Grid` with `spacing={2}` for page layout; prefer 12-column responsive layouts.
 - Cards: Group related content in `Card` (or `Paper`) with the themed light border and subtle shadow. Avoid “floating” elements.
 - Responsive: Ensure components work on xs→xl. Hide non-critical details on small screens, not critical actions.
 
 ### Components & Patterns
+
 - Buttons: `size="small"`, `variant="contained"` for primary actions, outlined/text for secondary/tertiary. No ALL CAPS; `textTransform: 'none'`.
 - Lists: `List` + `ListItem` for short, actionable sets.
 - Tables: Use dense row height; keep actions in a trailing column; keep columns ≤ 7 on desktop.
@@ -157,6 +163,7 @@
 - Icons: Use `@mui/icons-material`. Pair icons with labels (accessibility + clarity).
 
 ### Status & Colors
+
 - Status chips:
   - success = approved/ok,
   - warning = needs attention,
@@ -172,27 +179,32 @@
   - capacity exceeded → theme warning light.
 
 ### Interactions
+
 - Affordance: Primary action visible and enabled when valid; disabled state must include a reason (helper text or tooltip).
 - Confirmation: Only confirm destructive actions (e.g., Cancel, Reject). Use dialogs with clear verb-first buttons (“Cancel booking”, “Keep booking”).
 - Undo: Prefer “Undo” in `FeedbackSnackbar` where safe (e.g., client-side remove before API commit).
 
 ### Content Style
+
 - Copy: Plain, concise, second person (“You”).
 - Dates/Times: Show local time with clear format (e.g., Tue, Aug 12 · 9:30–10:00). Avoid ambiguity.
 - Errors: Actionable and specific (“Slot is full. Pick another time.”), not generic.
 
 ### Dashboards (by role)
- - Staff: “Today at a Glance” stats, Pantry Schedule snapshot, Volunteer Coverage, Quick Search, Cancellations, Notices & Events.
- - Volunteer: My Next Shifts, Available in My Roles, Announcements, Quick Actions, Profile & Training.
- - User: Upcoming Appointments, Next Available Slots, Notices, Quick Actions.
- - Each section should be a card with a concise header and an action (e.g., “Review All”, “Open Schedule”).
+
+- Staff: “Today at a Glance” stats, Pantry Schedule snapshot, Volunteer Coverage, Quick Search, Cancellations, Notices & Events.
+- Volunteer: My Next Shifts, Available in My Roles, Announcements, Quick Actions, Profile & Training.
+- User: Upcoming Appointments, Next Available Slots, Notices, Quick Actions.
+- Each section should be a card with a concise header and an action (e.g., “Review All”, “Open Schedule”).
 
 ### Accessibility
+
 - Keyboard: All interactive controls must be focusable; visible focus ring (default MUI is fine).
 - ARIA: Use semantic components; add `aria-label` on icon-only buttons.
 - Contrast: Rely on theme tokens; don’t reduce contrast below MUI defaults.
 
 ### Do / Don’t
+
 - Do reuse existing shared components (`FeedbackSnackbar`, search inputs, role-aware guards).
 - Do keep pages fast; fetch minimal data for first paint, then lazy-load details.
 - Don’t inline custom CSS or use non-themed colors.
@@ -211,12 +223,14 @@ Similarly, volunteers should be able to log into the app to see which roles requ
 ## Functional Overview
 
 ### Backend
+
 - Express server configures CORS, initializes default slots, and mounts routes for clients, slots, bookings, holidays, blocked slots, breaks, staff, volunteer roles, volunteer bookings, and authentication.
 - Booking logic checks slot capacity, enforces monthly visit limits, and sends confirmation emails when a booking is created.
 - JWT-based middleware extracts tokens from headers or cookies, verifies them, and loads the matching staff, client, or volunteer record from PostgreSQL.
 - A setup script provisions PostgreSQL tables for slots, users (clients), staff, volunteer roles, bookings, breaks, and related data when the server starts.
 
 ### Frontend
+
 - The React app manages authentication for shoppers, staff, and volunteers, switching between login components and role-specific navigation/routes such as slot booking, schedule management, and volunteer coordination.
 - `BookingUI` provides a calendar view that excludes weekends and holidays, fetches available slots, and submits bookings via the API.
 - Staff manage holidays, blocked slots, and staff breaks through `ManageAvailability`, which pulls data from and sends updates to the backend API.
@@ -226,6 +240,7 @@ Similarly, volunteers should be able to log into the app to see which roles requ
 ## Booking Workflow
 
 ### Clients and Staff
+
 - **Clients** book pantry appointments through a calendar; bookings are automatically approved.
 - **Staff** can cancel or reschedule bookings and mark visits. Assigning a client directly to a slot creates an approved booking. Cancellations require a reason.
 - Clients can view a booking history table listing all appointments, each with Cancel and Reschedule options.
@@ -264,6 +279,7 @@ The booking flow uses the following PostgreSQL tables. **PK** denotes a primary 
 Volunteer management coordinates role-based staffing for the food bank.
 
 ### Role Categories (`volunteer_master_roles`)
+
 1. Pantry
 2. Warehouse
 3. Gardening
@@ -271,6 +287,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 5. Special Events
 
 ### Subroles (`volunteer_roles`)
+
 1. Food Sorter (Warehouse)
 2. Production Worker (Warehouse)
 3. Driver Assistant (Warehouse)
@@ -290,24 +307,29 @@ Volunteer management coordinates role-based staffing for the food bank.
 ## API Reference
 
 ### Auth
+
 - `POST /auth/request-password-reset` → 204 No Content.
 - `POST /auth/change-password` → 204 No Content (auth required).
 
 ### Clients
+
 - `POST /users/login` → `{ token, role, name, bookingsThisMonth? }`
 - `POST /users` → `{ message: 'Client created' }`
 - `GET /users/search?search=query` → `[ { id, name, email, phone, client_id } ]`
 - `GET /users/me` → `{ id, firstName, lastName, email, phone, clientId, role, bookingsThisMonth }`
 
 ### Staff
+
 - `GET /staff/exists` → `{ exists: boolean }`
 - `POST /staff` → `{ message: 'Staff created' }`
 
 ### Slots
+
 - `GET /slots?date=YYYY-MM-DD` → `[ { id, startTime, endTime, maxCapacity, available } ]`
 - `GET /slots/all` → `[ { id, startTime, endTime, maxCapacity } ]`
 
 ### Bookings
+
 - `POST /bookings` → `{ message: 'Booking created', bookingsThisMonth, rescheduleToken }`
 - `GET /bookings?clientIds=1,2` → `[ { id, status, date, user_id, slot_id, is_staff_booking, reschedule_token, user_name, user_email, user_phone, client_id, bookings_this_month, start_time, end_time } ]` (agencies must specify `clientIds` linked to them)
 - `GET /bookings/history` → `[ { id, status, date, slot_id, reason, start_time, end_time, created_at, is_staff_booking, reschedule_token } ]`
@@ -318,36 +340,43 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `POST /bookings/staff` → `{ message: 'Booking created for client', rescheduleToken }`
 
 ### Holidays
+
 - `GET /holidays` → `[ { date, reason } ]`
 - `POST /holidays` → `{ message: 'Added' }`
 - `DELETE /holidays/:date` → `{ message: 'Removed' }`
 
 ### Blocked Slots
+
 - `GET /blocked-slots?date=YYYY-MM-DD` → `[ { slotId, reason } ]`
 - `POST /blocked-slots` → `{ message: 'Added' }`
 - `DELETE /blocked-slots/:date/:slotId` → `{ message: 'Removed' }`
 
 ### Recurring Blocked Slots (`src/routes/recurringBlockedSlots.ts`)
+
 - `GET /recurring-blocked-slots` → `[ { id, dayOfWeek, weekOfMonth, slotId, reason } ]`
 - `POST /recurring-blocked-slots` `{ dayOfWeek, weekOfMonth, slotId, reason }` → `{ message: 'Added' }`
 - `DELETE /recurring-blocked-slots/:id` → `{ message: 'Removed' }`
 
 ### Breaks
+
 - `GET /breaks` → `[ { dayOfWeek, slotId, reason } ]`
 - `POST /breaks` → `{ message: 'Added' }`
 - `DELETE /breaks/:day/:slotId` → `{ message: 'Removed' }`
 
 ### Roles
+
 - `GET /roles` → `[ { categoryId, categoryName, roleId, roleName } ]`
 - `GET /roles/:roleId/shifts` → `[ { shiftId, startTime, endTime, maxVolunteers } ]`
 
 ### Volunteers
+
 - `POST /volunteers/login` → `{ token, role: 'volunteer', name }`
 - `POST /volunteers` → `{ id }`
 - `GET /volunteers/search?search=query` → `[ { id, name, trainedAreas } ]`
 - `PUT /volunteers/:id/trained-areas` → `{ id, roleIds }`
 
 ### Volunteer Roles
+
 - `GET /volunteer-roles/mine?date=YYYY-MM-DD` → `[ { id, role_id, name, start_time, end_time, max_volunteers, category_id, category_name, is_wednesday_slot, booked, available, status, date } ]`
 - `POST /volunteer-roles` (requires `roleId` or `name` + `categoryId`) → `{ id, role_id, name, start_time, end_time, max_volunteers, category_id, is_wednesday_slot, is_active, category_name }`
 - `GET /volunteer-roles` (`?includeInactive=true` to include inactive shifts) → `[ { id, role_id, category_id, name, max_volunteers, category_name, shifts } ]`
@@ -356,6 +385,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `DELETE /volunteer-roles/:id` → `{ message: 'Deleted' }`
 
 ### Volunteer Master Roles
+
 - `GET /volunteer-master-roles` → `[ { id, name } ]`
 - `POST /volunteer-master-roles` → `{ id, name }`
 - `PUT /volunteer-master-roles/:id` → `{ id, name }`
@@ -363,6 +393,7 @@ Volunteer management coordinates role-based staffing for the food bank.
 - `POST /volunteer-roles/restore` → `{ message: 'Volunteer roles restored' }` (staff only; resets roles, shifts, and training links)
 
 ### Volunteer Bookings
+
 - `POST /volunteer-bookings` → `{ id, role_id, volunteer_id, date, status, reschedule_token, status_color }` (409 returns `{ attempted, existing }` on overlap)
 - `POST /volunteer-bookings/staff` → `{ id, role_id, volunteer_id, date, status, reschedule_token, status_color }`
 - `POST /volunteer-bookings/resolve-conflict` `{ existingBookingId, keep, roleId?, date? }` → `{ kept, booking }`
@@ -382,6 +413,7 @@ Volunteer booking statuses include `completed`, and cancellations must include a
 Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid for volunteer bookings and the backend responds with "Use completed instead of visited for volunteer shifts" when submitted.
 
 ### Volunteer Recurring Bookings (`src/routes/volunteer/volunteerBookings.ts`)
+
 - `POST /volunteer-bookings/recurring` `{ roleId, startDate, endDate, pattern, daysOfWeek }` → `{ recurringId, successes, skipped }`
 - `GET /volunteer-bookings/recurring` → `[ { id, role_id, start_date, end_date, pattern, days_of_week } ]`
 - `POST /volunteer-bookings/recurring/staff` `{ volunteerId, roleId, startDate, endDate, pattern, daysOfWeek, force? }` → `{ recurringId, successes, skipped }`
@@ -390,6 +422,7 @@ Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid 
 - `PATCH /volunteer-bookings/:id/cancel` → `{ id, role_id, volunteer_id, date, status }`
 
 ### Agencies (`src/routes/agencies.ts`)
+
 - `GET /agencies/:id/clients` → `[ clientId ]`
 - `POST /agencies/add-client` `{ agencyId, clientId }` → `204` (404 if client not found)
 - `DELETE /agencies/:id/clients/:clientId` → `204`
@@ -404,6 +437,7 @@ Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid 
   routes (e.g. `GET /agencies/me/clients`).
 
 ### Donors (`src/routes/donors.ts`)
+
 - `GET /donors?search=name` → `[ { id, name } ]`
 - `POST /donors` `{ name }` → `{ id, name }`
 - `GET /donors/:id` → `{ id, name, totalLbs, lastDonationISO }`
@@ -411,11 +445,13 @@ Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid 
 - `GET /donors/top?year=YYYY&limit=N` → `[ { name, totalLbs, lastDonationISO } ]`
 
 ### Events (`src/routes/events.ts`)
+
 - `GET /events` → `{ today: [event], upcoming: [event], past: [event] }`
 - `POST /events` `{ title, details, category, date, staffIds?, visibleToVolunteers?, visibleToClients? }` → `{ id }`
 - `DELETE /events/:id` → `{ message: 'Deleted' }`
 
 ### Warehouse Management
+
 - `/warehouse-overall` routes provide yearly summaries of donations, surplus, pig pound, and outgoing donations.
 - `GET /warehouse-overall?year=YYYY` lists monthly aggregates, and `GET /warehouse-overall/export?year=YYYY` exports it as a spreadsheet. Aggregates update in real time; manual rebuilds are no longer needed.
 - Frontend pages under `/warehouse-management/*` (Dashboard, Donation Log, Track Pigpound, Track Outgoing Donations, Track Surplus, Aggregations) surface these warehouse features.
@@ -476,7 +512,7 @@ Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid 
 
 ## Components & Workflow
 
-- **VolunteerSchedule** lets volunteers choose a role from a dropdown and view a grid of shifts. Columns correspond to slot numbers and rows show shift times (e.g. 9:30–12:00, 12:30–3:30). Cells display *Booked* or *Available* and clicking an available cell creates a request in `volunteer_bookings`. Past dates are disabled and same-day shifts that have already started are omitted.
+- **VolunteerSchedule** lets volunteers choose a role from a dropdown and view a grid of shifts. Columns correspond to slot numbers and rows show shift times (e.g. 9:30–12:00, 12:30–3:30). Cells display _Booked_ or _Available_ and clicking an available cell creates a request in `volunteer_bookings`. Past dates are disabled and same-day shifts that have already started are omitted.
 - The Volunteer Dashboard's **Available in My Roles** list excludes shifts the volunteer has already requested or booked and shows server-provided error messages when a booking attempt fails.
 - Volunteers can view their trained roles on the dashboard but cannot update them; staff manage trained areas through the volunteer search interface.
 - Volunteers may only book shifts for roles they are trained in; attempts to book untrained roles must be blocked and handled by staff.
@@ -488,4 +524,3 @@ Volunteer UIs and tests must use `completed` or `no_show`; `visited` is invalid 
 - The volunteer search page shows the selected volunteer's profile and role editor alongside their booking history in a two-column card layout.
 - Role selection in the volunteer search role editor uses a simple dropdown without search.
 - These workflows rely on `volunteer_slots`, `volunteer_roles`, `volunteer_master_roles`, `volunteer_bookings`, `volunteers`, and `volunteer_trained_roles`. Training records in `volunteer_trained_roles` restrict which roles a volunteer can book.
-

--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -36,6 +36,7 @@ import badgesRoutes from './routes/badges';
 import statsRoutes from './routes/stats';
 import volunteerStatsRoutes from './routes/volunteerStats';
 import timesheetsRoutes from './routes/timesheets';
+import leaveRequestsRoutes from './routes/leaveRequests';
 import { initializeSlots } from './data';
 import csrfMiddleware from './middleware/csrf';
 import errorHandler from './middleware/errorHandler';
@@ -89,6 +90,7 @@ app.use('/events', eventsRoutes);
 app.use('/badges', badgesRoutes);
 app.use('/stats', statsRoutes);
 app.use('/timesheets', timesheetsRoutes);
+app.use('/api/leave/requests', leaveRequestsRoutes);
 
 // Serve the frontend in production
 if (process.env.NODE_ENV === 'production') {

--- a/MJ_FB_Backend/src/controllers/leaveRequestController.ts
+++ b/MJ_FB_Backend/src/controllers/leaveRequestController.ts
@@ -1,0 +1,70 @@
+import { Request, Response, NextFunction } from "express";
+import {
+  insertLeaveRequest,
+  selectLeaveRequests,
+  updateLeaveRequestStatus,
+} from "../models/leaveRequest";
+
+export async function createLeaveRequest(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { startDate, endDate, reason } = req.body;
+    const record = await insertLeaveRequest(
+      Number(req.user!.id),
+      startDate,
+      endDate,
+      reason,
+    );
+    res.status(201).json(record);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listLeaveRequests(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const rows = await selectLeaveRequests();
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function approveLeaveRequest(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const record = await updateLeaveRequestStatus(
+      Number(req.params.id),
+      "approved",
+    );
+    res.json(record);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function rejectLeaveRequest(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const record = await updateLeaveRequestStatus(
+      Number(req.params.id),
+      "rejected",
+    );
+    res.json(record);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/MJ_FB_Backend/src/migrations/1733000000000_leave_requests.ts
+++ b/MJ_FB_Backend/src/migrations/1733000000000_leave_requests.ts
@@ -1,0 +1,31 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable("leave_requests", {
+    id: "id",
+    staff_id: {
+      type: "integer",
+      notNull: true,
+      references: "staff",
+      onDelete: "CASCADE",
+    },
+    start_date: { type: "date", notNull: true },
+    end_date: { type: "date", notNull: true },
+    status: { type: "varchar(20)", notNull: true, default: "pending" },
+    reason: { type: "text" },
+    created_at: {
+      type: "timestamp",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+    updated_at: {
+      type: "timestamp",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable("leave_requests");
+}

--- a/MJ_FB_Backend/src/models/leaveRequest.ts
+++ b/MJ_FB_Backend/src/models/leaveRequest.ts
@@ -1,0 +1,44 @@
+import pool from "../db";
+
+export interface LeaveRequest {
+  id: number;
+  staff_id: number;
+  start_date: string;
+  end_date: string;
+  status: string;
+  reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function insertLeaveRequest(
+  staffId: number,
+  startDate: string,
+  endDate: string,
+  reason?: string,
+): Promise<LeaveRequest> {
+  const res = await pool.query(
+    `INSERT INTO leave_requests (staff_id, start_date, end_date, reason)
+     VALUES ($1, $2, $3, $4) RETURNING *`,
+    [staffId, startDate, endDate, reason ?? null],
+  );
+  return res.rows[0];
+}
+
+export async function selectLeaveRequests(): Promise<LeaveRequest[]> {
+  const res = await pool.query(
+    `SELECT * FROM leave_requests ORDER BY start_date`,
+  );
+  return res.rows;
+}
+
+export async function updateLeaveRequestStatus(
+  id: number,
+  status: string,
+): Promise<LeaveRequest> {
+  const res = await pool.query(
+    `UPDATE leave_requests SET status = $1, updated_at = now() WHERE id = $2 RETURNING *`,
+    [status, id],
+  );
+  return res.rows[0];
+}

--- a/MJ_FB_Backend/src/routes/leaveRequests.ts
+++ b/MJ_FB_Backend/src/routes/leaveRequests.ts
@@ -1,0 +1,27 @@
+import express from "express";
+import { authMiddleware, authorizeRoles } from "../middleware/authMiddleware";
+import {
+  createLeaveRequest,
+  listLeaveRequests,
+  approveLeaveRequest,
+  rejectLeaveRequest,
+} from "../controllers/leaveRequestController";
+
+const router = express.Router();
+
+router.get("/", authMiddleware, authorizeRoles("admin"), listLeaveRequests);
+router.post("/", authMiddleware, authorizeRoles("staff"), createLeaveRequest);
+router.post(
+  "/:id/approve",
+  authMiddleware,
+  authorizeRoles("admin"),
+  approveLeaveRequest,
+);
+router.post(
+  "/:id/reject",
+  authMiddleware,
+  authorizeRoles("admin"),
+  rejectLeaveRequest,
+);
+
+export default router;

--- a/MJ_FB_Backend/tests/leaveRequests.test.ts
+++ b/MJ_FB_Backend/tests/leaveRequests.test.ts
@@ -1,0 +1,83 @@
+import "./setupTests";
+import {
+  createLeaveRequest,
+  approveLeaveRequest,
+} from "../src/controllers/leaveRequestController";
+import mockPool from "./utils/mockDb";
+
+const makeRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn(),
+});
+
+describe("leave requests controller", () => {
+  afterEach(() => {
+    (mockPool.query as jest.Mock).mockReset();
+  });
+
+  it("creates a leave request", async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          staff_id: 1,
+          start_date: "2024-01-02",
+          end_date: "2024-01-03",
+          status: "pending",
+          reason: null,
+          created_at: "now",
+          updated_at: "now",
+        },
+      ],
+      rowCount: 1,
+    });
+    const req: any = {
+      user: { id: "1", role: "staff", type: "staff" },
+      body: { startDate: "2024-01-02", endDate: "2024-01-03" },
+    };
+    const res = makeRes();
+    await createLeaveRequest(req, res as any, () => {});
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      id: 1,
+      staff_id: 1,
+      start_date: "2024-01-02",
+      end_date: "2024-01-03",
+      status: "pending",
+      reason: null,
+      created_at: "now",
+      updated_at: "now",
+    });
+  });
+
+  it("approves a leave request", async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          staff_id: 1,
+          start_date: "2024-01-02",
+          end_date: "2024-01-03",
+          status: "approved",
+          reason: null,
+          created_at: "now",
+          updated_at: "now",
+        },
+      ],
+      rowCount: 1,
+    });
+    const req: any = { params: { id: "1" } };
+    const res = makeRes();
+    await approveLeaveRequest(req, res as any, () => {});
+    expect(res.json).toHaveBeenCalledWith({
+      id: 1,
+      staff_id: 1,
+      start_date: "2024-01-02",
+      end_date: "2024-01-03",
+      status: "approved",
+      reason: null,
+      created_at: "now",
+      updated_at: "now",
+    });
+  });
+});

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - [MJ_FB_Backend](MJ_FB_Backend) – Node.js/Express API.
 - [MJ_FB_Frontend](MJ_FB_Frontend) – React single-page app.
 - [docs](docs/) with setup notes and a [Timesheets guide](docs/timesheets.md).
+- Leave request API under `/api/leave/requests` for staff vacations.
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 
@@ -50,8 +51,8 @@ Before merging a pull request, confirm the following:
 
 - Appointment booking workflow for clients with automatic approval and rescheduling.
 - Bookings support an optional **note** field. Clients can add notes during booking, and staff see them in booking dialogs. Notes are stored and returned via `/bookings` endpoints.
- - Client visit records include an optional **note** field. Staff and agency users can record notes for each visit and retrieve them through `/bookings/history?includeVisitNotes=true`.
- - Help page offers role-specific guidance with real-time search and a printable view. Admins can view all help topics, including client and volunteer guidance.
+- Client visit records include an optional **note** field. Staff and agency users can record notes for each visit and retrieve them through `/bookings/history?includeVisitNotes=true`.
+- Help page offers role-specific guidance with real-time search and a printable view. Admins can view all help topics, including client and volunteer guidance.
 - Staff or agency users can create bookings for unregistered clients via `/bookings/new-client`; the email field is optional, so bookings can be created without an email address. Staff can list or delete these pending clients through `/new-clients` routes and the Client Management **New Clients** tab.
 - Volunteer role management and scheduling restricted to trained areas; volunteers can only book shifts in roles they are trained for.
 - Volunteer management groups volunteer search, creation, and review under a **Volunteers** submenu. Its **Pending Reviews** tab shows the current week with `no_show` shifts and today's overdue `approved` bookings, allowing staff to mark them `completed` or `no_show`.
@@ -104,14 +105,14 @@ Before merging a pull request, confirm the following:
 - Adding a client visit automatically updates any approved booking for that client on the same date to `visited`.
 - The Manage Booking dialog now displays the client's name, a link to their profile, and their visit count for the current month to assist staff decisions.
 - Client booking history tables can filter bookings by `visited` and `no_show` statuses.
- - Booking requests are automatically approved; the submitted state has been removed.
- - Booking confirmations display "Shift booked"; the volunteer dashboard shows only approved bookings.
+- Booking requests are automatically approved; the submitted state has been removed.
+- Booking confirmations display "Shift booked"; the volunteer dashboard shows only approved bookings.
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.
 - **Volunteer Recurring Bookings** let volunteers schedule repeating shifts with start and end dates, choose daily, weekly, or weekday patterns, and cancel individual occurrences or the remaining series.
 - Staff can create recurring volunteer booking series for volunteers via `POST /volunteer-bookings/recurring/staff` and list active series with `GET /volunteer-bookings/recurring/volunteer/:volunteer_id`.
- - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts). Volunteers can create new series and manage existing ones from separate tabs on the **Recurring Bookings** page.
+- Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts). Volunteers can create new series and manage existing ones from separate tabs on the **Recurring Bookings** page.
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification (currently disabled pending further testing).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
@@ -137,9 +138,11 @@ git submodule update --init --recursive
 ## Backend setup (`MJ_FB_Backend`)
 
 Prerequisites:
+
 - Node.js 22 or later and npm (uses the built-in `fetch`; earlier versions are not supported)
 
 Install and run:
+
 ```bash
 cd MJ_FB_Backend
 npm install
@@ -152,28 +155,28 @@ The database schema is managed via TypeScript migrations in `src/migrations`; ru
 
 Create a `.env` file in `MJ_FB_Backend` with the following variables. The server fails to start if any required variable is missing.
 
-| Variable | Description |
-| --- | --- |
-| `PG_HOST` | PostgreSQL host |
-| `PG_PORT` | PostgreSQL port |
-| `PG_USER` | PostgreSQL username |
-| `PG_PASSWORD` | PostgreSQL password |
-| `PG_DATABASE` | PostgreSQL database name |
-| `JWT_SECRET` | Secret used to sign JWT tokens for clients, staff, volunteers, and agencies. Generate a strong random value, e.g., `openssl rand -hex 32` |
-| `JWT_REFRESH_SECRET` | Secret used to sign refresh JWT tokens for all roles. Use a different strong value from `JWT_SECRET`. |
-| `FRONTEND_ORIGIN` | Allowed origins for CORS and base URL for password setup links (comma separated; empty entries are ignored) |
-| `PORT` | Port for the backend server (defaults to 4000) |
-| `BREVO_API_KEY` | Brevo API key for transactional emails |
-| `BREVO_FROM_EMAIL` | Email address used as the sender |
-| `BREVO_FROM_NAME` | Optional sender name displayed in emails |
-| `EMAIL_QUEUE_MAX_RETRIES` | Max retry attempts for failed email jobs (default 5) |
-| `EMAIL_QUEUE_BACKOFF_MS` | Initial backoff delay in ms for email retries (default 1000) |
-| `PASSWORD_SETUP_TEMPLATE_ID` | Brevo template ID for invitation and password setup emails |
-| `BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for booking confirmation emails |
-| `BOOKING_REMINDER_TEMPLATE_ID` | Brevo template ID for booking reminder emails |
-| `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations |
-| `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Brevo template ID for volunteer shift reminder emails |
-| `PASSWORD_SETUP_TOKEN_TTL_HOURS` | Hours until password setup tokens expire (default 24) |
+| Variable                                     | Description                                                                                                                               |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `PG_HOST`                                    | PostgreSQL host                                                                                                                           |
+| `PG_PORT`                                    | PostgreSQL port                                                                                                                           |
+| `PG_USER`                                    | PostgreSQL username                                                                                                                       |
+| `PG_PASSWORD`                                | PostgreSQL password                                                                                                                       |
+| `PG_DATABASE`                                | PostgreSQL database name                                                                                                                  |
+| `JWT_SECRET`                                 | Secret used to sign JWT tokens for clients, staff, volunteers, and agencies. Generate a strong random value, e.g., `openssl rand -hex 32` |
+| `JWT_REFRESH_SECRET`                         | Secret used to sign refresh JWT tokens for all roles. Use a different strong value from `JWT_SECRET`.                                     |
+| `FRONTEND_ORIGIN`                            | Allowed origins for CORS and base URL for password setup links (comma separated; empty entries are ignored)                               |
+| `PORT`                                       | Port for the backend server (defaults to 4000)                                                                                            |
+| `BREVO_API_KEY`                              | Brevo API key for transactional emails                                                                                                    |
+| `BREVO_FROM_EMAIL`                           | Email address used as the sender                                                                                                          |
+| `BREVO_FROM_NAME`                            | Optional sender name displayed in emails                                                                                                  |
+| `EMAIL_QUEUE_MAX_RETRIES`                    | Max retry attempts for failed email jobs (default 5)                                                                                      |
+| `EMAIL_QUEUE_BACKOFF_MS`                     | Initial backoff delay in ms for email retries (default 1000)                                                                              |
+| `PASSWORD_SETUP_TEMPLATE_ID`                 | Brevo template ID for invitation and password setup emails                                                                                |
+| `BOOKING_CONFIRMATION_TEMPLATE_ID`           | Brevo template ID for booking confirmation emails                                                                                         |
+| `BOOKING_REMINDER_TEMPLATE_ID`               | Brevo template ID for booking reminder emails                                                                                             |
+| `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                                                                                     |
+| `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`     | Brevo template ID for volunteer shift reminder emails                                                                                     |
+| `PASSWORD_SETUP_TOKEN_TTL_HOURS`             | Hours until password setup tokens expire (default 24)                                                                                     |
 
 See [docs/emailTemplates.md](docs/emailTemplates.md) for a list of email templates and parameters.
 
@@ -191,46 +194,54 @@ After setting a password, users are redirected to the login page for their role.
      -H "Authorization: Bearer <staff-token>" \
     -H "Content-Type: application/json" \
     -d '{"name":"Sample Agency","email":"agency@example.com","contactInfo":"123-4567"}'
-  ```
-
-   The endpoint emails a password setup link and returns the new agency ID. You can also create one directly in SQL if needed:
-
-   ```bash
-   node -e "console.log(require('bcrypt').hashSync('secret123', 10))"
-   psql -U $PG_USER -d $PG_DATABASE \
-     -c "INSERT INTO agencies (name,email,password) VALUES ('Sample Agency','agency@example.com','<hashed-password>');"
    ```
+
+````
+
+ The endpoint emails a password setup link and returns the new agency ID. You can also create one directly in SQL if needed:
+
+ ```bash
+ node -e "console.log(require('bcrypt').hashSync('secret123', 10))"
+ psql -U $PG_USER -d $PG_DATABASE \
+   -c "INSERT INTO agencies (name,email,password) VALUES ('Sample Agency','agency@example.com','<hashed-password>');"
+````
 
 2. **Assign clients to the agency** – authenticate as staff or the
    agency and call the API:
 
    ```bash
-  # As staff assigning client 42 to agency 1
-  curl -X POST http://localhost:4000/agencies/add-client \
-    -H "Authorization: Bearer <token>" \
-   -H "Content-Type: application/json" \
-   -d '{"agencyId":1,"clientId":42}'
 
-   # As the agency itself
-   curl -X POST http://localhost:4000/agencies/add-client \
-     -H "Authorization: Bearer <agency-token>" \
-    -H "Content-Type: application/json" \
-    -d '{"agencyId":1,"clientId":42}'
-  ```
+   ```
 
-   In these examples, `clientId` is the public identifier from the `clients`
-   table (`clients.client_id`), which also serves as the table's primary key.
+# As staff assigning client 42 to agency 1
 
-  A client may be linked to only one agency at a time. If the client is
-  already associated with another agency, the request returns a `409 Conflict`
-  response containing that agency's name. Supplying a `clientId` that doesn't
-  exist results in a `404 Not Found` error.
+curl -X POST http://localhost:4000/agencies/add-client \
+ -H "Authorization: Bearer <token>" \
+ -H "Content-Type: application/json" \
+ -d '{"agencyId":1,"clientId":42}'
 
-   Remove a client with
-   `DELETE /agencies/:id/clients/:clientId` (use `me` for the authenticated agency).
+# As the agency itself
 
-   List clients for an agency with
-   `GET /agencies/:id/clients` (use `me` for the authenticated agency).
+curl -X POST http://localhost:4000/agencies/add-client \
+ -H "Authorization: Bearer <agency-token>" \
+ -H "Content-Type: application/json" \
+ -d '{"agencyId":1,"clientId":42}'
+
+````
+
+ In these examples, `clientId` is the public identifier from the `clients`
+ table (`clients.client_id`), which also serves as the table's primary key.
+
+A client may be linked to only one agency at a time. If the client is
+already associated with another agency, the request returns a `409 Conflict`
+response containing that agency's name. Supplying a `clientId` that doesn't
+exist results in a `404 Not Found` error.
+
+ Remove a client with
+ `DELETE /agencies/:id/clients/:clientId` (use `me` for the authenticated agency).
+
+ List clients for an agency with
+ `GET /agencies/:id/clients` (use `me` for the authenticated agency).
 
 ### Password Requirements
 
@@ -243,16 +254,18 @@ You can generate a secure `JWT_SECRET` with:
 
 ```bash
 openssl rand -hex 32
-```
+````
 
 **Production note:** The backend issues cookies with the `secure` flag when `NODE_ENV` is not `development`. Ensure that your production deployment uses HTTPS so these cookies are transmitted to clients.
 
 ## Frontend setup (`MJ_FB_Frontend`)
 
 Prerequisites:
+
 - Node.js 22 or later and npm
 
 Install and run:
+
 ```bash
 cd MJ_FB_Frontend
 npm install
@@ -335,12 +348,14 @@ This setup prepares the project so it can be hosted on Azure with containerized 
 An automated workflow in `.github/workflows/release.yml` builds, tests, and deploys the backend and frontend Docker images to Azure Container Apps. It runs on pushes to `main` and on tags beginning with `v`.
 
 Set the following repository **secrets**:
+
 - `AZURE_CREDENTIALS` – Azure service principal credentials in JSON format
 - `REGISTRY_LOGIN_SERVER` – Azure Container Registry login server
 - `REGISTRY_USERNAME` – Azure Container Registry username
 - `REGISTRY_PASSWORD` – Azure Container Registry password
 
 Define these repository **variables**:
+
 - `AZURE_RESOURCE_GROUP` – Resource group containing the container apps
 - `BACKEND_APP_NAME` – Backend container app name
 - `FRONTEND_APP_NAME` – Frontend container app name

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -28,6 +28,8 @@ node src/utils/timesheetSeeder.ts
 - `POST /timesheets/:id/leave-requests` – request vacation leave for a day.
 - `GET /timesheets/:id/leave-requests` – list leave requests awaiting review.
 - `POST /timesheets/leave-requests/:requestId/approve` – approve a leave request, applying vacation hours and locking the day.
+- `GET /api/leave/requests` – list all leave requests (admin only).
+- `POST /api/leave/requests` – submit a leave request for the logged in staff member.
 
 ## UI walkthrough
 
@@ -39,15 +41,15 @@ node src/utils/timesheetSeeder.ts
 
 After a timesheet is processed, staff can download the period as a CSV using the **Export CSV** action. The file lists one row per day with the following columns:
 
-| Column | Description |
-| --- | --- |
-| `date` | Work date |
-| `reg` | Regular hours |
-| `ot` | Overtime hours |
-| `stat` | Stat holiday hours |
-| `sick` | Sick hours |
-| `vac` | Vacation hours |
-| `note` | Free-form note |
+| Column       | Description                  |
+| ------------ | ---------------------------- |
+| `date`       | Work date                    |
+| `reg`        | Regular hours                |
+| `ot`         | Overtime hours               |
+| `stat`       | Stat holiday hours           |
+| `sick`       | Sick hours                   |
+| `vac`        | Vacation hours               |
+| `note`       | Free-form note               |
 | `paid_total` | Total paid hours for the day |
 
 Stat holidays are auto-filled with the day's expected hours and locked from editing. Days may also be locked when leave is approved.


### PR DESCRIPTION
## Summary
- create `leave_requests` table and data access helpers
- add controller and routes under `/api/leave/requests`
- document new endpoints in README and timesheet guide

## Testing
- `npm test` *(fails: clientVisitBookingStatus, volunteerBookingStatusEmail, bookingLimit, volunteerBookingConflict, bookingNewClient, volunteerRebookCancelled, bookingCapacity, dbPoolErrorHandler)*

------
https://chatgpt.com/codex/tasks/task_e_68b75bd1b058832d9af68c91b65660e3