### PR TITLE
chore: use node 22 for backend Docker build

### DIFF
--- a/MJ_FB_Backend/Dockerfile
+++ b/MJ_FB_Backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:18-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 COPY package*.json tsconfig.json ./
 COPY src ./src
@@ -7,7 +7,7 @@ COPY types ./types
 RUN npm ci && npm run build
 
 # Production stage
-FROM node:18-alpine
+FROM node:22-alpine
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev


### PR DESCRIPTION
## Summary
- use Node 22 alpine base image in backend Dockerfile for both build and runtime stages

## Testing
- `npm test` *(fails: Test Suites: 14 failed, 85 passed, 99 total)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0051e340832d9f8aa95fcd129920