### PR TITLE
Remove client notes from booking history

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
@@ -85,7 +85,7 @@ describe('Agency ClientHistory', () => {
         includeStaffNotes: true,
       }),
     );
-    expect(await screen.findByText(/client note/i)).toBeInTheDocument();
-    expect(screen.getByText(/staff note/i)).toBeInTheDocument();
+    expect(screen.queryByText(/client note/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/staff note/i, { selector: 'p' })).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
@@ -64,7 +64,7 @@ describe('ClientDashboard', () => {
     expect(chipLabel.closest('.MuiChip-colorSuccess')).toBeTruthy();
   });
 
-  it('shows client note in booking history', async () => {
+  it('hides client note in booking history', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([
       {
         id: 1,
@@ -85,6 +85,6 @@ describe('ClientDashboard', () => {
     );
 
     await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
-    expect(await screen.findByText('bring bag')).toBeInTheDocument();
+    expect(screen.queryByText('bring bag')).not.toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -147,10 +147,10 @@ describe('UserHistory', () => {
 
     expect(screen.getAllByText(/visited/i)).toHaveLength(2);
     expect(screen.getByText(/has staff note/i)).toBeInTheDocument();
-    expect(screen.getByText(/client note here/i)).toBeInTheDocument();
+    expect(screen.queryByText(/client note here/i)).not.toBeInTheDocument();
   });
 
-  it('shows both client and staff note labels for visited bookings', async () => {
+  it('shows staff note for visited bookings', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([
       {
         id: 1,
@@ -162,7 +162,6 @@ describe('UserHistory', () => {
         slot_id: null,
         is_staff_booking: false,
         reschedule_token: null,
-        client_note: 'client note',
         staff_note: 'staff note',
       },
     ]);
@@ -174,8 +173,8 @@ describe('UserHistory', () => {
     );
 
     await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
-    expect(screen.getByText(/Client note/i)).toBeInTheDocument();
-    expect(screen.getByText(/Staff note/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Client note/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/staff note/i, { selector: 'p' })).toBeInTheDocument();
   });
 });
 

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -282,6 +282,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -275,6 +275,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -278,6 +278,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -273,6 +273,5 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only",
-  "notes": "Notes"
+  "visits_with_notes_only": "View visits with notes only"
 }

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -174,7 +174,7 @@ export default function ClientHistory() {
                     <TableCell sx={cellSx}>{t('time')}</TableCell>
                     <TableCell sx={cellSx}>{t('status')}</TableCell>
                     <TableCell sx={cellSx}>{t('reason')}</TableCell>
-                    <TableCell sx={cellSx}>{t('notes')}</TableCell>
+                    <TableCell sx={cellSx}>{t('staff_note_label')}</TableCell>
                     <TableCell sx={cellSx}>{t('actions')}</TableCell>
                   </TableRow>
                 </TableHead>
@@ -204,15 +204,8 @@ export default function ClientHistory() {
                         <TableCell sx={cellSx}>{t(b.status)}</TableCell>
                         <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
                         <TableCell sx={cellSx}>
-                          {b.client_note && (
-                            <Typography variant="body2">
-                              {t('client_note_label')}: {b.client_note}
-                            </Typography>
-                          )}
                           {b.staff_note && (
-                            <Typography variant="body2">
-                              {t('staff_note_label')}: {b.staff_note}
-                            </Typography>
+                            <Typography variant="body2">{b.staff_note}</Typography>
                           )}
                         </TableCell>
                         <TableCell sx={cellSx}>

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -171,7 +171,6 @@ export default function ClientDashboard() {
                       primary={`${formatDate(next.date)} ${formatTime(
                         next.start_time || '',
                       )}`}
-                      secondary={next.client_note || undefined}
                     />
                   </ListItem>
                 </List>
@@ -211,7 +210,6 @@ export default function ClientDashboard() {
                         primary={
                           time ? `${formatDate(b.date)} ${time}` : formatDate(b.date)
                         }
-                        secondary={b.client_note || undefined}
                       />
                     </ListItem>
                   );

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -72,6 +72,7 @@ export default function UserHistory({
   });
   const { t } = useTranslation();
   const { role } = useAuth();
+  const showNotes = role === 'staff' || role === 'agency';
 
   const pageSize = 10;
 
@@ -246,14 +247,16 @@ export default function UserHistory({
                     <TableCell sx={cellSx}>{t('time')}</TableCell>
                     <TableCell sx={cellSx}>{t('status')}</TableCell>
                     <TableCell sx={cellSx}>{t('reason')}</TableCell>
-                    <TableCell sx={cellSx}>{t('notes')}</TableCell>
+                    {showNotes && (
+                      <TableCell sx={cellSx}>{t('staff_note_label')}</TableCell>
+                    )}
                     <TableCell sx={cellSx}>{t('actions')}</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {paginated.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={6} sx={{ textAlign: 'center' }}>
+                      <TableCell colSpan={showNotes ? 6 : 5} sx={{ textAlign: 'center' }}>
                         {t('no_bookings')}
                       </TableCell>
                     </TableRow>
@@ -275,18 +278,13 @@ export default function UserHistory({
                         </TableCell>
                         <TableCell sx={cellSx}>{t(b.status)}</TableCell>
                         <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
-                        <TableCell sx={cellSx}>
-                          {b.client_note && (
-                            <Typography variant="body2">
-                              {t('client_note_label')}: {b.client_note}
-                            </Typography>
-                          )}
-                          {b.staff_note && (
-                            <Typography variant="body2">
-                              {t('staff_note_label')}: {b.staff_note}
-                            </Typography>
-                          )}
-                        </TableCell>
+                        {showNotes && (
+                          <TableCell sx={cellSx}>
+                            {b.staff_note && (
+                              <Typography variant="body2">{b.staff_note}</Typography>
+                            )}
+                          </TableCell>
+                        )}
                         <TableCell sx={cellSx}>
                           {['approved'].includes(
                             b.status.toLowerCase()

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -4,7 +4,7 @@ Clients can enter a **client note** when booking an appointment. The client note
 
 Staff can add a **staff note** when recording client visits in the pantry schedule. Staff notes are stored with the visit.
 
-Staff history views display both notes for visited bookings, reinforcing expected behaviour.
+Staff and agency history views display only staff notes for visited bookings; client notes remain hidden.
 
 Staff users automatically receive staff notes in booking history responses. Agency users can include staff notes by adding `includeStaffNotes=true` to `/bookings/history`. Both roles can filter visit history by note text using the `notes` query parameter. The notes-only filter matches visits that contain either client or staff notes.
 
@@ -22,7 +22,6 @@ Add the following translation strings to locale files:
 - `dashboard`
 - `client_note_label`
 - `staff_note_label`
-- `notes`
 - `visits_with_notes_only`
 
 Document any new translation keys here when extending note functionality.


### PR DESCRIPTION
## Summary
- Hide client notes on the client dashboard and booking history tables
- Show only staff notes in staff/agency booking history
- Drop unused `notes` translation keys

## Testing
- `npm test -- src/__tests__/ClientDashboard.test.tsx src/__tests__/UserHistory.test.tsx src/__tests__/AgencyClientHistory.test.tsx`
- `npm test` *(fails: multiple existing test failures and environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d9b08c1c832d8dbc53868ba24aae