### PR TITLE
feat(admin): add tabbed settings page

### DIFF
--- a/MJ_FB_Frontend/AGENTS.md
+++ b/MJ_FB_Frontend/AGENTS.md
@@ -39,7 +39,7 @@
 ## Development Guidelines
 - In the frontend, favor composition of reusable components and keep pages focused on layout and data flow.
 - Use `FeedbackSnackbar` for user feedback instead of custom alert implementations.
-- Admin settings: cart tare and pantry slot capacity are managed in Admin → Pantry Settings, bread/can weight multipliers in Admin → Warehouse Settings, and volunteer roles in Admin → Volunteer Settings. Fetch these values from the backend rather than hard-coding or using environment variables.
+- Admin settings: use Admin → Settings for configuration—Pantry tab manages cart tare and pantry slot capacity, Warehouse tab handles bread/can weight multipliers, and Volunteer tab manages volunteer roles. Fetch these values from the backend rather than hard-coding or using environment variables.
 - The frontend requires a live internet connection; offline caching or offline-first optimizations must not be added.
 
 ## UI Rules & Design System

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -92,13 +92,7 @@ const DonorProfile = React.lazy(() =>
 const Exports = React.lazy(() => import('./pages/warehouse-management/Exports'));
 const AdminStaffForm = React.lazy(() => import('./pages/admin/AdminStaffForm'));
 const AdminStaffList = React.lazy(() => import('./pages/admin/AdminStaffList'));
-const WarehouseSettings = React.lazy(() =>
-  import('./pages/admin/WarehouseSettings')
-);
-const PantrySettings = React.lazy(() => import('./pages/admin/PantrySettings'));
-const VolunteerSettings = React.lazy(() =>
-  import('./pages/admin/VolunteerSettings')
-);
+const AdminSettings = React.lazy(() => import('./pages/admin/AdminSettings'));
 const Events = React.lazy(() => import('./pages/events/Events'));
 const PantryVisits = React.lazy(() => import('./pages/staff/PantryVisits'));
 const Timesheets = React.lazy(() => import('./pages/staff/timesheets'));
@@ -217,9 +211,7 @@ export default function App() {
           { label: 'Staff', to: '/admin/staff' },
           { label: t('timesheets.title'), to: '/admin/timesheet' },
           { label: t('leave.title'), to: '/admin/leave-requests' },
-          { label: 'Warehouse Settings', to: '/admin/warehouse-settings' },
-          { label: 'Pantry Settings', to: '/admin/pantry-settings' },
-          { label: 'Volunteer Settings', to: '/admin/volunteer-settings' },
+          { label: 'Settings', to: '/admin/settings' },
         ],
       });
 
@@ -444,9 +436,9 @@ export default function App() {
                       element={<AdminLeaveRequests />}
                     />
                   )}
