### PR TITLE
feat: allow viewing pantry visits by date

### DIFF
--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -220,6 +220,17 @@ export function getHelpContent(
       },
     },
     {
+      title: 'Look up past visits',
+      body: {
+        description: 'View client visits for a specific day.',
+        steps: [
+          'Open the Pantry Visits page.',
+          'Choose a date in the lookup field.',
+          'Click Go to load visits for that day.',
+        ],
+      },
+    },
+    {
       title: 'Manage volunteers',
       body: {
         description: 'Search, add, and review volunteers.',

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 - Pantry Visits can log daily sunshine bag weights, shown in the summary above the visit table.
 - Pantry Visits support bulk importing visits from spreadsheets.
+- Pantry Visits allow selecting any date to view visits beyond the current week.
 
 ## Deploying to Azure
 


### PR DESCRIPTION
## Summary
- allow selecting an arbitrary date on Pantry Visits and navigate accordingly
- document past visit lookup in help and README
- cover date navigation with tests

## Testing
- `npm test tests/volunteerBookingStatusEmail.test.ts` *(fails: Cannot find module 'read-excel-file/node')*
- `npm test src/pages/staff/__tests__/PantryVisits.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bbba292b50832d85ae6a3494465b90