### PR TITLE
feat: seed pay periods on startup

### DIFF
--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -15,6 +15,7 @@ import {
   stopVolunteerNoShowCleanupJob,
 } from './utils/volunteerNoShowCleanupJob';
 import { initEmailQueue, shutdownQueue } from './utils/emailQueue';
+import seedPayPeriods from './utils/payPeriodSeeder';
 import seedTimesheets from './utils/timesheetSeeder';
 
 const PORT = config.port;
@@ -37,6 +38,7 @@ async function init() {
     startVolunteerShiftReminderJob();
     startNoShowCleanupJob();
     startVolunteerNoShowCleanupJob();
+    await seedPayPeriods('2024-08-03', '2024-12-31');
     await seedTimesheets();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);

--- a/MJ_FB_Backend/src/utils/payPeriodSeeder.ts
+++ b/MJ_FB_Backend/src/utils/payPeriodSeeder.ts
@@ -1,0 +1,31 @@
+import pool from '../db';
+import logger from './logger';
+
+/**
+ * Seed 14-day pay periods between the provided start and end dates.
+ * Dates should be provided in YYYY-MM-DD format.
+ */
+export async function seedPayPeriods(start: string, end: string): Promise<void> {
+  try {
+    let current = new Date(start);
+    const endDate = new Date(end);
+
+    while (current <= endDate) {
+      const periodStart = current.toISOString().slice(0, 10);
+      const periodEndDate = new Date(current);
+      periodEndDate.setDate(periodEndDate.getDate() + 13);
+      const periodEnd = periodEndDate.toISOString().slice(0, 10);
+
+      await pool.query(
+        'INSERT INTO pay_periods (start_date, end_date) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+        [periodStart, periodEnd],
+      );
+
+      current.setDate(current.getDate() + 14);
+    }
+  } catch (err) {
+    logger.error('Error seeding pay periods:', err);
+  }
+}
+
+export default seedPayPeriods;

--- a/MJ_FB_Backend/tests/payPeriodSeeder.test.ts
+++ b/MJ_FB_Backend/tests/payPeriodSeeder.test.ts
@@ -1,0 +1,37 @@
+import pool from '../src/db';
+import { seedPayPeriods } from '../src/utils/payPeriodSeeder';
+
+describe('seedPayPeriods', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('inserts 14-day pay periods between dates', async () => {
+    const calls: any[] = [];
+    (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      return { rowCount: 1 };
+    });
+
+    await seedPayPeriods('2024-08-03', '2024-09-13');
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].sql).toContain('ON CONFLICT DO NOTHING');
+    expect(calls[0].params).toEqual(['2024-08-03', '2024-08-16']);
+    expect(calls[1].params).toEqual(['2024-08-17', '2024-08-30']);
+    expect(calls[2].params).toEqual(['2024-08-31', '2024-09-13']);
+  });
+
+  it('continues when pay period already exists', async () => {
+    const calls: any[] = [];
+    const results = [{ rowCount: 1 }, { rowCount: 0 }, { rowCount: 1 }];
+    (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      return results.shift();
+    });
+
+    await seedPayPeriods('2024-08-03', '2024-09-13');
+
+    expect(calls).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add pay period seeder inserting 14-day periods
- invoke seeder before timesheet seeding during server startup
- test pay period seeding and conflict handling

## Testing
- `PATH=/usr/local/bin:$PATH /usr/local/bin/npm test` *(fails: clientVisitBookingStatus, volunteerBookingStatusEmail, volunteerShopperBooking, bookingNewClient, volunteerRebookCancelled, bookingCapacity, volunteerBookingConflict, newClientsMigration, dbPoolErrorHandler)*
- `PATH=/usr/local/bin:$PATH /usr/local/bin/npm test tests/payPeriodSeeder.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8d5daeb5c832db11375d66d78ba09