### PR TITLE
docs: remove localization section from staff guide

### DIFF
--- a/docs/staff.md
+++ b/docs/staff.md
@@ -1,13 +1,3 @@
 # Staff management
 
 Staff accounts can be granted access to different areas of the system.
-
-## Localization
-
-Add the following translation strings to locale files:
-
-- `other`
-- `payroll_management`
-- `pantry_visits.summary.clients`
-- `pantry_visits.summary.total_weight`
-- `pantry_visits.summary.sunshine_bags`


### PR DESCRIPTION
## Summary
- remove localization instructions from staff management doc

## Testing
- `npm run test:backend` (fails: 15 failed, 85 passed)
- `npm run test:frontend` (fails with multiple test errors)


------
https://chatgpt.com/codex/tasks/task_e_68bbb2ea2674832d9bf4f00287ddc958