### PR TITLE
Defer timesheet updates until final submission

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -79,8 +79,8 @@ jest.mock('../../../api/timesheets', () => ({
   }),
   useAllTimesheets: (...args: any[]) => mockUseAllTimesheets(...args),
   useTimesheetDays: (...args: any[]) => mockUseTimesheetDays(...args),
-  useUpdateTimesheetDay: () => ({ mutate: mockUpdate }),
-  useSubmitTimesheet: () => ({ mutate: mockSubmit }),
+  updateTimesheetDay: (...args: any[]) => mockUpdate(...args),
+  useSubmitTimesheet: () => ({ mutateAsync: mockSubmit, isPending: false }),
   useRejectTimesheet: () => ({ mutate: jest.fn() }),
   useProcessTimesheet: () => ({ mutate: jest.fn() }),
 }));
@@ -101,6 +101,7 @@ jest.mock('../../../api/leaveRequests', () => ({
 beforeEach(() => {
   mockSubmit.mockClear();
   mockUpdate.mockClear();
+  mockUpdate.mockResolvedValue(undefined);
   mockUseTimesheetDays.mockClear();
   mockUseAllTimesheets.mockClear();
   mockSearchStaff.mockClear();
@@ -172,6 +173,7 @@ describe('Timesheets', () => {
     const user = userEvent.setup();
     render();
     await user.click(screen.getByRole('button', { name: /submit/i }));
+    expect(mockUpdate).toHaveBeenCalledTimes(3);
     expect(mockSubmit).toHaveBeenCalledWith(1);
   });
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -7,6 +7,10 @@ from the **Hello** menu in the top-right corner. Admins can review periods at
 `/admin/timesheet` and vacation requests at `/admin/leave-requests` from the
 Admin menu. Admins select a staff member before viewing their periods.
 
+Hours entered on the page are stored locally until you submit the period. No
+API requests are made while editing, preventing the page from refreshing after
+each change.
+
 ## Setup
 
 1. Start the backend once so `setupDatabase` creates the pay period, timesheet, and leave tables.


### PR DESCRIPTION
## Summary
- stop timesheet table from calling the update API on every field blur
- batch day updates and submit timesheet in a single action
- document that entries save when submitting the period

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68b9217b49a0832db9fdbe24a8c7a2ab