### PR TITLE
Require email when enabling online access for new clients

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -132,7 +132,7 @@ export async function createUser(req: Request, res: Response, next: NextFunction
     return res.status(400).json({ message: 'Client ID and role required' });
   }
 
-  if (onlineAccess && (!firstName || !lastName)) {
+  if (onlineAccess && (!firstName || !lastName || !email)) {
     return res.status(400).json({ message: 'Missing fields for online account' });
   }
 

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -33,9 +33,10 @@ export const createUserSchema = z
   })
   .refine(
     data =>
-      !data.onlineAccess || (!!data.firstName && !!data.lastName),
+      !data.onlineAccess ||
+      (!!data.firstName && !!data.lastName && !!data.email),
     {
-      message: 'firstName and lastName required for online access',
+      message: 'firstName, lastName, and email required for online access',
       path: ['onlineAccess'],
     },
   );

--- a/MJ_FB_Backend/tests/createUser.test.ts
+++ b/MJ_FB_Backend/tests/createUser.test.ts
@@ -63,4 +63,22 @@ describe('POST /users/add-client', () => {
       expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
     );
   });
+
+  it('requires email when online access enabled', async () => {
+    const res = await request(app)
+      .post('/users/add-client')
+      .send({
+        firstName: 'Jane',
+        lastName: 'Doe',
+        clientId: 123,
+        role: 'shopper',
+        onlineAccess: true,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].message).toBe(
+      'firstName, lastName, and email required for online access',
+    );
+    expect(sendTemplatedEmail).not.toHaveBeenCalled();
+  });
 });

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/AddClient.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/AddClient.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AddClient from '../client-management/AddClient';
+import { addUser } from '../../../api/users';
+
+jest.mock('../../../api/users', () => ({
+  ...jest.requireActual('../../../api/users'),
+  addUser: jest.fn(),
+}));
+
+it('requires email when online access enabled', async () => {
+  render(
+    <MemoryRouter>
+      <AddClient />
+    </MemoryRouter>,
+  );
+
+  fireEvent.click(screen.getByLabelText(/online access/i));
+  fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'Jane' } });
+  fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'Doe' } });
+  fireEvent.change(screen.getByLabelText(/client id/i), { target: { value: '123' } });
+
+  fireEvent.click(screen.getByRole('button', { name: /add client/i }));
+
+  expect(await screen.findByText('First name, last name, client ID and email required')).toBeInTheDocument();
+  expect(addUser).not.toHaveBeenCalled();
+});

--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -20,8 +20,8 @@ export default function AddClient() {
 
   async function submitUser() {
     if (onlineAccess) {
-      if (!firstName || !lastName || !clientId) {
-        setError('First name, last name and client ID required');
+      if (!firstName || !lastName || !clientId || !email) {
+        setError('First name, last name, client ID and email required');
         return;
       }
     } else if (!clientId) {
@@ -70,7 +70,13 @@ export default function AddClient() {
           <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
           <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
           <TextField label="Client ID" value={clientId} onChange={e => setClientId(e.target.value)} />
-          <TextField label="Email (optional)" type="email" value={email} onChange={e => setEmail(e.target.value)} />
+          <TextField
+            label={onlineAccess ? 'Email' : 'Email (optional)'}
+            type="email"
+            required={onlineAccess}
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
           <TextField
             label="Phone (optional)"
             type="tel"


### PR DESCRIPTION
## Summary
- require email when online access is enabled for new client accounts
- enforce email in client creation form and add coverage

## Testing
- `npm test` (backend) *(fails: clientVisitBookingStatus.test.ts, volunteerBookingStatusEmail.test.ts, volunteerShopperBooking.test.ts, bookingLimit.test.ts, volunteerBookingConflict.test.ts)*
- `npm test` (frontend)
- `npm test src/pages/staff/__tests__/AddClient.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b8dcd36d40832d98b286e1260efbf1