### PR TITLE
Expose staff visit notes in booking history

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -202,9 +202,11 @@ export async function fetchBookingHistory(
     `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.start_time END AS start_time,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.end_time END AS end_time,
-            b.created_at, b.is_staff_booking, b.reschedule_token, b.note AS client_note
+            b.created_at, b.is_staff_booking, b.reschedule_token, b.note AS client_note,
+            v.note AS staff_note
        FROM bookings b
        LEFT JOIN slots s ON b.slot_id = s.id
+       LEFT JOIN client_visits v ON v.client_id = b.user_id AND v.date = b.date
        WHERE ${where}
        ORDER BY b.created_at DESC${limitOffset}`,
     params,

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -150,4 +150,14 @@ describe('bookingRepository', () => {
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/LEFT JOIN\s+slots\s+s\s+ON b.slot_id = s.id/);
   });
+
+  it('fetchBookingHistory LEFT JOINs client_visits for staff notes', async () => {
+    setQueryResults({ rows: [] });
+    await fetchBookingHistory([1], false, undefined, false);
+    const call = (mockPool.query as jest.Mock).mock.calls[0];
+    expect(call[0]).toMatch(
+      /LEFT JOIN\s+client_visits\s+v\s+ON v.client_id = b.user_id AND v.date = b.date/,
+    );
+    expect(call[0]).toMatch(/v.note AS staff_note/);
+  });
 });


### PR DESCRIPTION
## Summary
- include staff visit notes in `fetchBookingHistory` by joining `client_visits`
- verify repository query joins `client_visits`
- test visibility so staff see both client and staff notes while shoppers only see client notes

## Testing
- `npm test -- tests/bookingRepository.test.ts tests/includeStaffNotesAuth.test.ts`
- `npm test` *(fails: Test Suites: 10 failed, 89 passed, 99 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca5cdce0832da1e964ab51db0524