### PR TITLE
chore(ci): use npm ci in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install backend dependencies
+        working-directory: MJ_FB_Backend
+        run: npm ci
+
+      - name: Install frontend dependencies
+        working-directory: MJ_FB_Frontend
+        run: npm ci
+
       - name: Docker login to ACR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- run npm ci in release workflow before building

## Testing
- `npm --prefix MJ_FB_Backend test` *(fails: 14 failed, 85 passed)*
- `npm --prefix MJ_FB_Frontend test` *(fails with jsdom TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f5fca73c832d8332b8256dcb7605