### PR TITLE
Normalize timesheet day note to null

### DIFF
--- a/MJ_FB_Frontend/src/api/timesheets.ts
+++ b/MJ_FB_Frontend/src/api/timesheets.ts
@@ -149,7 +149,7 @@ export function useUpdateTimesheetDay(timesheetId: number) {
                   stat_hours: statHours,
                   sick_hours: sickHours,
                   vac_hours: vacHours,
-                  note,
+                  note: note ?? null,
                 }
               : d,
           ),


### PR DESCRIPTION
## Summary
- ensure TimesheetDay mutation stores `note` as `null` when empty

## Testing
- `npm test` *(fails: An update to VolunteerSchedule inside a test was not wrapped in act(...))*
- `VITE_API_BASE=/api npm run build` *(fails: tsc compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3c966c8832d87c18d7d4db6c78a