### PR TITLE
Hide notes for completed or no-show bookings

### DIFF
--- a/MJ_FB_Backend/tests/bookingHistoryNotes.test.ts
+++ b/MJ_FB_Backend/tests/bookingHistoryNotes.test.ts
@@ -47,7 +47,7 @@ describe('booking history notes', () => {
     (bookingRepository.fetchBookingHistory as jest.Mock).mockResolvedValue([
       {
         id: 1,
-        status: 'visited',
+        status: 'approved',
         date: '2024-01-01',
         slot_id: 1,
         reason: null,
@@ -69,6 +69,7 @@ describe('booking history notes', () => {
         created_at: '2024-01-02',
         is_staff_booking: false,
         reschedule_token: null,
+        client_note: null,
         staff_note: 'visit note',
       },
     ]);
@@ -77,7 +78,7 @@ describe('booking history notes', () => {
     expect(res.status).toBe(200);
     expect(res.body[0].client_note).toBe('bring ID');
     expect(res.body[0].staff_note).toBeUndefined();
-    expect(res.body[1].client_note).toBeUndefined();
+    expect(res.body[1].client_note).toBeNull();
     expect(res.body[1].staff_note).toBeUndefined();
   });
 });

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -161,7 +161,7 @@ describe('bookingRepository', () => {
     expect(call[0]).toMatch(/v.note AS staff_note/);
   });
 
-  it('fetchBookingHistory returns client and staff notes for booking when includeVisits is true', async () => {
+  it('fetchBookingHistory returns staff notes and null client notes for visited bookings when includeVisits is true', async () => {
     (mockPool.query as jest.Mock)
       .mockResolvedValueOnce({
         rows: [
@@ -176,7 +176,7 @@ describe('bookingRepository', () => {
             created_at: '2024-01-01',
             is_staff_booking: false,
             reschedule_token: null,
-            client_note: 'bring ID',
+            client_note: null,
             staff_note: 'visit note',
           },
         ],
@@ -185,7 +185,14 @@ describe('bookingRepository', () => {
 
     const rows = await fetchBookingHistory([1], false, undefined, true);
     expect(rows).toHaveLength(1);
-    expect(rows[0].client_note).toBe('bring ID');
+    expect(rows[0].client_note).toBeNull();
     expect(rows[0].staff_note).toBe('visit note');
+  });
+
+  it('fetchBookingHistory can omit client notes when includeClientNotes is false', async () => {
+    setQueryResults({ rows: [] });
+    await fetchBookingHistory([1], false, undefined, false, undefined, undefined, false);
+    const call = (mockPool.query as jest.Mock).mock.calls[0];
+    expect(call[0]).toMatch(/NULL AS client_note/);
   });
 });

--- a/MJ_FB_Backend/tests/includeStaffNotesAuth.test.ts
+++ b/MJ_FB_Backend/tests/includeStaffNotesAuth.test.ts
@@ -60,7 +60,7 @@ describe('includeStaffNotes handling', () => {
     (fetchBookingHistory as jest.Mock).mockResolvedValue([
       {
         id: 1,
-        status: 'visited',
+        status: 'approved',
         date: '2024-01-01',
         slot_id: 1,
         reason: null,
@@ -82,6 +82,7 @@ describe('includeStaffNotes handling', () => {
         created_at: '2024-01-02',
         is_staff_booking: false,
         reschedule_token: null,
+        client_note: null,
         staff_note: 'visit note',
       },
     ]);
@@ -125,7 +126,7 @@ describe('includeStaffNotes handling', () => {
     (fetchBookingHistory as jest.Mock).mockResolvedValue([
       {
         id: 1,
-        status: 'visited',
+        status: 'approved',
         date: '2024-01-01',
         slot_id: 1,
         reason: null,
@@ -147,6 +148,7 @@ describe('includeStaffNotes handling', () => {
         created_at: '2024-01-02',
         is_staff_booking: false,
         reschedule_token: null,
+        client_note: null,
         staff_note: 'visit note',
       },
     ]);
@@ -156,11 +158,11 @@ describe('includeStaffNotes handling', () => {
     expect(res.body[1].staff_note).toBeUndefined();
   });
 
-  it('shows both notes to staff but hides staff notes from shoppers', async () => {
+  it('shows staff notes only to staff while shoppers see client notes', async () => {
     (fetchBookingHistory as jest.Mock).mockResolvedValue([
       {
         id: 1,
-        status: 'visited',
+        status: 'approved',
         date: '2024-01-01',
         slot_id: 1,
         reason: null,
@@ -170,6 +172,19 @@ describe('includeStaffNotes handling', () => {
         is_staff_booking: false,
         reschedule_token: 'tok',
         client_note: 'client note',
+      },
+      {
+        id: 2,
+        status: 'visited',
+        date: '2024-01-02',
+        slot_id: null,
+        reason: null,
+        start_time: null,
+        end_time: null,
+        created_at: '2024-01-02',
+        is_staff_booking: false,
+        reschedule_token: null,
+        client_note: null,
         staff_note: 'staff note',
       },
     ]);
@@ -177,12 +192,12 @@ describe('includeStaffNotes handling', () => {
     const staffRes = await request(app).get('/bookings/history?userId=1');
     expect(staffRes.status).toBe(200);
     expect(staffRes.body[0].client_note).toBe('client note');
-    expect(staffRes.body[0].staff_note).toBe('staff note');
+    expect(staffRes.body[1].staff_note).toBe('staff note');
 
     currentUser = { id: 1, role: 'shopper' };
     const shopperRes = await request(app).get('/bookings/history');
     expect(shopperRes.status).toBe(200);
     expect(shopperRes.body[0].client_note).toBe('client note');
-    expect(shopperRes.body[0].staff_note).toBeUndefined();
+    expect(shopperRes.body[1].staff_note).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Add optional `includeClientNotes` flag to booking history query
- Return `NULL` for client notes once bookings are visited or marked `no_show`
- Adjust booking history tests for new `client_note` handling

## Testing
- `npm test` *(fails: Test Suites: 10 failed, 89 passed, 99 total)*
- `npm test tests/bookingRepository.test.ts tests/bookingHistoryNotes.test.ts tests/includeStaffNotesAuth.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9d9af25cc832d8b2b0712f0748efc