### PR TITLE
Guard optional IDs before calling mutations

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
@@ -27,9 +27,10 @@ export default function AdminLeaveRequests() {
           <Button
             variant="contained"
             size="small"
-            onClick={() =>
-              approve.mutate({ requestId: r.id, timesheetId: r.timesheet_id })
-            }
+            onClick={() => {
+              if (!r.timesheet_id) return;
+              approve.mutate({ requestId: r.id, timesheetId: r.timesheet_id });
+            }}
           >
             {t('timesheets.approve_leave')}
           </Button>
@@ -37,9 +38,10 @@ export default function AdminLeaveRequests() {
             variant="contained"
             color="error"
             size="small"
-            onClick={() =>
-              reject.mutate({ requestId: r.id, timesheetId: r.timesheet_id })
-            }
+            onClick={() => {
+              if (!r.timesheet_id) return;
+              reject.mutate({ requestId: r.id, timesheetId: r.timesheet_id });
+            }}
           >
             {t('timesheets.reject_leave')}
           </Button>

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -80,6 +80,7 @@ export default function AgencyClientManager() {
       setSnackbar({ message: 'Select an agency first', severity: 'error' });
       return;
     }
+    if (!user.client_id) return;
     try {
       await addAgencyClient(agency.id, user.client_id);
       setSnackbar({ message: 'Client added', severity: 'success' });

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -251,6 +251,7 @@ export default function VolunteerDashboard() {
 
   async function resolveConflict(choice: 'existing' | 'new') {
     if (!conflict) return;
+    if (!conflict.existing.id) return;
     try {
       const booking = await resolveVolunteerBookingConflict(
         conflict.existing.id,


### PR DESCRIPTION
## Summary
- add guards for missing timesheet IDs in admin leave request actions
- ensure client ID exists before adding agency client
- check for existing booking ID when resolving volunteer booking conflicts

## Testing
- `npm run typecheck` *(fails: ConfigType import as type-only, JSX namespace missing, Plugin<any> mismatch)*
- `npm test` *(fails: fetchWithRetry test timeout and various test warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3d94580832dbb0d7b0099bfb2fc