### PR TITLE
Hide notes-only filter from client booking history

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -79,6 +79,22 @@ describe('UserHistory', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('hides notes filter for non-staff users', async () => {
+    mockUseAuth.mockReturnValue({ role: 'shopper' } as any);
+    (getBookingHistory as jest.Mock).mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
+    expect(
+      screen.queryByLabelText('View visits with notes only')
+    ).not.toBeInTheDocument();
+  });
+
   it('filters visits with notes only', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([
       {

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -227,15 +227,17 @@ export default function UserHistory({
                 <MenuItem value="past">{t('past')}</MenuItem>
               </Select>
             </FormControl>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={notesOnly}
-                  onChange={e => setNotesOnly(e.target.checked)}
-                />
-              }
-              label={t('visits_with_notes_only')}
-            />
+            {role === 'staff' && (
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={notesOnly}
+                    onChange={e => setNotesOnly(e.target.checked)}
+                  />
+                }
+                label={t('visits_with_notes_only')}
+              />
+            )}
             <TableContainer sx={{ overflowX: 'auto' }}>
               <Table size="small" sx={{ width: '100%', borderCollapse: 'collapse' }}>
                 <TableHead>

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -6,6 +6,8 @@ Staff can add a **staff note** when recording client visits in the pantry schedu
 
 Staff users automatically receive staff notes in booking history responses. Agency users can include staff notes by adding `includeStaffNotes=true` to `/bookings/history`. Both roles can filter visit history by note text using the `notes` query parameter. The notes-only filter matches visits that contain either client or staff notes.
 
+The "visits with notes only" filter appears only on staff booking history pages and is hidden from clients.
+
 ## Environment variables
 
 This feature does not require any additional environment variables.


### PR DESCRIPTION
## Summary
- show "visits with notes only" filter only to staff in booking history
- add tests for hiding notes filter from clients
- document that the notes-only filter is staff-only

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca54660c832d8ffc4056414c36d8