### PR TITLE
Add pay period seeder edge case tests

### DIFF
--- a/MJ_FB_Backend/tests/payPeriodCronJob.test.ts
+++ b/MJ_FB_Backend/tests/payPeriodCronJob.test.ts
@@ -45,8 +45,13 @@ describe('startPayPeriodCronJob/stopPayPeriodCronJob', () => {
     expect(seedPayPeriods).toHaveBeenCalledWith('2025-01-01', '2025-12-31');
   });
 
-  it('stops the cron job', () => {
+  it('schedules and stops the cron job', () => {
     startPayPeriodCronJob();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '0 0 30 11 *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
     stopPayPeriodCronJob();
     expect(stopMock).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- cover duplicate and cross-year edge cases in pay period seeding
- verify pay period cron job schedules and stops correctly

## Testing
- `npm test --runTestsByPath tests/payPeriodSeeder.test.ts tests/payPeriodCronJob.test.ts`
- `npm test` *(fails: Test Suites: 10 failed, 88 passed, 98 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d96cd5b4832db7cd7d55edc854ff