### PR TITLE
Allow admin access to timesheet day entries

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -36,6 +36,7 @@ import badgesRoutes from './routes/badges';
 import statsRoutes from './routes/stats';
 import volunteerStatsRoutes from './routes/volunteerStats';
 import timesheetsRoutes from './routes/timesheets';
+import adminTimesheetsRoutes from './routes/admin/timesheets';
 import leaveRequestsRoutes from './routes/leaveRequests';
 import { initializeSlots } from './data';
 import csrfMiddleware from './middleware/csrf';
@@ -90,6 +91,7 @@ app.use('/events', eventsRoutes);
 app.use('/badges', badgesRoutes);
 app.use('/stats', statsRoutes);
 app.use('/timesheets', timesheetsRoutes);
+app.use('/admin/timesheets', adminTimesheetsRoutes);
 app.use('/api/leave/requests', leaveRequestsRoutes);
 
 // Serve the frontend in production

--- a/MJ_FB_Backend/src/routes/admin/timesheets.ts
+++ b/MJ_FB_Backend/src/routes/admin/timesheets.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
+import { getTimesheetDaysAdmin } from '../../controllers/timesheetController';
+
+const router = express.Router();
+
+router.get('/:id/days', authMiddleware, authorizeRoles('admin'), getTimesheetDaysAdmin);
+
+export default router;

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 `/leave-requests` from the profile menu once logged in. Admin users also see
 **Timesheets** at `/admin/timesheet` and **Leave Requests** at
-`/admin/leave-requests` under the Admin menu for reviewing submissions.
+`/admin/leave-requests` under the Admin menu for reviewing submissions. Admins can
+also retrieve any staff timesheet's day entries through the API at
+`GET /admin/timesheets/:id/days`.
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -66,6 +66,7 @@ TIMESHEET_APPROVER_EMAILS=admin1@example.com,admin2@example.com # optional
 
 - `GET /timesheets/mine` – list pay periods for the logged in staff member.
 - `GET /timesheets/:id/days` – list daily entries for a timesheet.
+- `GET /admin/timesheets/:id/days` – admins can list daily entries for any staff timesheet.
 - `PATCH /timesheets/:id/days/:date` – update hours for a day. Body accepts `regHours`, `otHours`, `statHours`, `sickHours`, `vacHours`, and optional `note`.
 - `POST /timesheets/:id/submit` – submit a pay period.
 - `POST /timesheets/:id/reject` – reject a submitted timesheet.


### PR DESCRIPTION
## Summary
- Allow admins to bypass staff ownership checks when listing timesheet days
- Add `/admin/timesheets/:id/days` route for admin access
- Document admin timesheet day endpoint and add tests covering admin/staff restrictions

## Testing
- `npm test` *(fails: Node v22 is required)*


------
https://chatgpt.com/codex/tasks/task_e_68b8bfff944c832d9613e9537ef0e5f6