### PR TITLE
Guard auth cookies from dev cookie domain

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -24,7 +24,8 @@ JWT_REFRESH_SECRET=
 # Include both localhost and 127.0.0.1 for local development
 FRONTEND_ORIGIN=http://localhost:5173,http://127.0.0.1:5173
 # Optional domain to scope authentication cookies
-# Set to your production domain (e.g., example.com) to share cookies across subdomains
+# Set to your production domain (e.g., example.com) to share cookies across subdomains.
+# Omit in development so cookies default to localhost.
 COOKIE_DOMAIN=
 # Server port (defaults to 4000)
 PORT=4000

--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -364,7 +364,7 @@ export function csrfToken(_req: Request, res: Response) {
     sameSite: 'strict',
     secure,
     path: '/',
-    ...(config.cookieDomain ? { domain: config.cookieDomain } : {}),
+    ...(secure && config.cookieDomain ? { domain: config.cookieDomain } : {}),
   });
   res.json({ csrfToken: token });
 }

--- a/MJ_FB_Backend/src/utils/authUtils.ts
+++ b/MJ_FB_Backend/src/utils/authUtils.ts
@@ -15,7 +15,7 @@ export const cookieOptions: CookieOptions = {
   sameSite: isProduction ? 'none' : 'lax',
   secure: isProduction,
   path: '/',
-  ...(config.cookieDomain ? { domain: config.cookieDomain } : {}),
+  ...(isProduction && config.cookieDomain ? { domain: config.cookieDomain } : {}),
 };
 
 export type AuthPayload = {

--- a/MJ_FB_Backend/tests/cookieDomain.test.ts
+++ b/MJ_FB_Backend/tests/cookieDomain.test.ts
@@ -1,0 +1,37 @@
+import request from 'supertest';
+
+// Ensure cookie domain isn't applied in non-production environments
+// even if COOKIE_DOMAIN is set.
+describe('auth cookies in non-production', () => {
+  test('csrf cookie omits domain in development', async () => {
+    await jest.isolateModulesAsync(async () => {
+      process.env.COOKIE_DOMAIN = 'example.com';
+      process.env.NODE_ENV = 'development';
+      const { default: app } = await import('../src/app');
+      const res = await request(app).get('/api/auth/csrf-token');
+      const cookie = res.headers['set-cookie'][0];
+      expect(cookie).not.toMatch(/Domain=example\.com/);
+      delete process.env.COOKIE_DOMAIN;
+      process.env.NODE_ENV = 'test';
+    });
+  });
+
+  test('refresh token cookie omits domain in development', async () => {
+    await jest.isolateModulesAsync(async () => {
+      process.env.COOKIE_DOMAIN = 'example.com';
+      process.env.NODE_ENV = 'development';
+      const { default: issueAuthTokens } = await import('../src/utils/authUtils');
+      const express = (await import('express')).default;
+      const app = express();
+      app.post('/login', async (_req, res) => {
+        await issueAuthTokens(res, { id: 1, role: 'user', type: 'user' }, 'user:1');
+        res.end();
+      });
+      const res = await request(app).post('/login');
+      const cookies = res.headers['set-cookie'].join(';');
+      expect(cookies).not.toMatch(/Domain=example\.com/);
+      delete process.env.COOKIE_DOMAIN;
+      process.env.NODE_ENV = 'test';
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Skip COOKIE_DOMAIN on CSRF and refresh tokens outside production
- Document COOKIE_DOMAIN usage and default localhost behavior
- Test that development cookies omit domain even when COOKIE_DOMAIN is set

## Testing
- `npm test` *(fails: 16 failed, 85 passed)*
- `npm test tests/cookieDomain.test.ts tests/csrf.test.ts tests/refreshTokenVolunteer.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bbb4d8de20832daa5f4ad7eb12014f