### PR TITLE
feat: track household counts in pantry visits

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
@@ -56,6 +56,8 @@ describe('ManageBookingDialog', () => {
       expect(screen.getByLabelText(/weight without cart/i)).toHaveValue(3)
     );
 
+    fireEvent.change(screen.getByLabelText(/adults/i), { target: { value: '2' } });
+    fireEvent.change(screen.getByLabelText(/children/i), { target: { value: '1' } });
     fireEvent.change(screen.getByLabelText(/pet item/i), { target: { value: '1' } });
     fireEvent.change(screen.getByLabelText(/note/i), { target: { value: 'bring ID' } });
 
@@ -68,6 +70,8 @@ describe('ManageBookingDialog', () => {
         anonymous: false,
         weightWithCart: 30,
         weightWithoutCart: 3,
+        adults: 2,
+        children: 1,
         petItem: 1,
         note: 'bring ID',
       })

--- a/MJ_FB_Frontend/src/api/clientVisits.ts
+++ b/MJ_FB_Frontend/src/api/clientVisits.ts
@@ -16,7 +16,14 @@ export async function createClientVisit(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      ...payload,
+      date: payload.date,
+      clientId: payload.clientId,
+      anonymous: payload.anonymous,
+      weightWithCart: payload.weightWithCart,
+      weightWithoutCart: payload.weightWithoutCart,
+      petItem: payload.petItem,
+      adults: payload.adults,
+      children: payload.children,
       note: payload.note ?? undefined,
     }),
   });
@@ -32,6 +39,8 @@ export async function updateClientVisit(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       ...payload,
+      adults: payload.adults,
+      children: payload.children,
       note: payload.note ?? undefined,
     }),
   });

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -45,6 +45,8 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
   const [weightWithCart, setWeightWithCart] = useState('');
   const [weightWithoutCart, setWeightWithoutCart] = useState('');
   const [petItem, setPetItem] = useState('0');
+  const [adults, setAdults] = useState('');
+  const [children, setChildren] = useState('');
   const [note, setNote] = useState('');
   const [autoWeight, setAutoWeight] = useState(true);
   const [message, setMessage] = useState('');
@@ -61,6 +63,8 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
       setWeightWithCart('');
       setWeightWithoutCart('');
       setPetItem('0');
+      setAdults('');
+      setChildren('');
       setNote('');
       setAutoWeight(true);
     }
@@ -136,6 +140,8 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
             anonymous: false,
             weightWithCart: Number(weightWithCart),
             weightWithoutCart: Number(weightWithoutCart),
+            adults: Number(adults || 0),
+            children: Number(children || 0),
             petItem: Number(petItem || 0),
             note: note.trim() || undefined,
           });
@@ -243,6 +249,18 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
                   setWeightWithoutCart(e.target.value);
                   setAutoWeight(false);
                 }}
+              />
+              <TextField
+                label="Adults"
+                type="number"
+                value={adults}
+                onChange={e => setAdults(e.target.value)}
+              />
+              <TextField
+                label="Children"
+                type="number"
+                value={children}
+                onChange={e => setChildren(e.target.value)}
               />
               <TextField
                 label="Pet Item"

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -288,7 +288,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -281,7 +281,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -284,7 +284,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -279,7 +279,9 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bags": "Sunshine Bags"
+      "sunshine_bags": "Sunshine Bags",
+      "adults": "Adults",
+      "children": "Children"
     }
   }
 }

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -236,7 +236,7 @@ export function getHelpContent(
         steps: [
           'Open the schedule.',
           'Select a booking.',
-          'Mark visited or no-show, enter weight, and add a staff note if needed.',
+          'Mark visited or no-show, enter weight, adults, children, and add a staff note if needed.',
         ],
       },
     },

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -91,6 +91,8 @@ export default function PantryVisits() {
     clientId: '',
     weightWithCart: '',
     weightWithoutCart: '',
+    adults: '',
+    children: '',
     petItem: '0',
     note: '',
   });
@@ -146,7 +148,9 @@ export default function PantryVisits() {
     const clients = visits.length;
     const totalWeight = visits.reduce((sum, v) => sum + v.weightWithoutCart, 0);
     const sunshineBags = visits.reduce((sum, v) => sum + v.petItem, 0);
-    return { clients, totalWeight, sunshineBags };
+    const adults = visits.reduce((sum, v) => sum + v.adults, 0);
+    const children = visits.reduce((sum, v) => sum + v.children, 0);
+    return { clients, totalWeight, sunshineBags, adults, children };
   }, [visits]);
 
   function handleSaveVisit() {
@@ -164,6 +168,8 @@ export default function PantryVisits() {
       anonymous: form.anonymous,
       weightWithCart: Number(form.weightWithCart),
       weightWithoutCart: Number(form.weightWithoutCart),
+      adults: Number(form.adults || 0),
+      children: Number(form.children || 0),
       petItem: Number(form.petItem || 0),
       note: form.note.trim() || undefined,
     };
@@ -180,6 +186,8 @@ export default function PantryVisits() {
           clientId: '',
           weightWithCart: '',
           weightWithoutCart: '',
+          adults: '',
+          children: '',
           petItem: '0',
           note: '',
         });
