### PR TITLE
ci: add TypeScript compile check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: |
+          npm ci --prefix MJ_FB_Backend
+          npm ci --prefix MJ_FB_Frontend
+
+      - name: TypeScript compile check
+        run: npm run build --workspaces --if-present && npx tsc --noEmit
+
       - name: Docker login to ACR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- add TypeScript compile check to release workflow

## Testing
- `npm run test:backend`
- `CI=1 npm --prefix MJ_FB_Frontend test` *(fails: summary not captured)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f6099780832da002034e66e3d358