### PR TITLE
refactor: simplify staff tagging

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/EventForm.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/EventForm.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import dayjs from 'dayjs';
+import EventForm from '../components/EventForm';
+import { createEvent } from '../api/events';
+import { searchStaff } from '../api/staff';
+
+jest.mock('../api/events', () => ({
+  createEvent: jest.fn(),
+}));
+
+jest.mock('../api/staff', () => ({
+  searchStaff: jest.fn(),
+}));
+
+jest.mock('@mui/x-date-pickers', () => {
+  const TextField = require('@mui/material/TextField').default;
+  return {
+    LocalizationProvider: ({ children }: any) => <>{children}</>,
+    DatePicker: ({ label, value, onChange, slotProps }: any) => (
+      <TextField
+        label={label}
+        value={value ? dayjs(value).format('YYYY-MM-DD') : ''}
+        onChange={e => onChange(dayjs(e.target.value))}
+        {...(slotProps?.textField || {})}
+      />
+    ),
+  };
+});
+
+describe('EventForm', () => {
+  beforeEach(() => {
+    (createEvent as jest.Mock).mockResolvedValue({});
+    (searchStaff as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('submits without staff selection', async () => {
+    render(<EventForm open onClose={() => {}} onCreated={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByLabelText(/Category/i), { target: { value: 'harvest pantry' } });
+    fireEvent.change(screen.getByLabelText(/Start Date/i), { target: { value: '2024-01-01' } });
+    fireEvent.change(screen.getByLabelText(/End Date/i), { target: { value: '2024-01-02' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Create/i }));
+
+    await waitFor(() => expect(createEvent).toHaveBeenCalled());
+    expect((createEvent as jest.Mock).mock.calls[0][0].staffIds).toEqual([]);
+  });
+
+  it('submits with selected staff', async () => {
+    (searchStaff as jest.Mock).mockResolvedValue([{ id: 1, name: 'Alice' }]);
+    render(<EventForm open onClose={() => {}} onCreated={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByLabelText(/Category/i), { target: { value: 'harvest pantry' } });
+    fireEvent.change(screen.getByLabelText(/Start Date/i), { target: { value: '2024-01-01' } });
+    fireEvent.change(screen.getByLabelText(/End Date/i), { target: { value: '2024-01-02' } });
+
+    const staffInput = screen.getByLabelText(/Staff Involved/i);
+    fireEvent.change(staffInput, { target: { value: 'Ali' } });
+    await waitFor(() => expect(searchStaff).toHaveBeenCalledWith('Ali'));
+    const option = await screen.findByText('Alice');
+    fireEvent.click(option);
+
+    fireEvent.click(screen.getByRole('button', { name: /Create/i }));
+
+    await waitFor(() => expect(createEvent).toHaveBeenCalled());
+    expect((createEvent as jest.Mock).mock.calls[0][0].staffIds).toEqual([1]);
+  });
+});

--- a/MJ_FB_Frontend/src/components/EventForm.tsx
+++ b/MJ_FB_Frontend/src/components/EventForm.tsx
@@ -35,8 +35,6 @@ const categories = [
   'staff leave',
 ];
 
-const tagAllOption: StaffOption = { id: -1, name: 'Tag All' };
-
 export default function EventForm({ open, onClose, onCreated }: EventFormProps) {
   const { t } = useTranslation();
   const [title, setTitle] = useState('');
@@ -45,7 +43,7 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
   const [startDate, setStartDate] = useState<Dayjs | null>(null);
   const [endDate, setEndDate] = useState<Dayjs | null>(null);
   const [staffInput, setStaffInput] = useState('');
-  const [staffOptions, setStaffOptions] = useState<StaffOption[]>([tagAllOption]);
+  const [staffOptions, setStaffOptions] = useState<StaffOption[]>([]);
   const [selectedStaff, setSelectedStaff] = useState<StaffOption[]>([]);
   const [visibleToVolunteers, setVisibleToVolunteers] = useState(false);
   const [visibleToClients, setVisibleToClients] = useState(false);
@@ -55,32 +53,23 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
   useEffect(() => {
     let active = true;
     if (!staffInput) {
-      setStaffOptions([tagAllOption]);
+      setStaffOptions([]);
       return undefined;
     }
     searchStaff(staffInput)
       .then(data => {
-        if (active) setStaffOptions([tagAllOption, ...data]);
+        if (active) setStaffOptions(data);
       })
       .catch(() => {
-        if (active) setStaffOptions([tagAllOption]);
+        if (active) setStaffOptions([]);
       });
     return () => {
       active = false;
     };
   }, [staffInput]);
 
-  async function handleStaffChange(_: any, value: StaffOption[]) {
-    if (value.some(v => v.id === tagAllOption.id)) {
-      try {
-        const all = await searchStaff('%');
-        setSelectedStaff(all);
-      } catch {
-        setSelectedStaff([]);
-      }
-    } else {
-      setSelectedStaff(value);
-    }
+  function handleStaffChange(_: any, value: StaffOption[]) {
+    setSelectedStaff(value);
   }
 
   async function submit() {

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -199,11 +199,12 @@ export function getHelpContent(
     {
       title: 'Manage events',
       body: {
-        description: 'Create announcements or activities for staff and volunteers.',
+        description:
+          'Create announcements or activities. Staff see all events by default; use checkboxes to share with volunteers or clients.',
         steps: [
           'Open the Events page.',
           'Click Create Event.',
-          'Enter title, category, start and end dates, add details and staff if needed, then save.',
+          'Enter title, category, start and end dates, add details or staff if needed, select volunteer or client visibility, then save.',
         ],
       },
     },


### PR DESCRIPTION
## Summary
- remove Tag All option from EventForm and populate staff options only from search results
- keep staffIds in createEvent for specifically tagged staff
- document staff-visible events and add tests for EventForm

## Testing
- `npm test` *(fails: BookingUI.test.tsx, StaffRecurringBookings.test.tsx, EventForm.test.tsx, NoShowWeek.test.tsx, PasswordSetup.test.tsx, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb015c36c832dad28ec23475e92e8