### PR TITLE
Reorder News and Events card on client dashboard

### DIFF
--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -189,6 +189,11 @@ export default function ClientDashboard() {
               )}
             </SectionCard>
 
+          </Stack>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Stack spacing={2}>
             <SectionCard
               title={
                 <Stack direction="row" spacing={1} alignItems="center">
@@ -210,11 +215,7 @@ export default function ClientDashboard() {
                 </List>
               </Stack>
             </SectionCard>
-          </Stack>
-        </Grid>
 
-        <Grid size={{ xs: 12, md: 6 }}>
-          <Stack spacing={2}>
             <SectionCard
               title={t('next_available_slots')}
               icon={<EventAvailable color="primary" />}


### PR DESCRIPTION
## Summary
- move News & Events section into the right column of client dashboard above Next Available Slots

## Testing
- `npx -y node@22 /root/.nvm/versions/node/v20.19.4/lib/node_modules/npm/bin/npm-cli.js test` *(fails: StaffRecurringBookings, NoShowWeek, PasswordSetup tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d3dfb154832db88c06610bbd0e2c