### PR TITLE
feat: track dependents on client visits

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -300,14 +300,24 @@ export async function markBookingVisited(req: Request, res: Response, next: Next
   const weightWithoutCart = req.body?.weightWithoutCart as number | undefined;
   const petItem = req.body?.petItem as number | undefined;
   const note = req.body?.note as string | undefined;
+  const adults = req.body?.adults as number | undefined;
+  const children = req.body?.children as number | undefined;
   try {
     const insertRes = await pool.query(
-      `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous, note)
-       SELECT b.date, b.user_id, $1, $2, COALESCE($3,0), false, $4
+      `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous, note, adults, children)
+       SELECT b.date, b.user_id, $1, $2, COALESCE($3,0), false, $4, COALESCE($5,0), COALESCE($6,0)
        FROM bookings b
-       WHERE b.id = $5
+       WHERE b.id = $7
        RETURNING client_id`,
-      [weightWithCart ?? null, weightWithoutCart ?? null, petItem ?? 0, note ?? null, bookingId],
+      [
+        weightWithCart ?? null,
+        weightWithoutCart ?? null,
+        petItem ?? 0,
+        note ?? null,
+        adults ?? 0,
+        children ?? 0,
+        bookingId,
+      ],
     );
     await updateBooking(bookingId, { status: 'visited', request_data: requestData, note: null });
     const clientId: number | null = insertRes.rows[0]?.client_id ?? null;

--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -55,7 +55,7 @@ export async function listVisits(req: Request, res: Response, next: NextFunction
     const result = await pool.query(
       `SELECT v.id, v.date, v.client_id as "clientId", v.weight_with_cart as "weightWithCart",
               v.weight_without_cart as "weightWithoutCart", v.pet_item as "petItem", v.is_anonymous as "anonymous",
-              v.note as "note",
+              v.note as "note", v.adults, v.children,
               COALESCE(c.first_name || ' ' || c.last_name, '') as "clientName"
        FROM client_visits v
        LEFT JOIN clients c ON v.client_id = c.client_id
@@ -73,14 +73,34 @@ export async function listVisits(req: Request, res: Response, next: NextFunction
 export async function addVisit(req: Request, res: Response, next: NextFunction) {
   const client = await pool.connect();
   try {
-    const { date, clientId, weightWithCart, weightWithoutCart, petItem, anonymous, note } = req.body;
+    const {
+      date,
+      clientId,
+      weightWithCart,
+      weightWithoutCart,
+      petItem,
+      anonymous,
+      note,
+      adults,
+      children,
+    } = req.body;
     await client.query('BEGIN');
     const insertRes = await client.query(
-      `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous, note)
-       VALUES ($1, $2, $3, $4, COALESCE($5,0), $6, $7)
+      `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous, note, adults, children)
+       VALUES ($1, $2, $3, $4, COALESCE($5,0), $6, $7, $8, $9)
        RETURNING id, date, client_id as "clientId", weight_with_cart as "weightWithCart",
-                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous", note`,
-      [date, clientId ?? null, weightWithCart, weightWithoutCart, petItem ?? 0, anonymous ?? false, note ?? null]
+                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous", note, adults, children`,
+      [
+        date,
+        clientId ?? null,
+        weightWithCart,
+        weightWithoutCart,
+        petItem ?? 0,
+        anonymous ?? false,
+        note ?? null,
+        adults,
+        children,
+      ]
     );
     let clientName: string | null = null;
     if (clientId) {
@@ -144,15 +164,25 @@ export async function addVisit(req: Request, res: Response, next: NextFunction) 
 export async function updateVisit(req: Request, res: Response, next: NextFunction) {
   try {
     const { id } = req.params;
-    const { date, clientId, weightWithCart, weightWithoutCart, petItem, anonymous, note } = req.body;
+    const {
+      date,
+      clientId,
+      weightWithCart,
+      weightWithoutCart,
+      petItem,
+      anonymous,
+      note,
+      adults,
+      children,
+    } = req.body;
     const existing = await pool.query('SELECT client_id FROM client_visits WHERE id = $1', [id]);
     const prevClientId: number | null = existing.rows[0]?.client_id ?? null;
     const result = await pool.query(
       `UPDATE client_visits
-       SET date = $1, client_id = $2, weight_with_cart = $3, weight_without_cart = $4, pet_item = COALESCE($5,0), is_anonymous = $6, note = $7
-       WHERE id = $8
+       SET date = $1, client_id = $2, weight_with_cart = $3, weight_without_cart = $4, pet_item = COALESCE($5,0), is_anonymous = $6, note = $7, adults = $8, children = $9
+       WHERE id = $10
        RETURNING id, date, client_id as "clientId", weight_with_cart as "weightWithCart",
-                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous", note`,
+                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous", note, adults, children`,
       [
         date,
         clientId ?? null,
@@ -161,6 +191,8 @@ export async function updateVisit(req: Request, res: Response, next: NextFunctio
         petItem ?? 0,
         anonymous ?? false,
         note ?? null,
+        adults,
+        children,
         id,
       ]
     );

--- a/MJ_FB_Backend/src/migrations/1700000000000_add_adults_children_to_client_visits.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000000_add_adults_children_to_client_visits.ts
@@ -1,0 +1,12 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('client_visits', {
+    adults: { type: 'integer', notNull: true, default: 0 },
+    children: { type: 'integer', notNull: true, default: 0 },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumns('client_visits', ['adults', 'children']);
+}

--- a/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
@@ -6,6 +6,8 @@ export const clientVisitSchema = z.object({
   anonymous: z.boolean().optional(),
   weightWithCart: z.number().int(),
   weightWithoutCart: z.number().int(),
+  adults: z.number().int().min(0),
+  children: z.number().int().min(0),
   petItem: z.number().int().optional(),
   note: z.string().optional(),
 });

--- a/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
+++ b/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
@@ -65,7 +65,7 @@ describe('booking status updates', () => {
     expect(res.status).toBe(200);
     expect(pool.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO client_visits'),
-      [null, null, 0, 'remember ID', 2],
+      [null, null, 0, 'remember ID', 0, 0, 2],
     );
     expect(bookingRepo.updateBooking).toHaveBeenCalledWith(2, {
       status: 'visited',

--- a/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
@@ -70,9 +70,11 @@ describe('client visit booking integration', () => {
             clientId: 123,
             weightWithCart: 10,
             weightWithoutCart: 8,
-            petItem: 0,
-            anonymous: false,
-          },
+        petItem: 0,
+        anonymous: false,
+        adults: 0,
+        children: 0,
+      },
         ],
         rowCount: 1,
       }) // insert visit
@@ -121,6 +123,8 @@ describe('client visit booking integration', () => {
         weightWithoutCart: 8,
         petItem: 0,
         anonymous: false,
+        adults: 0,
+        children: 0,
       });
     expect(visitRes.status).toBe(201);
 
@@ -144,7 +148,17 @@ describe('client visit booking integration', () => {
       .mockResolvedValueOnce({}) // BEGIN
       .mockResolvedValueOnce({
         rows: [
-          { id: 7, date: '2024-01-02', clientId: 123, weightWithCart: 0, weightWithoutCart: 0, petItem: 0, anonymous: false },
+          {
+            id: 7,
+            date: '2024-01-02',
+            clientId: 123,
+            weightWithCart: 0,
+            weightWithoutCart: 0,
+            petItem: 0,
+            anonymous: false,
+            adults: 0,
+            children: 0,
+          },
         ],
         rowCount: 1,
       }) // insert visit
@@ -161,7 +175,7 @@ describe('client visit booking integration', () => {
 
     const res = await request(app)
       .post('/client-visits')
-      .send({ date: '2024-01-02', clientId: 123 });
+      .send({ date: '2024-01-02', clientId: 123, weightWithCart: 0, weightWithoutCart: 0, adults: 0, children: 0 });
 
     expect(res.status).toBe(201);
     expect(bookingRepository.updateBooking).toHaveBeenCalledWith(
@@ -177,7 +191,17 @@ describe('client visit booking integration', () => {
       .mockResolvedValueOnce({}) // BEGIN
       .mockResolvedValueOnce({
         rows: [
-          { id: 7, date: '2024-01-15', clientId: 123, weightWithCart: 0, weightWithoutCart: 0, petItem: 0, anonymous: false },
+          {
+            id: 7,
+            date: '2024-01-15',
+            clientId: 123,
+            weightWithCart: 0,
+            weightWithoutCart: 0,
+            petItem: 0,
+            anonymous: false,
+            adults: 0,
+            children: 0,
+          },
         ],
         rowCount: 1,
       }) // insert visit
@@ -194,7 +218,7 @@ describe('client visit booking integration', () => {
 
     const res = await request(app)
       .post('/client-visits')
-      .send({ date: '2024-01-15', clientId: 123 });
+      .send({ date: '2024-01-15', clientId: 123, weightWithCart: 0, weightWithoutCart: 0, adults: 0, children: 0 });
 
     expect(res.status).toBe(201);
     expect(bookingRepository.updateBooking).toHaveBeenCalledWith(

--- a/MJ_FB_Backend/tests/clientVisitController.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitController.test.ts
@@ -42,6 +42,8 @@ describe('client visit notes', () => {
             petItem: 0,
             anonymous: false,
             note: 'bring ID',
+            adults: 0,
+            children: 0,
           },
         ],
         rowCount: 1,
@@ -56,12 +58,20 @@ describe('client visit notes', () => {
 
     const res = await request(app)
       .post('/client-visits')
-      .send({ date: '2024-01-02', clientId: 123, weightWithCart: 10, weightWithoutCart: 9, note: 'bring ID' });
+      .send({
+        date: '2024-01-02',
+        clientId: 123,
+        weightWithCart: 10,
+        weightWithoutCart: 9,
+        note: 'bring ID',
+        adults: 0,
+        children: 0,
+      });
 
     expect(res.status).toBe(201);
     expect(queryMock).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO client_visits'),
-      ['2024-01-02', 123, 10, 9, 0, false, 'bring ID'],
+      ['2024-01-02', 123, 10, 9, 0, false, 'bring ID', 0, 0],
     );
     expect(res.body.note).toBe('bring ID');
   });
@@ -80,6 +90,8 @@ describe('client visit notes', () => {
             petItem: 0,
             anonymous: false,
             note: 'updated note',
+            adults: 0,
+            children: 0,
           },
         ],
         rowCount: 1,
@@ -89,12 +101,20 @@ describe('client visit notes', () => {
 
     const res = await request(app)
       .put('/client-visits/7')
-      .send({ date: '2024-01-02', clientId: 123, weightWithCart: 10, weightWithoutCart: 9, note: 'updated note' });
+      .send({
+        date: '2024-01-02',
+        clientId: 123,
+        weightWithCart: 10,
+        weightWithoutCart: 9,
+        note: 'updated note',
+        adults: 0,
+        children: 0,
+      });
 
     expect(res.status).toBe(200);
     expect((pool.query as jest.Mock).mock.calls[1]).toEqual([
       expect.stringContaining('UPDATE client_visits'),
-      ['2024-01-02', 123, 10, 9, 0, false, 'updated note', '7'],
+      ['2024-01-02', 123, 10, 9, 0, false, 'updated note', 0, 0, '7'],
     ]);
     expect(res.body.note).toBe('updated note');
   });
@@ -111,6 +131,8 @@ describe('client visit notes', () => {
           petItem: 0,
           anonymous: false,
           note: 'listed note',
+          adults: 0,
+          children: 0,
           clientName: 'Ann Client',
         },
       ],


### PR DESCRIPTION
## Summary
- add adults and children columns to client_visits
- validate adults and children in client visit schemas
- include dependents in visit creation, updates, listing, and booking visit workflow

## Testing
- `npm test tests/clientVisitController.test.ts tests/clientVisitBookingStatus.test.ts tests/bookingStatusUpdate.test.ts`
- `npm test` *(fails: TypeError in agency.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb01d621c832dab1ade62cbfdea92