### PR TITLE
Fix sunshine bag migration compatibility with node-pg-migrate

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000000_add_sunshine_bag_log.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000000_add_sunshine_bag_log.ts
@@ -1,14 +1,12 @@
-import { PoolClient } from 'pg';
+import type { MigrationBuilder } from 'node-pg-migrate';
 
-export async function up(client: PoolClient): Promise<void> {
-  await client.query(`
-    CREATE TABLE sunshine_bag_log (
-      date DATE PRIMARY KEY,
-      weight INTEGER NOT NULL
-    );
-  `);
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('sunshine_bag_log', {
+    date: { type: 'date', primaryKey: true },
+    weight: { type: 'integer', notNull: true },
+  });
 }
 
-export async function down(client: PoolClient): Promise<void> {
-  await client.query('DROP TABLE IF EXISTS sunshine_bag_log');
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('sunshine_bag_log');
 }


### PR DESCRIPTION
## Summary
- refactor sunshine bag log migration to use MigrationBuilder API instead of PoolClient

## Testing
- `npm test` *(fails: 15 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb33b6350832db1a394f2db6e4469