### PR TITLE
fix volunteer stats gauge

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerGroupStatsCard.tsx
@@ -64,7 +64,6 @@ export default function VolunteerGroupStatsCard() {
                   dataKey="value"
                   cornerRadius={5}
                   background
-                  clockWise
                   fill={theme.palette.primary.main}
                 />
               </RadialBarChart>


### PR DESCRIPTION
## Summary
- remove obsolete `clockWise` prop from volunteer stats radial gauge

## Testing
- `npm test src/__tests__/BookingUI.test.tsx`
- `npm run build` *(fails: Found 111 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3ce0664832dbad0b5e1dd587e2d