### PR TITLE
feat: add pantry visit summaries

### DIFF
--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -283,5 +283,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -276,5 +276,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -279,5 +279,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -274,5 +274,12 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
-  "no_reschedule_token": "No reschedule token"
+  "no_reschedule_token": "No reschedule token",
+  "pantry_visits": {
+    "summary": {
+      "clients": "Clients",
+      "total_weight": "Total Weight",
+      "sunshine_bags": "Sunshine Bags"
+    }
+  }
 }

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -142,6 +142,13 @@ export default function PantryVisits() {
       .catch(() => setClientFound(false));
   }, [form.clientId]);
 
+  const summary = useMemo(() => {
+    const clients = visits.length;
+    const totalWeight = visits.reduce((sum, v) => sum + v.weightWithoutCart, 0);
+    const sunshineBags = visits.reduce((sum, v) => sum + v.petItem, 0);
+    return { clients, totalWeight, sunshineBags };
+  }, [visits]);
+
   function handleSaveVisit() {
     if (!form.date || !form.weightWithCart || !form.weightWithoutCart) {
       setSnackbar({ open: true, message: 'Date and weights required', severity: 'error' });
@@ -282,7 +289,22 @@ export default function PantryVisits() {
 
   const tabs = weekDates.map(d => ({
     label: formatLocaleDate(d, { weekday: 'short' }),
-    content: table,
+    content: (
+      <>
+        <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+          <Typography variant="body2">
+            {t('pantry_visits.summary.clients')}: {summary.clients}
+          </Typography>
+          <Typography variant="body2">
+            {t('pantry_visits.summary.total_weight')}: {summary.totalWeight}
+          </Typography>
+          <Typography variant="body2">
+            {t('pantry_visits.summary.sunshine_bags')}: {summary.sunshineBags}
+          </Typography>
+        </Stack>
+        {table}
+      </>
+    ),
   }));
 
   return (

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -105,6 +105,42 @@ describe('PantryVisits', () => {
     expect(screen.queryByText('Bob')).not.toBeInTheDocument();
   });
 
+  it('shows summary for visits', async () => {
+    (getClientVisits as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        date: '2024-01-01',
+        clientId: 111,
+        clientName: 'Alice',
+        anonymous: false,
+        weightWithCart: 10,
+        weightWithoutCart: 5,
+        petItem: 2,
+      },
+      {
+        id: 2,
+        date: '2024-01-01',
+        clientId: 222,
+        clientName: 'Bob',
+        anonymous: false,
+        weightWithCart: 20,
+        weightWithoutCart: 15,
+        petItem: 1,
+      },
+    ]);
+    (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <PantryVisits />
+      </ThemeProvider>,
+    );
+
+    expect(await screen.findByText('Clients: 2')).toBeInTheDocument();
+    expect(screen.getByText('Total Weight: 20')).toBeInTheDocument();
+    expect(screen.getByText('Sunshine Bags: 3')).toBeInTheDocument();
+  });
+
   it('shows "No records" when there are no visits', async () => {
     (getClientVisits as jest.Mock).mockResolvedValue([]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });

--- a/docs/staff.md
+++ b/docs/staff.md
@@ -8,3 +8,6 @@ Add the following translation strings to locale files:
 
 - `other`
 - `payroll_management`
+- `pantry_visits.summary.clients`
+- `pantry_visits.summary.total_weight`
+- `pantry_visits.summary.sunshine_bags`


### PR DESCRIPTION
## Summary
- show daily pantry visit totals above table
- document new translation keys
- add tests for visit summary

## Testing
- `nvm use`
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bb5de6db40832d92335b7ff4f3ebb6