### PR TITLE
feat: add visit import preview

### DIFF
--- a/MJ_FB_Frontend/src/api/clientVisits.ts
+++ b/MJ_FB_Frontend/src/api/clientVisits.ts
@@ -49,11 +49,29 @@ export async function deleteClientVisit(id: number): Promise<void> {
   await handleResponse(res);
 }
 
-export async function importClientVisits(formData: FormData): Promise<void> {
-  const res = await apiFetch(`${API_BASE}/client-visits/import`, {
+export interface VisitImportSheet {
+  date: string;
+  rows: number;
+  errors: string[];
+}
+
+export interface VisitImportPreview {
+  sheets: VisitImportSheet[];
+}
+
+export async function importVisitsXlsx(
+  formData: FormData,
+  duplicateStrategy: 'skip' | 'update',
+  dryRun?: boolean,
+): Promise<VisitImportPreview | void> {
+  const url = new URL(`${API_BASE}/visits/import/xlsx`);
+  url.searchParams.set('duplicateStrategy', duplicateStrategy);
+  if (dryRun) url.searchParams.set('dryRun', 'true');
+
+  const res = await apiFetch(url.toString(), {
     method: 'POST',
     body: formData,
   });
-  await handleResponse(res);
+  return handleResponse(res);
 }
 

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -298,8 +298,16 @@
       "children": "Children",
       "sunshine_bag_weight": "Sunshine Bag Weight"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   }
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -287,9 +287,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -290,9 +290,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -285,9 +285,17 @@
       "adults": "Adults",
       "children": "Children"
     },
-    "bulk_import": "Bulk Import",
-    "bulk_import_success": "Visits imported",
-    "bulk_import_error": "Import failed"
+    "import_visits": "Import Visits",
+    "import": "Import",
+    "import_success": "Visits imported",
+    "import_error": "Import failed",
+    "dry_run": "Dry-run",
+    "duplicate_strategy": "Duplicates",
+    "skip": "Skip",
+    "update": "Update",
+    "sheet_date": "Date",
+    "sheet_rows": "Rows",
+    "sheet_errors": "Errors"
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -231,6 +231,18 @@ export function getHelpContent(
       },
     },
     {
+      title: 'Import visits from spreadsheet',
+      body: {
+        description: 'Upload an .xlsx file to add multiple visits.',
+        steps: [
+          'Open the Pantry Visits page.',
+          'Click Import Visits.',
+          'Choose a file and run Dry-run to preview.',
+          'Select a duplicate strategy and click Import.',
+        ],
+      },
+    },
+    {
       title: 'Manage volunteers',
       body: {
         description: 'Search, add, and review volunteers.',

--- a/docs/pantryVisits.md
+++ b/docs/pantryVisits.md
@@ -11,9 +11,17 @@ Add the following translation strings to locale files:
 - `pantry_visits.summary.sunshine_bag_weight`
 - `pantry_visits.summary.adults`
 - `pantry_visits.summary.children`
-- `pantry_visits.bulk_import`
-- `pantry_visits.bulk_import_success`
-- `pantry_visits.bulk_import_error`
+- `pantry_visits.import_visits`
+- `pantry_visits.import`
+- `pantry_visits.import_success`
+- `pantry_visits.import_error`
+- `pantry_visits.dry_run`
+- `pantry_visits.duplicate_strategy`
+- `pantry_visits.skip`
+- `pantry_visits.update`
+- `pantry_visits.sheet_date`
+- `pantry_visits.sheet_rows`
+- `pantry_visits.sheet_errors`
 
 ## Bulk import format
 
@@ -28,4 +36,4 @@ Pantry visits support bulk importing from an `.xlsx` spreadsheet. Include a head
 7. Pet Item (`0` or `1`)
 8. Note (optional)
 
-Save the file as `.xlsx` and upload it using the **Bulk Import** button on the Pantry Visits page.
+Save the file as `.xlsx` and upload it using the **Import Visits** button on the Pantry Visits page. Use **Dry-run** to preview sheets and choose how to handle duplicates before finalizing the import.


### PR DESCRIPTION
## Summary
- replace client visit import endpoint with XLSX handler supporting dry run and duplicate strategies
- add Import Visits dialog with preview table and duplicate handling
- localize new import strings and document keys

## Testing
- `npm test src/pages/staff/__tests__/PantryVisits.test.tsx`
- `npm test` *(fails: unable to find expected elements in other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbe80ff08832dbf4bea37d2bf970f