### PR TITLE
feat: add admin timesheet endpoints

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -36,7 +36,6 @@ import badgesRoutes from './routes/badges';
 import statsRoutes from './routes/stats';
 import volunteerStatsRoutes from './routes/volunteerStats';
 import timesheetsRoutes from './routes/timesheets';
-import adminTimesheetsRoutes from './routes/admin/timesheets';
 import leaveRequestsRoutes from './routes/leaveRequests';
 import { initializeSlots } from './data';
 import csrfMiddleware from './middleware/csrf';
@@ -91,7 +90,6 @@ app.use('/events', eventsRoutes);
 app.use('/badges', badgesRoutes);
 app.use('/stats', statsRoutes);
 app.use('/timesheets', timesheetsRoutes);
-app.use('/admin/timesheets', adminTimesheetsRoutes);
 app.use('/api/leave/requests', leaveRequestsRoutes);
 
 // Serve the frontend in production

--- a/MJ_FB_Backend/src/routes/admin/timesheets.ts
+++ b/MJ_FB_Backend/src/routes/admin/timesheets.ts
@@ -1,9 +1,0 @@
-import express from 'express';
-import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
-import { getTimesheetDaysAdmin } from '../../controllers/timesheetController';
-
-const router = express.Router();
-
-router.get('/:id/days', authMiddleware, authorizeRoles('admin'), getTimesheetDaysAdmin);
-
-export default router;

--- a/MJ_FB_Backend/src/routes/timesheets.ts
+++ b/MJ_FB_Backend/src/routes/timesheets.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import {
   listMyTimesheets,
+  listTimesheets,
   getTimesheetDays,
   updateTimesheetDay,
   submitTimesheet,
@@ -13,12 +14,17 @@ const router = express.Router();
 
 // list pay periods for the logged in staff member
 router.get('/mine', authMiddleware, authorizeRoles('staff'), listMyTimesheets);
-// deprecated: retain root path for backwards compatibility
-router.get('/', authMiddleware, authorizeRoles('staff'), listMyTimesheets);
-router.get('/:id/days', authMiddleware, authorizeRoles('staff'), getTimesheetDays);
+// admin can list timesheets for any staff
+router.get('/', authMiddleware, authorizeRoles('admin'), listTimesheets);
+router.get(
+  '/:id/days',
+  authMiddleware,
+  authorizeRoles('staff', 'admin'),
+  getTimesheetDays,
+);
 router.patch('/:id/days/:date', authMiddleware, authorizeRoles('staff'), updateTimesheetDay);
 router.post('/:id/submit', authMiddleware, authorizeRoles('staff'), submitTimesheet);
-router.post('/:id/reject', authMiddleware, authorizeRoles('staff'), rejectTimesheet);
-router.post('/:id/process', authMiddleware, authorizeRoles('staff'), processTimesheet);
+router.post('/:id/reject', authMiddleware, authorizeRoles('admin'), rejectTimesheet);
+router.post('/:id/process', authMiddleware, authorizeRoles('admin'), processTimesheet);
 
 export default router;

--- a/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
+++ b/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
@@ -1,8 +1,8 @@
 import '../setupTests';
 import {
   listMyTimesheets,
+  listTimesheets,
   getTimesheetDays,
-  getTimesheetDaysAdmin,
   updateTimesheetDay,
   submitTimesheet,
   rejectTimesheet,
@@ -20,6 +20,29 @@ describe('timesheet controller', () => {
     const res: any = { json: jest.fn() };
     await listMyTimesheets(req, res, () => {});
     expect(res.json).toHaveBeenCalledWith([{ id: 1 }]);
+  });
+
+  it('lists all timesheets for admin', async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ id: 1 }, { id: 2 }],
+      rowCount: 2,
+    });
+    const req: any = { user: { id: '99', role: 'admin', type: 'staff' }, query: {} };
+    const res: any = { json: jest.fn() };
+    await listTimesheets(req, res, () => {});
+    expect(res.json).toHaveBeenCalledWith([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('filters timesheets by staffId for admin', async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ id: 3 }], rowCount: 1 });
+    const req: any = {
+      user: { id: '99', role: 'admin', type: 'staff' },
+      query: { staffId: '3' },
+    };
+    const res: any = { json: jest.fn() };
+    await listTimesheets(req, res, () => {});
+    expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE t.staff_id = $1'), [3]);
+    expect(res.json).toHaveBeenCalledWith([{ id: 3 }]);
   });
 
   it('gets timesheet days', async () => {
@@ -102,7 +125,7 @@ describe('timesheet controller', () => {
       });
     const req: any = { user: { id: '99', role: 'admin', type: 'staff' }, params: { id: '1' } };
     const res: any = { json: jest.fn() };
-    await getTimesheetDaysAdmin(req, res, () => {});
+    await getTimesheetDays(req, res, () => {});
     expect(res.json).toHaveBeenCalledWith([
       {
         id: 3,

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -343,7 +343,7 @@ export default function Timesheets() {
               {t('timesheets.submit')}
             </Button>
           )}
-          {current.submitted_at && !current.approved_at && (
+          {current.submitted_at && !current.approved_at && inAdmin && (
             <>
               <Button
                 variant="contained"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 `/leave-requests` from the profile menu once logged in. Admin users also see
 **Timesheets** at `/admin/timesheet` and **Leave Requests** at
 `/admin/leave-requests` under the Admin menu for reviewing submissions. Admins can
-also retrieve any staff timesheet's day entries through the API at
-`GET /admin/timesheets/:id/days`.
+retrieve any staff timesheet's day entries through the API at
+`GET /timesheets/:id/days` and list periods via `GET /timesheets`.
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -65,12 +65,12 @@ TIMESHEET_APPROVER_EMAILS=admin1@example.com,admin2@example.com # optional
 ## API usage
 
 - `GET /timesheets/mine` – list pay periods for the logged in staff member.
-- `GET /timesheets/:id/days` – list daily entries for a timesheet.
-- `GET /admin/timesheets/:id/days` – admins can list daily entries for any staff timesheet.
+- `GET /timesheets` – admins can list pay periods for all staff and may filter with `?staffId=`.
+- `GET /timesheets/:id/days` – list daily entries for a timesheet. Admins may retrieve any staff timesheet.
 - `PATCH /timesheets/:id/days/:date` – update hours for a day. Body accepts `regHours`, `otHours`, `statHours`, `sickHours`, `vacHours`, and optional `note`.
 - `POST /timesheets/:id/submit` – submit a pay period.
-- `POST /timesheets/:id/reject` – reject a submitted timesheet.
-- `POST /timesheets/:id/process` – mark a timesheet as processed and exportable.
+- `POST /timesheets/:id/reject` – reject a submitted timesheet (admin only).
+- `POST /timesheets/:id/process` – mark a timesheet as processed and exportable (admin only).
 - `POST /timesheets/:id/leave-requests` – request vacation leave for a day.
 - `GET /timesheets/:id/leave-requests` – list leave requests awaiting review.
 - `POST /timesheets/leave-requests/:requestId/approve` – approve a leave request, applying vacation hours and locking the day.


### PR DESCRIPTION
## Summary
- allow admins to list timesheets and view any period
- show admin controls for processing or rejecting timesheets
- document new admin timesheet endpoints

## Testing
- `npm test` (backend) *(fails: Node v22 is required)*
- `npm test` (frontend) *(fails: Node v22 is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c2af4004832da94a1d905882b9c5