### PR TITLE
chore: remove unused variables and imports

### DIFF
--- a/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
@@ -1,4 +1,4 @@
-import { apiFetch, handleResponse } from '../client';
+import { apiFetch } from '../client';
 import {
   markBookingNoShow,
   markBookingVisited,

--- a/MJ_FB_Frontend/src/api/__tests__/timesheets.api.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/timesheets.api.test.ts
@@ -1,4 +1,4 @@
-import { apiFetch, handleResponse } from '../client';
+import { apiFetch } from '../client';
 import {
   listTimesheets,
   listAllTimesheets,

--- a/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
@@ -4,7 +4,6 @@ import Page from '../../components/Page';
 import { getMyAgencyClients } from '../../api/agencies';
 import { Stack, Typography } from '@mui/material';
 import { useAuth } from '../../hooks/useAuth';
-import { useTranslation } from 'react-i18next';
 
 interface AgencyClient {
   id: number;
@@ -35,7 +34,6 @@ export default function AgencySchedule() {
   }, []);
 
   const clientIds = clients.map(c => c.id);
-  const { t } = useTranslation();
 
   const searchAgencyUsers = useCallback(
     async (_token: string, term: string) => {

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -29,8 +29,6 @@ import { useTranslation } from 'react-i18next';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import type { Booking } from '../../types';
 
-const TIMEZONE = 'America/Regina';
-
 interface User {
   name: string;
   client_id: number;

--- a/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
@@ -19,7 +19,6 @@ import {
 } from '../../api/agencies';
 import { useAuth } from '../../hooks/useAuth';
 import Page from '../../components/Page';
-import { useTranslation } from 'react-i18next';
 
 interface AgencyClient {
   id: number;
@@ -33,8 +32,6 @@ export default function ClientList() {
   const [snackbar, setSnackbar] = useState<
     { message: string; severity: 'success' | 'error' } | null
   >(null);
-  const { t } = useTranslation();
-
   useAuth(); // ensure auth context
 
   const load = async () => {

--- a/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/StaffLogin.tsx
@@ -4,7 +4,6 @@ import type { LoginResponse } from '../../api/users';
 import type { ApiError } from '../../api/client';
 import { Typography, TextField, Link, Button } from '@mui/material';
 import Page from '../../components/Page';
-import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FeedbackModal from '../../components/FeedbackModal';
 import FormCard from '../../components/FormCard';

--- a/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
@@ -3,7 +3,6 @@ import { loginVolunteer } from '../../api/volunteers';
 import type { LoginResponse } from '../../api/users';
 import type { ApiError } from '../../api/client';
 import { TextField, Link, Button } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
 import PasswordResetDialog from '../../components/PasswordResetDialog';

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -32,7 +32,6 @@ import type { AlertColor } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs, { type TabItem } from '../../components/StyledTabs';
 import Page from '../../components/Page';
-import { useTranslation } from 'react-i18next';
 import {
   getHolidays,
   addHoliday,
@@ -97,8 +96,6 @@ export default function ManageAvailability() {
     message: string;
     severity: AlertColor;
   }>({ open: false, message: '', severity: 'success' });
-  const { t } = useTranslation();
-
   const showSnackbar = (message: string, severity: AlertColor) => {
     setSnackbar({ open: true, message, severity });
   };

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -15,15 +15,12 @@ import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import {
   Button,
-  Link,
   type AlertColor,
   useTheme,
   Checkbox,
   FormControlLabel,
   TextField,
 } from '@mui/material';
-import { useTranslation } from 'react-i18next';
-import RescheduleDialog from '../../components/RescheduleDialog';
 import ManageBookingDialog from '../../components/ManageBookingDialog';
 import Page from '../../components/Page';
 
@@ -57,7 +54,6 @@ export default function PantrySchedule({
   const [assignMessage, setAssignMessage] = useState('');
   const [isNewClient, setIsNewClient] = useState(false);
   const [newClient, setNewClient] = useState({ name: '', email: '', phone: '' });
-  const { t } = useTranslation();
 
   const theme = useTheme();
   const statusColors: Record<string, string> = {

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -39,8 +39,6 @@ import { toDate, formatDate } from '../../../utils/date';
 import Page from '../../../components/Page';
 import type { Booking } from '../../../types';
 
-const TIMEZONE = 'America/Regina';
-
 interface User {
   name: string;
   client_id: number;

--- a/MJ_FB_Frontend/src/pages/volunteer-management/PendingReviews.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/PendingReviews.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../api/volunteers';
 import type { VolunteerBookingDetail } from '../../types';
 import { formatTime } from '../../utils/time';
-import dayjs, { formatDate } from '../../utils/date';
+import dayjs from '../../utils/date';
 
 export default function PendingReviews() {
   const [bookings, setBookings] = useState<VolunteerBookingDetail[]>([]);

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -14,7 +14,6 @@ import {
   Button,
   Skeleton,
 } from '@mui/material';
-import { useTranslation } from 'react-i18next';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import dayjs, { Dayjs } from 'dayjs';
 import { useQuery } from '@tanstack/react-query';
@@ -74,8 +73,6 @@ export default function VolunteerBooking() {
   }>({ open: false, message: '', severity: 'success' });
   const [conflict, setConflict] = useState<VolunteerBookingConflict | null>(null);
   const slotsRef = useRef<HTMLDivElement>(null);
-  const { t } = useTranslation();
-
   useEffect(() => {
     if (!isDisabled(date)) return;
     let next = date;

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -592,8 +592,6 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
         const slotBookings = bookingsForDate.filter(
           b => b.role_id === role.id
         );
-        const approvedCount = slotBookings.length;
-        const canBook = approvedCount < role.max_volunteers;
         return {
           time: `${formatTime(role.start_time || '')} - ${formatTime(role.end_time || '')}`,
           cells: Array.from({ length: role.max_volunteers }).map((_, i) => {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, ReactNode } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import type { ReactNode } from 'react';
 import {
   getVolunteerRolesForVolunteer,
   requestVolunteerBooking,
@@ -47,7 +48,6 @@ import {
 } from '@mui/material';
 import { lighten } from '@mui/material/styles';
 import type { AlertColor } from '@mui/material';
-import { useTranslation } from 'react-i18next';
 
 const reginaTimeZone = 'America/Regina';
 
@@ -73,7 +73,6 @@ export default function VolunteerSchedule() {
   const [endDate, setEndDate] = useState('');
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
-  const { t } = useTranslation();
   const theme = useTheme();
   const approvedColor = lighten(theme.palette.success.light, 0.4);
   const todayStr = formatDate();

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
   Card,


### PR DESCRIPTION
## Summary
- remove unused `handleResponse` imports in API tests
- drop unused translation and router imports across pages
- delete unused variables like `approvedCount` and convert `ReactNode` to a type-only import

## Testing
- `npm test` *(fails: Unable to find elements and act warnings)*
- `npm run build` *(fails: TypeScript errors remain; no TS6133 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3c540d0832d86b927faaf70b433