### PR TITLE
feat: add admin timesheet management

### DIFF
--- a/MJ_FB_Backend/src/routes/timesheets.ts
+++ b/MJ_FB_Backend/src/routes/timesheets.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import {
   listMyTimesheets,
+  listTimesheets,
   getTimesheetDays,
   updateTimesheetDay,
   submitTimesheet,
@@ -11,14 +12,12 @@ import {
 
 const router = express.Router();
 
-// list pay periods for the logged in staff member
+router.get('/', authMiddleware, authorizeRoles('admin'), listTimesheets);
 router.get('/mine', authMiddleware, authorizeRoles('staff'), listMyTimesheets);
-// deprecated: retain root path for backwards compatibility
-router.get('/', authMiddleware, authorizeRoles('staff'), listMyTimesheets);
-router.get('/:id/days', authMiddleware, authorizeRoles('staff'), getTimesheetDays);
+router.get('/:id/days', authMiddleware, authorizeRoles('staff', 'admin'), getTimesheetDays);
 router.patch('/:id/days/:date', authMiddleware, authorizeRoles('staff'), updateTimesheetDay);
 router.post('/:id/submit', authMiddleware, authorizeRoles('staff'), submitTimesheet);
-router.post('/:id/reject', authMiddleware, authorizeRoles('staff'), rejectTimesheet);
-router.post('/:id/process', authMiddleware, authorizeRoles('staff'), processTimesheet);
+router.post('/:id/reject', authMiddleware, authorizeRoles('admin'), rejectTimesheet);
+router.post('/:id/process', authMiddleware, authorizeRoles('admin'), processTimesheet);
 
 export default router;

--- a/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
+++ b/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
@@ -1,6 +1,7 @@
 import '../setupTests';
 import {
   listMyTimesheets,
+  listTimesheets,
   getTimesheetDays,
   updateTimesheetDay,
   submitTimesheet,
@@ -19,6 +20,17 @@ describe('timesheet controller', () => {
     const res: any = { json: jest.fn() };
     await listMyTimesheets(req, res, () => {});
     expect(res.json).toHaveBeenCalledWith([{ id: 1 }]);
+  });
+
+  it('lists all timesheets for admin', async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ id: 2, staff_name: 'Alice A' }],
+      rowCount: 1,
+    });
+    const req: any = { user: { role: 'admin' } };
+    const res: any = { json: jest.fn() };
+    await listTimesheets(req, res, () => {});
+    expect(res.json).toHaveBeenCalledWith([{ id: 2, staff_name: 'Alice A' }]);
   });
 
   it('gets timesheet days', async () => {
@@ -53,6 +65,47 @@ describe('timesheet controller', () => {
         work_date: '2024-01-02',
         expected_hours: 3,
         reg_hours: 1,
+        ot_hours: 0,
+        stat_hours: 0,
+        sick_hours: 0,
+        vac_hours: 0,
+        note: null,
+        locked_by_rule: false,
+        locked_by_leave: false,
+      },
+    ]);
+  });
+
+  it('allows admin to get timesheet days', async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 3,
+          timesheet_id: 5,
+          work_date: '2024-02-01',
+          expected_hours: 8,
+          reg_hours: 8,
+          ot_hours: 0,
+          stat_hours: 0,
+          sick_hours: 0,
+          vac_hours: 0,
+          note: null,
+          locked_by_rule: false,
+          locked_by_leave: false,
+        },
+      ],
+      rowCount: 1,
+    });
+    const req: any = { user: { role: 'admin' }, params: { id: '5' } };
+    const res: any = { json: jest.fn() };
+    await getTimesheetDays(req, res, () => {});
+    expect(res.json).toHaveBeenCalledWith([
+      {
+        id: 3,
+        timesheet_id: 5,
+        work_date: '2024-02-01',
+        expected_hours: 8,
+        reg_hours: 8,
         ot_hours: 0,
         stat_hours: 0,
         sick_hours: 0,

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -96,6 +96,7 @@ const AdminSettings = React.lazy(() => import('./pages/admin/AdminSettings'));
 const Events = React.lazy(() => import('./pages/events/Events'));
 const PantryVisits = React.lazy(() => import('./pages/staff/PantryVisits'));
 const Timesheets = React.lazy(() => import('./pages/staff/timesheets'));
+const AdminTimesheets = React.lazy(() => import('./pages/admin/Timesheets'));
 const LeaveManagement = React.lazy(
   () => import('./pages/staff/LeaveManagement'),
 );
@@ -431,7 +432,7 @@ export default function App() {
                   {showAdmin && <Route path="/admin/staff/create" element={<AdminStaffForm />} />}
                   {showAdmin && <Route path="/admin/staff/:id" element={<AdminStaffForm />} />}
                   {showAdmin && (
-                    <Route path="/admin/timesheet" element={<Timesheets />} />
+                    <Route path="/admin/timesheet" element={<AdminTimesheets />} />
                   )}
                   {showAdmin && (
                     <Route

--- a/MJ_FB_Frontend/src/api/__tests__/timesheets.api.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/timesheets.api.test.ts
@@ -1,6 +1,7 @@
 import { apiFetch, handleResponse } from '../client';
 import {
   listTimesheets,
+  listAllTimesheets,
   getTimesheetDays,
   updateTimesheetDay,
   submitTimesheet,
@@ -22,6 +23,11 @@ describe('timesheets api', () => {
 
   it('lists my timesheets', async () => {
     await listTimesheets();
+    expect(apiFetch).toHaveBeenCalledWith('/api/timesheets/mine');
+  });
+
+  it('lists all timesheets', async () => {
+    await listAllTimesheets();
     expect(apiFetch).toHaveBeenCalledWith('/api/timesheets');
   });
 
@@ -31,12 +37,24 @@ describe('timesheets api', () => {
   });
 
   it('updates timesheet day', async () => {
-    await updateTimesheetDay(3, '2024-01-02', 7.5);
+    await updateTimesheetDay(3, '2024-01-02', {
+      regHours: 7.5,
+      otHours: 0,
+      statHours: 0,
+      sickHours: 0,
+      vacHours: 0,
+    });
     expect(apiFetch).toHaveBeenCalledWith(
       '/api/timesheets/3/days/2024-01-02',
       expect.objectContaining({
         method: 'PATCH',
-        body: JSON.stringify({ hours: 7.5 }),
+        body: JSON.stringify({
+          regHours: 7.5,
+          otHours: 0,
+          statHours: 0,
+          sickHours: 0,
+          vacHours: 0,
+        }),
       }),
     );
   });

--- a/MJ_FB_Frontend/src/api/timesheets.ts
+++ b/MJ_FB_Frontend/src/api/timesheets.ts
@@ -15,6 +15,10 @@ export interface TimesheetSummary {
   ot_hours: number;
 }
 
+export interface AdminTimesheetSummary extends TimesheetSummary {
+  staff_name: string;
+}
+
 export interface TimesheetDay {
   id: number;
   timesheet_id: number;
@@ -32,6 +36,11 @@ export interface TimesheetDay {
 
 export async function listTimesheets(): Promise<TimesheetSummary[]> {
   const res = await apiFetch(`${API_BASE}/timesheets/mine`);
+  return handleResponse(res);
+}
+
+export async function listAllTimesheets(): Promise<AdminTimesheetSummary[]> {
+  const res = await apiFetch(`${API_BASE}/timesheets`);
   return handleResponse(res);
 }
 
@@ -85,6 +94,14 @@ export function useTimesheets() {
   const { data, isFetching, error } = useQuery<TimesheetSummary[]>({
     queryKey: ['timesheets'],
     queryFn: listTimesheets,
+  });
+  return { timesheets: data ?? [], isLoading: isFetching, error };
+}
+
+export function useAllTimesheets() {
+  const { data, isFetching, error } = useQuery<AdminTimesheetSummary[]>({
+    queryKey: ['timesheets', 'all'],
+    queryFn: listAllTimesheets,
   });
   return { timesheets: data ?? [], isLoading: isFetching, error };
 }

--- a/MJ_FB_Frontend/src/pages/admin/Timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/Timesheets.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect } from 'react';
+import {
+  Box,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TableFooter,
+  Typography,
+  CircularProgress,
+  Button,
+  Tooltip,
+} from '@mui/material';
+import LockIcon from '@mui/icons-material/Lock';
+import Page from '../../components/Page';
+import StyledTabs, { type TabItem } from '../../components/StyledTabs';
+import { useTranslation } from 'react-i18next';
+import { formatLocaleDate } from '../../utils/date';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import type { ApiError } from '../../api/client';
+import {
+  useAllTimesheets,
+  useTimesheetDays,
+  useRejectTimesheet,
+  useProcessTimesheet,
+} from '../../api/timesheets';
+
+export default function AdminTimesheets() {
+  const { t } = useTranslation();
+  const { timesheets, isLoading: loadingSheets, error: sheetsError } =
+    useAllTimesheets();
+  const [tab, setTab] = useState(0);
+
+  useEffect(() => {
+    if (!timesheets.length) return;
+    const idx = timesheets.findIndex(p => !p.approved_at);
+    setTab(idx === -1 ? 0 : idx);
+  }, [timesheets.length]);
+
+  const current = timesheets[tab];
+  const { days: rawDays, error: daysError } = useTimesheetDays(current?.id);
+
+  const rejectMutation = useRejectTimesheet();
+  const processMutation = useProcessTimesheet();
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const err = sheetsError || daysError;
+    if (err) setMessage((err as ApiError).message || 'Error');
+  }, [sheetsError, daysError]);
+
+  function renderTable() {
+    if (!current) return null;
+    const totals = rawDays.reduce(
+      (acc, d) => {
+        const paid = d.reg_hours + d.ot_hours + d.stat_hours + d.sick_hours + d.vac_hours;
+        acc.reg += d.reg_hours;
+        acc.ot += d.ot_hours;
+        acc.stat += d.stat_hours;
+        acc.sick += d.sick_hours;
+        acc.vac += d.vac_hours;
+        acc.paid += paid;
+        acc.expected += d.expected_hours;
+        return acc;
+      },
+      { reg: 0, ot: 0, stat: 0, sick: 0, vac: 0, paid: 0, expected: 0 },
+    );
+    const shortfall = totals.expected - totals.paid;
+    const otBankRemaining = current.balance_hours;
+
+    return (
+      <Box>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('timesheets.date')}</TableCell>
+              <TableCell>{t('timesheets.reg')}</TableCell>
+              <TableCell>{t('timesheets.ot')}</TableCell>
+              <TableCell>{t('timesheets.stat')}</TableCell>
+              <TableCell>{t('timesheets.sick')}</TableCell>
+              <TableCell>{t('timesheets.vac')}</TableCell>
+              <TableCell>{t('timesheets.note')}</TableCell>
+              <TableCell>{t('timesheets.paid_total')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rawDays.map(d => {
+              const paid =
+                d.reg_hours + d.ot_hours + d.stat_hours + d.sick_hours + d.vac_hours;
+              return (
+                <TableRow key={d.id}>
+                  <TableCell>
+                    {formatLocaleDate(d.work_date)}
+                    {(d.locked_by_rule || d.locked_by_leave) && (
+                      <Tooltip
+                        title={
+                          d.locked_by_rule
+                            ? t('timesheets.lock_stat_tooltip')
+                            : t('timesheets.lock_leave_tooltip')
+                        }
+                      >
+                        <LockIcon sx={{ ml: 1, fontSize: 16 }} />
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                  <TableCell>{d.reg_hours}</TableCell>
+                  <TableCell>{d.ot_hours}</TableCell>
+                  <TableCell>{d.stat_hours}</TableCell>
+                  <TableCell>{d.sick_hours}</TableCell>
+                  <TableCell>{d.vac_hours}</TableCell>
+                  <TableCell>{d.note}</TableCell>
+                  <TableCell>{paid}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TableCell>{t('timesheets.summary.totals')}</TableCell>
+              <TableCell>{totals.reg}</TableCell>
+              <TableCell>{totals.ot}</TableCell>
+              <TableCell>{totals.stat}</TableCell>
+              <TableCell>{totals.sick}</TableCell>
+              <TableCell>{totals.vac}</TableCell>
+              <TableCell />
+              <TableCell>{totals.paid}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell colSpan={8}>
+                <Typography variant="body2">
+                  {t('timesheets.summary.expected')}: {totals.expected} •{' '}
+                  {t('timesheets.summary.shortfall')}: {shortfall} •{' '}
+                  {t('timesheets.summary.ot_bank_remaining')}: {otBankRemaining}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </Box>
+    );
+  }
+
+  const tabs: TabItem[] = timesheets.map(p => ({
+    label: `${p.staff_name}: ${formatLocaleDate(p.start_date)} - ${formatLocaleDate(
+      p.end_date,
+    )}`,
+    content: p.id === current?.id ? renderTable() : null,
+  }));
+
+  return (
+    <Page title={t('timesheets.title')}>
+      {loadingSheets ? (
+        <CircularProgress />
+      ) : (
+        <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />
+      )}
+      {current && current.submitted_at && !current.approved_at && (
+        <Box sx={{ mt: 2, display: 'flex', gap: 1 }}>
+          <Button
+            variant="contained"
+            onClick={() => rejectMutation.mutate(current.id)}
+          >
+            {t('timesheets.reject')}
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => processMutation.mutate(current.id)}
+          >
+            {t('timesheets.process')}
+          </Button>
+        </Box>
+      )}
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity="error"
+      />
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -394,8 +394,8 @@ export function getHelpContent(
         description: 'Approve or reject submitted timesheets.',
         steps: [
           'Go to Admin > Timesheets.',
-          'Open a period and review hours.',
-          'Approve or reject as needed.',
+          'Select a staff member and pay period.',
+          'Review hours, then approve or reject.',
         ],
       },
     },

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -25,8 +25,6 @@ import {
   useTimesheetDays,
   useUpdateTimesheetDay,
   useSubmitTimesheet,
-  useRejectTimesheet,
-  useProcessTimesheet,
 } from '../../api/timesheets';
 import {
   useCreateLeaveRequest,
@@ -81,8 +79,6 @@ export default function Timesheets() {
 
   const updateMutation = useUpdateTimesheetDay(current?.id ?? 0);
   const submitMutation = useSubmitTimesheet();
-  const rejectMutation = useRejectTimesheet();
-  const processMutation = useProcessTimesheet();
   const leaveMutation = useCreateLeaveRequest(current?.id ?? 0);
   const { requests } = useLeaveRequests(current?.id);
   const approveLeaveMutation = useApproveLeaveRequest();
@@ -297,22 +293,6 @@ export default function Timesheets() {
             >
               {t('timesheets.submit')}
             </Button>
-          )}
-          {current.submitted_at && !current.approved_at && (
-            <>
-              <Button
-                variant="contained"
-                onClick={() => rejectMutation.mutate(current.id)}
-              >
-                {t('timesheets.reject')}
-              </Button>
-              <Button
-                variant="contained"
-                onClick={() => processMutation.mutate(current.id)}
-              >
-                {t('timesheets.process')}
-              </Button>
-            </>
           )}
         </Box>
       )}

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -5,7 +5,8 @@ Staff can record daily hours and submit pay periods.
 Staff access timesheets at `/timesheet` and leave management at `/leave-requests`
 from the **Hello** menu in the top-right corner. Admins can review periods at
 `/admin/timesheet` and vacation requests at `/admin/leave-requests` from the
-Admin menu.
+Admin menu. The admin view lets reviewers select a staff member and pay period
+to approve or reject submissions.
 
 ## Setup
 
@@ -64,12 +65,13 @@ TIMESHEET_APPROVER_EMAILS=admin1@example.com,admin2@example.com # optional
 
 ## API usage
 
+- `GET /timesheets` – list pay periods for all staff (admin only).
 - `GET /timesheets/mine` – list pay periods for the logged in staff member.
 - `GET /timesheets/:id/days` – list daily entries for a timesheet.
 - `PATCH /timesheets/:id/days/:date` – update hours for a day. Body accepts `regHours`, `otHours`, `statHours`, `sickHours`, `vacHours`, and optional `note`.
 - `POST /timesheets/:id/submit` – submit a pay period.
-- `POST /timesheets/:id/reject` – reject a submitted timesheet.
-- `POST /timesheets/:id/process` – mark a timesheet as processed and exportable.
+- `POST /timesheets/:id/reject` – reject a submitted timesheet (admin only).
+- `POST /timesheets/:id/process` – mark a timesheet as processed and exportable (admin only).
 - `POST /timesheets/:id/leave-requests` – request vacation leave for a day.
 - `GET /timesheets/:id/leave-requests` – list leave requests awaiting review.
 - `POST /timesheets/leave-requests/:requestId/approve` – approve a leave request, applying vacation hours and locking the day.


### PR DESCRIPTION
## Summary
- allow admins to list any timesheet and view period details
- add admin UI and API hooks for reviewing timesheets
- document admin timesheet endpoints

## Testing
- `npm test` (backend) *(fails: clientVisitBookingStatus, volunteerBookingStatusEmail, volunteerBookingConflict, bookingNewClient, volunteerRebookCancelled, bookingCapacity, newClientsMigration, dbPoolErrorHandler)*
- `npm test` (frontend) *(fails: timesheets page and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bfe43c48832db1dd90c85187140a