### PR TITLE
Remove Staff Tools nav; keep staff links in profile menu

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -190,14 +190,6 @@ export default function App() {
         ],
       });
 
-    navGroups.push({
-      label: 'Staff Tools',
-      links: [
-        { label: t('timesheets.title'), to: '/timesheet' },
-        { label: t('leave.title'), to: '/leave-requests' },
-      ],
-    });
-
     const warehouseLinks = [
       { label: 'Dashboard', to: '/warehouse-management' },
       { label: 'Donation Log', to: '/warehouse-management/donation-log' },

--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -23,20 +23,11 @@ describe('Navbar component', () => {
     expect(screen.getByText(/Logout/i)).toBeInTheDocument();
   });
 
-  it('shows staff tools links in a dedicated nav group', () => {
+  it('shows staff links only in the profile menu', () => {
     render(
       <MemoryRouter>
         <Navbar
-          groups={[
-            { label: 'Home', links: [{ label: 'Home', to: '/' }] },
-            {
-              label: 'Staff Tools',
-              links: [
-                { label: 'Timesheets', to: '/timesheet' },
-                { label: 'Leave Management', to: '/leave-requests' },
-              ],
-            },
-          ]}
+          groups={[{ label: 'Home', links: [{ label: 'Home', to: '/' }] }]}
           onLogout={() => {}}
           name="Tester"
           role="staff"
@@ -49,10 +40,7 @@ describe('Navbar component', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText(/Staff Tools/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByText(/Staff Tools/i));
-    expect(screen.getByText(/Timesheets/i)).toBeInTheDocument();
-    expect(screen.getByText(/Leave Management/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Staff Tools/i)).toBeNull();
     fireEvent.click(screen.getByText(/Hello, Tester/i));
     const profileMenu = document.getElementById('profile-menu') as HTMLElement;
     expect(within(profileMenu).getByText(/Timesheets/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- remove Staff Tools nav section from app navigation
- keep staff Timesheets and Leave Management links only under Hello profile menu
- update Navbar test for profile-only staff links

## Testing
- `npm test` *(fails: StaffRecurringBookings.test.tsx, PasswordSetup.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cd9d354c832da01f63ecd2f8be2b