### PR TITLE
chore: clarify backend build output

### DIFF
--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "preinstall": "node -e \"if(!process.version.startsWith('v22')){console.error('Node v22+ required');process.exit(1);}\"",
     "dev": "tsx --env-file=.env src/server.ts",
-    "build": "tsc",
+    "build": "tsc && echo 'Backend build complete'",
     "start": "node dist/server.js",
     "pretest": "node -e \"if (!process.version.startsWith('v22')) { console.error('Node v22 is required'); process.exit(1); }\"",
     "test": "jest",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ nvm use
 
 Run all backend and frontend tests on this runtime to match production behavior.
 
+To compile the backend for production, run:
+
+```bash
+cd MJ_FB_Backend
+npm run build
+```
+
+The generated JavaScript lands in `MJ_FB_Backend/dist/` and the script prints a confirmation when complete.
+
 ## Timesheet and Leave Setup
 
 Timesheet features require backend migrations, seeded pay periods, and email


### PR DESCRIPTION
## Summary
- add explicit completion message to backend build
- document backend build step in root README

## Testing
- `npm test` *(fails: Timesheet not found; booking controller; agency tests; volunteer booking tests; etc)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ba4edd7a0c832da54c462fab60a3d4