### PR TITLE
Default password setup template ID

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -35,8 +35,8 @@ BREVO_FROM_NAME=MJ Food Bank
 EMAIL_QUEUE_MAX_RETRIES=5
 # Initial backoff delay in ms for email retries (optional, default 1000)
 EMAIL_QUEUE_BACKOFF_MS=1000
-# Brevo template ID used for invitation and password setup emails
-PASSWORD_SETUP_TEMPLATE_ID=1
+# Brevo template ID used for invitation and password setup emails (optional, defaults to 1478167)
+PASSWORD_SETUP_TEMPLATE_ID=1478167
 # Hours until password setup tokens expire (optional, default 24)
 PASSWORD_SETUP_TOKEN_TTL_HOURS=24
 

--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -41,7 +41,7 @@ Authentication cookies are scoped to the `/` path and use the same options when 
 
 `PASSWORD_SETUP_TOKEN_TTL_HOURS` – Hours until password setup tokens expire (default 24).
 
-`PASSWORD_SETUP_TEMPLATE_ID` – Brevo template ID used for password setup emails.
+`PASSWORD_SETUP_TEMPLATE_ID` – Brevo template ID used for password setup emails (default 1478167).
 
 `VOLUNTEER_NO_SHOW_HOURS` – Hours to wait before marking a volunteer shift as no-show (default 24).
 

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -21,7 +21,7 @@ const envSchema = z.object({
   BREVO_FROM_NAME: z.string().optional(),
   EMAIL_QUEUE_MAX_RETRIES: z.coerce.number().default(5),
   EMAIL_QUEUE_BACKOFF_MS: z.coerce.number().default(1000),
-  PASSWORD_SETUP_TEMPLATE_ID: z.coerce.number(),
+  PASSWORD_SETUP_TEMPLATE_ID: z.coerce.number().default(1478167),
   BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),

--- a/MJ_FB_Backend/tests/config.test.ts
+++ b/MJ_FB_Backend/tests/config.test.ts
@@ -4,6 +4,7 @@ describe('config', () => {
   const originalFrontend = process.env.FRONTEND_ORIGIN;
   const originalJwt = process.env.JWT_SECRET;
   const originalRefresh = process.env.JWT_REFRESH_SECRET;
+  const originalPasswordTemplate = process.env.PASSWORD_SETUP_TEMPLATE_ID;
 
   afterEach(() => {
     if (originalFrontend === undefined) {
@@ -20,6 +21,11 @@ describe('config', () => {
       delete process.env.JWT_REFRESH_SECRET;
     } else {
       process.env.JWT_REFRESH_SECRET = originalRefresh;
+    }
+    if (originalPasswordTemplate === undefined) {
+      delete process.env.PASSWORD_SETUP_TEMPLATE_ID;
+    } else {
+      process.env.PASSWORD_SETUP_TEMPLATE_ID = originalPasswordTemplate;
     }
     jest.resetModules();
   });
@@ -60,5 +66,12 @@ describe('config', () => {
     delete process.env.JWT_REFRESH_SECRET;
     jest.resetModules();
     expect(() => require('../src/config')).toThrow(/JWT_REFRESH_SECRET/);
+  });
+
+  it('defaults PASSWORD_SETUP_TEMPLATE_ID to 1478167 when missing', () => {
+    delete process.env.PASSWORD_SETUP_TEMPLATE_ID;
+    jest.resetModules();
+    const config = require('../src/config').default;
+    expect(config.passwordSetupTemplateId).toBe(1478167);
   });
 });

--- a/MJ_FB_Backend/tests/setupEnv.ts
+++ b/MJ_FB_Backend/tests/setupEnv.ts
@@ -12,7 +12,7 @@ process.env.BREVO_API_KEY = 'test-api-key';
 process.env.BREVO_FROM_EMAIL = 'noreply@example.com';
 process.env.BREVO_FROM_NAME = 'MJ Food Bank';
 process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS = '24';
-process.env.PASSWORD_SETUP_TEMPLATE_ID = '1';
+process.env.PASSWORD_SETUP_TEMPLATE_ID = '1478167';
 
 const requiredEnvVars = [
   'JWT_SECRET',
@@ -27,7 +27,6 @@ const requiredEnvVars = [
   'BREVO_FROM_EMAIL',
   'BREVO_FROM_NAME',
   'PASSWORD_SETUP_TOKEN_TTL_HOURS',
-  'PASSWORD_SETUP_TEMPLATE_ID',
 ];
 
 const missing = requiredEnvVars.filter((key) => !process.env[key]);

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `BREVO_FROM_NAME`                            | Optional sender name displayed in emails                                                                                                  |
 | `EMAIL_QUEUE_MAX_RETRIES`                    | Max retry attempts for failed email jobs (default 5)                                                                                      |
 | `EMAIL_QUEUE_BACKOFF_MS`                     | Initial backoff delay in ms for email retries (default 1000)                                                                              |
-| `PASSWORD_SETUP_TEMPLATE_ID`                 | Brevo template ID for invitation and password setup emails                                                                                |
+| `PASSWORD_SETUP_TEMPLATE_ID`                 | Brevo template ID for invitation and password setup emails (default 1478167)                                                                                |
 | `BOOKING_CONFIRMATION_TEMPLATE_ID`           | Brevo template ID for booking confirmation emails                                                                                         |
 | `BOOKING_REMINDER_TEMPLATE_ID`               | Brevo template ID for booking reminder emails                                                                                             |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                                                                                     |


### PR DESCRIPTION
## Summary
- default PASSWORD_SETUP_TEMPLATE_ID to 1478167 when missing
- document default template ID in backend docs and examples
- cover default behavior with config test

## Testing
- `npm test` *(fails: Test Suites: 11 failed, 88 passed)*
- `npm test tests/config.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6c52ba8832d9a441a45dccca2b9