### PR TITLE
feat: display leave requests in table

### DIFF
--- a/MJ_FB_Frontend/src/api/leaveRequests.ts
+++ b/MJ_FB_Frontend/src/api/leaveRequests.ts
@@ -4,9 +4,12 @@ import type { ApiError } from './client';
 
 export interface LeaveRequest {
   id: number;
-  timesheet_id: number;
-  work_date: string;
-  hours: number;
+  timesheet_id?: number;
+  work_date?: string;
+  hours?: number;
+  start_date?: string;
+  end_date?: string;
+  type?: string;
   status: 'pending' | 'approved' | 'rejected';
 }
 

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -264,6 +264,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -257,6 +257,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -260,6 +260,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -255,6 +255,12 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "type_label": "Type",
+    "status_label": "Status",
+    "type": {
+      "paid": "Paid",
+      "unpaid": "Unpaid"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
@@ -1,4 +1,15 @@
-import { Box, Button, TextField, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import Page from '../../components/Page';
 import { useTimesheets } from '../../api/timesheets';
@@ -50,16 +61,36 @@ export default function LeaveManagement() {
             </Button>
           </Box>
 
-          {requests.map(r => (
-            <Box key={r.id} sx={{ mb: 1 }}>
-              <Typography component="span" sx={{ mr: 1 }}>
-                {formatLocaleDate(r.work_date)} - {r.hours}h
-              </Typography>
-              <Typography component="span">
-                {t(`leave.status.${r.status}`)}
-              </Typography>
-            </Box>
-          ))}
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>{t('leave.start_date')}</TableCell>
+                  <TableCell>{t('leave.end_date')}</TableCell>
+                  <TableCell>{t('leave.type_label')}</TableCell>
+                  <TableCell>{t('leave.status_label')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {requests.map(r => (
+                  <TableRow key={r.id}>
+                    <TableCell>
+                      {formatLocaleDate(r.start_date ?? r.work_date)}
+                    </TableCell>
+                    <TableCell>
+                      {formatLocaleDate(r.end_date ?? r.work_date)}
+                    </TableCell>
+                    <TableCell>
+                      {r.type ? t(`leave.type.${r.type}`) : ''}
+                    </TableCell>
+                    <TableCell>
+                      {t(`leave.status.${r.status}`)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
         </Box>
       )}
     </Page>


### PR DESCRIPTION
## Summary
- replace leave request list with Material UI table showing start/end dates, type and status
- add translation keys for leave types and table headers across locales
- extend LeaveRequest model with optional start/end/type fields

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b921bfaf38832dbdf5d2430b5694cc