### PR TITLE
refactor: expose timesheets in profile

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -171,7 +171,6 @@ export default function App() {
       { label: 'Manage Availability', to: '/pantry/manage-availability' },
       { label: 'Pantry Schedule', to: '/pantry/schedule' },
       { label: 'Pantry Visits', to: '/pantry/visits' },
-      { label: t('timesheets.title'), to: '/timesheet' },
       { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Agency Management', to: '/pantry/agency-management' },
     ];

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -23,7 +23,7 @@ describe('Navbar component', () => {
     expect(screen.getByText(/Logout/i)).toBeInTheDocument();
   });
 
-  it('shows staff profile links', () => {
+  it('shows staff profile links only in the profile menu', () => {
     render(
       <MemoryRouter>
         <Navbar
@@ -39,6 +39,8 @@ describe('Navbar component', () => {
       </MemoryRouter>,
     );
 
+    expect(screen.queryByText(/Timesheets/i)).toBeNull();
+    expect(screen.queryByText(/Leave Management/i)).toBeNull();
     fireEvent.click(screen.getByText(/Hello, Tester/i));
     expect(screen.getByText(/Timesheets/i)).toBeInTheDocument();
     expect(screen.getByText(/Leave Management/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- remove Timesheets from Harvest Pantry nav group so it's only in the profile menu
- ensure Navbar test verifies Timesheets and Leave links are visible only after opening profile menu

## Testing
- `npm test` *(fails: unable to find elements in several suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b8984e9170832d9ed690380758b242