### PR TITLE
Remove unused id field from booking history initial user

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -385,7 +385,7 @@ export default function App() {
                       path="/booking-history"
                       element={
                         <UserHistory
-                          initialUser={{ id: 0, name, client_id: 0 }}
+                          initialUser={{ name, client_id: 0 }}
                         />
                       }
                     />
@@ -398,7 +398,7 @@ export default function App() {
                       path="/booking-history"
                       element={
                         <UserHistory
-                          initialUser={{ id: 0, name, client_id: 0 }}
+                          initialUser={{ name, client_id: 0 }}
                         />
                       }
                     />


### PR DESCRIPTION
## Summary
- drop unused `id` from `initialUser` objects passed to `UserHistory`

## Testing
- `npm run build` *(fails: 'ReactNode' is a type and must be imported using a type-only import, among other TS errors)*
- `npm test` *(fails: timesheets api invalid URL; jsdom location errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3ca5550832d89c73c47c7f0fa7b