### PR TITLE
feat: separate client and staff booking notes

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
@@ -57,7 +57,6 @@ describe('ManageBookingDialog', () => {
     );
 
     fireEvent.change(screen.getByLabelText(/pet item/i), { target: { value: '1' } });
-    fireEvent.change(screen.getByLabelText(/note/i), { target: { value: 'bring ID' } });
 
     fireEvent.click(screen.getByText(/submit/i));
 
@@ -79,7 +78,7 @@ describe('ManageBookingDialog', () => {
       <MemoryRouter>
         <ManageBookingDialog
           open
-          booking={{ id: 1, client_id: 5, user_id: 1, visits_this_month: 3, approved_bookings_this_month: 1, date: '2024-02-01', reschedule_token: '', user_name: 'Client', profile_link: 'https://portal.link2feed.ca/org/1605/intake/5', note: 'remember ID' }}
+          booking={{ id: 1, client_id: 5, user_id: 1, visits_this_month: 3, approved_bookings_this_month: 1, date: '2024-02-01', reschedule_token: '', user_name: 'Client', profile_link: 'https://portal.link2feed.ca/org/1605/intake/5', client_note: 'remember ID' }}
           onClose={() => {}}
           onUpdated={() => {}}
         />
@@ -93,20 +92,20 @@ describe('ManageBookingDialog', () => {
     expect(
       screen.getByText('Visits: 3, Approved bookings: 1'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Note: remember ID')).toBeInTheDocument();
+    expect(screen.getByText('Client note: remember ID')).toBeInTheDocument();
   });
   it('renders note when provided', () => {
     render(
       <MemoryRouter>
         <ManageBookingDialog
           open
-          booking={{ id: 2, client_id: 6, user_id: 1, visits_this_month: 0, approved_bookings_this_month: 0, date: '2024-02-02', reschedule_token: '', user_name: 'Another', profile_link: 'https://portal.link2feed.ca/org/1605/intake/6', note: 'bring cart' }}
+          booking={{ id: 2, client_id: 6, user_id: 1, visits_this_month: 0, approved_bookings_this_month: 0, date: '2024-02-02', reschedule_token: '', user_name: 'Another', profile_link: 'https://portal.link2feed.ca/org/1605/intake/6', client_note: 'bring cart' }}
           onClose={() => {}}
           onUpdated={() => {}}
         />
       </MemoryRouter>
     );
-    expect(screen.getByText('Note: bring cart')).toBeInTheDocument();
+    expect(screen.getByText('Client note: bring cart')).toBeInTheDocument();
   });
 
   it('omits note when not provided', () => {
@@ -120,7 +119,7 @@ describe('ManageBookingDialog', () => {
         />
       </MemoryRouter>
     );
-    expect(screen.queryByText(/Note:/)).toBeNull();
+    expect(screen.queryByText(/Client note:/)).toBeNull();
   });
   it('calculates monthly usage when counts are strings', () => {
     render(

--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -45,7 +45,7 @@ describe('UserHistory', () => {
         slot_id: null,
         is_staff_booking: false,
         reschedule_token: null,
-        note: 'bring ID',
+        staff_note: 'bring ID',
       },
     ]);
 
@@ -58,7 +58,7 @@ describe('UserHistory', () => {
     await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
     expect(getBookingHistory).toHaveBeenCalledWith({
       includeVisits: true,
-      includeVisitNotes: true,
+      includeStaffNotes: true,
     });
     expect(await screen.findByText(/approved/i)).toBeInTheDocument();
     expect(await screen.findByText(/visited/i)).toBeInTheDocument();
@@ -91,7 +91,7 @@ describe('UserHistory', () => {
         slot_id: null,
         is_staff_booking: false,
         reschedule_token: null,
-        note: 'has note',
+        client_note: 'has note',
       },
       {
         id: 2,

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -99,11 +99,16 @@ export async function createBooking(
 }
 
 function normalizeBooking(b: BookingResponse): Booking {
-  const { new_client_id, note, ...rest } = b;
+  const { new_client_id, client_note, clientNote, staff_note, staffNote, ...rest } = b;
   const newClientId = b.newClientId ?? new_client_id ?? null;
+  const clientNoteVal = client_note ?? clientNote ?? null;
+  const staffNoteVal = staff_note ?? staffNote ?? null;
   return {
     ...rest,
-    note: note ?? null,
+    client_note: clientNoteVal,
+    clientNote: clientNoteVal,
+    staff_note: staffNoteVal,
+    staffNote: staffNoteVal,
     start_time: b.start_time ?? b.startTime ?? null,
     end_time: b.end_time ?? b.endTime ?? null,
     startTime: b.startTime ?? b.start_time ?? null,
@@ -132,7 +137,7 @@ export async function getBookingHistory(
     past?: boolean;
     userId?: number;
     includeVisits?: boolean;
-    includeVisitNotes?: boolean;
+    includeStaffNotes?: boolean;
     clientIds?: number[];
     limit?: number;
     offset?: number;
@@ -143,7 +148,7 @@ export async function getBookingHistory(
   if (opts.past) params.append('past', 'true');
   if (opts.userId) params.append('userId', String(opts.userId));
   if (opts.includeVisits) params.append('includeVisits', 'true');
-  if (opts.includeVisitNotes) params.append('includeVisitNotes', 'true');
+  if (opts.includeStaffNotes) params.append('includeStaffNotes', 'true');
   if (opts.clientIds && opts.clientIds.length)
     params.append('clientIds', opts.clientIds.join(','));
   if (typeof opts.limit === 'number')

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -170,7 +170,12 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
               {Number(booking.approved_bookings_this_month)}
             </Typography>
           </Stack>
-          {booking.note && <Typography>Note: {booking.note}</Typography>}
+          {booking.client_note && (
+            <Typography>Client note: {booking.client_note}</Typography>
+          )}
+          {booking.staff_note && (
+            <Typography>Staff note: {booking.staff_note}</Typography>
+          )}
           <TextField
             select
             label="Status"

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -267,5 +267,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -259,5 +259,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -262,5 +262,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -257,5 +257,7 @@
       "approved": "Approved",
       "rejected": "Rejected"
     }
-  }
+  },
+  "client_note": "Client note",
+  "staff_note": "Staff note"
 }

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -87,9 +87,11 @@ export default function ClientHistory() {
       past?: boolean;
       userId?: number;
       includeVisits?: boolean;
+      includeStaffNotes?: boolean;
     } = {
       userId: selected.client_id,
       includeVisits: true,
+      includeStaffNotes: true,
     };
     if (filter === 'past') opts.past = true;
     else if (filter !== 'all') opts.status = filter;
@@ -171,13 +173,15 @@ export default function ClientHistory() {
                     <TableCell sx={cellSx}>{t('time')}</TableCell>
                     <TableCell sx={cellSx}>{t('status')}</TableCell>
                     <TableCell sx={cellSx}>{t('reason')}</TableCell>
+                    <TableCell sx={cellSx}>{t('client_note')}</TableCell>
+                    <TableCell sx={cellSx}>{t('staff_note')}</TableCell>
                     <TableCell sx={cellSx}>{t('actions')}</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {paginated.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={5} sx={{ textAlign: 'center' }}>
+                      <TableCell colSpan={7} sx={{ textAlign: 'center' }}>
                         {t('no_bookings')}
                       </TableCell>
                     </TableRow>
@@ -199,6 +203,8 @@ export default function ClientHistory() {
                         </TableCell>
                         <TableCell sx={cellSx}>{t(b.status)}</TableCell>
                         <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
+                        <TableCell sx={cellSx}>{b.client_note || ''}</TableCell>
+                        <TableCell sx={cellSx}>{b.staff_note || ''}</TableCell>
                         <TableCell sx={cellSx}>
                           {['approved'].includes(b.status.toLowerCase()) && (
                             <Stack direction="row" spacing={1}>

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -210,6 +210,7 @@ export default function ClientDashboard() {
                         primary={
                           time ? `${formatDate(b.date)} ${time}` : formatDate(b.date)
                         }
+                        secondary={b.client_note || undefined}
                       />
                     </ListItem>
                   );

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -219,18 +219,18 @@ export function getHelpContent(
     {
       title: 'Record visits and handle no-shows',
       body: {
-        description: 'Mark bookings as visited while logging weights and adding visit notes, or record no-shows.',
+        description: 'Mark bookings as visited while logging weights and adding staff notes, or record no-shows.',
         steps: [
           'Open the schedule.',
           'Select a booking.',
-          'Mark visited or no-show, enter weight, and add a visit note if needed.',
+          'Mark visited or no-show, enter weight, and add a staff note if needed.',
         ],
       },
     },
     {
       title: 'Filter visits by notes',
       body: {
-        description: 'Show only visits that contain notes.',
+        description: 'Show only visits that contain client or staff notes.',
         steps: [
           'Open Booking History.',
           'Enable the notes-only filter.',
@@ -241,11 +241,11 @@ export function getHelpContent(
     {
       title: 'View booking notes',
       body: {
-        description: 'Staff dialogs display any note submitted with a booking.',
+        description: 'Staff dialogs display client notes submitted with a booking and any staff visit notes.',
         steps: [
           'Open the schedule.',
           'Select a booking.',
-          'Read the note in the dialog.',
+          'Read the client and staff notes in the dialog.',
         ],
       },
     },

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -82,10 +82,10 @@ export default function UserHistory({
       past?: boolean;
       userId?: number;
       includeVisits?: boolean;
-      includeVisitNotes?: boolean;
+      includeStaffNotes?: boolean;
     } = { includeVisits: true };
     if (role === 'staff' || role === 'agency') {
-      opts.includeVisitNotes = true;
+      opts.includeStaffNotes = true;
     }
     if (!initialUser) opts.userId = selected.client_id;
     if (filter === 'past') opts.past = true;
@@ -116,7 +116,9 @@ export default function UserHistory({
   }, [searchParams, initialUser]);
 
   const filtered = notesOnly
-    ? bookings.filter(b => b.status === 'visited' && b.note)
+    ? bookings.filter(
+        b => b.status === 'visited' && (b.client_note || b.staff_note),
+      )
     : bookings;
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const paginated = filtered.slice((page - 1) * pageSize, page * pageSize);
@@ -242,14 +244,24 @@ export default function UserHistory({
                     <TableCell sx={cellSx}>{t('time')}</TableCell>
                     <TableCell sx={cellSx}>{t('status')}</TableCell>
                     <TableCell sx={cellSx}>{t('reason')}</TableCell>
-                    <TableCell sx={cellSx}>Note</TableCell>
+                    {role === 'staff' || role === 'agency' ? (
+                      <>
+                        <TableCell sx={cellSx}>{t('client_note')}</TableCell>
+                        <TableCell sx={cellSx}>{t('staff_note')}</TableCell>
+                      </>
+                    ) : (
+                      <TableCell sx={cellSx}>{t('client_note')}</TableCell>
+                    )}
                     <TableCell sx={cellSx}>{t('actions')}</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {paginated.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={6} sx={{ textAlign: 'center' }}>
+                      <TableCell
+                        colSpan={role === 'staff' || role === 'agency' ? 7 : 6}
+                        sx={{ textAlign: 'center' }}
+                      >
                         {t('no_bookings')}
                       </TableCell>
                     </TableRow>
@@ -271,7 +283,14 @@ export default function UserHistory({
                         </TableCell>
                         <TableCell sx={cellSx}>{t(b.status)}</TableCell>
                         <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
-                        <TableCell sx={cellSx}>{b.note || ''}</TableCell>
+                        {role === 'staff' || role === 'agency' ? (
+                          <>
+                            <TableCell sx={cellSx}>{b.client_note || ''}</TableCell>
+                            <TableCell sx={cellSx}>{b.staff_note || ''}</TableCell>
+                          </>
+                        ) : (
+                          <TableCell sx={cellSx}>{b.client_note || ''}</TableCell>
+                        )}
                         <TableCell sx={cellSx}>
                           {['approved'].includes(
                             b.status.toLowerCase()

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -233,20 +233,26 @@ export interface BookingResponse {
   startTime?: string | null;
   endTime?: string | null;
   reason?: string;
-  note?: string | null;
+  client_note?: string | null;
+  clientNote?: string | null;
+  staff_note?: string | null;
+  staffNote?: string | null;
 }
 
 export interface Booking
   extends Omit<
     BookingResponse,
-    'new_client_id' | 'startTime' | 'endTime' | 'note'
+    'new_client_id' | 'startTime' | 'endTime' | 'clientNote' | 'staffNote'
   > {
   start_time: string | null;
   end_time: string | null;
   startTime: string | null;
   endTime: string | null;
   newClientId: number | null;
-  note?: string | null;
+  client_note?: string | null;
+  clientNote?: string | null;
+  staff_note?: string | null;
+  staffNote?: string | null;
 }
 
 export interface VolunteerBookingInfo {

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,10 +1,10 @@
 # Booking notes
 
-Clients can include an optional note when booking an appointment. The note is stored with the booking and appears in staff dialogs when managing client bookings or volunteer shifts.
+Clients can include an optional note when booking an appointment. The note is stored with the booking and appears in staff dialogs when managing client bookings or volunteer shifts. This is returned as `client_note` in booking history.
 
-Staff can add notes when recording client visits in the pantry schedule. These notes are stored with the visit.
+Staff can add notes when recording client visits in the pantry schedule. These notes are stored with the visit and returned as `staff_note`.
 
-Staff and agency users can include visit notes in booking history responses by adding `includeVisitNotes=true` to `/bookings/history` and filter visit history by note text using the `notes` query parameter.
+Staff and agency users can include staff visit notes in booking history responses by adding `includeStaffNotes=true` to `/bookings/history` and filter visit history by note text using the `notes` query parameter. Client notes are always included.
 
 ## Environment variables
 
@@ -17,5 +17,7 @@ Add the following translation strings to locale files:
 - `help.client.booking_appointments.steps.2`
 - `note_label`
 - `note_prefix`
+- `client_note`
+- `staff_note`
 
 Document any new translation keys here when extending note functionality.


### PR DESCRIPTION
## Summary
- support `client_note` and `staff_note` on bookings
- replace `includeVisitNotes` with `includeStaffNotes` in booking history API
- show client and staff notes in history views and dialogs

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e27c4364832da94b01db44bf689d