### PR TITLE
Show booking notes in booking history

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -743,7 +743,9 @@ export async function getBookingHistory(
     );
     if (!includeVisitNotes) {
       for (const row of rows as any[]) {
-        if ('note' in row) delete (row as any).note;
+        if ('note' in row && row.slot_id === null) {
+          delete (row as any).note;
+        }
       }
     }
     res.json(rows);

--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -202,7 +202,7 @@ export async function fetchBookingHistory(
     `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.start_time END AS start_time,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.end_time END AS end_time,
-            b.created_at, b.is_staff_booking, b.reschedule_token
+            b.created_at, b.is_staff_booking, b.reschedule_token, b.note
        FROM bookings b
        LEFT JOIN slots s ON b.slot_id = s.id
        WHERE ${where}

--- a/MJ_FB_Backend/tests/bookingHistoryNotes.test.ts
+++ b/MJ_FB_Backend/tests/bookingHistoryNotes.test.ts
@@ -1,0 +1,81 @@
+import request from 'supertest';
+import express from 'express';
+import bookingsRouter from '../src/routes/bookings';
+import * as bookingRepository from '../src/models/bookingRepository';
+
+jest.mock('../src/models/bookingRepository', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/models/bookingRepository'),
+  fetchBookingHistory: jest.fn(),
+}));
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    req: any,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: 1, role: 'shopper', userId: 1 };
+    next();
+  },
+  authorizeAccess: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+  optionalAuthMiddleware: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/bookings', bookingsRouter);
+app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  res.status(err.status || 500).json({ message: err.message });
+});
+
+describe('booking history notes', () => {
+  it('includes booking notes by default', async () => {
+    (bookingRepository.fetchBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'approved',
+        date: '2024-01-01',
+        slot_id: 1,
+        reason: null,
+        start_time: '09:00:00',
+        end_time: '09:30:00',
+        created_at: '2024-01-01',
+        is_staff_booking: false,
+        reschedule_token: 'tok',
+        note: 'bring ID',
+      },
+      {
+        id: 2,
+        status: 'visited',
+        date: '2024-01-02',
+        slot_id: null,
+        reason: null,
+        start_time: null,
+        end_time: null,
+        created_at: '2024-01-02',
+        is_staff_booking: false,
+        reschedule_token: null,
+        note: 'visit note',
+      },
+    ]);
+
+    const res = await request(app).get('/bookings/history');
+    expect(res.status).toBe(200);
+    expect(res.body[0].note).toBe('bring ID');
+    expect(res.body[1].note).toBeUndefined();
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -156,7 +156,7 @@ describe('Booking confirmation', () => {
     await screen.findByText(/confirm booking/i);
   });
 
-  it.skip('submits note with booking', async () => {
+  it('submits note with booking', async () => {
     (getSlots as jest.Mock).mockResolvedValue([
       { id: '1', startTime: '11:00:00', endTime: '11:30:00', available: 1 },
     ]);

--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import UserHistory from '../pages/staff/client-management/UserHistory';
 import { getBookingHistory, cancelBooking } from '../api/bookings';
 import { getUserByClientId, updateUserInfo } from '../api/users';
+import { useAuth } from '../hooks/useAuth';
 
 jest.mock('../api/bookings', () => ({
   getBookingHistory: jest.fn(),
@@ -14,7 +15,13 @@ jest.mock('../api/users', () => ({
   updateUserInfo: jest.fn(),
 }));
 
+jest.mock('../hooks/useAuth');
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
 describe('UserHistory', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ role: 'staff' } as any);
+  });
   it('renders bookings and walk-in visits', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([
       {

--- a/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
@@ -37,7 +37,7 @@ describe('bookings api', () => {
     await createBooking('3', '2024-05-01', 'note');
     expect(apiFetch).toHaveBeenCalledWith('/api/bookings', expect.objectContaining({
       method: 'POST',
-      body: JSON.stringify({ slotId: 3, date: '2024-05-01', requestData: 'note' }),
+      body: JSON.stringify({ slotId: 3, date: '2024-05-01', note: 'note' }),
     }));
   });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -31,7 +31,7 @@ interface SlotsByDateResponse {
 interface CreateBookingBody {
   slotId: number;
   date: string;
-  requestData: string;
+  note: string;
   userId?: number;
 }
 
@@ -84,7 +84,7 @@ export async function createBooking(
   const body: CreateBookingBody = {
     slotId: Number(slotId),
     date,
-    requestData: note,
+    note,
   };
   if (userId) body.userId = userId;
   const res = await apiFetch(`${API_BASE}/bookings`, {

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { getBookingHistory, cancelBooking } from '../../../api/bookings';
 import { getUserByClientId, updateUserInfo } from '../../../api/users';
+import { useAuth } from '../../../hooks/useAuth';
 import { formatTime } from '../../../utils/time';
 import {
   Box,
@@ -70,6 +71,7 @@ export default function UserHistory({
     password: '',
   });
   const { t } = useTranslation();
+  const { role } = useAuth();
 
   const pageSize = 10;
 
@@ -81,7 +83,10 @@ export default function UserHistory({
       userId?: number;
       includeVisits?: boolean;
       includeVisitNotes?: boolean;
-    } = { includeVisits: true, includeVisitNotes: true };
+    } = { includeVisits: true };
+    if (role === 'staff' || role === 'agency') {
+      opts.includeVisitNotes = true;
+    }
     if (!initialUser) opts.userId = selected.client_id;
     if (filter === 'past') opts.past = true;
     else if (filter !== 'all') opts.status = filter;


### PR DESCRIPTION
## Summary
- return booking notes from history API and keep visit notes private
- send booking note from client booking flow
- only request visit notes for staff/agency history views

## Testing
- `npm test` (backend) *(fails: client visit booking integration, volunteer booking status email, etc.)*
- `npm test` (frontend) *(fails: BookingUI note submission, other UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b8de76b540832d907d8f939986408a