### PR TITLE
Add vacation request dialog for leave management

### DIFF
--- a/MJ_FB_Frontend/src/api/leaveRequests.ts
+++ b/MJ_FB_Frontend/src/api/leaveRequests.ts
@@ -14,10 +14,9 @@ export interface LeaveRequest {
 }
 
 export async function createLeaveRequest(
-  timesheetId: number,
-  data: { date: string; hours: number },
+  data: { type: string; startDate: string; endDate: string },
 ): Promise<LeaveRequest> {
-  const res = await apiFetch(`${API_BASE}/timesheets/${timesheetId}/leave-requests`, {
+  const res = await apiFetch(`${API_BASE}/leave/requests`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
@@ -64,13 +63,19 @@ export function useAllLeaveRequests() {
   return { requests: data ?? [], isLoading: isFetching, error };
 }
 
-export function useCreateLeaveRequest(timesheetId: number) {
+export function useCreateLeaveRequest(timesheetId?: number) {
   const qc = useQueryClient();
-  return useMutation<LeaveRequest, ApiError, { date: string; hours: number }>({
-    mutationFn: data => createLeaveRequest(timesheetId, data),
+  return useMutation<
+    LeaveRequest,
+    ApiError,
+    { type: string; startDate: string; endDate: string }
+  >({
+    mutationFn: data => createLeaveRequest(data),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['leaveRequests', timesheetId] });
-      qc.invalidateQueries({ queryKey: ['timesheets', timesheetId, 'days'] });
+      if (timesheetId) {
+        qc.invalidateQueries({ queryKey: ['leaveRequests', timesheetId] });
+        qc.invalidateQueries({ queryKey: ['timesheets', timesheetId, 'days'] });
+      }
     },
   });
 }

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -110,7 +110,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -269,8 +269,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -110,7 +110,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -262,8 +262,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -265,8 +265,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -108,7 +108,7 @@
         "description": "Submit and track leave requests.",
         "steps": [
           "Open the Leave Management page from the profile menu.",
-          "Submit new leave requests with date and hours.",
+          "Submit new leave requests with type and dates.",
           "Review the status of your requests."
         ]
       }
@@ -260,8 +260,10 @@
     "status_label": "Status",
     "type": {
       "paid": "Paid",
-      "unpaid": "Unpaid"
-    }
+      "personal": "Personal",
+      "sick": "Sick"
+    },
+    "request_vacation": "Request Vacation"
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",

--- a/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
@@ -1,6 +1,14 @@
 import {
   Box,
   Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
   Table,
   TableBody,
   TableCell,
@@ -8,58 +16,105 @@ import {
   TableHead,
   TableRow,
   TextField,
-  Typography,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import Page from '../../components/Page';
 import { useTimesheets } from '../../api/timesheets';
 import { useCreateLeaveRequest, useLeaveRequests } from '../../api/leaveRequests';
 import { formatLocaleDate } from '../../utils/date';
+import { useState } from 'react';
 
 export default function LeaveManagement() {
   const { t } = useTranslation();
   const { timesheets } = useTimesheets();
   const current =
     timesheets.find(p => !p.approved_at) || timesheets[timesheets.length - 1];
-  const leaveMutation = useCreateLeaveRequest(current?.id ?? 0);
+  const leaveMutation = useCreateLeaveRequest(current?.id);
   const { requests } = useLeaveRequests(current?.id);
+  const [open, setOpen] = useState(false);
 
   return (
     <Page title={t('leave.title')}>
       {current && (
         <Box sx={{ mt: 2 }}>
-          <Box
-            component="form"
-            sx={{ display: 'flex', gap: 1, mb: 3 }}
-            onSubmit={e => {
-              e.preventDefault();
-              const form = e.currentTarget as typeof e.currentTarget & {
-                date: { value: string };
-                hours: { value: string };
-              };
-              leaveMutation.mutate({
-                date: form.date.value,
-                hours: Number(form.hours.value),
-              });
-              form.reset();
-            }}
+          <Button
+            variant="contained"
+            size="small"
+            onClick={() => setOpen(true)}
+            sx={{ mb: 3 }}
           >
-            <TextField
-              name="date"
-              type="date"
-              size="small"
-              InputLabelProps={{ shrink: true }}
-            />
-            <TextField
-              name="hours"
-              type="number"
-              size="small"
-              defaultValue={8}
-            />
-            <Button type="submit" variant="contained">
-              {t('timesheets.submit')}
-            </Button>
-          </Box>
+            {t('leave.request_vacation')}
+          </Button>
+          <Dialog open={open} onClose={() => setOpen(false)}>
+            <Box
+              component="form"
+              onSubmit={e => {
+                e.preventDefault();
+                const form = e.currentTarget as typeof e.currentTarget & {
+                  type: { value: string };
+                  start: { value: string };
+                  end: { value: string };
+                };
+                leaveMutation.mutate(
+                  {
+                    type: form.type.value,
+                    startDate: form.start.value,
+                    endDate: form.end.value,
+                  },
+                  { onSuccess: () => setOpen(false) },
+                );
+              }}
+            >
+              <DialogTitle>{t('leave.request_vacation')}</DialogTitle>
+              <DialogContent
+                sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+              >
+                <FormControl size="small">
+                  <InputLabel id="leave-type-label">
+                    {t('leave.type_label')}
+                  </InputLabel>
+                  <Select
+                    labelId="leave-type-label"
+                    name="type"
+                    label={t('leave.type_label')}
+                    defaultValue="paid"
+                  >
+                    <MenuItem value="paid">{t('leave.type.paid')}</MenuItem>
+                    <MenuItem value="personal">
+                      {t('leave.type.personal')}
+                    </MenuItem>
+                    <MenuItem value="sick">{t('leave.type.sick')}</MenuItem>
+                  </Select>
+                </FormControl>
+                <TextField
+                  name="start"
+                  type="date"
+                  size="small"
+                  label={t('leave.start_date')}
+                  InputLabelProps={{ shrink: true }}
+                />
+                <TextField
+                  name="end"
+                  type="date"
+                  size="small"
+                  label={t('leave.end_date')}
+                  InputLabelProps={{ shrink: true }}
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button
+                  size="small"
+                  onClick={() => setOpen(false)}
+                  color="inherit"
+                >
+                  {t('cancel')}
+                </Button>
+                <Button type="submit" variant="contained" size="small">
+                  {t('submit')}
+                </Button>
+              </DialogActions>
+            </Box>
+          </Dialog>
 
           <TableContainer>
             <Table size="small">

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/LeaveManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/LeaveManagement.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
+import LeaveManagement from '../LeaveManagement';
+
+const mockMutate = jest.fn();
+
+jest.mock('../../../api/timesheets', () => ({
+  useTimesheets: () => ({
+    timesheets: [
+      {
+        id: 1,
+        start_date: '2024-01-01',
+        end_date: '2024-01-07',
+        approved_at: null,
+      },
+    ],
+  }),
+}));
+
+jest.mock('../../../api/leaveRequests', () => ({
+  useCreateLeaveRequest: () => ({ mutate: mockMutate }),
+  useLeaveRequests: () => ({ requests: [], isLoading: false, error: null }),
+}));
+
+describe('LeaveManagement', () => {
+  it('submits leave request', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MemoryRouter>
+        <LeaveManagement />
+      </MemoryRouter>,
+    );
+    await user.click(
+      screen.getByRole('button', { name: /request vacation/i }),
+    );
+    await user.type(screen.getByLabelText(/start date/i), '2024-01-01');
+    await user.type(screen.getByLabelText(/end date/i), '2024-01-02');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        type: 'paid',
+        startDate: '2024-01-01',
+        endDate: '2024-01-02',
+      },
+      expect.any(Object),
+    );
+  });
+});

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -158,3 +158,6 @@ Add the following translation strings to locale files:
 - `leave.status.pending`
 - `leave.status.approved`
 - `leave.status.rejected`
+- `leave.request_vacation`
+- `leave.type.personal`
+- `leave.type.sick`


### PR DESCRIPTION
## Summary
- add Request Vacation dialog with leave type and date range
- extend leave API helper for type and date parameters
- localize new leave request strings

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*
- `npx jest src/pages/staff/__tests__/LeaveManagement.test.tsx` *(fails: ReferenceError: clearImmediate is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a16e7c5c832dba1b408965c54e3f