### PR TITLE
Track adults and children on pantry visits

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
@@ -56,6 +56,8 @@ describe('ManageBookingDialog', () => {
       expect(screen.getByLabelText(/weight without cart/i)).toHaveValue(3)
     );
 
+    fireEvent.change(screen.getByLabelText(/adults/i), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText(/children/i), { target: { value: '2' } });
     fireEvent.change(screen.getByLabelText(/pet item/i), { target: { value: '1' } });
     fireEvent.change(screen.getByLabelText(/note/i), { target: { value: 'bring ID' } });
 
@@ -68,6 +70,8 @@ describe('ManageBookingDialog', () => {
         anonymous: false,
         weightWithCart: 30,
         weightWithoutCart: 3,
+        adults: 1,
+        children: 2,
         petItem: 1,
         note: 'bring ID',
       })

--- a/MJ_FB_Frontend/src/api/clientVisits.ts
+++ b/MJ_FB_Frontend/src/api/clientVisits.ts
@@ -17,6 +17,8 @@ export async function createClientVisit(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       ...payload,
+      adults: payload.adults,
+      children: payload.children,
       note: payload.note ?? undefined,
     }),
   });
@@ -32,6 +34,8 @@ export async function updateClientVisit(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       ...payload,
+      adults: payload.adults ?? undefined,
+      children: payload.children ?? undefined,
       note: payload.note ?? undefined,
     }),
   });

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -44,6 +44,8 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
   const [reason, setReason] = useState('');
   const [weightWithCart, setWeightWithCart] = useState('');
   const [weightWithoutCart, setWeightWithoutCart] = useState('');
+  const [adults, setAdults] = useState('');
+  const [children, setChildren] = useState('');
   const [petItem, setPetItem] = useState('0');
   const [note, setNote] = useState('');
   const [autoWeight, setAutoWeight] = useState(true);
@@ -60,6 +62,8 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
       setReason('');
       setWeightWithCart('');
       setWeightWithoutCart('');
+      setAdults('');
+      setChildren('');
       setPetItem('0');
       setNote('');
       setAutoWeight(true);
@@ -136,6 +140,8 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
             anonymous: false,
             weightWithCart: Number(weightWithCart),
             weightWithoutCart: Number(weightWithoutCart),
+            adults: Number(adults || 0),
+            children: Number(children || 0),
             petItem: Number(petItem || 0),
             note: note.trim() || undefined,
           });
@@ -243,6 +249,18 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
                   setWeightWithoutCart(e.target.value);
                   setAutoWeight(false);
                 }}
+              />
+              <TextField
+                label={t('adults_label')}
+                type="number"
+                value={adults}
+                onChange={e => setAdults(e.target.value)}
+              />
+              <TextField
+                label={t('children_label')}
+                type="number"
+                value={children}
+                onChange={e => setChildren(e.target.value)}
               />
               <TextField
                 label="Pet Item"

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -283,6 +283,8 @@
   "client_note_label": "Client note (optional)",
   "staff_note_label": "Staff note",
   "visits_with_notes_only": "View visits with notes only",
+  "adults_label": "Adults",
+  "children_label": "Children",
   "no_reschedule_token": "No reschedule token",
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",
@@ -290,6 +292,8 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
+      "adults": "Adults",
+      "children": "Children",
       "sunshine_bag_weight": "Sunshine Bag Weight"
     }
   }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -281,9 +281,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -284,9 +284,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -279,9 +279,13 @@
     "summary": {
       "clients": "Clients",
       "total_weight": "Total Weight",
-      "sunshine_bag_weight": "Sunshine Bag Weight"
+      "sunshine_bag_weight": "Sunshine Bag Weight",
+      "adults": "Adults",
+      "children": "Children"
     }
   },
   "sunshine_bag_label": "Sunshine bag?",
-  "sunshine_bag_weight_label": "Sunshine Bag Weight"
+  "sunshine_bag_weight_label": "Sunshine Bag Weight",
+  "adults_label": "Adults",
+  "children_label": "Children"
 }

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -94,6 +94,8 @@ export default function PantryVisits() {
     clientId: '',
     weightWithCart: '',
     weightWithoutCart: '',
+    adults: '',
+    children: '',
     petItem: '0',
     note: '',
   });
