### PR TITLE
Fix admin timesheet staff search

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -56,6 +56,7 @@ const mockUseTimesheetDays = jest.fn(() => ({
 }));
 const mockUseAllTimesheets = jest.fn();
 const mockSearchStaff = jest.fn();
+const mockAdminSearchStaff = jest.fn();
 
 jest.mock('../../../api/timesheets', () => ({
   useTimesheets: () => ({
@@ -87,6 +88,9 @@ jest.mock('../../../api/timesheets', () => ({
 jest.mock('../../../api/staff', () => ({
   searchStaff: (...args: any[]) => mockSearchStaff(...args),
 }));
+jest.mock('../../../api/adminStaff', () => ({
+  searchStaff: (...args: any[]) => mockAdminSearchStaff(...args),
+}));
 jest.mock('../../../api/leaveRequests', () => ({
   useCreateLeaveRequest: () => ({ mutate: jest.fn() }),
   useLeaveRequests: () => ({ requests: [], isLoading: false, error: null }),
@@ -99,6 +103,7 @@ beforeEach(() => {
   mockUseTimesheetDays.mockClear();
   mockUseAllTimesheets.mockClear();
   mockSearchStaff.mockClear();
+  mockAdminSearchStaff.mockClear();
 });
 
 function render(path = '/timesheet') {
@@ -212,7 +217,9 @@ describe('Timesheets', () => {
   });
 
   it('loads timesheets after selecting staff in admin', async () => {
-    mockSearchStaff.mockResolvedValueOnce([{ id: 2, name: 'Alice' }]);
+    mockAdminSearchStaff.mockResolvedValueOnce([
+      { id: 2, firstName: 'Alice', lastName: 'Smith', email: '', access: [] },
+    ]);
     mockUseAllTimesheets.mockImplementation((id?: number) =>
       id === 2
         ? {
@@ -239,7 +246,7 @@ describe('Timesheets', () => {
     render('/admin/timesheet');
     const input = screen.getByLabelText('Staff');
     await user.type(input, 'Ali');
-    const option = await screen.findByText('Alice');
+    const option = await screen.findByText('Alice Smith');
     await user.click(option);
     expect(mockUseAllTimesheets).toHaveBeenLastCalledWith(2);
     await screen.findByText('Reject');

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -36,7 +36,11 @@ import {
   useApproveLeaveRequest,
 } from '../../api/leaveRequests';
 import { useMatch } from 'react-router-dom';
-import { searchStaff, type StaffOption } from '../../api/staff';
+import {
+  searchStaff as searchStaffApi,
+  type StaffOption,
+} from '../../api/staff';
+import { searchStaff as searchAdminStaff } from '../../api/adminStaff';
 
 interface Day {
   date: string;
@@ -65,9 +69,14 @@ export default function Timesheets() {
         active = false;
       };
     }
-    searchStaff(staffInput)
+    const search = inAdmin ? searchAdminStaff : searchStaffApi;
+    search(staffInput)
       .then(data => {
-        if (active) setStaffOptions(data);
+        if (!active) return;
+        const options = inAdmin
+          ? data.map(d => ({ id: d.id, name: `${d.firstName} ${d.lastName}` }))
+          : data;
+        setStaffOptions(options);
       })
       .catch(() => {
         if (active) setStaffOptions([]);
@@ -75,7 +84,7 @@ export default function Timesheets() {
     return () => {
       active = false;
     };
-  }, [staffInput]);
+  }, [staffInput, inAdmin]);
   const { timesheets, isLoading: loadingSheets, error: sheetsError } = inAdmin
     ? useAllTimesheets(staff?.id)
     : useTimesheets();


### PR DESCRIPTION
## Summary
- fix admin timesheet staff dropdown by calling admin staff search endpoint
- add tests for admin staff selection using admin search

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b91b82d570832dbb011926c0143d05