### PR TITLE
Include backend types in Docker build stage

### DIFF
--- a/MJ_FB_Backend/Dockerfile
+++ b/MJ_FB_Backend/Dockerfile
@@ -3,6 +3,7 @@ FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json tsconfig.json ./
 COPY src ./src
+COPY types ./types
 RUN npm ci && npm run build
 
 # Production stage


### PR DESCRIPTION
## Summary
- Copy backend `types` directory during the Docker build stage so Express request extensions are available at compile time

## Testing
- `npm test` *(fails: client visit booking integration, volunteer booking status email, volunteer shopper booking, volunteer booking conflict, booking new client, volunteer rebook cancelled, booking capacity, new clients migration, db pool error handler)*
- `npm run build` *(fails: type errors in runMigrations.ts and AuthRequest.ts)*
- `docker build -t backend-test .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b9edef9cc8832dbe126a474793d092