### PR TITLE
feat: add vacation request dialog

### DIFF
--- a/MJ_FB_Frontend/src/api/leaveRequests.ts
+++ b/MJ_FB_Frontend/src/api/leaveRequests.ts
@@ -5,14 +5,15 @@ import type { ApiError } from './client';
 export interface LeaveRequest {
   id: number;
   timesheet_id: number;
-  work_date: string;
-  hours: number;
+  start_date: string;
+  end_date: string;
+  type: 'paid' | 'personal' | 'sick';
   status: 'pending' | 'approved' | 'rejected';
 }
 
 export async function createLeaveRequest(
   timesheetId: number,
-  data: { date: string; hours: number },
+  data: { type: string; start: string; end: string },
 ): Promise<LeaveRequest> {
   const res = await apiFetch(`${API_BASE}/timesheets/${timesheetId}/leave-requests`, {
     method: 'POST',
@@ -63,7 +64,11 @@ export function useAllLeaveRequests() {
 
 export function useCreateLeaveRequest(timesheetId: number) {
   const qc = useQueryClient();
-  return useMutation<LeaveRequest, ApiError, { date: string; hours: number }>({
+  return useMutation<
+    LeaveRequest,
+    ApiError,
+    { type: string; start: string; end: string }
+  >({
     mutationFn: data => createLeaveRequest(timesheetId, data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['leaveRequests', timesheetId] });

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -264,6 +264,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -257,6 +257,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -260,6 +260,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -255,6 +255,13 @@
       "pending": "Pending",
       "approved": "Approved",
       "rejected": "Rejected"
+    },
+    "request_vacation": "Request Vacation",
+    "type": "Type",
+    "types": {
+      "paid": "Paid",
+      "personal": "Personal",
+      "sick": "Sick"
     }
   },
   "client_note_label": "Client note (optional)",

--- a/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
@@ -12,13 +12,19 @@ export default function AdminLeaveRequests() {
   return (
     <Page title={t('leave.title')}>
       {requests.map(r => (
-        <Box key={r.id} sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 1 }}>
+        <Box
+          key={r.id}
+          sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 1 }}
+        >
           <Typography component="span" sx={{ flexGrow: 1 }}>
-            {formatLocaleDate(r.work_date)} - {r.hours}h
+            {formatLocaleDate(r.start_date)} - {formatLocaleDate(r.end_date)} {' '}
+            {t(`leave.types.${r.type}`)}
           </Typography>
           <Button
             size="small"
-            onClick={() => approve.mutate({ requestId: r.id, timesheetId: r.timesheet_id })}
+            onClick={() =>
+              approve.mutate({ requestId: r.id, timesheetId: r.timesheet_id })
+            }
           >
             {t('timesheets.approve_leave')}
           </Button>

--- a/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
@@ -1,9 +1,23 @@
-import { Box, Button, TextField, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import Page from '../../components/Page';
 import { useTimesheets } from '../../api/timesheets';
 import { useCreateLeaveRequest, useLeaveRequests } from '../../api/leaveRequests';
 import { formatLocaleDate } from '../../utils/date';
+import { useState } from 'react';
 
 export default function LeaveManagement() {
   const { t } = useTranslation();
@@ -12,48 +26,91 @@ export default function LeaveManagement() {
     timesheets.find(p => !p.approved_at) || timesheets[timesheets.length - 1];
   const leaveMutation = useCreateLeaveRequest(current?.id ?? 0);
   const { requests } = useLeaveRequests(current?.id);
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState('paid');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
 
   return (
     <Page title={t('leave.title')}>
       {current && (
         <Box sx={{ mt: 2 }}>
-          <Box
-            component="form"
-            sx={{ display: 'flex', gap: 1, mb: 3 }}
-            onSubmit={e => {
-              e.preventDefault();
-              const form = e.currentTarget as typeof e.currentTarget & {
-                date: { value: string };
-                hours: { value: string };
-              };
-              leaveMutation.mutate({
-                date: form.date.value,
-                hours: Number(form.hours.value),
-              });
-              form.reset();
-            }}
+          <Button
+            variant="contained"
+            size="small"
+            onClick={() => setOpen(true)}
+            sx={{ mb: 3 }}
           >
-            <TextField
-              name="date"
-              type="date"
-              size="small"
-              InputLabelProps={{ shrink: true }}
-            />
-            <TextField
-              name="hours"
-              type="number"
-              size="small"
-              defaultValue={8}
-            />
-            <Button type="submit" variant="contained">
-              {t('timesheets.submit')}
-            </Button>
-          </Box>
+            {t('leave.request_vacation')}
+          </Button>
+
+          <Dialog open={open} onClose={() => setOpen(false)}>
+            <Box
+              component="form"
+              onSubmit={e => {
+                e.preventDefault();
+                leaveMutation.mutate(
+                  { type, start, end },
+                  {
+                    onSuccess: () => {
+                      setOpen(false);
+                      setStart('');
+                      setEnd('');
+                      setType('paid');
+                    },
+                  },
+                );
+              }}
+            >
+              <DialogTitle>{t('leave.request_vacation')}</DialogTitle>
+              <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+                <FormControl size="small">
+                  <InputLabel>{t('leave.type')}</InputLabel>
+                  <Select
+                    label={t('leave.type')}
+                    value={type}
+                    onChange={e => setType(e.target.value)}
+                  >
+                    <MenuItem value="paid">{t('leave.types.paid')}</MenuItem>
+                    <MenuItem value="personal">{t('leave.types.personal')}</MenuItem>
+                    <MenuItem value="sick">{t('leave.types.sick')}</MenuItem>
+                  </Select>
+                </FormControl>
+                <TextField
+                  label={t('leave.start_date')}
+                  type="date"
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  value={start}
+                  onChange={e => setStart(e.target.value)}
+                />
+                <TextField
+                  label={t('leave.end_date')}
+                  type="date"
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  value={end}
+                  onChange={e => setEnd(e.target.value)}
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => setOpen(false)} size="small">
+                  {t('cancel')}
+                </Button>
+                <Button type="submit" variant="contained" size="small">
+                  {t('timesheets.submit')}
+                </Button>
+              </DialogActions>
+            </Box>
+          </Dialog>
 
           {requests.map(r => (
             <Box key={r.id} sx={{ mb: 1 }}>
               <Typography component="span" sx={{ mr: 1 }}>
-                {formatLocaleDate(r.work_date)} - {r.hours}h
+                {formatLocaleDate(r.start_date)} - {formatLocaleDate(r.end_date)}
+              </Typography>
+              <Typography component="span" sx={{ mr: 1 }}>
+                {t(`leave.types.${r.type}`)}
               </Typography>
               <Typography component="span">
                 {t(`leave.status.${r.status}`)}

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/LeaveManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/LeaveManagement.test.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
+import LeaveManagement from '../LeaveManagement';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockCreate = jest.fn();
+
+jest.mock('../../../api/leaveRequests', () => ({
+  useCreateLeaveRequest: () => ({ mutate: mockCreate }),
+  useLeaveRequests: () => ({ requests: [], isLoading: false, error: null }),
+}));
+
+jest.mock('../../../api/timesheets', () => ({
+  useTimesheets: () => ({
+    timesheets: [
+      {
+        id: 1,
+        staff_id: 1,
+        start_date: '2024-01-01',
+        end_date: '2024-01-07',
+        submitted_at: null,
+        approved_at: null,
+        total_hours: 0,
+        expected_hours: 0,
+        balance_hours: 0,
+        ot_hours: 0,
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe('LeaveManagement', () => {
+  it('submits a vacation request', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MemoryRouter>
+        <LeaveManagement />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Request Vacation' }));
+    await user.selectOptions(screen.getByLabelText('Type'), 'paid');
+    await user.type(screen.getByLabelText('Start Date'), '2024-06-01');
+    await user.type(screen.getByLabelText('End Date'), '2024-06-02');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      type: 'paid',
+      start: '2024-06-01',
+      end: '2024-06-02',
+    }, expect.anything());
+  });
+});

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -150,3 +150,8 @@ Add the following translation strings to locale files:
 - `leave.status.pending`
 - `leave.status.approved`
 - `leave.status.rejected`
+- `leave.request_vacation`
+- `leave.type`
+- `leave.types.paid`
+- `leave.types.personal`
+- `leave.types.sick`


### PR DESCRIPTION
## Summary
- allow staff to request vacation through a dialog with type and dates
- expand leave request API to accept type/start/end
- show type and date range on admin leave request view

## Testing
- `npm test` *(fails: Node v22 is required)*
- `npx jest` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b921b99d70832d9cefc2de8412833d