### PR TITLE
refactor: narrow StyledTabs icon type

### DIFF
--- a/MJ_FB_Frontend/src/components/StyledTabs.tsx
+++ b/MJ_FB_Frontend/src/components/StyledTabs.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import { Paper, Tabs, Tab, Box, type SxProps, type Theme } from '@mui/material';
 
 export interface TabItem {
   label: ReactNode;
-  icon?: ReactNode;
+  icon?: ReactElement;
   content: ReactNode;
 }
 


### PR DESCRIPTION
## Summary
- narrow `StyledTabs` tab icon to `ReactElement`
- import `ReactElement` as a type

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3d52828832d9e01be8ee5265592