### PR TITLE
feat: support separate client and staff notes

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
@@ -51,4 +51,41 @@ describe('Agency ClientHistory', () => {
     await waitFor(() => expect(cancelBooking).toHaveBeenCalledWith('10'));
     expect(getBookingHistory).toHaveBeenCalledTimes(2);
   });
+
+  it('shows both client and staff notes', async () => {
+    const { getMyAgencyClients } = require('../api/agencies');
+    const { getBookingHistory } = require('../api/bookings');
+    (getMyAgencyClients as jest.Mock).mockResolvedValue([
+      { client_id: 1, name: 'Client One' },
+    ]);
+    (getBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'visited',
+        date: '2024-01-01',
+        start_time: null,
+        end_time: null,
+        created_at: '2024-01-01',
+        slot_id: null,
+        is_staff_booking: false,
+        reschedule_token: null,
+        client_note: 'client note',
+        staff_note: 'staff note',
+      },
+    ]);
+
+    render(<ClientHistory />);
+
+    fireEvent.click(screen.getByText('select client'));
+
+    await waitFor(() =>
+      expect(getBookingHistory).toHaveBeenCalledWith({
+        userId: 1,
+        includeVisits: true,
+        includeStaffNotes: true,
+      }),
+    );
+    expect(await screen.findByText(/client note/i)).toBeInTheDocument();
+    expect(screen.getByText(/staff note/i)).toBeInTheDocument();
+  });
 });

