### PR TITLE
Test adult and child counts in visit flows

### DIFF
--- a/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
+++ b/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
@@ -61,11 +61,11 @@ describe('booking status updates', () => {
     const res = await request(app)
       .post('/bookings/2/visited')
       .set('x-role', 'staff')
-      .send({ requestData: 'note', note: 'remember ID' });
+      .send({ requestData: 'note', note: 'remember ID', adults: 1, children: 2 });
     expect(res.status).toBe(200);
     expect(pool.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO client_visits'),
-      [null, null, 0, 'remember ID', 0, 0, 2],
+      [null, null, 0, 'remember ID', 1, 2, 2],
     );
     expect(bookingRepo.updateBooking).toHaveBeenCalledWith(2, {
       status: 'visited',

--- a/MJ_FB_Backend/tests/clientVisitController.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitController.test.ts
@@ -42,8 +42,8 @@ describe('client visit notes', () => {
             petItem: 0,
             anonymous: false,
             note: 'bring ID',
-            adults: 0,
-            children: 0,
+            adults: 1,
+            children: 2,
           },
         ],
         rowCount: 1,
@@ -64,16 +64,18 @@ describe('client visit notes', () => {
         weightWithCart: 10,
         weightWithoutCart: 9,
         note: 'bring ID',
-        adults: 0,
-        children: 0,
+        adults: 1,
+        children: 2,
       });
 
     expect(res.status).toBe(201);
     expect(queryMock).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO client_visits'),
-      ['2024-01-02', 123, 10, 9, 0, false, 'bring ID', 0, 0],
+      ['2024-01-02', 123, 10, 9, 0, false, 'bring ID', 1, 2],
     );
     expect(res.body.note).toBe('bring ID');
+    expect(res.body.adults).toBe(1);
+    expect(res.body.children).toBe(2);
   });
 
   it('persists note on update', async () => {
@@ -90,8 +92,8 @@ describe('client visit notes', () => {
             petItem: 0,
             anonymous: false,
             note: 'updated note',
-            adults: 0,
-            children: 0,
+            adults: 1,
+            children: 2,
           },
         ],
         rowCount: 1,
@@ -107,16 +109,18 @@ describe('client visit notes', () => {
         weightWithCart: 10,
         weightWithoutCart: 9,
         note: 'updated note',
-        adults: 0,
-        children: 0,
+        adults: 1,
+        children: 2,
       });
 
     expect(res.status).toBe(200);
     expect((pool.query as jest.Mock).mock.calls[1]).toEqual([
       expect.stringContaining('UPDATE client_visits'),
-      ['2024-01-02', 123, 10, 9, 0, false, 'updated note', 0, 0, '7'],
+      ['2024-01-02', 123, 10, 9, 0, false, 'updated note', 1, 2, '7'],
     ]);
     expect(res.body.note).toBe('updated note');
+    expect(res.body.adults).toBe(1);
+    expect(res.body.children).toBe(2);
   });
 
   it('lists notes', async () => {
@@ -131,8 +135,8 @@ describe('client visit notes', () => {
           petItem: 0,
           anonymous: false,
           note: 'listed note',
-          adults: 0,
-          children: 0,
+          adults: 1,
+          children: 2,
           clientName: 'Ann Client',
         },
       ],
@@ -142,5 +146,7 @@ describe('client visit notes', () => {
     const res = await request(app).get('/client-visits?date=2024-01-02');
     expect(res.status).toBe(200);
     expect(res.body[0].note).toBe('listed note');
+    expect(res.body[0].adults).toBe(1);
+    expect(res.body[0].children).toBe(2);
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageBookingDialog.test.tsx
@@ -56,8 +56,12 @@ describe('ManageBookingDialog', () => {
       expect(screen.getByLabelText(/weight without cart/i)).toHaveValue(3)
     );
 
-    fireEvent.change(screen.getByLabelText(/adults/i), { target: { value: '1' } });
-    fireEvent.change(screen.getByLabelText(/children/i), { target: { value: '2' } });
+    const adultsInput = screen.getByLabelText(/adults/i);
+    const childrenInput = screen.getByLabelText(/children/i);
+    expect(adultsInput).toBeInTheDocument();
+    expect(childrenInput).toBeInTheDocument();
+    fireEvent.change(adultsInput, { target: { value: '1' } });
+    fireEvent.change(childrenInput, { target: { value: '2' } });
     fireEvent.change(screen.getByLabelText(/pet item/i), { target: { value: '1' } });
     fireEvent.change(screen.getByLabelText(/note/i), { target: { value: 'bring ID' } });
 

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -80,6 +80,8 @@ describe('PantryVisits', () => {
         weightWithCart: 10,
         weightWithoutCart: 5,
         petItem: 0,
+        adults: 1,
+        children: 2,
       },
       {
         id: 2,
@@ -90,6 +92,8 @@ describe('PantryVisits', () => {
         weightWithCart: 20,
         weightWithoutCart: 15,
         petItem: 1,
+        adults: 3,
+        children: 4,
       },
     ]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
@@ -125,6 +129,8 @@ describe('PantryVisits', () => {
         weightWithCart: 10,
         weightWithoutCart: 5,
         petItem: 2,
+        adults: 1,
+        children: 2,
       },
       {
         id: 2,
@@ -135,6 +141,8 @@ describe('PantryVisits', () => {
         weightWithCart: 20,
         weightWithoutCart: 15,
         petItem: 1,
+        adults: 3,
+        children: 4,
       },
     ]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
@@ -148,6 +156,8 @@ describe('PantryVisits', () => {
 
     expect(await screen.findByText('Clients: 2')).toBeInTheDocument();
     expect(screen.getByText('Total Weight: 20')).toBeInTheDocument();
+    expect(screen.getByText('Adults: 4')).toBeInTheDocument();
+    expect(screen.getByText('Children: 6')).toBeInTheDocument();
     expect(screen.getByText('Sunshine Bag Weight: 12')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- cover adult and child counts in client visit controller tests
- send and verify household counts when marking bookings visited
- mock and assert adult/child fields and totals in pantry visit and booking dialog tests

## Testing
- `npm test tests/clientVisitController.test.ts tests/bookingStatusUpdate.test.ts`
- `npm test src/pages/staff/__tests__/PantryVisits.test.tsx src/__tests__/ManageBookingDialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bbbbc3a900832d922a740e1a70f0c7