### PR TITLE
Fix document title without layout context

### DIFF
--- a/MJ_FB_Frontend/src/components/layout/MainLayout.tsx
+++ b/MJ_FB_Frontend/src/components/layout/MainLayout.tsx
@@ -15,7 +15,11 @@ interface MainLayoutProps {
   children: ReactNode;
 }
 
-const PageTitleContext = createContext<(title: string) => void>(() => {});
+const setDocumentTitle = (title: string) => {
+  document.title = title ? `MJ Foodbank - ${title}` : 'MJ Foodbank';
+};
+
+const PageTitleContext = createContext<(title: string) => void>(setDocumentTitle);
 
 export function usePageTitle(title: string) {
   const setTitle = useContext(PageTitleContext);


### PR DESCRIPTION
## Summary
- set default page title setter to update document.title when no MainLayout context

## Testing
- `npm test --silent src/__tests__/Page.test.tsx`
- `npm test --silent` (fails: BookingUI test due to nested button)


------
https://chatgpt.com/codex/tasks/task_e_68b9e7f7e2f4832db581164247a30577