### PR TITLE
fix: exclude frontend tests from build

### DIFF
--- a/MJ_FB_Frontend/tsconfig.app.json
+++ b/MJ_FB_Frontend/tsconfig.app.json
@@ -24,5 +24,9 @@
     "noUncheckedSideEffectImports": true
   },
   "include": ["src"],
-  "exclude": ["src/__tests__"]
+  "exclude": [
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude test files from TypeScript build to avoid missing testUtils modules

## Testing
- `npm run build`
- `npm test` *(fails: Node v22 is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01af144c832daeb95759a842bd92