### PR TITLE
refactor: rename cacheTime to gcTime

### DIFF
--- a/MJ_FB_Frontend/src/hooks/useHolidays.ts
+++ b/MJ_FB_Frontend/src/hooks/useHolidays.ts
@@ -5,14 +5,14 @@ import type { Holiday } from '../types';
 export default function useHolidays(
   enabled = true,
   staleTime = 5 * 60 * 1000,
-  cacheTime = 30 * 60 * 1000,
+  gcTime = 30 * 60 * 1000,
 ) {
   const { data, isFetching, refetch, error } = useQuery<Holiday[]>({
     queryKey: ['holidays'],
     queryFn: getHolidays,
     enabled,
     staleTime,
-    cacheTime,
+    gcTime,
   });
 
   return { holidays: data ?? [], isLoading: isFetching, refetch, error };

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -46,7 +46,7 @@ function useSlots(
   date: Dayjs,
   enabled: boolean,
   staleTime = 5 * 60 * 1000,
-  cacheTime = 30 * 60 * 1000,
+  gcTime = 30 * 60 * 1000,
 ) {
   const dateStr = date.format('YYYY-MM-DD');
   const { data, isFetching, refetch, error } = useQuery<Slot[]>({
@@ -54,7 +54,7 @@ function useSlots(
     queryFn: () => getSlots(dateStr),
     enabled,
     staleTime,
-    cacheTime,
+    gcTime,
   });
   return { slots: data ?? [], isLoading: isFetching, refetch, error };
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -36,7 +36,7 @@ function useVolunteerSlots(
   date: Dayjs,
   enabled: boolean,
   staleTime = 5 * 60 * 1000,
-  cacheTime = 30 * 60 * 1000,
+  gcTime = 30 * 60 * 1000,
 ) {
   const dateStr = date.format('YYYY-MM-DD');
   const { data, isFetching, refetch, error } = useQuery<VolunteerRole[]>({
@@ -44,7 +44,7 @@ function useVolunteerSlots(
     queryFn: () => getVolunteerRolesForVolunteer(dateStr),
     enabled,
     staleTime,
-    cacheTime,
+    gcTime,
   });
   return { slots: data ?? [], isLoading: isFetching, refetch, error };
 }


### PR DESCRIPTION
## Summary
- rename cacheTime to gcTime in TanStack Query hooks and pages

## Testing
- `npm test` *(fails: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3d36aa8832dbe1d9288c5c77185