### PR TITLE
Clarify booking history note handling

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -51,6 +51,8 @@ Tests load these variables via `tests/setupTests.ts`, which imports `tests/setup
 
 Clients may include a **client note** when booking. Staff can record a **staff note** when marking a visit in the pantry schedule. Staff users automatically receive staff notes from `/bookings/history`; agency users can append `includeStaffNotes=true` to retrieve them. The `notes` query parameter filters history by note text.
 
+Booking history joins bookings with `client_visits` and only exposes `staff_note` when the requester is staff or `includeStaffNotes=true`.
+
 ## Password Policy
 
 Passwords must be at least 8 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character. Requests with weak passwords are rejected before hashing.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Before merging a pull request, confirm the following:
 - Booking requests are automatically approved; the submitted state has been removed.
 - Booking confirmations display "Shift booked"; the volunteer dashboard shows only approved bookings.
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
+- When `includeStaffNotes=true` or the requester is staff, `/bookings/history` returns both `client_note` and `staff_note` for each entry.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
 - Agencies can list bookings for their linked clients via `/bookings?clientIds=1,2`.
 - **Volunteer Recurring Bookings** let volunteers schedule repeating shifts with start and end dates, choose daily, weekly, or weekday patterns, and cancel individual occurrences or the remaining series.


### PR DESCRIPTION
## Summary
- Document that `/bookings/history` returns both `client_note` and `staff_note` when the requester is staff or `includeStaffNotes=true`
- Highlight backend booking history join with `client_visits` and conditional `staff_note` exposure

## Testing
- `npm test` *(fails: Test Suites: 11 failed, 88 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca6fdd80832da34d97523d06644b