### PR TITLE
chore: add root test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ All schema changes must be implemented via migrations in `MJ_FB_Backend/src/migr
 
 - Use Node.js 22 or later for development; the backend relies on the native `fetch` API.
 - The frontend requires a live internet connection; offline caching or offline-first optimizations must not be added.
-- Run the relevant backend and frontend test suites via `npm test` after making changes. Tests must be executed with `npm test` so `jest.setup.ts` loads required polyfills and provides a default `VITE_API_BASE`.
+- Run the relevant backend or frontend test suites using `npm run test:backend` or `npm run test:frontend` after making changes. These scripts call each submodule's `npm test` so `jest.setup.ts` loads required polyfills and provides a default `VITE_API_BASE`.
+
+```bash
+npm run test:backend   # backend tests
+npm run test:frontend  # frontend tests
+```
 - Update `AGENTS.md` with new repository instructions.
 - Reflect user-facing or setup changes in this `README.md`.
 - Backend tests use `tests/setupTests.ts` to load required environment variables, polyfill `global.fetch` with `undici`, and mock the database. If you run a test file directly instead of through Jest, manually import `'../setupTests'` so these helpers are initialized.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mj_foodbank_booking",
+  "private": true,
+  "scripts": {
+    "test:backend": "npm --prefix MJ_FB_Backend test",
+    "test:frontend": "npm --prefix MJ_FB_Frontend test"
+  }
+}


### PR DESCRIPTION
## Summary
- add root package.json scripts to run backend or frontend tests
- document test scripts in README

## Testing
- `npm --prefix MJ_FB_Backend test 2>&1 | tail -n 20`
- `npm run test:frontend` *(fails: numerous act() warnings and failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ee0f53b0832d967f34c99f6cdcab