### PR TITLE
Allow editing stat holidays on timesheets

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/HelpPage.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/HelpPage.test.tsx
@@ -92,7 +92,7 @@ describe('HelpPage', () => {
     } as any);
     renderPage();
     expect(
-      screen.getByText(/Fill in hours or request leave days./i),
+      screen.getByText(/Fill in hours for each day\./i),
     ).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/api/timesheets.ts
+++ b/MJ_FB_Frontend/src/api/timesheets.ts
@@ -132,8 +132,24 @@ export function useUpdateTimesheetDay(timesheetId: number) {
     }
   >({
     mutationFn: ({ date, ...rest }) => updateTimesheetDay(timesheetId, date, rest),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['timesheets', timesheetId, 'days'] });
+    onSuccess: (_, { date, regHours, otHours, statHours, sickHours, vacHours, note }) => {
+      qc.setQueryData<TimesheetDay[]>(
+        ['timesheets', timesheetId, 'days'],
+        old =>
+          old?.map(d =>
+            d.work_date === date
+              ? {
+                  ...d,
+                  reg_hours: regHours,
+                  ot_hours: otHours,
+                  stat_hours: statHours,
+                  sick_hours: sickHours,
+                  vac_hours: vacHours,
+                  note,
+                }
+              : d,
+          ),
+      );
       qc.invalidateQueries({ queryKey: ['timesheets'] });
       qc.invalidateQueries({ queryKey: ['allTimesheets'] });
     },

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -100,7 +100,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -236,7 +236,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "add_row": "Add row",
     "remove_row": "Remove row",
     "export_csv": "Export CSV",
@@ -251,8 +250,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -100,7 +100,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -229,7 +229,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -244,8 +243,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -232,7 +232,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -247,8 +246,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -98,7 +98,7 @@
         "description": "Record hours and submit pay periods.",
         "steps": [
           "Open the Timesheets page from the profile menu.",
-          "Fill in hours or request leave days.",
+          "Fill in hours for each day.",
           "Submit the period for review.",
           "Export a CSV for payroll."
         ]
@@ -227,7 +227,6 @@
     "vac": "Vac",
     "note": "Note",
     "paid_total": "Paid Total",