--- a/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
@@ -39,7 +39,7 @@ describe('ClientDashboard', () => {
     );
 
     await waitFor(() => expect(getEvents).toHaveBeenCalled());
-    expect(screen.getByText(/Client Event/)).toBeInTheDocument();
+    expect(await screen.findByText(/Client Event/)).toBeInTheDocument();
   });
 
   it('displays visited bookings with success chip', async () => {
@@ -60,7 +60,31 @@ describe('ClientDashboard', () => {
       </MemoryRouter>,
     );
 
-    const chipLabel = await screen.findByText('visited');
+    const chipLabel = await screen.findByText(/visited/i);
     expect(chipLabel.closest('.MuiChip-colorSuccess')).toBeTruthy();
+  });
+
+  it('shows client note in booking history', async () => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'approved',
+        date: '2024-01-01',
+        start_time: '09:00:00',
+        client_note: 'bring bag',
+      },
+    ]);
+    (getSlots as jest.Mock).mockResolvedValue([]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+
+    render(
+      <MemoryRouter>
+        <ClientDashboard />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
+    expect(await screen.findByText('bring bag')).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -62,7 +62,7 @@ describe('UserHistory', () => {
     });
     expect(await screen.findByText(/approved/i)).toBeInTheDocument();
     expect(await screen.findByText(/visited/i)).toBeInTheDocument();
-    expect(screen.getByText('bring ID')).toBeInTheDocument();
+    expect(screen.getByText(/bring ID/i)).toBeInTheDocument();
   });
 
   it('hides edit client button when initialUser is provided', async () => {
@@ -91,7 +91,7 @@ describe('UserHistory', () => {
         slot_id: null,
         is_staff_booking: false,
         reschedule_token: null,
-        staff_note: 'has note',
+        staff_note: 'has staff note',
       },
       {
         id: 2,
@@ -100,6 +100,18 @@ describe('UserHistory', () => {
         start_time: null,
         end_time: null,
         created_at: '2024-01-02',
+        slot_id: null,
+        is_staff_booking: false,
+        reschedule_token: null,
+        client_note: 'client note here',
+      },
+      {
+        id: 3,
+        status: 'visited',
+        date: '2024-01-03',
+        start_time: null,
+        end_time: null,
+        created_at: '2024-01-03',
         slot_id: null,
         is_staff_booking: false,
         reschedule_token: null,
@@ -113,12 +125,13 @@ describe('UserHistory', () => {
     );
 
     await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
+    expect(screen.getAllByText(/visited/i)).toHaveLength(3);
+
+    fireEvent.click(screen.getByLabelText('View visits with notes only'));
+
     expect(screen.getAllByText(/visited/i)).toHaveLength(2);
-
-    fireEvent.click(screen.getByLabelText('View visits with staff notes only'));
-
-    expect(screen.getAllByText(/visited/i)).toHaveLength(1);
-    expect(screen.getByText('has note')).toBeInTheDocument();
+    expect(screen.getByText(/has staff note/i)).toBeInTheDocument();
+    expect(screen.getByText(/client note here/i)).toBeInTheDocument();
   });
 });
 

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -99,11 +99,12 @@ export async function createBooking(
 }
 
 function normalizeBooking(b: BookingResponse): Booking {
-  const { new_client_id, note, ...rest } = b;
+  const { new_client_id, client_note, staff_note, ...rest } = b;
   const newClientId = b.newClientId ?? new_client_id ?? null;
   return {
     ...rest,
-    note: note ?? null,
+    client_note: client_note ?? null,
+    staff_note: staff_note ?? null,
     start_time: b.start_time ?? b.startTime ?? null,
     end_time: b.end_time ?? b.endTime ?? null,
     startTime: b.startTime ?? b.start_time ?? null,

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -37,7 +37,6 @@
   "invalid_or_expired_token": "Invalid or expired token",
   "dashboard": "Dashboard",
   "client_dashboard": "Client Dashboard",
-  "dashboard": "Dashboard",
   "book_appointment": "Book Appointment",
   "booking_history": "Booking History",
   "booking": "Booking",
@@ -271,5 +270,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -263,5 +263,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -266,5 +266,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -35,7 +35,6 @@
   "invalid_or_expired_token": "Calaamad aan sax ahayn ama dhacday",
   "dashboard": "Dashboard",
   "client_dashboard": "Dashboard-ka macmiilka",
-  "dashboard": "Dashboard",
   "book_appointment": "Qor ballan",
   "booking_history": "Taariikhda ballamaha",
   "booking": "Ballan",
@@ -262,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -35,7 +35,6 @@
   "invalid_or_expired_token": "Di-wasto o paso na ang token",
   "dashboard": "Dashboard",
   "client_dashboard": "Dashboard ng kliyente",
-  "dashboard": "Dashboard",
   "book_appointment": "Magpa-book ng appointment",
   "booking_history": "Kasaysayan ng booking",
   "booking": "Booking",
@@ -262,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -261,5 +261,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_staff_notes_only": "View visits with staff notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "notes": "Notes"
 }

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -18,6 +18,7 @@ import {
   useMediaQuery,
   useTheme,
   Stack,
+  Typography,
 } from '@mui/material';
 import RescheduleDialog from '../../components/RescheduleDialog';
 import EntitySearch from '../../components/EntitySearch';
@@ -82,14 +83,16 @@ export default function ClientHistory() {
 
   const loadBookings = useCallback(() => {
     if (!selected) return Promise.resolve();
-      const opts: {
+    const opts: {
       status?: string;
       past?: boolean;
       userId?: number;
       includeVisits?: boolean;
+      includeStaffNotes?: boolean;
     } = {
       userId: selected.client_id,
       includeVisits: true,
+      includeStaffNotes: true,
     };
     if (filter === 'past') opts.past = true;
     else if (filter !== 'all') opts.status = filter;
@@ -171,13 +174,14 @@ export default function ClientHistory() {
                     <TableCell sx={cellSx}>{t('time')}</TableCell>
                     <TableCell sx={cellSx}>{t('status')}</TableCell>
                     <TableCell sx={cellSx}>{t('reason')}</TableCell>
+                    <TableCell sx={cellSx}>{t('notes')}</TableCell>
                     <TableCell sx={cellSx}>{t('actions')}</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {paginated.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={5} sx={{ textAlign: 'center' }}>
+                      <TableCell colSpan={6} sx={{ textAlign: 'center' }}>
                         {t('no_bookings')}
                       </TableCell>
                     </TableRow>
@@ -199,6 +203,18 @@ export default function ClientHistory() {
                         </TableCell>
                         <TableCell sx={cellSx}>{t(b.status)}</TableCell>
                         <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
+                        <TableCell sx={cellSx}>
+                          {b.client_note && (
+                            <Typography variant="body2">
+                              {t('client_note_label')}: {b.client_note}
+                            </Typography>
+                          )}
+                          {b.staff_note && (
+                            <Typography variant="body2">
+                              {t('staff_note_label')}: {b.staff_note}
+                            </Typography>
+                          )}
+                        </TableCell>
                         <TableCell sx={cellSx}>
                           {['approved'].includes(b.status.toLowerCase()) && (
                             <Stack direction="row" spacing={1}>

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -171,6 +171,7 @@ export default function ClientDashboard() {
                       primary={`${formatDate(next.date)} ${formatTime(
                         next.start_time || '',
                       )}`}
+                      secondary={next.client_note || undefined}
                     />
                   </ListItem>
                 </List>
@@ -210,6 +211,7 @@ export default function ClientDashboard() {
                         primary={
                           time ? `${formatDate(b.date)} ${time}` : formatDate(b.date)
                         }
+                        secondary={b.client_note || undefined}
                       />
                     </ListItem>
                   );

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -228,12 +228,12 @@ export function getHelpContent(
       },
     },
     {
-      title: 'Filter visits by staff notes',
+      title: 'Filter visits by notes',
       body: {
-        description: 'Show only visits that contain staff notes.',
+        description: 'Show only visits that contain client or staff notes.',
         steps: [
           'Open Booking History.',
-          'Enable the staff notes-only filter.',
+          'Enable the notes-only filter.',
           'Review the matching visits.',
         ],
       },

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -234,7 +234,7 @@ export default function UserHistory({
                   onChange={e => setNotesOnly(e.target.checked)}
                 />
               }
-              label={t('visits_with_staff_notes_only')}
+              label={t('visits_with_notes_only')}
             />
             <TableContainer sx={{ overflowX: 'auto' }}>
               <Table size="small" sx={{ width: '100%', borderCollapse: 'collapse' }}>
@@ -244,7 +244,7 @@ export default function UserHistory({
                     <TableCell sx={cellSx}>{t('time')}</TableCell>
                     <TableCell sx={cellSx}>{t('status')}</TableCell>
                     <TableCell sx={cellSx}>{t('reason')}</TableCell>
-                    <TableCell sx={cellSx}>Note</TableCell>
+                    <TableCell sx={cellSx}>{t('notes')}</TableCell>
                     <TableCell sx={cellSx}>{t('actions')}</TableCell>
                   </TableRow>
                 </TableHead>
@@ -274,7 +274,16 @@ export default function UserHistory({
                         <TableCell sx={cellSx}>{t(b.status)}</TableCell>
                         <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
                         <TableCell sx={cellSx}>
-                          {b.client_note || b.staff_note || ''}
+                          {b.client_note && (
+                            <Typography variant="body2">
+                              {t('client_note_label')}: {b.client_note}
+                            </Typography>
+                          )}
+                          {b.staff_note && (
+                            <Typography variant="body2">
+                              {t('staff_note_label')}: {b.staff_note}
+                            </Typography>
+                          )}
                         </TableCell>
                         <TableCell sx={cellSx}>
                           {['approved'].includes(

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -233,7 +233,6 @@ export interface BookingResponse {
   startTime?: string | null;
   endTime?: string | null;
   reason?: string;
-  note?: string | null;
   client_note?: string | null;
   staff_note?: string | null;
 }

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -4,7 +4,7 @@ Clients can enter a **client note** when booking an appointment. The client note
 
 Staff can add a **staff note** when recording client visits in the pantry schedule. Staff notes are stored with the visit.
 
-Staff and agency users can include staff notes in booking history responses by adding `includeStaffNotes=true` to `/bookings/history` and filter visit history by note text using the `notes` query parameter.
+Staff and agency users can include staff notes in booking history responses by adding `includeStaffNotes=true` to `/bookings/history` and filter visit history by note text using the `notes` query parameter. The notes-only filter matches visits that contain either client or staff notes.
 
 ## Environment variables
 
@@ -18,6 +18,7 @@ Add the following translation strings to locale files:
 - `dashboard`
 - `client_note_label`
 - `staff_note_label`
-- `visits_with_staff_notes_only`
+- `notes`
+- `visits_with_notes_only`
 
 Document any new translation keys here when extending note functionality.


### PR DESCRIPTION
## Summary
- map `client_note` and `staff_note` in booking API
- show client and staff notes in booking history views
- add translations and docs for notes-only filters

## Testing
- `npx jest src/__tests__/UserHistory.test.tsx src/__tests__/AgencyClientHistory.test.tsx src/__tests__/ClientDashboard.test.tsx`
- `npm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e60b7c44832d91bb306008a70b63