### PR TITLE
Seed pay periods before starting timesheet cron job

### DIFF
--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -17,6 +17,10 @@ import {
 import { initEmailQueue, shutdownQueue } from './utils/emailQueue';
 import seedPayPeriods from './utils/payPeriodSeeder';
 import seedTimesheets from './utils/timesheetSeeder';
+import {
+  startTimesheetSeedJob,
+  stopTimesheetSeedJob,
+} from './utils/timesheetSeedJob';
 
 const PORT = config.port;
 
@@ -40,6 +44,7 @@ async function init() {
     startVolunteerNoShowCleanupJob();
     await seedPayPeriods('2024-08-03', '2024-12-31');
     await seedTimesheets();
+    startTimesheetSeedJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);
@@ -52,6 +57,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   stopVolunteerShiftReminderJob();
   stopNoShowCleanupJob();
   stopVolunteerNoShowCleanupJob();
+  stopTimesheetSeedJob();
   shutdownQueue();
   if (server) {
     server.close();

--- a/MJ_FB_Backend/src/utils/timesheetSeedJob.ts
+++ b/MJ_FB_Backend/src/utils/timesheetSeedJob.ts
@@ -1,0 +1,16 @@
+import scheduleDailyJob from './scheduleDailyJob';
+import seedTimesheets from './timesheetSeeder';
+
+/**
+ * Ensure timesheets exist for active staff each day.
+ */
+const timesheetSeedJob = scheduleDailyJob(
+  () => seedTimesheets(),
+  '5 0 * * *',
+  false,
+  true,
+);
+
+export const startTimesheetSeedJob = timesheetSeedJob.start;
+export const stopTimesheetSeedJob = timesheetSeedJob.stop;
+

--- a/MJ_FB_Backend/tests/timesheetSeedJob.test.ts
+++ b/MJ_FB_Backend/tests/timesheetSeedJob.test.ts
@@ -1,0 +1,39 @@
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+jest.mock('../src/utils/scheduleDailyJob', () => {
+  const actual = jest.requireActual('../src/utils/scheduleDailyJob');
+  return {
+    __esModule: true,
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
+  };
+});
+
+const { startTimesheetSeedJob, stopTimesheetSeedJob } = require('../src/utils/timesheetSeedJob');
+
+describe('startTimesheetSeedJob/stopTimesheetSeedJob', () => {
+  let scheduleMock: jest.Mock;
+  let stopMock: jest.Mock;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    scheduleMock = require('node-cron').schedule as jest.Mock;
+    stopMock = jest.fn();
+    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+  });
+
+  afterEach(() => {
+    stopTimesheetSeedJob();
+    jest.useRealTimers();
+    scheduleMock.mockReset();
+  });
+
+  it('schedules and stops the cron job', () => {
+    startTimesheetSeedJob();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '5 0 * * *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+    stopTimesheetSeedJob();
+    expect(stopMock).toHaveBeenCalled();
+  });
+});
+

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -17,10 +17,17 @@ cd MJ_FB_Backend
 npm run migrate
 ```
 
-2. Insert biweekly records into the `pay_periods` table so each period has a
-   `start_date` and `end_date`.
+2. Upcoming pay periods are seeded automatically when the backend starts.
+   Adjust the range in `src/server.ts` or run the seeder manually if you
+   need additional periods:
 
-3. Seed current pay periods for active staff (optional):
+```bash
+node src/utils/payPeriodSeeder.ts START_DATE END_DATE
+```
+
+3. Timesheets for active staff are created on startup and refreshed daily
+   by a cron job. You can seed them manually for the current pay period if
+   necessary:
 
 ```bash
 node src/utils/timesheetSeeder.ts


### PR DESCRIPTION
## Summary
- seed pay periods before timesheet setup
- launch and stop daily timesheet seeding cron job
- document automatic pay period and timesheet seeding

## Testing
- `npm test` *(fails: Test Suites: 10 failed, 87 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d77730f0832d93476497d7c034b2