### PR TITLE
Ensure logout clears session cookie on storage changes

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AuthProvider.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AuthProvider.test.tsx
@@ -57,6 +57,7 @@ describe('AuthProvider cardUrl cleanup', () => {
     (apiFetch as jest.Mock)
       .mockResolvedValueOnce({ ok: true, status: 200 })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cardUrl: '/card.pdf' }) });
+    (apiLogout as jest.Mock).mockResolvedValue(undefined);
 
     renderWithProviders(<TestComponent />);
 
@@ -71,6 +72,7 @@ describe('AuthProvider cardUrl cleanup', () => {
     await waitFor(() =>
       expect(screen.getByTestId('card')).toHaveTextContent(''),
     );
+    expect(apiLogout).toHaveBeenCalled();
   });
 });
 

--- a/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/useAuthRefresh.test.tsx
@@ -62,4 +62,18 @@ describe('AuthProvider with no prior session', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     expect(screen.queryByText('Session expired')).toBeNull();
   });
+
+  it('does not set token when refresh succeeds without auth', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+
+    function Child() {
+      const { token, ready } = useAuth();
+      return <div>{ready ? token : ''}</div>;
+    }
+
+    renderWithProviders(<Child />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByText('cookie')).toBeNull();
+  });
 });

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -71,6 +71,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       if (!newRole || !newName) {
         clearAuth();
+        void apiLogout();
         setSessionMessage('Session ended in another tab');
       } else {
         setRole(newRole as Role);
@@ -97,11 +98,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const res = await apiFetch(`${API_BASE}/auth/refresh`, {
           method: 'POST',
         });
+        const hasRole = !!localStorage.getItem('role');
         if (res.ok) {
-          if (active) setToken('cookie');
+          if (active && hasRole) setToken('cookie');
         } else if (res.status === 409) {
           // Another tab already refreshed; token cookie is still valid
-          if (active) setToken('cookie');
+          if (active && hasRole) setToken('cookie');
         } else if (res.status === 401) {
           if (active) handleExpired();
         } else if (tries < 1) {


### PR DESCRIPTION
## Summary
- Call logout endpoint when localStorage loses auth data to remove cookie
- Prevent refresh from re-establishing token when no role is stored
- Cover new behavior in auth provider tests

## Testing
- `npm test` *(fails: fetchWithRetry, BookingUI, StaffRecurringBookings, NoShowWeek, PasswordSetup, AgencyAccess, AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c9abfab4832da4c6a1fe01c8252c