### PR TITLE
Auto-fill timesheet entries when leave approved

### DIFF
--- a/MJ_FB_Backend/src/models/leaveRequest.ts
+++ b/MJ_FB_Backend/src/models/leaveRequest.ts
@@ -5,6 +5,7 @@ export interface LeaveRequest {
   staff_id: number;
   start_date: string;
   end_date: string;
+  type: string;
   status: string;
   reason: string | null;
   created_at: string;
@@ -15,12 +16,13 @@ export async function insertLeaveRequest(
   staffId: number,
   startDate: string,
   endDate: string,
+  type: string,
   reason?: string,
 ): Promise<LeaveRequest> {
   const res = await pool.query(
-    `INSERT INTO leave_requests (staff_id, start_date, end_date, reason)
-     VALUES ($1, $2, $3, $4) RETURNING *`,
-    [staffId, startDate, endDate, reason ?? null],
+    `INSERT INTO leave_requests (staff_id, start_date, end_date, type, reason)
+     VALUES ($1, $2, $3, $4, $5) RETURNING *`,
+    [staffId, startDate, endDate, type, reason ?? null],
   );
   return res.rows[0];
 }

--- a/MJ_FB_Backend/tests/leaveRequests.test.ts
+++ b/MJ_FB_Backend/tests/leaveRequests.test.ts
@@ -1,4 +1,8 @@
 import "./setupTests";
+jest.mock("../src/models/timesheet", () => ({
+  insertLeaveTimesheetDay: jest.fn().mockResolvedValue(undefined),
+}));
+import { insertLeaveTimesheetDay } from "../src/models/timesheet";
 import {
   createLeaveRequest,
   approveLeaveRequest,
@@ -13,6 +17,7 @@ const makeRes = () => ({
 describe("leave requests controller", () => {
   afterEach(() => {
     (mockPool.query as jest.Mock).mockReset();
+    (insertLeaveTimesheetDay as jest.Mock).mockReset();
   });
 
   it("creates a leave request", async () => {
@@ -23,6 +28,7 @@ describe("leave requests controller", () => {
           staff_id: 1,
           start_date: "2024-01-02",
           end_date: "2024-01-03",
+          type: "vacation",
           status: "pending",
           reason: null,
           created_at: "now",
@@ -33,7 +39,7 @@ describe("leave requests controller", () => {
     });
     const req: any = {
       user: { id: "1", role: "staff", type: "staff" },
-      body: { startDate: "2024-01-02", endDate: "2024-01-03" },
+      body: { startDate: "2024-01-02", endDate: "2024-01-03", type: "vacation" },
     };
     const res = makeRes();
     await createLeaveRequest(req, res as any, () => {});
@@ -43,6 +49,7 @@ describe("leave requests controller", () => {
       staff_id: 1,
       start_date: "2024-01-02",
       end_date: "2024-01-03",
+      type: "vacation",
       status: "pending",
       reason: null,
       created_at: "now",
@@ -58,6 +65,7 @@ describe("leave requests controller", () => {
           staff_id: 1,
           start_date: "2024-01-02",
           end_date: "2024-01-03",
+          type: "sick",
           status: "approved",
           reason: null,
           created_at: "now",
@@ -74,10 +82,13 @@ describe("leave requests controller", () => {
       staff_id: 1,
       start_date: "2024-01-02",
       end_date: "2024-01-03",
+      type: "sick",
       status: "approved",
       reason: null,
       created_at: "now",
       updated_at: "now",
     });
+    expect(insertLeaveTimesheetDay).toHaveBeenNthCalledWith(1, 1, "2024-01-02", "sick");
+    expect(insertLeaveTimesheetDay).toHaveBeenNthCalledWith(2, 1, "2024-01-03", "sick");
   });
 });

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ TIMESHEET_APPROVER_EMAILS=admin1@example.com,admin2@example.com # optional
 ```
 
 Staff submit leave through `/api/leave/requests`; admins approve or reject via
-`/api/leave/requests/:id/approve` and `/api/leave/requests/:id/reject`.
+`/api/leave/requests/:id/approve` and `/api/leave/requests/:id/reject`. When
+approved, default sick or vacation hours are applied to the timesheet but remain
+editable by staff.
 
 Individuals who use the food bank are referred to as clients throughout the application.
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -54,9 +54,9 @@ in `summary.ot_bank_remaining`.
 
 Staff can request vacation leave by posting to
 `/timesheets/:id/leave-requests`. Pending requests appear under the same path
-and globally via `/api/leave/requests` for admins. Approving a request applies
-vacation hours to that day and locks it from editing; rejection simply removes
-the request.
+and globally via `/api/leave/requests` for admins. Approving a request
+automatically fills the day with default sick or vacation hours but keeps it
+editable; rejection simply removes the request.
 
 ## Email settings
 


### PR DESCRIPTION
## Summary
- auto-fill timesheet entries for each day of approved non-personal leave
- extend leave request records with type and wire through controller
- document that approved leave pre-populates timesheet hours but stays editable

## Testing
- `npm test` *(fails: Test Suites: 11 failed, 88 passed)*
- `npm test tests/leaveRequests.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b921d0fdc0832dad3360a014720707