### PR TITLE
fix: avoid timesheet render loop

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -117,6 +117,15 @@ describe('Timesheets', () => {
     expect(screen.getByText('OT')).toBeInTheDocument();
   });
 
+  it('handles empty timesheet days without crashing', () => {
+    mockUseTimesheetDays.mockReturnValueOnce({
+      days: [],
+      isLoading: false,
+      error: null,
+    });
+    expect(() => render()).not.toThrow();
+  });
+
   it('shows stat day lock icon and tooltip', () => {
     render();
     const rows = screen.getAllByRole('row');

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -91,6 +91,7 @@ export default function Timesheets() {
   const { days: rawDays, error: daysError } = useTimesheetDays(current?.id);
   const [days, setDays] = useState<Day[]>([]);
   useEffect(() => {
+    if (!rawDays.length) return;
     setDays(
       rawDays.map(d => ({
         date: d.work_date,


### PR DESCRIPTION
## Summary
- prevent `Timesheets` from looping when no day data is returned
- add regression test covering empty timesheet days

## Testing
- `npm test` *(fails: StaffRecurringBookings.test.tsx, NoShowWeek.test.tsx, PasswordSetup.test.tsx, Profile.test.tsx, fetchWithRetry.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cd1ccf44832d98a31eea6c13f3ad