### PR TITLE
Handle multi-sheet client visit imports

### DIFF
--- a/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
@@ -18,7 +18,6 @@ export const updateVisitSchema = clientVisitSchema;
 export type ClientVisitSchema = z.infer<typeof clientVisitSchema>;
 
 export const importClientVisitsSchema = z.object({
-  date: z.date(),
   familySize: z.string().regex(/^\d+A\d*C?$/),
   weightWithCart: z.number().int().min(0),
   weightWithoutCart: z.number().int().min(0),


### PR DESCRIPTION
## Summary
- Drop `date` from bulk import schema and rely on sheet names for visit dates
- Iterate through Excel sheets, validate YYYY-MM-DD sheet names, accumulate row errors, and import visits
- Expand import tests to cover multi-sheet processing, invalid sheet names, and per-sheet error reporting

## Testing
- `npm test tests/importClientVisits.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbbe6a1924832d8658a00e7b0d2e8d