### PR TITLE
fix: correct event index column

### DIFF
--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -555,7 +555,7 @@ CREATE TABLE IF NOT EXISTS email_queue (
     `CREATE INDEX IF NOT EXISTS client_visits_client_id_idx ON client_visits (client_id);`
   );
   await client.query(
-    `CREATE INDEX IF NOT EXISTS events_date_idx ON events (date);`
+    `CREATE INDEX IF NOT EXISTS events_start_date_idx ON events (start_date);`
   );
   await client.query(
     `CREATE INDEX IF NOT EXISTS surplus_log_date_idx ON surplus_log (date);`


### PR DESCRIPTION
## Summary
- fix database setup failing due to missing `date` column in `events` table by indexing `start_date`

## Testing
- `npm test` *(fails: Node v22 is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b91feb214c832d8264bebb28517d7d