### PR TITLE
Normalize booking API responses to arrays

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -80,7 +80,9 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    getBookings().then(setBookings).catch(() => {});
+    getBookings()
+      .then(b => setBookings(Array.isArray(b) ? b : [b]))
+      .catch(() => {});
     getEvents().then(setEvents).catch(() => {});
 
     const today = new Date();
@@ -265,7 +267,9 @@ function UserDashboard() {
   });
 
   useEffect(() => {
-    getBookings().then(setBookings).catch(() => {});
+    getBookings()
+      .then(b => setBookings(Array.isArray(b) ? b : [b]))
+      .catch(() => {});
 
     const todayStr = formatLocalDate(new Date());
     getSlotsRange(todayStr, 5)

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -78,7 +78,7 @@ export default function ClientDashboard() {
 
   useEffect(() => {
     getBookingHistory({ includeVisits: true })
-      .then(setBookings)
+      .then(b => setBookings(Array.isArray(b) ? b : [b]))
       .catch(() => {});
   }, []);
 


### PR DESCRIPTION
## Summary
- Wrap bookings fetched in Dashboard and ClientDashboard so single booking responses are coerced into arrays

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3cce68c832da9010680bce55ba6