@@ -163,7 +165,9 @@ export default function PantryVisits() {
   const summary = useMemo(() => {
     const clients = visits.length;
     const totalWeight = visits.reduce((sum, v) => sum + v.weightWithoutCart, 0);
-    return { clients, totalWeight };
+    const adults = visits.reduce((sum, v) => sum + v.adults, 0);
+    const children = visits.reduce((sum, v) => sum + v.children, 0);
+    return { clients, totalWeight, adults, children };
   }, [visits]);
 
   function handleSaveVisit() {
@@ -184,6 +188,8 @@ export default function PantryVisits() {
             clientId: '',
             weightWithCart: '',
             weightWithoutCart: '',
+            adults: '',
+            children: '',
             petItem: '0',
             note: '',
           });
@@ -208,6 +214,8 @@ export default function PantryVisits() {
       anonymous: form.anonymous,
       weightWithCart: Number(form.weightWithCart),
       weightWithoutCart: Number(form.weightWithoutCart),
+      adults: Number(form.adults || 0),
+      children: Number(form.children || 0),
       petItem: Number(form.petItem || 0),
       note: form.note.trim() || undefined,
     };
@@ -226,6 +234,8 @@ export default function PantryVisits() {
           clientId: '',
           weightWithCart: '',
           weightWithoutCart: '',
+          adults: '',
+          children: '',
           petItem: '0',
           note: '',
         });
@@ -258,6 +268,8 @@ export default function PantryVisits() {
             <TableCell>Profile</TableCell>
             <TableCell>Weight With Cart</TableCell>
             <TableCell>Weight Without Cart</TableCell>
+            <TableCell>{t('adults_label')}</TableCell>
+            <TableCell>{t('children_label')}</TableCell>
             <TableCell>Pet Item</TableCell>
             <TableCell>Note</TableCell>
             <TableCell align="right"></TableCell>
@@ -266,7 +278,7 @@ export default function PantryVisits() {
         <TableBody>
           {filteredVisits.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={9} align="center">
+              <TableCell colSpan={11} align="center">
                 No records
               </TableCell>
             </TableRow>
@@ -291,6 +303,8 @@ export default function PantryVisits() {
                 </TableCell>
                 <TableCell>{v.weightWithCart}</TableCell>
                 <TableCell>{v.weightWithoutCart}</TableCell>
+                <TableCell>{v.adults}</TableCell>
+                <TableCell>{v.children}</TableCell>
                 <TableCell>{v.petItem}</TableCell>
                 <TableCell>{v.note || ''}</TableCell>
                 <TableCell align="right">
@@ -306,6 +320,8 @@ export default function PantryVisits() {
                         clientId: v.clientId ? String(v.clientId) : '',
                         weightWithCart: String(v.weightWithCart),
                         weightWithoutCart: String(v.weightWithoutCart),
+                        adults: String(v.adults),
+                        children: String(v.children),
                         petItem: String(v.petItem),
                         note: v.note ?? '',
                       });
@@ -347,6 +363,12 @@ export default function PantryVisits() {
             {t('pantry_visits.summary.total_weight')}: {summary.totalWeight}
           </Typography>
           <Typography variant="body2">
+            {t('pantry_visits.summary.adults')}: {summary.adults}
+          </Typography>
+          <Typography variant="body2">
+            {t('pantry_visits.summary.children')}: {summary.children}
+          </Typography>
+          <Typography variant="body2">
             {t('pantry_visits.summary.sunshine_bag_weight')}: {sunshineBagWeight}
           </Typography>
         </Stack>
@@ -372,6 +394,8 @@ export default function PantryVisits() {
                 clientId: '',
                 weightWithCart: '',
                 weightWithoutCart: '',
+                adults: '',
+                children: '',
                 petItem: '0',
                 note: '',
               });
@@ -456,6 +480,18 @@ export default function PantryVisits() {
                     setForm({ ...form, weightWithoutCart: e.target.value });
                     setAutoWeight(false);
                   }}
+                />
+                <TextField
+                  label={t('adults_label')}
+                  type="number"
+                  value={form.adults}
+                  onChange={e => setForm({ ...form, adults: e.target.value })}
+                />
+                <TextField
+                  label={t('children_label')}
+                  type="number"
+                  value={form.children}
+                  onChange={e => setForm({ ...form, children: e.target.value })}
                 />
                 <TextField
                   label="Pet Item"

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -269,6 +269,8 @@ export interface ClientVisit {
   anonymous: boolean;
   weightWithCart: number;
   weightWithoutCart: number;
+  adults: number;
+  children: number;
   petItem: number;
   note?: string;
 }

--- a/docs/bookings.md
+++ b/docs/bookings.md
@@ -4,4 +4,6 @@
 
 Add the following translation strings to locale files:
 
+- `adults_label`
+- `children_label`
 - `no_reschedule_token`

--- a/docs/pantryVisits.md
+++ b/docs/pantryVisits.md
@@ -4,6 +4,10 @@
 
 Add the following translation strings to locale files:
 
+- `adults_label`
+- `children_label`
 - `sunshine_bag_label`
 - `sunshine_bag_weight_label`
 - `pantry_visits.summary.sunshine_bag_weight`
+- `pantry_visits.summary.adults`
+- `pantry_visits.summary.children`


### PR DESCRIPTION
## Summary
- record adults and children on pantry visits and booking check-ins
- show adults and children columns and totals on the Pantry Visits page
- document and localize new adults/children labels

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb2938280832d964e1a7c6e02f03a