### PR TITLE
Expose timesheet routes at root

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -155,8 +155,8 @@ export default function App() {
   const profileLinks: NavLink[] | undefined = isStaff
     ? [
         { label: t('news_and_events'), to: '/events' },
-        { label: t('timesheets.title'), to: '/pantry/timesheets' },
-        { label: t('leave.title'), to: '/pantry/leave-requests' },
+        { label: t('timesheets.title'), to: '/timesheet' },
+        { label: t('leave.title'), to: '/leave-requests' },
       ]
     : undefined;
   if (!role) {
@@ -177,7 +177,7 @@ export default function App() {
       { label: 'Manage Availability', to: '/pantry/manage-availability' },
       { label: 'Pantry Schedule', to: '/pantry/schedule' },
       { label: 'Pantry Visits', to: '/pantry/visits' },
-      { label: t('timesheets.title'), to: '/pantry/timesheets' },
+      { label: t('timesheets.title'), to: '/timesheet' },
       { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Agency Management', to: '/pantry/agency-management' },
     ];
@@ -215,7 +215,7 @@ export default function App() {
         label: 'Admin',
         links: [
           { label: 'Staff', to: '/admin/staff' },
-          { label: t('timesheets.title'), to: '/admin/timesheets' },
+          { label: t('timesheets.title'), to: '/admin/timesheet' },
           { label: t('leave.title'), to: '/admin/leave-requests' },
           { label: 'Warehouse Settings', to: '/admin/warehouse-settings' },
           { label: 'Pantry Settings', to: '/admin/pantry-settings' },
@@ -345,11 +345,11 @@ export default function App() {
                     <Route path="/pantry/visits" element={<PantryVisits />} />
                   )}
                   {showStaff && (
-                    <Route path="/pantry/timesheets" element={<Timesheets />} />
+                    <Route path="/timesheet" element={<Timesheets />} />
                   )}
                   {showStaff && (
                     <Route
-                      path="/pantry/leave-requests"
+                      path="/leave-requests"
                       element={<LeaveManagement />}
                     />
                   )}
@@ -436,7 +436,7 @@ export default function App() {
                   {showAdmin && <Route path="/admin/staff/create" element={<AdminStaffForm />} />}
                   {showAdmin && <Route path="/admin/staff/:id" element={<AdminStaffForm />} />}
                   {showAdmin && (
-                    <Route path="/admin/timesheets" element={<Timesheets />} />
+                    <Route path="/admin/timesheet" element={<Timesheets />} />
                   )}
                   {showAdmin && (
                     <Route

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -32,8 +32,8 @@ describe('Navbar component', () => {
           name="Tester"
           role="staff"
           profileLinks={[
-            { label: 'Timesheets', to: '/pantry/timesheets' },
-            { label: 'Leave Management', to: '/pantry/leave-requests' },
+            { label: 'Timesheets', to: '/timesheet' },
+            { label: 'Leave Management', to: '/leave-requests' },
           ]}
         />
       </MemoryRouter>,

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - [docs](docs/) with setup notes and a [Timesheets guide](docs/timesheets.md).
 - Leave request API under `/api/leave/requests` for staff vacations.
 
-Staff can reach **Timesheets** and **Leave Management** from the profile menu
-once logged in. Admin users also see **Timesheets** and **Leave Requests** under
-the Admin menu for reviewing submissions.
+Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
+`/leave-requests` from the profile menu once logged in. Admin users also see
+**Timesheets** at `/admin/timesheet` and **Leave Requests** at
+`/admin/leave-requests` under the Admin menu for reviewing submissions.
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -2,9 +2,10 @@
 
 Staff can record daily hours and submit pay periods.
 
-Staff access timesheets and leave management from the **Hello** menu in the
-top-right corner. Admins can review periods and vacation requests from the
-**Admin → Timesheets** and **Admin → Leave Requests** menu items.
+Staff access timesheets at `/timesheet` and leave management at `/leave-requests`
+from the **Hello** menu in the top-right corner. Admins can review periods at
+`/admin/timesheet` and vacation requests at `/admin/leave-requests` from the
+Admin menu.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Move staff timesheet and leave request pages to `/timesheet` and `/leave-requests`
- Serve admin review pages at `/admin/timesheet` and `/admin/leave-requests`
- Document new timesheet and leave request paths

## Testing
- `npm test` *(fails: Cannot find module '../../../testUtils/renderWithProviders'; other tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c5d7bbc832db338d09bb1b5962a