### PR TITLE
feat: log staff leave event

### DIFF
--- a/MJ_FB_Backend/src/controllers/leaveRequestController.ts
+++ b/MJ_FB_Backend/src/controllers/leaveRequestController.ts
@@ -4,6 +4,8 @@ import {
   selectLeaveRequests,
   updateLeaveRequestStatus,
 } from "../models/leaveRequest";
+import seedTimesheets from "../utils/timesheetSeeder";
+import { insertEvent } from "../models/event";
 
 export async function createLeaveRequest(
   req: Request,
@@ -47,6 +49,16 @@ export async function approveLeaveRequest(
       Number(req.params.id),
       "approved",
     );
+    await seedTimesheets(record.staff_id);
+    await insertEvent({
+      title: "Staff Leave",
+      category: "staff_leave",
+      startDate: record.start_date,
+      endDate: record.end_date,
+      createdBy: record.staff_id,
+      visibleToClients: true,
+      visibleToVolunteers: true,
+    });
     res.json(record);
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/src/models/event.ts
+++ b/MJ_FB_Backend/src/models/event.ts
@@ -1,10 +1,63 @@
+import pool from "../db";
+
 export interface Event {
   id: number;
   title: string;
   details: string | null;
   category: string | null;
-  date: string;
+  start_date: string;
+  end_date: string;
   created_by: number;
+  visible_to_volunteers: boolean;
+  visible_to_clients: boolean;
   created_at: string;
   updated_at: string;
+}
+
+export interface InsertEventParams {
+  title: string;
+  details?: string | null;
+  category?: string | null;
+  startDate: string;
+  endDate: string;
+  createdBy: number;
+  visibleToVolunteers?: boolean;
+  visibleToClients?: boolean;
+}
+
+export async function insertEvent({
+  title,
+  details = null,
+  category = null,
+  startDate,
+  endDate,
+  createdBy,
+  visibleToVolunteers = false,
+  visibleToClients = false,
+}: InsertEventParams): Promise<Event> {
+  const res = await pool.query(
+    `INSERT INTO events (
+        title,
+        details,
+        category,
+        start_date,
+        end_date,
+        created_by,
+        visible_to_volunteers,
+        visible_to_clients
+     )
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+     RETURNING *`,
+    [
+      title,
+      details,
+      category,
+      startDate,
+      endDate,
+      createdBy,
+      visibleToVolunteers,
+      visibleToClients,
+    ],
+  );
+  return res.rows[0];
 }

--- a/MJ_FB_Backend/tests/leaveRequests.test.ts
+++ b/MJ_FB_Backend/tests/leaveRequests.test.ts
@@ -4,6 +4,17 @@ import {
   approveLeaveRequest,
 } from "../src/controllers/leaveRequestController";
 import mockPool from "./utils/mockDb";
+import seedTimesheets from "../src/utils/timesheetSeeder";
+import { insertEvent } from "../src/models/event";
+
+jest.mock("../src/utils/timesheetSeeder", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("../src/models/event", () => ({
+  insertEvent: jest.fn(),
+}));
 
 const makeRes = () => ({
   status: jest.fn().mockReturnThis(),
@@ -13,6 +24,8 @@ const makeRes = () => ({
 describe("leave requests controller", () => {
   afterEach(() => {
     (mockPool.query as jest.Mock).mockReset();
+    (seedTimesheets as jest.Mock).mockReset();
+    (insertEvent as jest.Mock).mockReset();
   });
 
   it("creates a leave request", async () => {
@@ -79,5 +92,16 @@ describe("leave requests controller", () => {
       created_at: "now",
       updated_at: "now",
     });
+    expect(seedTimesheets).toHaveBeenCalledWith(1);
+    expect(insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "staff_leave",
+        startDate: "2024-01-02",
+        endDate: "2024-01-03",
+        createdBy: 1,
+        visibleToClients: true,
+        visibleToVolunteers: true,
+      }),
+    );
   });
 });

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -55,8 +55,9 @@ in `summary.ot_bank_remaining`.
 Staff can request vacation leave by posting to
 `/timesheets/:id/leave-requests`. Pending requests appear under the same path
 and globally via `/api/leave/requests` for admins. Approving a request applies
-vacation hours to that day and locks it from editing; rejection simply removes
-the request.
+vacation hours to that day and locks it from editing; an approved request also
+creates a `staff_leave` event visible to clients and volunteers. Rejection
+simply removes the request.
 
 ## Email settings
 


### PR DESCRIPTION
## Summary
- log staff leave in events table after prefilling timesheets
- expose insertEvent model helper for calendar events
- document auto-created staff leave events in timesheets docs

## Testing
- `npm test tests/leaveRequests.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b921d45218832da3592e02cbf7a3c8