### PR TITLE
Place notices card within dashboard metrics grid

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -420,6 +420,12 @@ export default function WarehouseDashboard() {
         gap={2}
         mb={2}
       >
+        <Card variant="outlined" sx={{ gridColumn: { lg: '4 / 5' } }}>
+          <CardHeader title="Notices & Events" avatar={<Announcement color="primary" />} />
+          <CardContent>
+            <EventList events={visibleEvents} limit={5} />
+          </CardContent>
+        </Card>
         <Card variant="outlined">
           <CardHeader
             title="Top Donors"
@@ -497,14 +503,6 @@ export default function WarehouseDashboard() {
         </Card>
         <VolunteerCoverageCard masterRoleFilter={['Warehouse']} />
       </Box>
-
-      <Card variant="outlined" sx={{ mb: 2 }}>
-        <CardHeader title="Notices & Events" avatar={<Announcement color="primary" />} />
-        <CardContent>
-          <EventList events={visibleEvents} limit={5} />
-        </CardContent>
-      </Card>
-
       <Typography variant="caption" color="text.secondary">
         Tip: Press Ctrl/Cmd+K in the search box to quickly filter donors/receivers.
       </Typography>


### PR DESCRIPTION
## Summary
- move "Notices & Events" card into metrics grid and anchor it as last column of first row

## Testing
- `npm test` *(fails: NoShowWeek.test.tsx, PasswordSetup.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d3eaf2bc832dae1f1b7231fb4899