### PR TITLE
feat(frontend): expose staff tools nav group

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -147,11 +147,7 @@ export default function App() {
 
   const navGroups: NavGroup[] = [];
   const profileLinks: NavLink[] | undefined = isStaff
-    ? [
-        { label: t('news_and_events'), to: '/events' },
-        { label: t('timesheets.title'), to: '/timesheet' },
-        { label: t('leave.title'), to: '/leave-requests' },
-      ]
+    ? [{ label: t('news_and_events'), to: '/events' }]
     : undefined;
   if (!role) {
     navGroups.push(
@@ -189,6 +185,14 @@ export default function App() {
           },
         ],
       });
+
+    navGroups.push({
+      label: 'Staff Tools',
+      links: [
+        { label: t('timesheets.title'), to: '/timesheet' },
+        { label: t('leave.title'), to: '/leave-requests' },
+      ],
+    });
 
     const warehouseLinks = [
       { label: 'Dashboard', to: '/warehouse-management' },

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import Navbar from '../components/Navbar';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -23,27 +23,36 @@ describe('Navbar component', () => {
     expect(screen.getByText(/Logout/i)).toBeInTheDocument();
   });
 
-  it('shows staff profile links only in the profile menu', () => {
+  it('shows staff tools links in a dedicated nav group', () => {
     render(
       <MemoryRouter>
         <Navbar
-          groups={[{ label: 'Home', links: [{ label: 'Home', to: '/' }] }]}
+          groups={[
+            { label: 'Home', links: [{ label: 'Home', to: '/' }] },
+            {
+              label: 'Staff Tools',
+              links: [
+                { label: 'Timesheets', to: '/timesheet' },
+                { label: 'Leave Management', to: '/leave-requests' },
+              ],
+            },
+          ]}
           onLogout={() => {}}
           name="Tester"
           role="staff"
-          profileLinks={[
-            { label: 'Timesheets', to: '/timesheet' },
-            { label: 'Leave Management', to: '/leave-requests' },
-          ]}
+          profileLinks={[{ label: 'News & Events', to: '/events' }]}
         />
       </MemoryRouter>,
     );
 
-    expect(screen.queryByText(/Timesheets/i)).toBeNull();
-    expect(screen.queryByText(/Leave Management/i)).toBeNull();
-    fireEvent.click(screen.getByText(/Hello, Tester/i));
+    expect(screen.getByText(/Staff Tools/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/Staff Tools/i));
     expect(screen.getByText(/Timesheets/i)).toBeInTheDocument();
     expect(screen.getByText(/Leave Management/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/Hello, Tester/i));
+    const profileMenu = document.getElementById('profile-menu') as HTMLElement;
+    expect(within(profileMenu).queryByText(/Timesheets/i)).toBeNull();
+    expect(within(profileMenu).queryByText(/Leave Management/i)).toBeNull();
   });
 
   it('renders without greeting when name is absent', () => {


### PR DESCRIPTION
## Summary
- move Timesheets and Leave Requests into new Staff Tools nav group
- adjust profile menu to show only News & Events
- test Staff Tools navigation visibility

## Testing
- `cd MJ_FB_Frontend && npm test src/__tests__/Navbar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b8bd380fd4832db5950082195be88a