### PR TITLE
Add booking history notes test

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -181,7 +181,7 @@ export async function fetchBookingHistory(
   client: Queryable = pool,
 ) {
   const params: any[] = [userIds];
-  let where = `b.user_id = ANY($1)`;
+  let where = `b.user_id = ANY($1::int[])`;
   if (past) {
     where += ' AND b.date < CURRENT_DATE';
   }
@@ -202,16 +202,18 @@ export async function fetchBookingHistory(
     `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.start_time END AS start_time,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.end_time END AS end_time,
-            b.created_at, b.is_staff_booking, b.reschedule_token, b.note AS client_note
+            b.created_at, b.is_staff_booking, b.reschedule_token, b.note AS client_note,
+            cv.note AS staff_note
        FROM bookings b
        LEFT JOIN slots s ON b.slot_id = s.id
+       LEFT JOIN client_visits cv ON cv.client_id = b.user_id AND cv.date = b.date
        WHERE ${where}
        ORDER BY b.created_at DESC${limitOffset}`,
     params,
   );
   let rows = res.rows;
   if (includeVisits && (!status || status === 'visited')) {
-    const visitWhere = ['c.client_id = ANY($1)'];
+    const visitWhere = ['c.client_id = ANY($1::int[])'];
     if (past) {
       visitWhere.push('v.date < CURRENT_DATE');
     }


### PR DESCRIPTION
## Summary
- include staff notes in `fetchBookingHistory` by joining `client_visits`
- test booking history returns both client and staff notes

## Testing
- `npm test tests/bookingRepository.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9ca73cae4832d9318be5538a6c2d3