### PR TITLE
Clear booking notes when booking status changes

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -270,7 +270,7 @@ export async function markBookingNoShow(req: Request, res: Response, next: NextF
       [bookingId],
     );
 
-    await updateBooking(bookingId, { status: 'no_show', request_data: reason });
+    await updateBooking(bookingId, { status: 'no_show', request_data: reason, note: null });
 
     const booking = result.rows[0];
     if (booking?.email && booking?.reschedule_token) {
@@ -302,7 +302,7 @@ export async function markBookingVisited(req: Request, res: Response, next: Next
        RETURNING client_id`,
       [weightWithCart ?? null, weightWithoutCart ?? null, petItem ?? 0, note ?? null, bookingId],
     );
-    await updateBooking(bookingId, { status: 'visited', request_data: requestData });
+    await updateBooking(bookingId, { status: 'visited', request_data: requestData, note: null });
     const clientId: number | null = insertRes.rows[0]?.client_id ?? null;
     if (clientId) await refreshClientVisitCount(clientId);
     res.json({ message: 'Booking marked as visited' });

--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -102,7 +102,7 @@ export async function addVisit(req: Request, res: Response, next: NextFunction) 
         [clientId, formatReginaDate(date)]
       );
       if ((sameDayRes.rowCount ?? 0) > 0) {
-        await updateBooking(sameDayRes.rows[0].id, { status: 'visited' }, client);
+        await updateBooking(sameDayRes.rows[0].id, { status: 'visited', note: null }, client);
       }
 
       // Handle other approved bookings in the month
@@ -122,11 +122,11 @@ export async function addVisit(req: Request, res: Response, next: NextFunction) 
         if (bookingDate > visitDate) {
           await updateBooking(
             row.id,
-            { status: 'visited', slot_id: null, date: formatReginaDate(date) },
+            { status: 'visited', slot_id: null, date: formatReginaDate(date), note: null },
             client,
           );
         } else {
-          await updateBooking(row.id, { status: 'no_show' }, client);
+          await updateBooking(row.id, { status: 'no_show', note: null }, client);
         }
       }
     }

--- a/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
@@ -8,7 +8,7 @@ import scheduleDailyJob from './scheduleDailyJob';
 export async function cleanupNoShows(): Promise<void> {
   try {
     await pool.query(
-      "UPDATE bookings SET status='no_show' WHERE status='approved' AND date < CURRENT_DATE",
+      "UPDATE bookings SET status='no_show', note=NULL WHERE status='approved' AND date < CURRENT_DATE",
     );
   } catch (err) {
     logger.error('Failed to clean up no-shows', err);

--- a/MJ_FB_Backend/tests/bookingController.test.ts
+++ b/MJ_FB_Backend/tests/bookingController.test.ts
@@ -207,7 +207,7 @@ describe('markBookingNoShow', () => {
 
     await markBookingNoShow(req, res, next);
 
-    expect(updateBooking).toHaveBeenCalledWith(1, { status: 'no_show', request_data: '' });
+    expect(updateBooking).toHaveBeenCalledWith(1, { status: 'no_show', request_data: '', note: null });
     expect(enqueueEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         to: 'client@example.com',

--- a/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
+++ b/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
@@ -49,6 +49,7 @@ describe('booking status updates', () => {
     expect(bookingRepo.updateBooking).toHaveBeenCalledWith(1, {
       status: 'no_show',
       request_data: 'missed',
+      note: null,
     });
   });
 
@@ -69,6 +70,7 @@ describe('booking status updates', () => {
     expect(bookingRepo.updateBooking).toHaveBeenCalledWith(2, {
       status: 'visited',
       request_data: 'note',
+      note: null,
     });
   });
 

--- a/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
@@ -126,7 +126,7 @@ describe('client visit booking integration', () => {
 
     expect(bookingRepository.updateBooking).toHaveBeenCalledWith(
       55,
-      { status: 'visited' },
+      { status: 'visited', note: null },
       expect.anything(),
     );
 
@@ -166,7 +166,7 @@ describe('client visit booking integration', () => {
     expect(res.status).toBe(201);
     expect(bookingRepository.updateBooking).toHaveBeenCalledWith(
       77,
-      { status: 'visited', slot_id: null, date: '2024-01-02' },
+      { status: 'visited', slot_id: null, date: '2024-01-02', note: null },
       expect.anything(),
     );
   });
@@ -199,7 +199,7 @@ describe('client visit booking integration', () => {
     expect(res.status).toBe(201);
     expect(bookingRepository.updateBooking).toHaveBeenCalledWith(
       88,
-      { status: 'no_show' },
+      { status: 'no_show', note: null },
       expect.anything(),
     );
   });

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -23,7 +23,7 @@ describe('cleanupNoShows', () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1 });
     await cleanupNoShows();
     expect(pool.query).toHaveBeenCalledWith(
-      "UPDATE bookings SET status='no_show' WHERE status='approved' AND date < CURRENT_DATE",
+      "UPDATE bookings SET status='no_show', note=NULL WHERE status='approved' AND date < CURRENT_DATE",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Clear any existing note when marking bookings as `no_show` or `visited`
- Reset notes for same-day or adjusted bookings created via client visits
- Nightly no-show cleanup also nulls out stale notes

## Testing
- `npm test` *(fails: Test Suites: 10 failed, 89 passed, 99 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d9ac3434832d88a4922e1c14b8ed