### PR TITLE
Add reschedule guard and booking note field

### DIFF
--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -103,6 +103,7 @@ function normalizeBooking(b: BookingResponse): Booking {
   const newClientId = b.newClientId ?? new_client_id ?? null;
   return {
     ...rest,
+    note: client_note ?? undefined,
     client_note: client_note ?? null,
     staff_note: staff_note ?? null,
     start_time: b.start_time ?? b.startTime ?? null,

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -100,6 +100,11 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
             setMessage('Please select date and time');
             return;
           }
+          if (!booking.reschedule_token) {
+            setSeverity('error');
+            setMessage('No reschedule token');
+            return;
+          }
           await rescheduleBookingByToken(booking.reschedule_token, slotId, date);
           onUpdated('Booking rescheduled', 'success');
           onClose();

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -282,5 +282,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -275,5 +275,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -278,5 +278,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -273,5 +273,6 @@
   },
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
-  "visits_with_notes_only": "View visits with notes only"
+  "visits_with_notes_only": "View visits with notes only",
+  "no_reschedule_token": "No reschedule token"
 }

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -244,6 +244,7 @@ export interface Booking
   startTime: string | null;
   endTime: string | null;
   newClientId: number | null;
+  note?: string;
 }
 
 export interface VolunteerBookingInfo {

--- a/docs/bookings.md
+++ b/docs/bookings.md
@@ -1,0 +1,7 @@
+# Bookings
+
+## Localization
+
+Add the following translation strings to locale files:
+
+- `no_reschedule_token`


### PR DESCRIPTION
## Summary
- prevent reschedule when booking lacks a token
- expose optional note field on Booking objects and normalize API responses
- document and localize new reschedule token error message

## Testing
- `npm test` *(fails: Unable to find an element with the text: Sunday, Dec 31, 2023...)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3d0c08c832d8aefcf5f6f270043