### PR TITLE
test: show both booking notes

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -133,5 +133,33 @@ describe('UserHistory', () => {
     expect(screen.getByText(/has staff note/i)).toBeInTheDocument();
     expect(screen.getByText(/client note here/i)).toBeInTheDocument();
   });
+
+  it('shows both client and staff note labels for visited bookings', async () => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'visited',
+        date: '2024-01-01',
+        start_time: null,
+        end_time: null,
+        created_at: '2024-01-01',
+        slot_id: null,
+        is_staff_booking: false,
+        reschedule_token: null,
+        client_note: 'client note',
+        staff_note: 'staff note',
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
+    expect(screen.getByText(/Client note/i)).toBeInTheDocument();
+    expect(screen.getByText(/Staff note/i)).toBeInTheDocument();
+  });
 });
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -4,6 +4,8 @@ Clients can enter a **client note** when booking an appointment. The client note
 
 Staff can add a **staff note** when recording client visits in the pantry schedule. Staff notes are stored with the visit.
 
+Staff history views display both notes for visited bookings, reinforcing expected behaviour.
+
 Staff users automatically receive staff notes in booking history responses. Agency users can include staff notes by adding `includeStaffNotes=true` to `/bookings/history`. Both roles can filter visit history by note text using the `notes` query parameter. The notes-only filter matches visits that contain either client or staff notes.
 
 ## Environment variables


### PR DESCRIPTION
## Summary
- verify staff history shows both client and staff notes
- document that staff history displays both note types

## Testing
- `npm test src/__tests__/UserHistory.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9ca6a055c832d8fff394e7514b328