### PR TITLE
feat: make db CA path configurable

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -13,7 +13,7 @@ PG_PORT=5432
 PG_DATABASE=mj_fb_db
 # Optional CA bundle path for Postgres SSL
 # Defaults to certs/rds-global-bundle.pem if unset
-PGSSLROOTCERT=
+PG_CA_CERT=
 # Secret used for signing JWT tokens for clients, staff, volunteers, and agencies
 # Generate a strong random value, e.g.:
 #   openssl rand -hex 32

--- a/MJ_FB_Backend/src/db.ts
+++ b/MJ_FB_Backend/src/db.ts
@@ -6,10 +6,11 @@ import config from './config';
 import logger from './utils/logger';
 
 /**
- * Use the REGIONAL RDS trust bundle for your region.
- * Adjust the path if your project lives elsewhere or your region isn't ca-central-1.
+ * Path to the RDS CA bundle.
+ * Defaults to the global bundle in certs but can be overridden with PG_CA_CERT.
  */
-const CA_PATH = '/home/ubuntu/apps/MJ_FoodBank_Booking/MJ_FB_Backend/certs/rds-ca-central-1-bundle.pem';
+const CA_PATH = process.env.PG_CA_CERT ||
+  path.join(__dirname, '../certs/rds-global-bundle.pem');
 
 // Toggle: set PG_INSECURE_SSL=true to skip cert verification TEMPORARILY (for debugging)
 const INSECURE = process.env.PG_INSECURE_SSL === 'true';

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The generated JavaScript lands in `MJ_FB_Backend/dist/` and the script prints a 
 
 The backend trusts the AWS RDS certificate chain stored at
 `MJ_FB_Backend/certs/rds-global-bundle.pem`. Override this path with the
-`PGSSLROOTCERT` environment variable if the bundle is located elsewhere.
+`PG_CA_CERT` environment variable if the bundle is located elsewhere.
 `PG_HOST` should reference the Lightsail endpoint DNS name rather than an IP
 address so hostname verification succeeds.
 


### PR DESCRIPTION
## Summary
- use relative RDS CA bundle path and allow override with `PG_CA_CERT`
- document optional CA cert variable in env example and README

## Testing
- `npm test` *(fails: 16 failed, 83 passed)*
- `npx tsx verify_start.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bb58e5e9c0832d8de76b03b47af500