### PR TITLE
Add start and end dates to events

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Events.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Events.test.tsx
@@ -25,7 +25,8 @@ describe('Events page', () => {
         {
           id: 1,
           title: 'Today Event',
-          date: new Date().toISOString(),
+          startDate: new Date().toISOString(),
+          endDate: new Date().toISOString(),
           createdBy: 1,
           createdByName: 'Alice Smith',
           details: 'Details today',
@@ -35,7 +36,8 @@ describe('Events page', () => {
         {
           id: 2,
           title: 'Future Event',
-          date: new Date(Date.now() + 86400000).toISOString(),
+          startDate: new Date(Date.now() + 86400000).toISOString(),
+          endDate: new Date(Date.now() + 86400000).toISOString(),
           createdBy: 1,
           createdByName: 'Alice Smith',
           details: 'Future details',
@@ -45,7 +47,8 @@ describe('Events page', () => {
         {
           id: 3,
           title: 'Past Event',
-          date: new Date(Date.now() - 86400000).toISOString(),
+          startDate: new Date(Date.now() - 86400000).toISOString(),
+          endDate: new Date(Date.now() - 86400000).toISOString(),
           createdBy: 1,
           createdByName: 'Alice Smith',
           details: 'Past details',
@@ -72,7 +75,8 @@ describe('Events page', () => {
         {
           id: 1,
           title: 'Delete Me',
-          date: new Date().toISOString(),
+          startDate: new Date().toISOString(),
+          endDate: new Date().toISOString(),
           createdBy: 1,
           createdByName: 'Alice Smith',
         },

--- a/MJ_FB_Frontend/src/api/events.ts
+++ b/MJ_FB_Frontend/src/api/events.ts
@@ -3,7 +3,8 @@ import { API_BASE, apiFetch, handleResponse } from './client';
 export interface Event {
   id: number;
   title: string;
-  date: string; // ISO string
+  startDate: string; // ISO string
+  endDate: string; // ISO string
   details?: string;
   category?: string;
   staffIds?: number[];
@@ -28,7 +29,8 @@ export async function createEvent(data: {
   title: string;
   details?: string;
   category: string;
-  date: string;
+  startDate: string;
+  endDate: string;
   staffIds: number[];
   visibleToVolunteers?: boolean;
   visibleToClients?: boolean;

--- a/MJ_FB_Frontend/src/components/EventForm.tsx
+++ b/MJ_FB_Frontend/src/components/EventForm.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { useTranslation } from 'react-i18next';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import { createEvent } from '../api/events';
 import { searchStaff, type StaffOption } from '../api/staff';
@@ -36,10 +37,12 @@ const categories = [
 const tagAllOption: StaffOption = { id: -1, name: 'Tag All' };
 
 export default function EventForm({ open, onClose, onCreated }: EventFormProps) {
+  const { t } = useTranslation();
   const [title, setTitle] = useState('');
   const [details, setDetails] = useState('');
   const [category, setCategory] = useState('');
-  const [date, setDate] = useState<Date | null>(null);
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
   const [staffInput, setStaffInput] = useState('');
   const [staffOptions, setStaffOptions] = useState<StaffOption[]>([tagAllOption]);
   const [selectedStaff, setSelectedStaff] = useState<StaffOption[]>([]);
@@ -80,8 +83,12 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
   }
 
   async function submit() {
-    if (!title || !category || !date) {
-      setError('Please fill in title, category, and date');
+    if (!title || !category || !startDate || !endDate) {
+      setError('Please fill in title, category, start date, and end date');
+      return;
+    }
+    if (endDate < startDate) {
+      setError('End date cannot be before start date');
       return;
     }
     try {
@@ -89,7 +96,8 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
         title,
         details,
         category,
-        date: formatReginaDate(date),
+        startDate: formatReginaDate(startDate),
+        endDate: formatReginaDate(endDate),
         staffIds: selectedStaff.map(s => s.id),
         visibleToVolunteers,
         visibleToClients,
@@ -98,7 +106,8 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
       setTitle('');
       setDetails('');
       setCategory('');
-      setDate(null);
+      setStartDate(null);
+      setEndDate(null);
       setSelectedStaff([]);
       setVisibleToVolunteers(false);
       setVisibleToClients(false);
@@ -147,9 +156,15 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
           </TextField>
           <LocalizationProvider dateAdapter={AdapterDateFns}>
             <DatePicker
-              label="Date"
-              value={date}
-              onChange={newDate => setDate(newDate)}
+              label={t('start_date')}
+              value={startDate}
+              onChange={newDate => setStartDate(newDate)}
+              slotProps={{ textField: { fullWidth: true, margin: 'normal' } }}
+            />
+            <DatePicker
+              label={t('end_date')}
+              value={endDate}
+              onChange={newDate => setEndDate(newDate)}
               slotProps={{ textField: { fullWidth: true, margin: 'normal' } }}
             />
           </LocalizationProvider>

--- a/MJ_FB_Frontend/src/components/EventList.tsx
+++ b/MJ_FB_Frontend/src/components/EventList.tsx
@@ -1,6 +1,7 @@
 import { List, ListItem, Typography, ListItemText, IconButton } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { Event } from '../api/events';
+import { formatLocaleDate } from '../utils/date';
 
 interface EventListProps {
   events: Event[];
@@ -12,6 +13,12 @@ export default function EventList({ events, limit, onDelete }: EventListProps) {
   const items = limit ? events.slice(0, limit) : events;
   if (!items.length)
     return <Typography variant="body2">No events</Typography>;
+
+  function formatDateRange(start: string, end: string) {
+    const startText = formatLocaleDate(start);
+    const endText = formatLocaleDate(end);
+    return startText === endText ? startText : `${startText} - ${endText}`;
+  }
   return (
     <List>
       {items.map(ev => (
@@ -27,7 +34,7 @@ export default function EventList({ events, limit, onDelete }: EventListProps) {
           }
         >
           <ListItemText
-            primary={`${new Date(ev.date).toLocaleDateString()} - ${ev.title}`}
+            primary={`${formatDateRange(ev.startDate, ev.endDate)} - ${ev.title}`}
             secondary={
               <>
                 {ev.details && (

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -197,6 +197,17 @@ export function getHelpContent(
       },
     },
     {
+      title: 'Manage events',
+      body: {
+        description: 'Create announcements or activities for staff and volunteers.',
+        steps: [
+          'Open the Events page.',
+          'Click Create Event.',
+          'Enter title, category, start and end dates, add details and staff if needed, then save.',
+        ],
+      },
+    },
+    {
       title: 'Manage volunteers',
       body: {
         description: 'Search, add, and review volunteers.',


### PR DESCRIPTION
## Summary
- support start/end dates in event API calls
- update event form and list to handle start and end dates
- document event creation in help page

## Testing
- `npm test` *(fails: Unable to find an element with the text: Alice)*

------
https://chatgpt.com/codex/tasks/task_e_68b9211e50fc832d965a9882320d558b