### PR TITLE
feat(agency-dashboard): reposition news section

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
@@ -185,6 +185,11 @@ export default function AgencyDashboard() {
               )}
             </SectionCard>
 
+          </Stack>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Stack spacing={2}>
             <SectionCard title={t('news_and_events')} icon={<Announcement color="primary" />}>
               <Stack spacing={2}>
                 <EventList events={[...events.today, ...events.upcoming]} limit={5} />
@@ -199,11 +204,7 @@ export default function AgencyDashboard() {
                 </List>
               </Stack>
             </SectionCard>
-          </Stack>
-        </Grid>
 
-        <Grid size={{ xs: 12, md: 6 }}>
-          <Stack spacing={2}>
             <SectionCard title="Next Available Slots" icon={<EventAvailable color="primary" />}>
               <List>
                 {nextSlots.length ? (


### PR DESCRIPTION
## Summary
- move News & Events card to top of right column on agency dashboard

## Testing
- `npm test` *(fails: Node v22 is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d3e14e88832d87bf5a3131f552b5