### PR TITLE
docs: clarify pantry visit bulk import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,12 @@
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/src/locales` when client-visible text is added.
 - Pantry visits track daily sunshine bag weights via the `sunshine_bag_log` table.
+- Bulk pantry visit imports use the `POST /client-visits/import` endpoint; see `docs/pantryVisits.md` for sheet naming, duplicate handling, and dry-run options.
 - Booking notes consist of **client notes** (entered when booking) and **staff notes** (recorded during visits). Staff users automatically receive staff notes in booking history responses, while agency users can include them with `includeStaffNotes=true`.
 - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes.
 - A cron job seeds pay periods for the upcoming year every **Nov 30** using `seedPayPeriods`.
 - Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to Azure".
-- Document new environment variables in the repository README and `.env.example` files.
+- Always document new environment variables in the repository README and `.env.example` files.
 - Implement all database schema changes via migrations in `MJ_FB_Backend/src/migrations`; do not modify `src/setupDatabase.ts` for schema updates.
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.
 - Use the shared `PasswordField` component for any password input so users can toggle visibility.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ npm run test:frontend  # frontend tests
 
 - Update `AGENTS.md` with new repository instructions.
 - Reflect user-facing or setup changes in this `README.md`.
+- Document new environment variables in this `README.md` and the relevant `.env.example` files when introducing them.
 - Backend tests use `tests/setupTests.ts` to polyfill `global.fetch` with `undici` and mock the database. Environment variables come from `.env.test`, which Jest loads automatically. If you run a test file directly instead of through Jest, manually import `'../setupTests'` so these helpers are initialized.
 
 ## Help Page Updates
@@ -406,7 +407,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Staff can enter pay period timesheets with daily hour categories, request vacation leave, and submit periods for approval with admin review and processing.
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 - Pantry Visits can log daily sunshine bag weights, shown in the summary above the visit table.
-- Pantry Visits support bulk importing visits from spreadsheets.
+- Pantry Visits support bulk importing visits from spreadsheets via `POST /client-visits/import` (see `docs/pantryVisits.md`).
 - Pantry Visits allow selecting any date to view visits beyond the current week.
 
 ## Deploying to Azure

--- a/docs/pantryVisits.md
+++ b/docs/pantryVisits.md
@@ -16,16 +16,28 @@ Add the following translation strings to locale files:
 - `pantry_visits.bulk_import_error`
 
 ## Bulk import format
+ 
+Pantry visits support bulk importing from an `.xlsx` spreadsheet. Each sheet represents visits for a single day and must be named using the visit date in `YYYY-MM-DD` format. Because the sheet name holds the date, rows omit a `date` column.
 
-Pantry visits support bulk importing from an `.xlsx` spreadsheet. Include a header row and use the following column order:
+Include a header row on every sheet and use the following column order:
 
-1. Date (`YYYY-MM-DD`)
-2. Client ID
-3. Weight With Cart
-4. Weight Without Cart
-5. Adults
-6. Children
-7. Pet Item (`0` or `1`)
-8. Note (optional)
+1. Client ID
+2. Weight With Cart
+3. Weight Without Cart
+4. Adults
+5. Children
+6. Pet Item (`0` or `1`)
+7. Note (optional)
+
+### Duplicate handling
+
+The importer checks for an existing visit for the same client on a given date. Control how duplicates are processed with the `duplicateStrategy` query parameter:
+
+- `skip` (default) – keep the existing visit and ignore the row.
+- `overwrite` – replace the existing visit with the new data.
+
+### Dry run
+
+Append `dryRun=true` to validate the spreadsheet and preview counts without creating any visits. After reviewing the response, rerun the request without `dryRun` to perform the import.
 
 Save the file as `.xlsx` and upload it using the **Bulk Import** button on the Pantry Visits page.


### PR DESCRIPTION
## Summary
- explain sheet naming and duplicate handling for pantry visit imports
- reference `POST /client-visits/import` in README and AGENTS
- remind contributors to document new environment variables

## Testing
- `npm run test:backend` *(fails: 15 failed, 87 passed)*
- `CI=true npm run test:frontend` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbe88c654832dbf04019efad73950