### PR TITLE
test: ensure staff see events

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
@@ -29,4 +29,31 @@ describe('StaffDashboard', () => {
     expect(screen.getByText('News & Events')).toBeInTheDocument();
     expect(screen.queryByText('No-Show Rankings')).toBeNull();
   });
+
+  it('shows events returned by the API', async () => {
+    (getBookings as jest.Mock).mockResolvedValue([]);
+    (getSlotsRange as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({
+      today: [
+        {
+          id: 1,
+          title: 'Staff Meeting',
+          startDate: '2024-01-01',
+          endDate: '2024-01-01',
+          createdBy: 1,
+          createdByName: 'Alice',
+        },
+      ],
+      upcoming: [],
+      past: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <Dashboard role="staff" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Staff Meeting/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add unit test verifying staff dashboards display API events

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions, multiple suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb2ca41d0832d8afd577d2bd6fdd0