### PR TITLE
docs: clarify client note localization

### DIFF
--- a/docs/notes.md
+++ b/docs/notes.md
@@ -21,7 +21,7 @@ Add the following translation strings to locale files:
 - `help.client.booking_appointments.steps.2`
 - `dashboard`
 - `client_note_label`
-- `staff_note_label`
-- `visits_with_notes_only`
+ 
+Translations are maintained only for client-visible text.
 
 Document any new translation keys here when extending note functionality.


### PR DESCRIPTION
## Summary
- update booking notes localization to remove staff-only keys and clarify translation policy

## Testing
- `npm run test:backend` *(fails: ReferenceError: Cannot access 'sendNextDayVolunteerShiftRemindersMock' before initialization)*
- `npm run test:frontend` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbb2ecac30832db662b0116d897280