### PR TITLE
refactor: extract admin settings tabs

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -8,6 +8,7 @@ const Dashboard = React.lazy(
 import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import MainLayout from './components/layout/MainLayout';
+import Page from './components/Page';
 import { useAuth, AgencyGuard } from './hooks/useAuth';
 import type { StaffAccess } from './types';
 import { getVolunteerBookingsForReview } from './api/volunteers';
@@ -95,9 +96,11 @@ const AdminStaffList = React.lazy(() => import('./pages/admin/AdminStaffList'));
 const WarehouseSettings = React.lazy(() =>
   import('./pages/admin/WarehouseSettings')
 );
-const PantrySettings = React.lazy(() => import('./pages/admin/PantrySettings'));
-const VolunteerSettings = React.lazy(() =>
-  import('./pages/admin/VolunteerSettings')
+const PantrySettingsTab = React.lazy(() =>
+  import('./pages/admin/settings/PantrySettingsTab')
+);
+const VolunteerSettingsTab = React.lazy(() =>
+  import('./pages/admin/settings/VolunteerSettingsTab')
 );
 const Events = React.lazy(() => import('./pages/events/Events'));
 const PantryVisits = React.lazy(() => import('./pages/staff/PantryVisits'));
@@ -445,8 +448,26 @@ export default function App() {
                     />
                   )}
                   {showAdmin && <Route path="/admin/warehouse-settings" element={<WarehouseSettings />} />}
-                  {showAdmin && <Route path="/admin/pantry-settings" element={<PantrySettings />} />}
-                  {showAdmin && <Route path="/admin/volunteer-settings" element={<VolunteerSettings />} />}
+                  {showAdmin && (
+                    <Route
+                      path="/admin/pantry-settings"
+                      element={
+                        <Page title="Pantry Settings">
+                          <PantrySettingsTab />
+                        </Page>
+                      }
+                    />
+                  )}
+                  {showAdmin && (
+                    <Route
+                      path="/admin/volunteer-settings"
+                      element={
+                        <Page title="Volunteer Settings">
+                          <VolunteerSettingsTab />
+                        </Page>
+                      }
+                    />
+                  )}
                   {showVolunteerManagement && (
                     <>
                       <Route

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/PantrySettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/PantrySettings.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import PantrySettings from '../PantrySettings';
+import PantrySettingsTab from '../settings/PantrySettingsTab';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from '../../../theme';
 
@@ -19,14 +19,14 @@ jest.mock('../../../api/appConfig', () => ({
 const { getAllSlots, updateSlotCapacity } = jest.requireMock('../../../api/slots');
 const { getAppConfig, updateAppConfig } = jest.requireMock('../../../api/appConfig');
 
-describe('PantrySettings', () => {
+describe('PantrySettingsTab', () => {
   it('updates capacity and cart tare', async () => {
     (getAllSlots as jest.Mock).mockResolvedValue<Slot[]>([{ maxCapacity: 5 }]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 10 });
 
     render(
       <ThemeProvider theme={theme}>
-        <PantrySettings />
+        <PantrySettingsTab />
       </ThemeProvider>,
     );
 

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettings.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import VolunteerSettings from '../VolunteerSettings';
+import VolunteerSettingsTab from '../settings/VolunteerSettingsTab';
 
 jest.mock('../../../api/volunteers', () => ({
   getVolunteerMasterRoles: jest.fn(),
@@ -20,7 +20,7 @@ const {
   restoreVolunteerRoles,
 } = jest.requireMock('../../../api/volunteers');
 
-describe('VolunteerSettings page', () => {
+describe('VolunteerSettingsTab page', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getVolunteerMasterRoles as jest.Mock).mockResolvedValue([
@@ -52,7 +52,7 @@ describe('VolunteerSettings page', () => {
   it('renders master role sections with buttons', async () => {
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -70,7 +70,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -94,7 +94,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -133,7 +133,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -165,7 +165,7 @@ describe('VolunteerSettings page', () => {
   it('shows validation errors for required fields', async () => {
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -189,7 +189,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -218,7 +218,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -235,7 +235,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 

--- a/MJ_FB_Frontend/src/pages/admin/settings/PantrySettingsTab.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/settings/PantrySettingsTab.tsx
@@ -8,12 +8,11 @@ import {
   Button,
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
-import Page from '../../components/Page';
-import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import { getAllSlots, updateSlotCapacity } from '../../api/slots';
-import { getAppConfig, updateAppConfig } from '../../api/appConfig';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import { getAllSlots, updateSlotCapacity } from '../../../api/slots';
+import { getAppConfig, updateAppConfig } from '../../../api/appConfig';
 
-export default function PantrySettings() {
+export default function PantrySettingsTab() {
   const [capacity, setCapacity] = useState<number>(0);
   const [cartTare, setCartTare] = useState<number>(0);
   const [snackbar, setSnackbar] = useState<
@@ -66,7 +65,7 @@ export default function PantrySettings() {
   };
 
   return (
-    <Page title="Pantry Settings">
+    <>
       <Grid container spacing={2} p={2}>
         <Grid size={12}>
           <Card>
@@ -119,6 +118,6 @@ export default function PantrySettings() {
         message={snackbar?.message || ''}
         severity={snackbar?.severity}
       />
-    </Page>
+    </>
   );
 }

--- a/MJ_FB_Frontend/src/pages/admin/settings/VolunteerSettingsTab.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/settings/VolunteerSettingsTab.tsx
@@ -22,11 +22,10 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import Page from '../../components/Page';
-import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import MasterRoleDialog, { type MasterRole } from './components/MasterRoleDialog';
-import SubRoleDialog from './components/SubRoleDialog';
-import ShiftDialog from './components/ShiftDialog';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import MasterRoleDialog, { type MasterRole } from '../components/MasterRoleDialog';
+import SubRoleDialog from '../components/SubRoleDialog';
+import ShiftDialog from '../components/ShiftDialog';
 import {
   getVolunteerMasterRoles,
   getVolunteerRoles,
@@ -38,11 +37,11 @@ import {
   toggleVolunteerRole,
   deleteVolunteerRole,
   restoreVolunteerRoles,
-} from '../../api/volunteers';
-import { formatTime } from '../../utils/time';
-import type { VolunteerRoleWithShifts } from '../../types';
+} from '../../../api/volunteers';
+import { formatTime } from '../../../utils/time';
+import type { VolunteerRoleWithShifts } from '../../../types';
 
-export default function VolunteerSettings() {
+export default function VolunteerSettingsTab() {
   const [masterRoles, setMasterRoles] = useState<MasterRole[]>([]);
   const [roles, setRoles] = useState<VolunteerRoleWithShifts[]>([]);
   const [snack, setSnack] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({ open: false, message: '', severity: 'success' });
@@ -354,7 +353,7 @@ export default function VolunteerSettings() {
   }
 
   return (
-    <Page title="Volunteer Settings">
+    <>
       <Box p={2}>
         <Box mb={2}>
           <Stack direction="row" spacing={1}>
@@ -591,6 +590,6 @@ export default function VolunteerSettings() {
         message={snack.message}
         onClose={() => setSnack({ ...snack, open: false })}
       />
-    </Page>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- extract pantry and volunteer settings forms into reusable tabs
- wrap standalone admin routes with Page while reusing tab content

## Testing
- `npm test` *(fails: Cannot find module '../../../testUtils/renderWithProviders' in timesheets.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b8614e7264832d997badd6b0720912