### PR TITLE
docs: document Node 22 requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Pull Request Guidelines
 
 - Ensure tests are added or updated for any code changes and run the relevant test suites after each task.
+- Use Node.js 22+; run `nvm use` to switch to the pinned version in `.nvmrc`.
 - Keep recurring-booking tests current in both the backend and frontend whenever this feature changes.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Document translation strings for localization in `docs/` and update `MJ_FB_Frontend/src/locales` when user-facing text is added.

--- a/MJ_FB_Frontend/AGENTS.md
+++ b/MJ_FB_Frontend/AGENTS.md
@@ -14,6 +14,9 @@
 - Tests polyfill `global.fetch` with `undici` via top-level assignments in `tests/setupFetch.ts`. Ensure this file remains configured in Jest's setup files.
 - Tests load required environment variables from `tests/setupEnv.ts`, which is listed in Jest's `setupFilesAfterEnv`. When running a test file directly, import `'../setupEnv'` so these variables are set, or run the test through Jest.
 
+## Environment
+- Requires Node.js 22+; run `nvm use` to match the version in `.nvmrc`.
+
 ## Project Layout
 - React app built with Vite.
 - Build requires `VITE_API_BASE` to be set in `MJ_FB_Frontend/.env`.

--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -5,6 +5,10 @@ Authenticated users can access a role-based help page at `/help`. Admins can vie
 
 Client bookings include a confirmation step summarizing the selected date, time, and current-month visit count, with an optional client note field for staff.
 
+## Node Version
+
+Use **Node.js 22+**. Run `nvm use` to switch to the version pinned in the repository’s `.nvmrc`.
+
 ## Development
 
 Install dependencies and run the dev server:


### PR DESCRIPTION
## Summary
- document Node.js 22 requirement in contributor guide and frontend docs
- root `.nvmrc` pins Node 22 for `nvm use`

## Testing
- `npm test` (backend, fails: clientVisitBookingStatus, volunteerBookingStatusEmail, bookingNewClient, and others)
- `npm test` (frontend, fails with numerous jsdom errors)


------
https://chatgpt.com/codex/tasks/task_e_68b9ee129d4c832daaafd047469f5946