### PR TITLE
refactor: centralize id param parsing

### DIFF
--- a/MJ_FB_Backend/src/controllers/admin/adminStaffController.ts
+++ b/MJ_FB_Backend/src/controllers/admin/adminStaffController.ts
@@ -6,6 +6,7 @@ import { createStaffSchema, updateStaffSchema } from '../../schemas/admin/staffS
 import { generatePasswordSetupToken } from '../../utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../../utils/emailUtils';
 import config from '../../config';
+import { parseIdParam } from '../../utils/parseIdParam';
 
 export async function listStaff(_req: Request, res: Response, next: NextFunction) {
   try {
@@ -27,8 +28,8 @@ export async function listStaff(_req: Request, res: Response, next: NextFunction
 }
 
 export async function getStaff(req: Request, res: Response, next: NextFunction) {
-  const id = Number(req.params.id);
-  if (!id) return res.status(400).json({ message: 'Invalid ID' });
+  const id = parseIdParam(req.params.id);
+  if (id === null) return res.status(400).json({ message: 'Invalid ID' });
   try {
     const result = await pool.query(
       'SELECT id, first_name, last_name, email, access FROM staff WHERE id = $1',
@@ -82,8 +83,8 @@ export async function createStaff(req: Request, res: Response, next: NextFunctio
 }
 
 export async function updateStaff(req: Request, res: Response, next: NextFunction) {
-  const id = Number(req.params.id);
-  if (!id) return res.status(400).json({ message: 'Invalid ID' });
+  const id = parseIdParam(req.params.id);
+  if (id === null) return res.status(400).json({ message: 'Invalid ID' });
   const parsed = updateStaffSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ errors: parsed.error.issues });
@@ -114,8 +115,8 @@ export async function updateStaff(req: Request, res: Response, next: NextFunctio
 }
 
 export async function deleteStaff(req: Request, res: Response, next: NextFunction) {
-  const id = Number(req.params.id);
-  if (!id) return res.status(400).json({ message: 'Invalid ID' });
+  const id = parseIdParam(req.params.id);
+  if (id === null) return res.status(400).json({ message: 'Invalid ID' });
   try {
     const result = await pool.query('DELETE FROM staff WHERE id = $1', [id]);
     if ((result.rowCount ?? 0) === 0) {

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -16,6 +16,7 @@ import { generatePasswordSetupToken } from '../utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../utils/emailUtils';
 import { enqueueEmail } from '../utils/emailQueue';
 import config from '../config';
+import { parseIdParam } from '../utils/parseIdParam';
 
 export async function createAgency(
   req: Request,
@@ -127,10 +128,10 @@ export async function removeClientFromAgency(
     }
     const requestedId = req.params.id;
     const paramId =
-      requestedId === 'me' ? Number(req.user?.id) : Number(requestedId);
+      requestedId === 'me' ? Number(req.user?.id) : parseIdParam(requestedId);
     const agencyId = req.user.role === 'agency' ? Number(req.user.id) : paramId;
-    const clientId = Number(req.params.clientId);
-    if (!agencyId || !clientId) {
+    const clientId = parseIdParam(req.params.clientId);
+    if (agencyId == null || clientId == null) {
       return res.status(400).json({ message: 'Missing fields' });
     }
     if (req.user.role === 'agency' && requestedId !== 'me' && agencyId !== paramId) {
@@ -162,9 +163,10 @@ export async function getAgencyClients(
       return res.status(403).json({ message: 'Forbidden' });
     }
     const requestedId = req.params.id;
-    const paramId = requestedId === 'me' ? Number(req.user?.id) : Number(requestedId);
+    const paramId =
+      requestedId === 'me' ? Number(req.user?.id) : parseIdParam(requestedId);
     const agencyId = req.user.role === 'agency' ? Number(req.user.id) : paramId;
-    if (!agencyId) {
+    if (agencyId == null) {
       return res.status(400).json({ message: 'Missing fields' });
     }
     if (

--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -13,6 +13,7 @@ import {
 import { enqueueEmail } from '../utils/emailQueue';
 import { buildCancelRescheduleLinks } from '../utils/emailUtils';
 import logger from '../utils/logger';
+import { parseIdParam } from '../utils/parseIdParam';
 import {
   SlotCapacityError,
   checkSlotCapacity,
@@ -258,7 +259,10 @@ export async function cancelBooking(req: AuthRequest, res: Response, next: NextF
 }
 
 export async function markBookingNoShow(req: Request, res: Response, next: NextFunction) {
-  const bookingId = Number(req.params.id);
+  const bookingId = parseIdParam(req.params.id);
+  if (bookingId === null) {
+    return res.status(400).json({ message: 'Invalid ID' });
+  }
   const reason = (req.body?.reason as string) || '';
   try {
     const result = await pool.query(
@@ -287,7 +291,10 @@ export async function markBookingNoShow(req: Request, res: Response, next: NextF
 }
 
 export async function markBookingVisited(req: Request, res: Response, next: NextFunction) {
-  const bookingId = Number(req.params.id);
+  const bookingId = parseIdParam(req.params.id);
+  if (bookingId === null) {
+    return res.status(400).json({ message: 'Invalid ID' });
+  }
   const requestData = (req.body?.requestData as string) || '';
   const weightWithCart = req.body?.weightWithCart as number | undefined;
   const weightWithoutCart = req.body?.weightWithoutCart as number | undefined;

--- a/MJ_FB_Backend/src/controllers/eventController.ts
+++ b/MJ_FB_Backend/src/controllers/eventController.ts
@@ -4,6 +4,7 @@ import logger from '../utils/logger';
 import { createEventSchema } from '../schemas/eventSchemas';
 import { formatReginaDate } from '../utils/dateUtils';
 import type { PoolClient } from 'pg';
+import { parseIdParam } from '../utils/parseIdParam';
 
 export async function listEvents(req: Request, res: Response, next: NextFunction) {
   try {
@@ -107,8 +108,8 @@ export async function createEvent(req: Request, res: Response, next: NextFunctio
 }
 
 export async function deleteEvent(req: Request, res: Response, next: NextFunction) {
-  const id = Number(req.params.id);
-  if (Number.isNaN(id)) {
+  const id = parseIdParam(req.params.id);
+  if (id === null) {
     return res.status(400).json({ message: 'Invalid id' });
   }
   try {

--- a/MJ_FB_Backend/src/controllers/leaveRequestController.ts
+++ b/MJ_FB_Backend/src/controllers/leaveRequestController.ts
@@ -8,6 +8,7 @@ import {
 } from "../models/leaveRequest";
 import { ensureTimesheetDay } from "../models/timesheet";
 import { insertEvent } from "../models/event";
+import { parseIdParam } from "../utils/parseIdParam";
 
 export async function createLeaveRequest(
   req: Request,
@@ -58,10 +59,11 @@ export async function approveLeaveRequest(
   next: NextFunction,
 ): Promise<void> {
   try {
-    const record = await updateLeaveRequestStatus(
-      Number(req.params.id),
-      "approved",
-    );
+    const id = parseIdParam(req.params.id);
+    if (id === null) {
+      return void res.status(400).json({ message: "Invalid ID" });
+    }
+    const record = await updateLeaveRequestStatus(id, "approved");
     if (record.type !== LeaveType.Personal) {
       const start = new Date(record.start_date);
       const end = new Date(record.end_date);
@@ -97,10 +99,11 @@ export async function rejectLeaveRequest(
   next: NextFunction,
 ): Promise<void> {
   try {
-    const record = await updateLeaveRequestStatus(
-      Number(req.params.id),
-      "rejected",
-    );
+    const id = parseIdParam(req.params.id);
+    if (id === null) {
+      return void res.status(400).json({ message: "Invalid ID" });
+    }
+    const record = await updateLeaveRequestStatus(id, "rejected");
     res.json(record);
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/src/controllers/newClientController.ts
+++ b/MJ_FB_Backend/src/controllers/newClientController.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { fetchNewClients, deleteNewClient as removeNewClient } from '../models/newClient';
+import { parseIdParam } from '../utils/parseIdParam';
 
 export async function getNewClients(
   _req: Request,
@@ -20,8 +21,8 @@ export async function deleteNewClient(
   next: NextFunction,
 ) {
   try {
-    const id = Number(req.params.id);
-    if (!Number.isInteger(id)) {
+    const id = parseIdParam(req.params.id);
+    if (id === null) {
       return res.status(400).json({ message: 'Invalid id' });
     }
     await removeNewClient(id);

--- a/MJ_FB_Backend/src/controllers/timesheetController.ts
+++ b/MJ_FB_Backend/src/controllers/timesheetController.ts
@@ -10,6 +10,7 @@ import {
   processTimesheet as modelProcessTimesheet,
 } from '../models/timesheet';
 import pool from '../db';
+import { parseIdParam } from '../utils/parseIdParam';
 
 export async function listMyTimesheets(
   req: Request,
@@ -54,7 +55,10 @@ export async function getTimesheetDays(
   try {
     if (!req.user || req.user.type !== 'staff')
       return res.status(401).json({ message: 'Unauthorized' });
-    const timesheetId = Number(req.params.id);
+    const timesheetId = parseIdParam(req.params.id);
+    if (timesheetId === null) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
     const ts = await getTimesheetById(timesheetId);
     if (!ts || (ts.staff_id !== Number(req.user.id) && req.user.role !== 'admin')) {
       return next({
@@ -74,7 +78,10 @@ export async function updateTimesheetDay(req: Request, res: Response, next: Next
   try {
     if (!req.user || req.user.type !== 'staff')
       return res.status(401).json({ message: 'Unauthorized' });
-    const timesheetId = Number(req.params.id);
+    const timesheetId = parseIdParam(req.params.id);
+    if (timesheetId === null) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
     const workDate = req.params.date;
     const {
       regHours = 0,
@@ -110,7 +117,10 @@ export async function submitTimesheet(req: Request, res: Response, next: NextFun
   try {
     if (!req.user || req.user.type !== 'staff')
       return res.status(401).json({ message: 'Unauthorized' });
-    const timesheetId = Number(req.params.id);
+    const timesheetId = parseIdParam(req.params.id);
+    if (timesheetId === null) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
     const ts = await getTimesheetById(timesheetId);
     if (!ts || ts.staff_id !== Number(req.user.id)) {
       return next({
@@ -133,7 +143,10 @@ export async function submitTimesheet(req: Request, res: Response, next: NextFun
 
 export async function rejectTimesheet(req: Request, res: Response, next: NextFunction) {
   try {
-    const timesheetId = Number(req.params.id);
+    const timesheetId = parseIdParam(req.params.id);
+    if (timesheetId === null) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
     await modelRejectTimesheet(timesheetId);
     res.json({ message: 'Rejected' });
   } catch (err) {
@@ -143,7 +156,10 @@ export async function rejectTimesheet(req: Request, res: Response, next: NextFun
 
 export async function processTimesheet(req: Request, res: Response, next: NextFunction) {
   try {
-    const timesheetId = Number(req.params.id);
+    const timesheetId = parseIdParam(req.params.id);
+    if (timesheetId === null) {
+      return res.status(400).json({ message: 'Invalid ID' });
+    }
     await modelProcessTimesheet(timesheetId);
     res.json({ message: 'Processed' });
   } catch (err) {

--- a/MJ_FB_Backend/src/routes/roles.ts
+++ b/MJ_FB_Backend/src/routes/roles.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import pool from '../db';
 import logger from '../utils/logger';
+import { parseIdParam } from '../utils/parseIdParam';
 
 const router = Router();
 
@@ -39,8 +40,8 @@ router.get('/', async (req: Request, res: Response) => {
 
 // GET /api/roles/:roleId/shifts - returns all shifts for a role
 router.get('/:roleId/shifts', async (req: Request, res: Response) => {
-  const roleId = Number(req.params.roleId);
-  if (!Number.isInteger(roleId) || roleId <= 0) {
+  const roleId = parseIdParam(req.params.roleId);
+  if (roleId === null) {
     return res.status(400).json({ message: 'Invalid roleId' });
   }
   try {

--- a/MJ_FB_Backend/src/utils/parseIdParam.ts
+++ b/MJ_FB_Backend/src/utils/parseIdParam.ts
@@ -1,0 +1,6 @@
+export function parseIdParam(value: unknown): number | null {
+  const id = Number(value);
+  return Number.isNaN(id) || id < 1 ? null : id;
+}
+
+export default parseIdParam;


### PR DESCRIPTION
## Summary
- add parseIdParam helper to normalize numeric ID parsing
- use parseIdParam across admin staff, booking, timesheet, leave, event, agency, new client controllers and roles route

## Testing
- `npm test` *(fails: Test Suites: 14 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba27a78cdc832d80e2116739581a96