### PR TITLE
Allow admin access on staff timesheet and leave routes

### DIFF
--- a/MJ_FB_Backend/src/routes/leaveRequests.ts
+++ b/MJ_FB_Backend/src/routes/leaveRequests.ts
@@ -10,7 +10,7 @@ import {
 const router = express.Router();
 
 router.get("/", authMiddleware, authorizeRoles("admin"), listLeaveRequests);
-router.post("/", authMiddleware, authorizeRoles("staff"), createLeaveRequest);
+router.post("/", authMiddleware, authorizeRoles("staff", "admin"), createLeaveRequest);
 router.post(
   "/:id/approve",
   authMiddleware,

--- a/MJ_FB_Backend/src/routes/timesheets.ts
+++ b/MJ_FB_Backend/src/routes/timesheets.ts
@@ -13,7 +13,7 @@ import {
 const router = express.Router();
 
 // list pay periods for the logged in staff member
-router.get('/mine', authMiddleware, authorizeRoles('staff'), listMyTimesheets);
+router.get('/mine', authMiddleware, authorizeRoles('staff', 'admin'), listMyTimesheets);
 // admin can list timesheets for any staff
 router.get('/', authMiddleware, authorizeRoles('admin'), listTimesheets);
 router.get(
@@ -22,8 +22,8 @@ router.get(
   authorizeRoles('staff', 'admin'),
   getTimesheetDays,
 );
-router.patch('/:id/days/:date', authMiddleware, authorizeRoles('staff'), updateTimesheetDay);
-router.post('/:id/submit', authMiddleware, authorizeRoles('staff'), submitTimesheet);
+router.patch('/:id/days/:date', authMiddleware, authorizeRoles('staff', 'admin'), updateTimesheetDay);
+router.post('/:id/submit', authMiddleware, authorizeRoles('staff', 'admin'), submitTimesheet);
 router.post('/:id/reject', authMiddleware, authorizeRoles('admin'), rejectTimesheet);
 router.post('/:id/process', authMiddleware, authorizeRoles('admin'), processTimesheet);
 


### PR DESCRIPTION
## Summary
- permit `admin` users to view and submit timesheets and modify day entries
- allow `admin` to create leave requests alongside `staff`

## Testing
- `npm test` *(fails: 11 failed, 88 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b55849cc832d8a5b9efd61e43d70