### PR TITLE
docs: explain automated pay period seeding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Document translation strings for localization in `docs/` and update `MJ_FB_Frontend/src/locales` when user-facing text is added.
 - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes.
+- A cron job seeds pay periods for the upcoming year every **Nov 30** using `seedPayPeriods`.
 - A GitHub Actions workflow in `.github/workflows/release.yml` builds, tests, and deploys container images to Azure Container Apps. Configure repository secrets `AZURE_CREDENTIALS`, `REGISTRY_LOGIN_SERVER`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD` and variables `AZURE_RESOURCE_GROUP`, `BACKEND_APP_NAME`, and `FRONTEND_APP_NAME`; see `docs/release.md` for details.
 - Document new environment variables in the repository README and `.env.example` files.
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,13 @@ cd MJ_FB_Backend
 npm run migrate
 ```
 
-2. Seed upcoming pay periods in the `pay_periods` table (biweekly records with
-   `start_date` and `end_date`).
+2. Pay periods are seeded automatically on backend startup via the
+   `seedPayPeriods` utility. A cron job runs every **Nov 30** to generate pay
+   periods for the upcoming year. Seed a custom range manually if needed:
+
+```bash
+node src/utils/payPeriodSeeder.ts START_DATE END_DATE
+```
 
 3. Seed timesheets for active staff:
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -17,8 +17,9 @@ cd MJ_FB_Backend
 npm run migrate
 ```
 
-2. Upcoming pay periods are seeded automatically when the backend starts.
-   Adjust the range in `src/server.ts` or run the seeder manually if you
+2. Pay periods are seeded automatically on backend startup via the
+   `seedPayPeriods` utility. A cron job runs every **Nov 30** to generate
+   pay periods for the upcoming year. Seed a custom range manually if you
    need additional periods:
 
 ```bash


### PR DESCRIPTION
## Summary
- document `seedPayPeriods` utility and Nov 30 cron job in README and timesheets guide
- note annual pay-period generation job in `AGENTS.md`

## Testing
- `npm test` (backend) *(fails: 10 failing test suites)*
- `npm test` (frontend) *(fails: see errors in output)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d96c0c48832da57b54de97829d05