-                  {showAdmin && <Route path="/admin/warehouse-settings" element={<WarehouseSettings />} />}
-                  {showAdmin && <Route path="/admin/pantry-settings" element={<PantrySettings />} />}
-                  {showAdmin && <Route path="/admin/volunteer-settings" element={<VolunteerSettings />} />}
+                  {showAdmin && (
+                    <Route path="/admin/settings" element={<AdminSettings />} />
+                  )}
                   {showVolunteerManagement && (
                     <>
                       <Route

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -116,10 +116,7 @@ describe('App authentication persistence', () => {
       screen.queryByRole('menuitem', { name: 'App Config' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole('menuitem', { name: 'Warehouse Settings' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('menuitem', { name: 'Pantry Settings' }),
+      screen.getByRole('menuitem', { name: 'Settings' }),
     ).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/pages/admin/AdminSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminSettings.tsx
@@ -1,0 +1,19 @@
+import Page from '../../components/Page';
+import StyledTabs from '../../components/StyledTabs';
+import WarehouseSettings from './WarehouseSettings';
+import PantrySettings from './PantrySettings';
+import VolunteerSettings from './VolunteerSettings';
+
+export default function AdminSettings() {
+  return (
+    <Page title="Settings">
+      <StyledTabs
+        tabs={[
+          { label: 'Warehouse', content: <WarehouseSettings /> },
+          { label: 'Pantry', content: <PantrySettings /> },
+          { label: 'Volunteer', content: <VolunteerSettings /> },
+        ]}
+      />
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/AdminSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/AdminSettings.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import { theme } from '../../../theme';
+import AdminSettings from '../AdminSettings';
+
+jest.mock('../WarehouseSettings', () => () => <div>Warehouse Content</div>);
+jest.mock('../PantrySettings', () => () => <div>Pantry Content</div>);
+jest.mock('../VolunteerSettings', () => () => <div>Volunteer Content</div>);
+
+describe('AdminSettings', () => {
+  it('renders tabs and switches content', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <AdminSettings />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('Warehouse Content')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: 'Pantry' }));
+    expect(screen.getByText('Pantry Content')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: 'Volunteer' }));
+    expect(screen.getByText('Volunteer Content')).toBeInTheDocument();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Before merging a pull request, confirm the following:
 - Volunteer bookings are auto-approved with no submitted state and appear immediately on schedules.
 - Volunteer booking statuses include `completed`, and cancelling a booking now requires a reason.
 - Volunteer interfaces show `completed` or `no_show`; submitting `visited` for a volunteer shift now returns `Use completed instead of visited for volunteer shifts`.
-- Admins can manage volunteer master roles, sub-roles, and their shifts from the Volunteer Settings page. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
-- Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Volunteer Settings page's **Restore Original Roles & Shifts** button.
+- Admins can manage volunteer master roles, sub-roles, and their shifts from the Settings page's Volunteer tab. Deleting a master role also removes its sub-roles and shifts. Deleting sub-roles and shifts now requires confirmation to avoid accidental removal. Sub-roles are created via a dedicated dialog that captures the sub-role name and initial shift, while additional shifts use a separate dialog.
+- Staff can restore volunteer roles and shifts to their original defaults via `POST /volunteer-roles/restore` or the Settings page's Volunteer tab **Restore Original Roles & Shifts** button.
 - Walk-in visit tracking (`clientVisits`) via [clientVisitController](MJ_FB_Backend/src/controllers/clientVisitController.ts).
 - Staff can mark bookings as no-show or visited through `/bookings/:id/no-show` and `/bookings/:id/visited` endpoints.
 - Walk-in bookings created via `/bookings/preapproved` are saved with status `approved` (the `preapproved` status has been removed).
@@ -155,9 +155,9 @@ Before merging a pull request, confirm the following:
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)).
 - Self-service client registration with email OTP verification (currently disabled pending further testing).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
-- Staff can set a cart tare value and a single maximum booking capacity applied to all pantry time slots through the Admin → Pantry Settings page or `PUT /slots/capacity`.
-- Bread and can surplus weight multipliers are configurable via the Admin → Warehouse Settings page.
-- Volunteer roles and shifts are managed through the Admin → Volunteer Settings page.
+- Staff can set a cart tare value and a single maximum booking capacity applied to all pantry time slots through the Admin → Settings → Pantry tab or `PUT /slots/capacity`.
+- Bread and can surplus weight multipliers are configurable via the Admin → Settings → Warehouse tab.
+- Volunteer roles and shifts are managed through the Admin → Settings → Volunteer tab.
 - `/volunteer-roles` now returns each role with `id` representing the role ID (the `role_id` field has been removed).
 - Creating volunteer role slots (`POST /volunteer-roles`) accepts either an existing `roleId` or a new `name` with `categoryId`.
 - Volunteer role start and end times are selected via a native time picker and stored as `HH:MM:SS`.
@@ -324,8 +324,8 @@ The build will fail if this variable is missing.
 Refer to the submodule repositories for detailed configuration and environment variables.
 
 The backend surplus tracking feature uses two optional environment variables to
-set default multipliers; values are editable in the Admin → Warehouse Settings
-page and cached on the server:
+set default multipliers; values are editable in the Admin → Settings → Warehouse tab
+and cached on the server:
 
 - `BREAD_WEIGHT_MULTIPLIER` (default `10`)
 - `CANS_WEIGHT_MULTIPLIER` (default `20`)
@@ -344,8 +344,8 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Warehouse Aggregations page provides yearly totals and supports exporting them via `/warehouse-overall/export`.
 - Page and form titles render in uppercase with a lighter font weight for clarity.
 - Admin staff creation page provides a link back to the staff list for easier navigation.
-- Admin navigation includes Pantry Settings and Volunteer Settings pages.
-- Pantry Settings page lets staff configure a cart tare value and one max booking capacity used for all pantry times.
+- Admin navigation includes a Settings page with Pantry, Warehouse, and Volunteer tabs.
+- The Settings page's Pantry tab lets staff configure a cart tare value and one max booking capacity used for all pantry times.
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
 - Filled pantry schedule slots display the client's ID in parentheses, or show `[NEW CLIENT] Name` when booked for an unregistered individual.
 - Staff can book new clients directly from the pantry schedule's **Assign User** modal by checking **New client** and entering a name (email and phone optional).


### PR DESCRIPTION
## Summary
- add AdminSettings page with tabs for Warehouse, Pantry, and Volunteer settings
- route Admin navigation to new consolidated Settings page
- document Settings page usage in README and AGENTS guidelines

## Testing
- `npm test` *(fails: Cannot find module '../../../testUtils/renderWithProviders' from 'src/pages/staff/__tests__/timesheets.test.tsx', plus other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b8611d8ce4832db9f5956993a8b730