### PR TITLE
Ensure dashboards handle missing event data

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
@@ -42,6 +42,22 @@ describe('ClientDashboard', () => {
     expect(await screen.findByText(/Client Event/)).toBeInTheDocument();
   });
 
+  it('handles undefined events response', async () => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([]);
+    (getSlots as jest.Mock).mockResolvedValue([]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue(undefined);
+
+    render(
+      <MemoryRouter>
+        <ClientDashboard />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getEvents).toHaveBeenCalled());
+    expect(await screen.findByText(/No events/i)).toBeInTheDocument();
+  });
+
   it('displays visited bookings with success chip', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([
       {

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -83,7 +83,13 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
     getBookings()
       .then(b => setBookings(Array.isArray(b) ? b : [b]))
       .catch(() => {});
-    getEvents().then(setEvents).catch(() => {});
+    getEvents()
+      .then(data =>
+        setEvents(data ?? { today: [], upcoming: [], past: [] }),
+      )
+      .catch(() =>
+        setEvents({ today: [], upcoming: [], past: [] }),
+      );
 
     const today = new Date();
     const start = new Date(today);
@@ -285,7 +291,13 @@ function UserDashboard() {
       })
       .catch(() => {});
 
-    getEvents().then(setEvents).catch(() => {});
+    getEvents()
+      .then(data =>
+        setEvents(data ?? { today: [], upcoming: [], past: [] }),
+      )
+      .catch(() =>
+        setEvents({ today: [], upcoming: [], past: [] }),
+      );
   }, []);
 
   const appointments = bookings.filter(b => b.status === 'approved');

--- a/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyDashboard.tsx
@@ -116,7 +116,13 @@ export default function AgencyDashboard() {
   }, []);
 
   useEffect(() => {
-    getEvents().then(setEvents).catch(() => {});
+    getEvents()
+      .then(data =>
+        setEvents(data ?? { today: [], upcoming: [], past: [] }),
+      )
+      .catch(() =>
+        setEvents({ today: [], upcoming: [], past: [] }),
+      );
   }, []);
 
   const today = toDate();

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -103,7 +103,13 @@ export default function ClientDashboard() {
   }, []);
 
   useEffect(() => {
-    getEvents().then(setEvents).catch(() => {});
+    getEvents()
+      .then(data =>
+        setEvents(data ?? { today: [], upcoming: [], past: [] }),
+      )
+      .catch(() =>
+        setEvents({ today: [], upcoming: [], past: [] }),
+      );
   }, []);
 
   const today = toDate();

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -125,9 +125,12 @@ export default function VolunteerDashboard() {
 
   useEffect(() => {
     getEvents()
-      .then(setEvents)
+      .then(data =>
+        setEvents(data ?? { today: [], upcoming: [], past: [] }),
+      )
       .catch(err => {
         console.error('Failed to load events', err);
+        setEvents({ today: [], upcoming: [], past: [] });
         setSnackbarSeverity('error');
         setMessage('Failed to load events');
       });

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -139,7 +139,13 @@ export default function WarehouseDashboard() {
   }, [search]);
 
   useEffect(() => {
-    getEvents().then(setEvents).catch(() => {});
+    getEvents()
+      .then(data =>
+        setEvents(data ?? { today: [], upcoming: [], past: [] }),
+      )
+      .catch(() =>
+        setEvents({ today: [], upcoming: [], past: [] }),
+      );
   }, []);
 
   async function loadData(selectedYear: number) {


### PR DESCRIPTION
## Summary
- Guard dashboard event fetches against undefined responses
- Reset events state on fetch failure to avoid crashes
- Test client dashboard when events API returns undefined

## Testing
- `npm test src/__tests__/ClientDashboard.test.tsx`
- `npm test` *(fails: An update to VolunteerSchedule inside a test was not wrapped in act(...))*

------
https://chatgpt.com/codex/tasks/task_e_68bb4e246328832d9cecf6ffb08efc89