### PR TITLE
refactor: clarify admin settings tabs

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/AdminSettings.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminSettings.tsx
@@ -1,8 +1,8 @@
 import Page from '../../components/Page';
 import StyledTabs from '../../components/StyledTabs';
 import WarehouseSettings from './settings/WarehouseSettings';
-import PantrySettings from './settings/PantrySettings';
-import VolunteerSettings from './settings/VolunteerSettings';
+import PantrySettingsTab from './settings/PantrySettingsTab';
+import VolunteerSettingsTab from './settings/VolunteerSettingsTab';
 
 export default function AdminSettings() {
   return (
@@ -10,8 +10,8 @@ export default function AdminSettings() {
       <StyledTabs
         tabs={[
           { label: 'Warehouse', content: <WarehouseSettings /> },
-          { label: 'Pantry', content: <PantrySettings /> },
-          { label: 'Volunteer', content: <VolunteerSettings /> },
+          { label: 'Pantry', content: <PantrySettingsTab /> },
+          { label: 'Volunteer', content: <VolunteerSettingsTab /> },
         ]}
       />
     </Page>

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/AdminSettings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/AdminSettings.test.tsx
@@ -5,8 +5,8 @@ import { theme } from '../../../theme';
 import AdminSettings from '../AdminSettings';
 
 jest.mock('../settings/WarehouseSettings', () => () => <div>Warehouse Content</div>);
-jest.mock('../settings/PantrySettings', () => () => <div>Pantry Content</div>);
-jest.mock('../settings/VolunteerSettings', () => () => <div>Volunteer Content</div>);
+jest.mock('../settings/PantrySettingsTab', () => () => <div>Pantry Content</div>);
+jest.mock('../settings/VolunteerSettingsTab', () => () => <div>Volunteer Content</div>);
 
 describe('AdminSettings', () => {
   it('renders tabs and switches content', () => {

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/PantrySettingsTab.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/PantrySettingsTab.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import PantrySettings from '../settings/PantrySettings';
+import PantrySettingsTab from '../settings/PantrySettingsTab';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from '../../../theme';
 
@@ -19,14 +19,14 @@ jest.mock('../../../api/appConfig', () => ({
 const { getAllSlots, updateSlotCapacity } = jest.requireMock('../../../api/slots');
 const { getAppConfig, updateAppConfig } = jest.requireMock('../../../api/appConfig');
 
-describe('PantrySettings', () => {
+describe('PantrySettingsTab', () => {
   it('updates capacity and cart tare', async () => {
     (getAllSlots as jest.Mock).mockResolvedValue<Slot[]>([{ maxCapacity: 5 }]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 10 });
 
     render(
       <ThemeProvider theme={theme}>
-        <PantrySettings />
+        <PantrySettingsTab />
       </ThemeProvider>,
     );
 

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettingsTab.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/VolunteerSettingsTab.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import VolunteerSettings from '../settings/VolunteerSettings';
+import VolunteerSettingsTab from '../settings/VolunteerSettingsTab';
 
 jest.mock('../../../api/volunteers', () => ({
   getVolunteerMasterRoles: jest.fn(),
@@ -20,7 +20,7 @@ const {
   restoreVolunteerRoles,
 } = jest.requireMock('../../../api/volunteers');
 
-describe('VolunteerSettings page', () => {
+describe('VolunteerSettingsTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getVolunteerMasterRoles as jest.Mock).mockResolvedValue([
@@ -52,7 +52,7 @@ describe('VolunteerSettings page', () => {
   it('renders master role sections with buttons', async () => {
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -70,7 +70,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -94,7 +94,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -133,7 +133,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -165,7 +165,7 @@ describe('VolunteerSettings page', () => {
   it('shows validation errors for required fields', async () => {
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -189,7 +189,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -218,7 +218,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 
@@ -235,7 +235,7 @@ describe('VolunteerSettings page', () => {
 
     render(
       <MemoryRouter>
-        <VolunteerSettings />
+        <VolunteerSettingsTab />
       </MemoryRouter>
     );
 

--- a/MJ_FB_Frontend/src/pages/admin/settings/PantrySettingsTab.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/settings/PantrySettingsTab.tsx
@@ -12,7 +12,7 @@ import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import { getAllSlots, updateSlotCapacity } from '../../../api/slots';
 import { getAppConfig, updateAppConfig } from '../../../api/appConfig';
 
-export default function PantrySettings() {
+export default function PantrySettingsTab() {
   const [capacity, setCapacity] = useState<number>(0);
   const [cartTare, setCartTare] = useState<number>(0);
   const [snackbar, setSnackbar] = useState<

--- a/MJ_FB_Frontend/src/pages/admin/settings/VolunteerSettingsTab.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/settings/VolunteerSettingsTab.tsx
@@ -41,7 +41,7 @@ import {
 import { formatTime } from '../../../utils/time';
 import type { VolunteerRoleWithShifts } from '../../../types';
 
-export default function VolunteerSettings() {
+export default function VolunteerSettingsTab() {
   const [masterRoles, setMasterRoles] = useState<MasterRole[]>([]);
   const [roles, setRoles] = useState<VolunteerRoleWithShifts[]>([]);
   const [snack, setSnack] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({ open: false, message: '', severity: 'success' });


### PR DESCRIPTION
## Summary
- rename PantrySettings and VolunteerSettings components to PantrySettingsTab and VolunteerSettingsTab
- update AdminSettings imports to use new tab components
- adjust related tests for new filenames

## Testing
- `CI=true npx jest src/pages/admin/__tests__/PantrySettingsTab.test.tsx --runInBand`
- `CI=true npx jest src/pages/admin/__tests__/VolunteerSettingsTab.test.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b87ec9e778832d9e9ef744b62a753e