### PR TITLE
chore: remove unsupported tsconfig option from migrations

### DIFF
--- a/MJ_FB_Backend/src/runMigrations.ts
+++ b/MJ_FB_Backend/src/runMigrations.ts
@@ -15,7 +15,6 @@ export async function runMigrations() {
       dir: 'src/migrations',
       direction: 'up',
       migrationsTable: 'pgmigrations',
-      tsconfig: 'tsconfig.json',
       logger: {
         info: msg => logger.info(msg),
         warn: msg => logger.warn(msg),


### PR DESCRIPTION
## Summary
- remove unsupported `tsconfig` option from node-pg-migrate call

## Testing
- `npm run build` *(fails: Interface 'AuthRequest' incorrectly extends interface 'Request'...)*
- `npm test` *(fails: 10 failed, 89 passed)*
- `npm run migrate` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b9edf6fb48832d87a41c700e61ff76