### PR TITLE
Ensure CSRF token endpoint works in dev

### DIFF
--- a/MJ_FB_Frontend/.env.example
+++ b/MJ_FB_Frontend/.env.example
@@ -1,5 +1,5 @@
 # Backend API base URL (required; build fails if missing)
-VITE_API_BASE=http://localhost:4000
+VITE_API_BASE=http://localhost:4000/api
 # Origin used in invitation links; should match the first entry in BACKEND `FRONTEND_ORIGIN`
 VITE_FRONTEND_ORIGIN=http://localhost:5173
 

--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -32,7 +32,7 @@ Run tests with `npm test` so `.env.test` and `jest.setup.ts` execute, providing 
 The frontend requires `VITE_API_BASE` to be defined. Create a `.env` file in this directory with:
 
 ```
-VITE_API_BASE=http://localhost:4000
+VITE_API_BASE=http://localhost:4000/api
 ```
 
 The build will fail if this variable is missing.

--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -13,7 +13,7 @@ import './src/i18n';
 const { fetch, Headers, Request, Response, FormData, File } = require('undici');
 (Element.prototype as any).scrollIntoView = jest.fn();
 if (!process.env.VITE_API_BASE) {
-  process.env.VITE_API_BASE = 'http://localhost:4000';
+  process.env.VITE_API_BASE = 'http://localhost:4000/api';
 }
 (globalThis as any).VITE_API_BASE = process.env.VITE_API_BASE;
 

--- a/MJ_FB_Frontend/src/api/client.ts
+++ b/MJ_FB_Frontend/src/api/client.ts
@@ -1,15 +1,18 @@
 import { fetchWithRetry } from './fetchWithRetry';
 
-const API_BASE =
+let API_BASE =
   (typeof process !== 'undefined' ? process.env?.VITE_API_BASE : undefined) ??
   (globalThis as any).VITE_API_BASE;
 
 if (!API_BASE) {
   const message =
-    'VITE_API_BASE is not defined. Set it in the frontend .env file (e.g. VITE_API_BASE=http://localhost:4000)';
+    'VITE_API_BASE is not defined. Set it in the frontend .env file (e.g. VITE_API_BASE=http://localhost:4000/api)';
   console.error(message);
   throw new Error(message);
 }
+
+API_BASE = API_BASE.replace(/\/$/, '');
+if (!API_BASE.endsWith('/api')) API_BASE += '/api';
 
 function getCsrfToken() {
   return document.cookie

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ After setting a password, users are redirected to the login page for their role.
 1. **Create an agency** – as staff, call `POST /agencies` with the agency details:
 
    ```bash
-   curl -X POST http://localhost:4000/agencies \
+   curl -X POST http://localhost:4000/api/agencies \
      -H "Authorization: Bearer <staff-token>" \
     -H "Content-Type: application/json" \
     -d '{"name":"Sample Agency","email":"agency@example.com","contactInfo":"123-4567"}'
@@ -302,14 +302,14 @@ After setting a password, users are redirected to the login page for their role.
 
 # As staff assigning client 42 to agency 1
 
-curl -X POST http://localhost:4000/agencies/add-client \
+curl -X POST http://localhost:4000/api/agencies/add-client \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"agencyId":1,"clientId":42}'
 
 # As the agency itself
 
-curl -X POST http://localhost:4000/agencies/add-client \
+curl -X POST http://localhost:4000/api/agencies/add-client \
  -H "Authorization: Bearer <agency-token>" \
  -H "Content-Type: application/json" \
  -d '{"agencyId":1,"clientId":42}'
@@ -364,7 +364,7 @@ npm start   # or npm run dev
 The frontend requires `VITE_API_BASE` to point to the backend API. Create a `.env` file in `MJ_FB_Frontend` with:
 
 ```
-VITE_API_BASE=http://localhost:4000
+VITE_API_BASE=http://localhost:4000/api
 ```
 
 The build will fail if this variable is missing.


### PR DESCRIPTION
## Summary
- normalize API base URL to include `/api`
- document `VITE_API_BASE` with `/api` and fix README curl examples

## Testing
- `npm test` (backend, fails: Test Suites: 15 failed)
- `npm test` (frontend, fails: TypeError: Cannot read properties of null)


------
https://chatgpt.com/codex/tasks/task_e_68bbb6b6f490832d82dbfd16ea8969bf