### PR TITLE
feat: skip timesheet seeding if pay periods missing

### DIFF
--- a/MJ_FB_Backend/src/utils/timesheetSeeder.ts
+++ b/MJ_FB_Backend/src/utils/timesheetSeeder.ts
@@ -10,6 +10,15 @@ import logger from './logger';
  */
 export async function seedTimesheets(staffId?: number): Promise<void> {
   try {
+    // Ensure the pay_periods table exists before querying it
+    const tableCheck = await pool.query(
+      "SELECT to_regclass('public.pay_periods') as table",
+    );
+    if (!tableCheck.rows[0] || !tableCheck.rows[0].table) {
+      logger.warn('Skipping timesheet seeding: pay_periods table not found');
+      return;
+    }
+
     // Determine current pay period
     const payPeriodRes = await pool.query(
       `SELECT id, start_date, end_date FROM pay_periods WHERE CURRENT_DATE BETWEEN start_date AND end_date`,

--- a/MJ_FB_Backend/tests/timesheetSeeder.test.ts
+++ b/MJ_FB_Backend/tests/timesheetSeeder.test.ts
@@ -1,4 +1,5 @@
 import pool from '../src/db';
+import logger from '../src/utils/logger';
 import { seedTimesheets } from '../src/utils/timesheetSeeder';
 
 describe('seedTimesheets', () => {
@@ -10,6 +11,9 @@ describe('seedTimesheets', () => {
     const calls: any[] = [];
     (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
       calls.push({ sql, params });
+      if (sql.includes("to_regclass('public.pay_periods')")) {
+        return { rows: [{ table: 'pay_periods' }], rowCount: 1 };
+      }
       if (sql.includes('FROM pay_periods')) {
         return { rows: [{ id: 1, start_date: '2024-06-01', end_date: '2024-06-15' }], rowCount: 1 };
       }
@@ -39,6 +43,9 @@ describe('seedTimesheets', () => {
     const calls: any[] = [];
     (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
       calls.push({ sql, params });
+      if (sql.includes("to_regclass('public.pay_periods')")) {
+        return { rows: [{ table: 'pay_periods' }], rowCount: 1 };
+      }
       if (sql.includes('FROM pay_periods')) {
         return { rows: [{ id: 2, start_date: '2024-06-01', end_date: '2024-06-15' }], rowCount: 1 };
       }
@@ -58,5 +65,21 @@ describe('seedTimesheets', () => {
     const insertDays = calls.find((c) => c.sql.startsWith('INSERT INTO timesheet_days'));
     expect(insertDays).toBeDefined();
     expect(insertDays.params).toEqual([50, '2024-06-01', '2024-06-05', '2024-06-15']);
+  });
+
+  it('skips seeding when pay_periods table is missing', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation();
+    (pool.query as jest.Mock).mockImplementation(async (sql: string) => {
+      if (sql.includes("to_regclass('public.pay_periods')")) {
+        return { rows: [{ table: null }], rowCount: 1 };
+      }
+      throw new Error('should not query other tables');
+    });
+
+    await seedTimesheets();
+
+    expect(warn).toHaveBeenCalledWith('Skipping timesheet seeding: pay_periods table not found');
+    warn.mockRestore();
+    expect((pool.query as jest.Mock).mock.calls).toHaveLength(1);
   });
 });

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -13,7 +13,8 @@ npm run migrate
 ```
 
 2. Insert biweekly records into the `pay_periods` table so each period has a
-   `start_date` and `end_date`.
+   `start_date` and `end_date`. If the table is missing, the backend logs a
+   warning and skips seeding.
 
 3. Seed current pay periods for active staff (optional):
 


### PR DESCRIPTION
## Summary
- Skip timesheet seeding when `pay_periods` table is absent and warn instead of erroring
- Cover missing-table scenario in timesheet seeder tests
- Document that the seeder is skipped when `pay_periods` table is missing

## Testing
- `npm test` *(fails: clientVisitBookingStatus.test.ts, volunteerBookingStatusEmail.test.ts, volunteerShopperBooking.test.ts, bookingLimit.test.ts, volunteerBookingConflict.test.ts, bookingCapacity.test.ts, bookingNewClient.test.ts, volunteerRebookCancelled.test.ts)*
- `npm test tests/timesheetSeeder.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b7b48f44ec832d99e9e8ad6f9f6c02