### PR TITLE
Refactor warehouse dashboard grid layout

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -342,11 +342,11 @@ export default function WarehouseDashboard() {
 
       <Box
         display="grid"
-        gridTemplateColumns={{ xs: '1fr', lg: '2fr 1fr' }}
+        gridTemplateColumns={{ xs: '1fr', lg: 'repeat(3, 1fr)' }}
         gap={2}
         mb={2}
       >
-        <Card variant="outlined">
+        <Card variant="outlined" sx={{ gridColumn: { lg: '1 / span 2' } }}>
           <CardHeader title="Monthly Trend" />
           <CardContent sx={{ height: 300 }}>
             <ResponsiveContainer width="100%" height="100%">
@@ -375,7 +375,10 @@ export default function WarehouseDashboard() {
             </ResponsiveContainer>
           </CardContent>
         </Card>
-        <Card variant="outlined">
+        <Card
+          variant="outlined"
+          sx={{ gridColumn: { lg: '1 / span 2' } }}
+        >
           <CardHeader title="Composition (This Year)" />
           <CardContent sx={{ height: 300 }}>
             <ResponsiveContainer width="100%" height="100%">
@@ -412,21 +415,7 @@ export default function WarehouseDashboard() {
             </ResponsiveContainer>
           </CardContent>
         </Card>
-      </Box>
-
-      <Box
-        display="grid"
-        gridTemplateColumns={{ xs: '1fr', lg: '1fr 1fr 1fr 1fr' }}
-        gap={2}
-        mb={2}
-      >
-        <Card variant="outlined" sx={{ gridColumn: { lg: '4 / 5' } }}>
-          <CardHeader title="Notices & Events" avatar={<Announcement color="primary" />} />
-          <CardContent>
-            <EventList events={visibleEvents} limit={5} />
-          </CardContent>
-        </Card>
-        <Card variant="outlined">
+        <Card variant="outlined" sx={{ gridColumn: { lg: '3 / 4' } }}>
           <CardHeader
             title="Top Donors"
             subheader="This year by total lbs"
@@ -454,7 +443,7 @@ export default function WarehouseDashboard() {
             )}
           </CardContent>
         </Card>
-        <Card variant="outlined">
+        <Card variant="outlined" sx={{ gridColumn: { lg: '3 / 4' } }}>
           <CardHeader
             title="Top Receivers"
             subheader="This year by total lbs"
@@ -482,7 +471,7 @@ export default function WarehouseDashboard() {
             )}
           </CardContent>
         </Card>
-        <Card variant="outlined">
+        <Card variant="outlined" sx={{ gridColumn: { lg: '3 / 4' } }}>
           <CardHeader title="Quick Actions" />
           <CardContent>
             <Stack spacing={1}>
@@ -495,10 +484,29 @@ export default function WarehouseDashboard() {
               <Button size="small" variant="contained" fullWidth onClick={() => go('/warehouse-management/track-pigpound')}>
                 Log Pig Pound
               </Button>
-              <Button size="small" variant="contained" fullWidth onClick={() => go('/warehouse-management/track-outgoing-donations')}>
+              <Button
+                size="small"
+                variant="contained"
+                fullWidth
+                onClick={() => go('/warehouse-management/track-outgoing-donations')}
+              >
                 Track Outgoing Donations
               </Button>
             </Stack>
+          </CardContent>
+        </Card>
+      </Box>
+
+      <Box
+        display="grid"
+        gridTemplateColumns={{ xs: '1fr', lg: '2fr 1fr' }}
+        gap={2}
+        mb={2}
+      >
+        <Card variant="outlined">
+          <CardHeader title="Notices & Events" avatar={<Announcement color="primary" />} />
+          <CardContent>
+            <EventList events={visibleEvents} limit={5} />
           </CardContent>
         </Card>
         <VolunteerCoverageCard masterRoleFilter={['Warehouse']} />


### PR DESCRIPTION
## Summary
- Reorganize warehouse dashboard charts and side cards into a three-column grid at large breakpoints
- Consolidate Top Donors, Top Receivers, and Quick Actions into a stacked right-hand column
- Streamline lower section to show Notices & Events alongside Volunteer Coverage

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e3688c40832dad921ee4f41c7285