### PR TITLE
docs: mandate migrations for schema changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - A cron job seeds pay periods for the upcoming year every **Nov 30** using `seedPayPeriods`.
 - A GitHub Actions workflow in `.github/workflows/release.yml` builds, tests, and deploys container images to Azure Container Apps. Configure repository secrets `AZURE_CREDENTIALS`, `REGISTRY_LOGIN_SERVER`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD` and variables `AZURE_RESOURCE_GROUP`, `BACKEND_APP_NAME`, and `FRONTEND_APP_NAME`; see `docs/release.md` for details.
 - Document new environment variables in the repository README and `.env.example` files.
+- Implement all database schema changes via migrations in `MJ_FB_Backend/src/migrations`; do not modify `src/setupDatabase.ts` for schema updates.
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.
 
 See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/AGENTS.md` for frontend-specific guidance.

--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -38,6 +38,7 @@
 - `middleware/` – shared Express middleware (authentication, validation, etc.).
 - `schemas/`, `types/`, and `utils/` – validation, shared types, and helpers.
 - The database schema is managed via TypeScript migrations in `src/migrations`. The backend runs pending migrations automatically on startup and logs each applied migration name. You can also run them manually with `npm run migrate`.
+- Do not modify `src/setupDatabase.ts` for schema changes; create migrations instead.
 - Booking statuses include `'visited'`; staff can mark bookings as `no_show` or `visited` via `/bookings/:id/no-show` and `/bookings/:id/visited`.
 - The pantry schedule's booking dialog allows staff to mark a booking as visited while recording cart weights and notes to create a client visit.
 - The Manage Booking dialog shows the client's name, profile link, and current-month visit count.

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -2,6 +2,11 @@ import { Client } from 'pg';
 import config from './config';
 import logger from './utils/logger';
 
+/**
+ * Initializes the database if it does not exist.
+ * All schema changes must be implemented via migrations in src/migrations.
+ * Do not modify this file for schema updates.
+ */
 export async function setupDatabase() {
   const dbName = config.pgDatabase;
   const dbConfig = {

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Individuals who use the food bank are referred to as clients throughout the appl
 The `clients` table uses `client_id` as its primary key. Do not reference an `id` column for clients; always use `client_id` in database queries and API responses.
 
 The backend automatically runs any pending database migrations on startup and logs each applied migration name to the console.
+All schema changes must be implemented via migrations in `MJ_FB_Backend/src/migrations`; do not edit `src/setupDatabase.ts` for schema updates.
 
 ## Contribution Guidelines
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -9,8 +9,7 @@ Admin menu. Admins select a staff member before viewing their periods.
 
 ## Setup
 
-1. Start the backend once so `setupDatabase` creates the pay period, timesheet, and leave tables.
-   Future schema updates can still be applied via migrations:
+1. Start the backend once so `setupDatabase` creates the pay period, timesheet, and leave tables. All future schema changes must be implemented via migrations instead of editing `setupDatabase`:
 
 ```bash
 cd MJ_FB_Backend


### PR DESCRIPTION
## Summary
- require all database schema updates to use migrations, not `setupDatabase.ts`
- clarify timesheet setup steps and README to emphasize migrations
- add guidance in AGENTS files and comment in `setupDatabase.ts`

## Testing
- `npm test` (backend) *(fails: multiple failing test suites)*
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68b92070c8c4832da236751bf282bd33