### PR TITLE
Add dashboard link to shopper navigation

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -227,6 +227,7 @@ export default function App() {
     navGroups.push({
       label: t('booking'),
       links: [
+        { label: t('dashboard'), to: '/' },
         { label: t('book_appointment'), to: '/book-appointment' },
         { label: t('booking_history'), to: '/booking-history' },
       ],

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -34,6 +34,7 @@
   "submit": "አስገባ",
   "invalid_or_expired_token": "ልክ ያልሆነ ወይም ጊዜው ያለፈ ቶክን",
   "client_dashboard": "የደንበኛ ዳሽቦርድ",
+  "dashboard": "Dashboard",
   "book_appointment": "ቀጠሮ ይያዙ",
   "booking_history": "የቀጠሮ ታሪክ",
   "booking": "ቀጠሮ",

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -34,6 +34,7 @@
   "submit": "إرسال",
   "invalid_or_expired_token": "رمز غير صالح أو منتهي الصلاحية",
   "client_dashboard": "لوحة تحكم العميل",
+  "dashboard": "Dashboard",
   "book_appointment": "حجز موعد",
   "booking_history": "سجل الحجوزات",
   "booking": "حجز",

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -36,6 +36,7 @@
   "submit": "Submit",
   "invalid_or_expired_token": "Invalid or expired token",
   "client_dashboard": "Client Dashboard",
+  "dashboard": "Dashboard",
   "book_appointment": "Book Appointment",
   "booking_history": "Booking History",
   "booking": "Booking",

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -36,6 +36,7 @@
   "submit": "Enviar",
   "invalid_or_expired_token": "Token inválido o expirado",
   "client_dashboard": "Panel del cliente",
+  "dashboard": "Dashboard",
   "book_appointment": "Reservar cita",
   "booking_history": "Historial de reservas",
   "booking": "Reserva",

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -34,6 +34,7 @@
   "submit": "ارسال",
   "invalid_or_expired_token": "توکن نامعتبر یا منقضی‌شده",
   "client_dashboard": "داشبورد مشتری",
+  "dashboard": "Dashboard",
   "book_appointment": "رزرو قرار",
   "booking_history": "تاریخچه رزرو",
   "booking": "رزرو",

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -34,6 +34,7 @@
   "submit": "Envoyer",
   "invalid_or_expired_token": "Jeton invalide ou expiré",
   "client_dashboard": "Tableau de bord client",
+  "dashboard": "Dashboard",
   "book_appointment": "Prendre rendez-vous",
   "booking_history": "Historique des réservations",
   "booking": "Réservation",

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -34,6 +34,7 @@
   "submit": "सबमिट",
   "invalid_or_expired_token": "अमान्य या समाप्त टोकन",
   "client_dashboard": "क्लाइंट डैशबोर्ड",
+  "dashboard": "Dashboard",
   "book_appointment": "नियुक्ति बुक करें",
   "booking_history": "बुकिंग इतिहास",
   "booking": "बुकिंग",

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -34,6 +34,7 @@
   "submit": "സമർപ്പിക്കുക",
   "invalid_or_expired_token": "അസാധുവായ അല്ലെങ്കിൽ കാലഹരണപ്പെട്ട ടോക്കൺ",
   "client_dashboard": "ക്ലയന്റ് ഡാഷ്ബോർഡ്",
+  "dashboard": "Dashboard",
   "book_appointment": "അപ്പോയിന്റ്മെന്റ് ബുക്ക് ചെയ്യുക",
   "booking_history": "ബുക്കിംഗ് ചരിത്രം",
   "booking": "ബുക്കിംഗ്",

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -34,6 +34,7 @@
   "submit": "ਜਮ੍ਹਾ ਕਰੋ",
   "invalid_or_expired_token": "ਅਣਵੈਧ ਜਾਂ ਮਿਆਦ ਪੂਰੀ ਹੋਇਆ ਟੋਕਨ",
   "client_dashboard": "ਗਾਹਕ ਡੈਸ਼ਬੋਰਡ",
+  "dashboard": "Dashboard",
   "book_appointment": "ਮੁਲਾਕਾਤ ਬੁੱਕ ਕਰੋ",
   "booking_history": "ਬੁਕਿੰਗ ਇਤਿਹਾਸ",
   "booking": "ਬੁਕਿੰਗ",

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -34,6 +34,7 @@
   "submit": "سپارل",
   "invalid_or_expired_token": "ناسم یا ختم شوی توکن",
   "client_dashboard": "د پېرېدونکي ډشبورډ",
+  "dashboard": "Dashboard",
   "book_appointment": "وخت ونیسئ",
   "booking_history": "د ریزرو تاریخ",
   "booking": "ریزرو",

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -34,6 +34,7 @@
   "submit": "Gudbi",
   "invalid_or_expired_token": "Calaamad aan sax ahayn ama dhacday",
   "client_dashboard": "Dashboard-ka macmiilka",
+  "dashboard": "Dashboard",
   "book_appointment": "Qor ballan",
   "booking_history": "Taariikhda ballamaha",
   "booking": "Ballan",

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -34,6 +34,7 @@
   "submit": "Tuma",
   "invalid_or_expired_token": "Ishara batili au imekwisha muda",
   "client_dashboard": "Dashibodi ya mteja",
+  "dashboard": "Dashboard",
   "book_appointment": "Panga miadi",
   "booking_history": "Historia ya miadi",
   "booking": "Uwekaji miadi",

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -34,6 +34,7 @@
   "submit": "சமர்ப்பிக்க",
   "invalid_or_expired_token": "தவறான அல்லது காலாவதியான டோக்கன்",
   "client_dashboard": "வாடிக்கையாளர் டாஷ்போர்டு",
+  "dashboard": "Dashboard",
   "book_appointment": "நியமனத்தை முன்பதிவு செய்",
   "booking_history": "முன்பதிவு வரலாறு",
   "booking": "முன்பதிவு",

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -34,6 +34,7 @@
   "submit": "ስብሑ",
   "invalid_or_expired_token": "ትክክል ዘይኮነ ወይ ግዜ ዘለፈ ቶክን",
   "client_dashboard": "ዳሽቦርድ ደንበኛ",
+  "dashboard": "Dashboard",
   "book_appointment": "ቀጽል ቆርቆሮ",
   "booking_history": "ታሪኽ ቆርቆሮ",
   "booking": "ቆርቆሮ",

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -34,6 +34,7 @@
   "submit": "Isumite",
   "invalid_or_expired_token": "Di-wasto o paso na ang token",
   "client_dashboard": "Dashboard ng kliyente",
+  "dashboard": "Dashboard",
   "book_appointment": "Magpa-book ng appointment",
   "booking_history": "Kasaysayan ng booking",
   "booking": "Booking",

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -34,6 +34,7 @@
   "submit": "Надіслати",
   "invalid_or_expired_token": "Недійсний або прострочений токен",
   "client_dashboard": "Панель клієнта",
+  "dashboard": "Dashboard",
   "book_appointment": "Записатися на прийом",
   "booking_history": "Історія бронювань",
   "booking": "Бронювання",

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -34,6 +34,7 @@
   "submit": "提交",
   "invalid_or_expired_token": "令牌无效或已过期",
   "client_dashboard": "客户仪表板",
+  "dashboard": "Dashboard",
   "book_appointment": "预约",
   "booking_history": "预约历史",
   "booking": "预约",

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,9 @@
+# Navigation
+
+Clients can access the dashboard from the navigation menu.
+
+## Localization
+
+Add the following translation strings to locale files:
+
+- `dashboard`


### PR DESCRIPTION
## Summary
- show Dashboard link for shoppers to return home
- add `dashboard` translation to all locale files
- document dashboard translation key

## Testing
- `npm test` *(fails: multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e3f9af78832d8d0de4f194e39499