@@ -212,6 +220,8 @@ export default function PantryVisits() {
             <TableCell>Profile</TableCell>
             <TableCell>Weight With Cart</TableCell>
             <TableCell>Weight Without Cart</TableCell>
+            <TableCell>Adults</TableCell>
+            <TableCell>Children</TableCell>
             <TableCell>Pet Item</TableCell>
             <TableCell>Note</TableCell>
             <TableCell align="right"></TableCell>
@@ -220,7 +230,7 @@ export default function PantryVisits() {
         <TableBody>
           {filteredVisits.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={9} align="center">
+              <TableCell colSpan={11} align="center">
                 No records
               </TableCell>
             </TableRow>
@@ -245,6 +255,8 @@ export default function PantryVisits() {
                 </TableCell>
                 <TableCell>{v.weightWithCart}</TableCell>
                 <TableCell>{v.weightWithoutCart}</TableCell>
+                <TableCell>{v.adults}</TableCell>
+                <TableCell>{v.children}</TableCell>
                 <TableCell>{v.petItem}</TableCell>
                 <TableCell>{v.note || ''}</TableCell>
                 <TableCell align="right">
@@ -258,6 +270,8 @@ export default function PantryVisits() {
                         clientId: v.clientId ? String(v.clientId) : '',
                         weightWithCart: String(v.weightWithCart),
                         weightWithoutCart: String(v.weightWithoutCart),
+                        adults: String(v.adults),
+                        children: String(v.children),
                         petItem: String(v.petItem),
                         note: v.note ?? '',
                       });
@@ -301,6 +315,12 @@ export default function PantryVisits() {
           <Typography variant="body2">
             {t('pantry_visits.summary.sunshine_bags')}: {summary.sunshineBags}
           </Typography>
+          <Typography variant="body2">
+            {t('pantry_visits.summary.adults')}: {summary.adults}
+          </Typography>
+          <Typography variant="body2">
+            {t('pantry_visits.summary.children')}: {summary.children}
+          </Typography>
         </Stack>
         {table}
       </>
@@ -322,6 +342,8 @@ export default function PantryVisits() {
                 clientId: '',
                 weightWithCart: '',
                 weightWithoutCart: '',
+                adults: '',
+                children: '',
                 petItem: '0',
                 note: '',
               });
@@ -391,6 +413,18 @@ export default function PantryVisits() {
                 setForm({ ...form, weightWithoutCart: e.target.value });
                 setAutoWeight(false);
               }}
+            />
+            <TextField
+              label="Adults"
+              type="number"
+              value={form.adults}
+              onChange={e => setForm({ ...form, adults: e.target.value })}
+            />
+            <TextField
+              label="Children"
+              type="number"
+              value={form.children}
+              onChange={e => setForm({ ...form, children: e.target.value })}
             />
             <TextField
               label="Pet Item"

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -72,6 +72,8 @@ describe('PantryVisits', () => {
         weightWithCart: 10,
         weightWithoutCart: 5,
         petItem: 0,
+        adults: 1,
+        children: 2,
       },
       {
         id: 2,
@@ -82,6 +84,8 @@ describe('PantryVisits', () => {
         weightWithCart: 20,
         weightWithoutCart: 15,
         petItem: 1,
+        adults: 2,
+        children: 3,
       },
     ]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
@@ -116,6 +120,8 @@ describe('PantryVisits', () => {
         weightWithCart: 10,
         weightWithoutCart: 5,
         petItem: 2,
+        adults: 1,
+        children: 1,
       },
       {
         id: 2,
@@ -126,6 +132,8 @@ describe('PantryVisits', () => {
         weightWithCart: 20,
         weightWithoutCart: 15,
         petItem: 1,
+        adults: 2,
+        children: 3,
       },
     ]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
@@ -139,6 +147,8 @@ describe('PantryVisits', () => {
     expect(await screen.findByText('Clients: 2')).toBeInTheDocument();
     expect(screen.getByText('Total Weight: 20')).toBeInTheDocument();
     expect(screen.getByText('Sunshine Bags: 3')).toBeInTheDocument();
+    expect(screen.getByText('Adults: 3')).toBeInTheDocument();
+    expect(screen.getByText('Children: 4')).toBeInTheDocument();
   });
 
   it('shows "No records" when there are no visits', async () => {

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -270,5 +270,7 @@ export interface ClientVisit {
   weightWithCart: number;
   weightWithoutCart: number;
   petItem: number;
+  adults: number;
+  children: number;
   note?: string;
 }

--- a/docs/staff.md
+++ b/docs/staff.md
@@ -11,3 +11,5 @@ Add the following translation strings to locale files:
 - `pantry_visits.summary.clients`
 - `pantry_visits.summary.total_weight`
 - `pantry_visits.summary.sunshine_bags`
+- `pantry_visits.summary.adults`
+- `pantry_visits.summary.children`


### PR DESCRIPTION
## Summary
- track adults and children in ClientVisit payloads
- record and summarize adult/child counts in Pantry Visits UI
- prompt for adults and children when marking booking as visited

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb0219d64832db90d13b468bc0e5c