### PR TITLE
Fix staff access roles migration

### DIFF
--- a/MJ_FB_Backend/src/migrations/1699999999999_add_staff_access_roles.ts
+++ b/MJ_FB_Backend/src/migrations/1699999999999_add_staff_access_roles.ts
@@ -1,18 +1,14 @@
 import { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.alterTable('staff', {
-    dropConstraint: 'staff_access_check',
-  });
+  pgm.dropConstraint('staff', 'staff_access_check');
   pgm.addConstraint('staff', 'staff_access_check', {
     check: "access <@ ARRAY['pantry','volunteer_management','warehouse','admin','other','payroll_management']",
   });
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
-  pgm.alterTable('staff', {
-    dropConstraint: 'staff_access_check',
-  });
+  pgm.dropConstraint('staff', 'staff_access_check');
   pgm.addConstraint('staff', 'staff_access_check', {
     check: "access <@ ARRAY['pantry','volunteer_management','warehouse','admin']",
   });


### PR DESCRIPTION
## Summary
- fix SQL syntax error by replacing `pgm.alterTable` with `pgm.dropConstraint` in staff access roles migration

## Testing
- `npm test` *(fails: multiple test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dac2c4bc832d948f1015934c0a42