-    "lock_stat_tooltip": "Stat holiday is locked at 8h",
     "summary": {
       "totals": "Totals",
       "expected": "Expected Hours",
@@ -242,8 +241,6 @@
     "reject": "Reject",
     "process": "Process",
     "lock_leave_tooltip": "Leave day is locked",
-    "request_leave": "Request Leave",
-    "review_leave": "Review Leave Requests",
     "approve_leave": "Approve",
     "staff": "Staff",
     "select_staff": "Select Staff"

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -87,11 +87,6 @@ jest.mock('../../../api/timesheets', () => ({
 jest.mock('../../../api/staff', () => ({
   searchStaff: (...args: any[]) => mockSearchStaff(...args),
 }));
-jest.mock('../../../api/leaveRequests', () => ({
-  useCreateLeaveRequest: () => ({ mutate: jest.fn() }),
-  useLeaveRequests: () => ({ requests: [], isLoading: false, error: null }),
-  useApproveLeaveRequest: () => ({ mutate: jest.fn() }),
-}));
 
 beforeEach(() => {
   mockSubmit.mockClear();
@@ -126,14 +121,13 @@ describe('Timesheets', () => {
     expect(() => render()).not.toThrow();
   });
 
-  it('shows stat day lock icon and tooltip', () => {
+  it('prefills stat day and allows editing', () => {
     render();
     const rows = screen.getAllByRole('row');
     const statRow = rows[1];
-    expect(within(statRow).getByTestId('LockIcon')).toBeInTheDocument();
-    expect(screen.getByText('Stat holiday is locked at 8h')).toBeInTheDocument();
-    const regInput = within(statRow).getAllByRole('spinbutton')[0];
-    expect(regInput).toBeDisabled();
+    const statInput = within(statRow).getAllByRole('spinbutton')[2];
+    expect(statInput).toHaveValue(8);
+    expect(statInput).not.toBeDisabled();
   });
 
   it('shows hint when day total exceeds cap', async () => {

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -30,11 +30,6 @@ import {
   useRejectTimesheet,
   useProcessTimesheet,
 } from '../../api/timesheets';
-import {
-  useCreateLeaveRequest,
-  useLeaveRequests,
-  useApproveLeaveRequest,
-} from '../../api/leaveRequests';
 import { useMatch } from 'react-router-dom';
 import { searchStaff, type StaffOption } from '../../api/staff';
 
@@ -47,7 +42,6 @@ interface Day {
   vac: number;
   note: string;
   expected: number;
-  lockedRule: boolean;
   lockedLeave: boolean;
 }
 
@@ -102,7 +96,6 @@ export default function Timesheets() {
         vac: d.vac_hours,
         note: d.note ?? '',
         expected: d.expected_hours,
-        lockedRule: d.locked_by_rule,
         lockedLeave: d.locked_by_leave,
       })),
     );
@@ -112,9 +105,6 @@ export default function Timesheets() {
   const submitMutation = useSubmitTimesheet();
   const rejectMutation = useRejectTimesheet();
   const processMutation = useProcessTimesheet();
-  const leaveMutation = useCreateLeaveRequest(current?.id ?? 0);
-  const { requests } = useLeaveRequests(current?.id);
-  const approveLeaveMutation = useApproveLeaveRequest();
   const [message, setMessage] = useState('');
 
   useEffect(() => {
@@ -193,20 +183,13 @@ export default function Timesheets() {
             {days.map((d, i) => {
               const paid = d.reg + d.ot + d.stat + d.sick + d.vac;
               const over = paid > 8;
-              const disabled =
-                inputsDisabled || d.lockedRule || d.lockedLeave;
+              const disabled = inputsDisabled || d.lockedLeave;
               return (
                 <TableRow key={d.date}>
                   <TableCell>
                     {formatLocaleDate(d.date)}
-                    {(d.lockedRule || d.lockedLeave) && (
-                      <Tooltip
-                        title={
-                          d.lockedRule
-                            ? t('timesheets.lock_stat_tooltip')
-                            : t('timesheets.lock_leave_tooltip')
-                        }
-                      >
+                    {d.lockedLeave && (
+                      <Tooltip title={t('timesheets.lock_leave_tooltip')}>
                         <LockIcon sx={{ ml: 1, fontSize: 16 }} />
                       </Tooltip>
                     )}
@@ -238,7 +221,10 @@ export default function Timesheets() {
                       type="number"
                       value={d.stat}
                       size="small"
-                      disabled
+                      disabled={disabled}
+                      error={over}
+                      onChange={e => handleChange(i, 'stat', e.target.value)}
+                      onBlur={() => handleBlur(i)}
                     />
                   </TableCell>
                   <TableCell>
@@ -359,73 +345,6 @@ export default function Timesheets() {
                 {t('timesheets.process')}
               </Button>
             </>
-          )}
-        </Box>
-      )}
-      {current && (!inAdmin || staff) && (
-        <Box sx={{ mt: 4 }}>
-          <Typography variant="h6">
-            {t('timesheets.request_leave')}
-          </Typography>
-          <Box
-            component="form"
-            sx={{ display: 'flex', gap: 1, mt: 1 }}
-            onSubmit={e => {
-              e.preventDefault();
-              const form = e.currentTarget as typeof e.currentTarget & {
-                date: { value: string };
-                hours: { value: string };
-              };
-              leaveMutation.mutate({
-                date: form.date.value,
-                hours: Number(form.hours.value),
-              });
-              form.reset();
-            }}
-          >
-            <TextField
-              name="date"
-              type="date"
-              size="small"
-              InputLabelProps={{ shrink: true }}
-            />
-            <TextField
-              name="hours"
-              type="number"
-              size="small"
-              defaultValue={8}
-            />
-            <Button type="submit" variant="contained">
-              {t('timesheets.submit')}
-            </Button>
-          </Box>
-          {requests.length > 0 && (
-            <Box sx={{ mt: 2 }}>
-              <Typography variant="subtitle1">
-                {t('timesheets.review_leave')}
-              </Typography>
-              {requests.map(r => (
-                <Box
-                  key={r.id}
-                  sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 1 }}
-                >
-                  <span>
-                    {formatLocaleDate(r.work_date)} - {r.hours}
-                  </span>
-                  <Button
-                    size="small"
-                    onClick={() =>
-                      approveLeaveMutation.mutate({
-                        requestId: r.id,
-                        timesheetId: current.id,
-                      })
-                    }
-                  >
-                    {t('timesheets.approve_leave')}
-                  </Button>
-                </Box>
-              ))}
-            </Box>
           )}
         </Box>
       )}

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -43,9 +43,9 @@ the current period.
 
 ## Stat holidays and OT banking
 
-A database trigger auto-fills stat holidays with the day's expected hours and
-locks them from editing. The same trigger validates that paid hours do not
-exceed eight per day.
+A database trigger auto-fills stat holidays with the day's expected hours.
+Staff can adjust these hours if needed. The same trigger validates that paid
+hours do not exceed eight per day.
 
 Overtime is banked via the `ot_hours` field. When a period is submitted, any
 shortfall is covered by available OT bank and the remaining balance is reported
@@ -107,7 +107,7 @@ After a timesheet is processed, staff can download the period as a CSV using the
 | `note`       | Free-form note               |
 | `paid_total` | Total paid hours for the day |
 
-Stat holidays are auto-filled with the day's expected hours and locked from editing. Days may also be locked when leave is approved.
+Stat holidays are auto-filled with the day's expected hours. Days may also be locked when leave is approved.
 
 ## Localization
 
@@ -122,13 +122,10 @@ Add the following translation strings to locale files:
 - `timesheets.vac`
 - `timesheets.note`
 - `timesheets.paid_total`
-- `timesheets.lock_stat_tooltip`
 - `timesheets.lock_leave_tooltip`
 - `timesheets.submit`
 - `timesheets.reject`
 - `timesheets.process`
-- `timesheets.request_leave`
-- `timesheets.review_leave`
 - `timesheets.approve_leave`
 - `timesheets.summary.totals`
 - `timesheets.summary.expected`


### PR DESCRIPTION
## Summary
- Avoid refetching timesheet days so edits no longer reload the page
- Let staff edit stat holiday hours and drop leave request UI from timesheet view
- Document editable holidays and update help text

## Testing
- `npm test` *(fails: BookingUI.test.tsx unable to find time slot, StaffRecurringBookings.test.tsx cancel button missing, NoShowWeek.test.tsx date mismatch, PasswordSetup.test.tsx resend link missing, AgencyAccess.test.tsx navigation errors, fetchWithRetry.test.ts timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b91c0c9368832dbb8a720427ae4c45