### PR TITLE
docs: clarify booking translations

### DIFF
--- a/docs/bookings.md
+++ b/docs/bookings.md
@@ -2,7 +2,7 @@
 
 ## Localization
 
-Add the following translation strings to locale files:
+Translations apply only to client-visible booking messages (e.g., `no_reschedule_token`). Add the following translation strings to locale files:
 
 - `adults_label`
 - `children_label`


### PR DESCRIPTION
## Summary
- note that booking translations only cover client-visible messages

## Testing
- `npm run test:backend` *(fails: 15 failed, 86 passed)*
- `npm run test:frontend` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbb627cab4832dbf438c9177a4f5f4