### PR TITLE
feat(db): configure SSL root cert

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -5,12 +5,15 @@
 PG_USER=your_pg_username
 # PostgreSQL password
 PG_PASSWORD=your_pg_password
-# Database host
+# Database host (use Lightsail endpoint DNS name, not an IP)
 PG_HOST=localhost
 # Database port
 PG_PORT=5432
 # Database name
 PG_DATABASE=mj_fb_db
+# Optional CA bundle path for Postgres SSL
+# Defaults to certs/rds-global-bundle.pem if unset
+PGSSLROOTCERT=
 # Secret used for signing JWT tokens for clients, staff, volunteers, and agencies
 # Generate a strong random value, e.g.:
 #   openssl rand -hex 32

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ npm run build
 
 The generated JavaScript lands in `MJ_FB_Backend/dist/` and the script prints a confirmation when complete.
 
+## Database SSL
+
+The backend trusts the AWS RDS certificate chain stored at
+`MJ_FB_Backend/certs/rds-global-bundle.pem`. Override this path with the
+`PGSSLROOTCERT` environment variable if the bundle is located elsewhere.
+`PG_HOST` should reference the Lightsail endpoint DNS name rather than an IP
+address so hostname verification succeeds.
+
 ## Timesheet and Leave Setup
 
 Timesheet features require backend migrations, seeded pay periods, and email


### PR DESCRIPTION
## Summary
- load RDS CA bundle for Postgres and allow path override via PGSSLROOTCERT
- document PGSSLROOTCERT and DNS-only PG_HOST requirement

## Testing
- `npm test` *(fails: Test Suites: 14 failed, 85 passed, 99 total)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6673d160832d8137679fdb63ef38