### PR TITLE
Add pay period seeding cron job

### DIFF
--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -14,6 +14,7 @@ import {
   startVolunteerNoShowCleanupJob,
   stopVolunteerNoShowCleanupJob,
 } from './utils/volunteerNoShowCleanupJob';
+import { startPayPeriodCronJob, stopPayPeriodCronJob } from './utils/payPeriodCronJob';
 import { initEmailQueue, shutdownQueue } from './utils/emailQueue';
 import seedPayPeriods from './utils/payPeriodSeeder';
 import seedTimesheets from './utils/timesheetSeeder';
@@ -38,6 +39,7 @@ async function init() {
     startVolunteerShiftReminderJob();
     startNoShowCleanupJob();
     startVolunteerNoShowCleanupJob();
+    startPayPeriodCronJob();
     await seedPayPeriods('2024-08-03', '2024-12-31');
     await seedTimesheets();
   } catch (err) {
@@ -52,6 +54,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   stopVolunteerShiftReminderJob();
   stopNoShowCleanupJob();
   stopVolunteerNoShowCleanupJob();
+  stopPayPeriodCronJob();
   shutdownQueue();
   if (server) {
     server.close();

--- a/MJ_FB_Backend/src/utils/payPeriodCronJob.ts
+++ b/MJ_FB_Backend/src/utils/payPeriodCronJob.ts
@@ -1,0 +1,21 @@
+import { seedPayPeriods } from './payPeriodSeeder';
+import scheduleDailyJob from './scheduleDailyJob';
+
+/**
+ * Seed pay periods for the upcoming year.
+ */
+export async function seedNextYear(): Promise<void> {
+  const now = new Date();
+  const nextYear = now.getFullYear() + 1;
+  const start = `${nextYear}-01-01`;
+  const end = `${nextYear}-12-31`;
+  await seedPayPeriods(start, end);
+}
+
+/**
+ * Schedule the job to run annually on Nov 30.
+ */
+const payPeriodCronJob = scheduleDailyJob(seedNextYear, '0 0 30 11 *', false);
+
+export const startPayPeriodCronJob = payPeriodCronJob.start;
+export const stopPayPeriodCronJob = payPeriodCronJob.stop;

--- a/MJ_FB_Backend/tests/payPeriodCronJob.test.ts
+++ b/MJ_FB_Backend/tests/payPeriodCronJob.test.ts
@@ -1,0 +1,53 @@
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+
+jest.doMock('../src/utils/scheduleDailyJob', () => {
+  const actual = jest.requireActual('../src/utils/scheduleDailyJob');
+  return {
+    __esModule: true,
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
+  };
+});
+
+jest.mock('../src/utils/payPeriodSeeder', () => ({ seedPayPeriods: jest.fn() }));
+
+const { seedPayPeriods } = require('../src/utils/payPeriodSeeder');
+const payPeriodJob = require('../src/utils/payPeriodCronJob');
+const { startPayPeriodCronJob, stopPayPeriodCronJob } = payPeriodJob;
+
+describe('startPayPeriodCronJob/stopPayPeriodCronJob', () => {
+  let scheduleMock: jest.Mock;
+  let stopMock: jest.Mock;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-06-01T00:00:00Z'));
+    scheduleMock = require('node-cron').schedule as jest.Mock;
+    stopMock = jest.fn();
+    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    stopPayPeriodCronJob();
+    jest.useRealTimers();
+    scheduleMock.mockReset();
+    (seedPayPeriods as jest.Mock).mockReset();
+  });
+
+  it('schedules annual pay period seeding and seeds next year', async () => {
+    startPayPeriodCronJob();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '0 0 30 11 *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+    const jobFn = scheduleMock.mock.calls[0][1];
+    await jobFn();
+    expect(seedPayPeriods).toHaveBeenCalledWith('2025-01-01', '2025-12-31');
+  });
+
+  it('stops the cron job', () => {
+    startPayPeriodCronJob();
+    stopPayPeriodCronJob();
+    expect(stopMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add scheduled job to generate next year's pay periods every November 30
- integrate pay period cron job with server lifecycle
- cover job scheduling and stop behavior in new unit tests

## Testing
- `npm test` *(fails: Test Suites: 10 failed, 87 passed, 97 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d76cb368832da998e713104ba1b1