### PR TITLE
Show client booking notes in staff modal

### DIFF
--- a/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
@@ -37,7 +37,7 @@ describe('bookings api', () => {
     await createBooking('3', '2024-05-01', 'note');
     expect(apiFetch).toHaveBeenCalledWith('/api/bookings', expect.objectContaining({
       method: 'POST',
-      body: JSON.stringify({ slotId: 3, date: '2024-05-01', requestData: 'note' }),
+      body: JSON.stringify({ slotId: 3, date: '2024-05-01', note: 'note' }),
     }));
   });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -31,7 +31,7 @@ interface SlotsByDateResponse {
 interface CreateBookingBody {
   slotId: number;
   date: string;
-  requestData: string;
+  note?: string;
   userId?: number;
 }
 
@@ -84,8 +84,8 @@ export async function createBooking(
   const body: CreateBookingBody = {
     slotId: Number(slotId),
     date,
-    requestData: note,
   };
+  if (note) body.note = note;
   if (userId) body.userId = userId;
   const res = await apiFetch(`${API_BASE}/bookings`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Send client booking notes using `note` field so staff can view them in Manage Booking dialog
- Update API test to reflect note field

## Testing
- `npm test` (frontend) *(fails: Unable to find button "Cancel")*
- `npm test` (backend) *(fails: client visit booking integration expected 201 received 400)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ddb10fd0832d896f7176610eb66e