### PR TITLE
feat: add staff timesheet and leave links

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -147,7 +147,11 @@ export default function App() {
 
   const navGroups: NavGroup[] = [];
   const profileLinks: NavLink[] | undefined = isStaff
-    ? [{ label: t('news_and_events'), to: '/events' }]
+    ? [
+        { label: t('news_and_events'), to: '/events' },
+        { label: t('timesheets.title'), to: '/timesheet' },
+        { label: t('leave.title'), to: '/leave-requests' },
+      ]
     : undefined;
   if (!role) {
     navGroups.push(

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -40,7 +40,11 @@ describe('Navbar component', () => {
           onLogout={() => {}}
           name="Tester"
           role="staff"
-          profileLinks={[{ label: 'News & Events', to: '/events' }]}
+          profileLinks={[
+            { label: 'News & Events', to: '/events' },
+            { label: 'Timesheets', to: '/timesheet' },
+            { label: 'Leave Management', to: '/leave-requests' },
+          ]}
         />
       </MemoryRouter>,
     );
@@ -51,8 +55,8 @@ describe('Navbar component', () => {
     expect(screen.getByText(/Leave Management/i)).toBeInTheDocument();
     fireEvent.click(screen.getByText(/Hello, Tester/i));
     const profileMenu = document.getElementById('profile-menu') as HTMLElement;
-    expect(within(profileMenu).queryByText(/Timesheets/i)).toBeNull();
-    expect(within(profileMenu).queryByText(/Leave Management/i)).toBeNull();
+    expect(within(profileMenu).getByText(/Timesheets/i)).toBeInTheDocument();
+    expect(within(profileMenu).getByText(/Leave Management/i)).toBeInTheDocument();
   });
 
   it('renders without greeting when name is absent', () => {

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -97,7 +97,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -107,7 +107,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -97,7 +97,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -107,7 +107,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -95,7 +95,7 @@
         "title": "Timesheets",
         "description": "Record hours and submit pay periods.",
         "steps": [
-          "Open the Timesheets page.",
+          "Open the Timesheets page from the profile menu.",
           "Fill in hours or request leave days.",
           "Submit the period for review.",
           "Export a CSV for payroll."
@@ -105,7 +105,7 @@
         "title": "Leave Management",
         "description": "Submit and track leave requests.",
         "steps": [
-          "Open the Leave Management page.",
+          "Open the Leave Management page from the profile menu.",
           "Submit new leave requests with date and hours.",
           "Review the status of your requests."
         ]


### PR DESCRIPTION
## Summary
- show Timesheets and Leave Management under the staff profile menu
- verify navbar profile menu includes Timesheets and Leave links in tests
- clarify help translations that Timesheets and Leave pages open from the profile menu

## Testing
- `npm test` *(fails: Cannot find module '../../../testUtils/renderWithProviders' from 'src/pages/staff/__tests__/timesheets.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68b8bfdb357c832dbed957212af0383a