### PR TITLE
Add timesheet and leave management navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes.
 - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes. Timesheets now support vacation leave requests via `/timesheets/:id/leave-requests`; ensure related translations are added.
 - Global review endpoints exist under `/api/leave/requests` for leave submissions; document changes and translations when updating leave features.
+- Staff access timesheets and leave requests from the profile menu; admins review them under Admin → Timesheets and Admin → Leave Requests.
 - A GitHub Actions workflow in `.github/workflows/release.yml` builds, tests, and deploys container images to Azure Container Apps. Configure repository secrets `AZURE_CREDENTIALS`, `REGISTRY_LOGIN_SERVER`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD` and variables `AZURE_RESOURCE_GROUP`, `BACKEND_APP_NAME`, and `FRONTEND_APP_NAME`; see `docs/release.md` for details.
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The backend requires Node.js 22+ for native `fetch`; earlier versions are not supported.

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -102,6 +102,12 @@ const VolunteerSettings = React.lazy(() =>
 const Events = React.lazy(() => import('./pages/events/Events'));
 const PantryVisits = React.lazy(() => import('./pages/staff/PantryVisits'));
 const Timesheets = React.lazy(() => import('./pages/staff/timesheets'));
+const LeaveManagement = React.lazy(
+  () => import('./pages/staff/LeaveManagement'),
+);
+const AdminLeaveRequests = React.lazy(
+  () => import('./pages/admin/LeaveRequests'),
+);
 const AgencyLogin = React.lazy(() => import('./pages/agency/Login'));
 const AgencyBookAppointment = React.lazy(() =>
   import('./pages/agency/AgencyBookAppointment')
@@ -147,7 +153,11 @@ export default function App() {
 
   const navGroups: NavGroup[] = [];
   const profileLinks: NavLink[] | undefined = isStaff
-    ? [{ label: 'Events', to: '/events' }]
+    ? [
+        { label: t('news_and_events'), to: '/events' },
+        { label: t('timesheets.title'), to: '/pantry/timesheets' },
+        { label: t('leave.title'), to: '/pantry/leave-requests' },
+      ]
     : undefined;
   if (!role) {
     navGroups.push(
@@ -205,6 +215,8 @@ export default function App() {
         label: 'Admin',
         links: [
           { label: 'Staff', to: '/admin/staff' },
+          { label: t('timesheets.title'), to: '/admin/timesheets' },
+          { label: t('leave.title'), to: '/admin/leave-requests' },
           { label: 'Warehouse Settings', to: '/admin/warehouse-settings' },
           { label: 'Pantry Settings', to: '/admin/pantry-settings' },
           { label: 'Volunteer Settings', to: '/admin/volunteer-settings' },
@@ -335,6 +347,12 @@ export default function App() {
                   {showStaff && (
                     <Route path="/pantry/timesheets" element={<Timesheets />} />
                   )}
+                  {showStaff && (
+                    <Route
+                      path="/pantry/leave-requests"
+                      element={<LeaveManagement />}
+                    />
+                  )}
                   {showWarehouse && (
                     <Route path="/warehouse-management" element={<WarehouseDashboard />} />
                   )}
@@ -417,6 +435,15 @@ export default function App() {
                   {showAdmin && <Route path="/admin/staff" element={<AdminStaffList />} />}
                   {showAdmin && <Route path="/admin/staff/create" element={<AdminStaffForm />} />}
                   {showAdmin && <Route path="/admin/staff/:id" element={<AdminStaffForm />} />}
+                  {showAdmin && (
+                    <Route path="/admin/timesheets" element={<Timesheets />} />
+                  )}
+                  {showAdmin && (
+                    <Route
+                      path="/admin/leave-requests"
+                      element={<AdminLeaveRequests />}
+                    />
+                  )}
                   {showAdmin && <Route path="/admin/warehouse-settings" element={<WarehouseSettings />} />}
                   {showAdmin && <Route path="/admin/pantry-settings" element={<PantrySettings />} />}
                   {showAdmin && <Route path="/admin/volunteer-settings" element={<VolunteerSettings />} />}

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -23,6 +23,27 @@ describe('Navbar component', () => {
     expect(screen.getByText(/Logout/i)).toBeInTheDocument();
   });
 
+  it('shows staff profile links', () => {
+    render(
+      <MemoryRouter>
+        <Navbar
+          groups={[{ label: 'Home', links: [{ label: 'Home', to: '/' }] }]}
+          onLogout={() => {}}
+          name="Tester"
+          role="staff"
+          profileLinks={[
+            { label: 'Timesheets', to: '/pantry/timesheets' },
+            { label: 'Leave Management', to: '/pantry/leave-requests' },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText(/Hello, Tester/i));
+    expect(screen.getByText(/Timesheets/i)).toBeInTheDocument();
+    expect(screen.getByText(/Leave Management/i)).toBeInTheDocument();
+  });
+
   it('renders without greeting when name is absent', () => {
     render(
       <MemoryRouter>

--- a/MJ_FB_Frontend/src/api/leaveRequests.ts
+++ b/MJ_FB_Frontend/src/api/leaveRequests.ts
@@ -31,6 +31,11 @@ export async function listLeaveRequests(
   return handleResponse(res);
 }
 
+export async function listAllLeaveRequests(): Promise<LeaveRequest[]> {
+  const res = await apiFetch(`${API_BASE}/leave/requests`);
+  return handleResponse(res);
+}
+
 export async function approveLeaveRequest(requestId: number): Promise<void> {
   const res = await apiFetch(
     `${API_BASE}/timesheets/leave-requests/${requestId}/approve`,
@@ -44,6 +49,14 @@ export function useLeaveRequests(timesheetId?: number) {
     queryKey: ['leaveRequests', timesheetId],
     queryFn: () => listLeaveRequests(timesheetId!),
     enabled: !!timesheetId,
+  });
+  return { requests: data ?? [], isLoading: isFetching, error };
+}
+
+export function useAllLeaveRequests() {
+  const { data, isFetching, error } = useQuery<LeaveRequest[]>({
+    queryKey: ['leaveRequests'],
+    queryFn: listAllLeaveRequests,
   });
   return { requests: data ?? [], isLoading: isFetching, error };
 }

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -102,6 +102,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -102,6 +102,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -100,6 +100,15 @@
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
+      },
+      "leave": {
+        "title": "Leave Management",
+        "description": "Submit and track leave requests.",
+        "steps": [
+          "Open the Leave Management page.",
+          "Submit new leave requests with date and hours.",
+          "Review the status of your requests."
+        ]
       }
     }
   },

--- a/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
@@ -1,0 +1,29 @@
+import { Box, Button, Typography } from '@mui/material';
+import Page from '../../components/Page';
+import { useAllLeaveRequests, useApproveLeaveRequest } from '../../api/leaveRequests';
+import { formatLocaleDate } from '../../utils/date';
+import { useTranslation } from 'react-i18next';
+
+export default function AdminLeaveRequests() {
+  const { t } = useTranslation();
+  const { requests } = useAllLeaveRequests();
+  const approve = useApproveLeaveRequest();
+
+  return (
+    <Page title={t('leave.title')}>
+      {requests.map(r => (
+        <Box key={r.id} sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 1 }}>
+          <Typography component="span" sx={{ flexGrow: 1 }}>
+            {formatLocaleDate(r.work_date)} - {r.hours}h
+          </Typography>
+          <Button
+            size="small"
+            onClick={() => approve.mutate({ requestId: r.id, timesheetId: r.timesheet_id })}
+          >
+            {t('timesheets.approve_leave')}
+          </Button>
+        </Box>
+      ))}
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -294,6 +294,17 @@ export function getHelpContent(
         ],
       },
     },
+    {
+      title: t('help.pantry.leave.title'),
+      body: {
+        description: t('help.pantry.leave.description'),
+        steps: [
+          t('help.pantry.leave.steps.0'),
+          t('help.pantry.leave.steps.1'),
+          t('help.pantry.leave.steps.2'),
+        ],
+      },
+    },
   ],
   warehouse: [
     {
@@ -377,7 +388,29 @@ export function getHelpContent(
         ],
       },
     },
+    {
+      title: 'Review timesheets',
+      body: {
+        description: 'Approve or reject submitted timesheets.',
+        steps: [
+          'Go to Admin > Timesheets.',
+          'Open a period and review hours.',
+          'Approve or reject as needed.',
+        ],
+      },
+    },
+    {
+      title: 'Approve leave requests',
+      body: {
+        description: 'Review staff vacation requests.',
+        steps: [
+          'Navigate to Admin > Leave Requests.',
+          'Review pending requests.',
+          'Approve requests to apply vacation hours.',
+        ],
+      },
+    },
   ],
-  };
+};
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
@@ -1,0 +1,67 @@
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import Page from '../../components/Page';
+import { useTimesheets } from '../../api/timesheets';
+import { useCreateLeaveRequest, useLeaveRequests } from '../../api/leaveRequests';
+import { formatLocaleDate } from '../../utils/date';
+
+export default function LeaveManagement() {
+  const { t } = useTranslation();
+  const { timesheets } = useTimesheets();
+  const current =
+    timesheets.find(p => !p.approved_at) || timesheets[timesheets.length - 1];
+  const leaveMutation = useCreateLeaveRequest(current?.id ?? 0);
+  const { requests } = useLeaveRequests(current?.id);
+
+  return (
+    <Page title={t('leave.title')}>
+      {current && (
+        <Box sx={{ mt: 2 }}>
+          <Box
+            component="form"
+            sx={{ display: 'flex', gap: 1, mb: 3 }}
+            onSubmit={e => {
+              e.preventDefault();
+              const form = e.currentTarget as typeof e.currentTarget & {
+                date: { value: string };
+                hours: { value: string };
+              };
+              leaveMutation.mutate({
+                date: form.date.value,
+                hours: Number(form.hours.value),
+              });
+              form.reset();
+            }}
+          >
+            <TextField
+              name="date"
+              type="date"
+              size="small"
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              name="hours"
+              type="number"
+              size="small"
+              defaultValue={8}
+            />
+            <Button type="submit" variant="contained">
+              {t('timesheets.submit')}
+            </Button>
+          </Box>
+
+          {requests.map(r => (
+            <Box key={r.id} sx={{ mb: 1 }}>
+              <Typography component="span" sx={{ mr: 1 }}>
+                {formatLocaleDate(r.work_date)} - {r.hours}h
+              </Typography>
+              <Typography component="span">
+                {t(`leave.status.${r.status}`)}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Page>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - [docs](docs/) with setup notes and a [Timesheets guide](docs/timesheets.md).
 - Leave request API under `/api/leave/requests` for staff vacations.
 
+Staff can reach **Timesheets** and **Leave Management** from the profile menu
+once logged in. Admin users also see **Timesheets** and **Leave Requests** under
+the Admin menu for reviewing submissions.
+
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 
 ## Node Version

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -2,6 +2,10 @@
 
 Staff can record daily hours and submit pay periods.
 
+Staff access timesheets and leave management from the **Hello** menu in the
+top-right corner. Admins can review periods and vacation requests from the
+**Admin → Timesheets** and **Admin → Leave Requests** menu items.
+
 ## Setup
 
 1. Start the backend once so `setupDatabase` creates the pay period, timesheet, and leave tables.


### PR DESCRIPTION
## Summary
- expose Timesheets and Leave Management links in staff profile menu
- allow admins to reach Timesheets and Leave Requests from Admin menu
- document new navigation and update help/locale entries

## Testing
- `npm test` (backend) *(fails: clientVisitBookingStatus.test, bookingNewClient.test, volunteerBookingStatusEmail.test, bookingLimit.test, volunteerBookingConflict.test, volunteerRebookCancelled.test, bookingCapacity.test, newClientsMigration.test, dbPoolErrorHandler.test)*
- `npm test` (frontend) *(fails: jsdom navigation errors, missing test utilities, HelpPage test, AgencyAccess test)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd682e08832d9f2567cb52a93d42