### PR TITLE
Add donation entry volunteer role

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000001_add_donation_entry_role.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000001_add_donation_entry_role.ts
@@ -1,0 +1,17 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(
+    "INSERT INTO volunteer_roles (id, name, category_id) VALUES (16, 'Donation Entry', 2) ON CONFLICT (id) DO NOTHING;"
+  );
+  pgm.sql(
+    "SELECT setval('volunteer_roles_id_seq', (SELECT COALESCE(MAX(id),0) FROM volunteer_roles));"
+  );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql("DELETE FROM volunteer_roles WHERE id = 16 OR name = 'Donation Entry';");
+  pgm.sql(
+    "SELECT setval('volunteer_roles_id_seq', (SELECT COALESCE(MAX(id),0) FROM volunteer_roles));"
+  );
+}

--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -6,7 +6,8 @@ export type StaffAccess =
   | 'warehouse'
   | 'admin'
   | 'other'
-  | 'payroll_management';
+  | 'payroll_management'
+  | 'donation_entry';
 
 export interface Staff {
   id: number;

--- a/MJ_FB_Backend/src/routes/donors.ts
+++ b/MJ_FB_Backend/src/routes/donors.ts
@@ -14,9 +14,9 @@ const router = Router();
 
 // Public endpoint to list top donors
 router.get('/top', topDonors);
-router.get('/', authMiddleware, authorizeAccess('warehouse'), listDonors);
-router.post('/', authMiddleware, authorizeAccess('warehouse'), validate(addDonorSchema), addDonor);
-router.get('/:id', authMiddleware, authorizeAccess('warehouse'), getDonor);
-router.get('/:id/donations', authMiddleware, authorizeAccess('warehouse'), donorDonations);
+router.get('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), listDonors);
+router.post('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), validate(addDonorSchema), addDonor);
+router.get('/:id', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), getDonor);
+router.get('/:id/donations', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), donorDonations);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/warehouse/donations.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/donations.ts
@@ -13,11 +13,11 @@ import { addDonationSchema, updateDonationSchema } from '../../schemas/warehouse
 
 const router = Router();
 
-router.get('/', authMiddleware, authorizeAccess('warehouse'), listDonations);
-router.get('/aggregations', authMiddleware, authorizeAccess('warehouse'), donorAggregations);
+router.get('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), listDonations);
+router.get('/aggregations', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), donorAggregations);
 router.get('/aggregations/export', exportDonorAggregations);
-router.post('/', authMiddleware, authorizeAccess('warehouse'), validate(addDonationSchema), addDonation);
-router.put('/:id', authMiddleware, authorizeAccess('warehouse'), validate(updateDonationSchema), updateDonation);
-router.delete('/:id', authMiddleware, authorizeAccess('warehouse'), deleteDonation);
+router.post('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), validate(addDonationSchema), addDonation);
+router.put('/:id', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), validate(updateDonationSchema), updateDonation);
+router.delete('/:id', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), deleteDonation);
 
 export default router;

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -646,7 +646,8 @@ INSERT INTO volunteer_roles (id, name, category_id) VALUES
 (12, 'Volunteer Marketing Associate', 4),
 (13, 'Client Resource Associate', 4),
 (14, 'Assistant Volunteer Coordinator', 4),
-(15, 'Volunteer Office Administrator', 4)
+(15, 'Volunteer Office Administrator', 4),
+(16, 'Donation Entry', 2)
 ON CONFLICT (id) DO NOTHING;
 
 -- Align sequence for volunteer_roles as well to avoid duplicate key errors

--- a/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
+++ b/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import express from 'express';
+import volunteersRouter from '../src/routes/volunteer/volunteers';
+import pool from '../src/db';
+import bcrypt from 'bcrypt';
+
+jest.mock('../src/db');
+jest.mock('bcrypt');
+jest.mock('../src/utils/authUtils', () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue({ token: 'tok', refreshToken: 'ref' }),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/volunteers', volunteersRouter);
+
+describe('donation entry volunteer login', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns donation_entry access when trained for Donation Entry role', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 1, first_name: 'Jane', last_name: 'Doe', username: 'jane', password: 'hashed', user_id: null, user_role: null }],
+      })
+      .mockResolvedValueOnce({ rows: [{ name: 'Donation Entry' }] });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+    const res = await request(app)
+      .post('/volunteers/login')
+      .send({ username: 'jane', password: 'pw' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.access).toEqual(['donation_entry']);
+  });
+});

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -175,6 +175,7 @@ describe('Volunteer login with shopper profile', () => {
       userRole: 'shopper',
       token: 'token',
       refreshToken: 'token',
+      access: [],
     });
     expect((jwt.sign as jest.Mock).mock.calls[0][0]).toMatchObject({
       id: 1,

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -123,6 +123,8 @@ export default function App() {
   const showVolunteerManagement = isStaff && hasAccess('volunteer_management');
   const showWarehouse = isStaff && hasAccess('warehouse');
   const showAdmin = isStaff && access.includes('admin');
+  const showDonationEntry = role === 'volunteer' && access.includes('donation_entry');
+  const showDonationLog = showWarehouse || showDonationEntry;
 
   const staffRootPath = getStaffRootPath(access as StaffAccess[]);
   const singleAccessOnly = isStaff && staffRootPath !== '/';
@@ -205,6 +207,12 @@ export default function App() {
           { label: 'Settings', to: '/admin/settings' },
         ],
       });
+
+  } else if (showDonationEntry) {
+    navGroups.push({
+      label: 'Warehouse Management',
+      links: [{ label: 'Donation Log', to: '/warehouse-management/donation-log' }],
+    });
 
   } else if (role === 'agency') {
     navGroups.push({
@@ -289,7 +297,11 @@ export default function App() {
                     path="/"
                     element={
                       role === 'volunteer' ? (
-                        <VolunteerDashboard />
+                        showDonationEntry ? (
+                          <Navigate to="/warehouse-management/donation-log" replace />
+                        ) : (
+                          <VolunteerDashboard />
+                        )
                       ) : role === 'agency' ? (
                         <AgencyGuard>
                           <AgencyDashboard />
@@ -340,7 +352,7 @@ export default function App() {
                   {showWarehouse && (
                     <Route path="/warehouse-management" element={<WarehouseDashboard />} />
                   )}
-                  {showWarehouse && (
+                  {showDonationLog && (
                     <Route path="/warehouse-management/donation-log" element={<DonationLog />} />
                   )}
                   {showWarehouse && (

--- a/MJ_FB_Frontend/src/__tests__/DonationEntryAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DonationEntryAccess.test.tsx
@@ -1,0 +1,45 @@
+import { screen } from '@testing-library/react';
+import App from '../App';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
+import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
+
+let fetchMock: jest.Mock;
+
+describe('donation entry volunteer access', () => {
+  beforeEach(() => {
+    fetchMock = mockFetch();
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        json: async () => ({}),
+        headers: new Headers(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+        headers: new Headers(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+        headers: new Headers(),
+      });
+    localStorage.setItem('role', 'volunteer');
+    localStorage.setItem('name', 'Donation User');
+    localStorage.setItem('access', JSON.stringify(['donation_entry']));
+    window.history.pushState({}, '', '/');
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    localStorage.clear();
+  });
+
+  it('redirects to donation log', async () => {
+    renderWithProviders(<App />);
+    expect(await screen.findByText(/Donation Log/i)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -125,6 +125,17 @@ export function getHelpContent(
         ],
       },
     },
+    {
+      title: 'Record donations',
+      body: {
+        description: 'Log warehouse donations on the Donation Log page.',
+        steps: [
+          t('help.dashboard_nav_step'),
+          'Open the Donation Log.',
+          'Enter the donor and weight, then save.',
+        ],
+      },
+    },
   ],
   agency: [
     {

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -7,7 +7,8 @@ export type StaffAccess =
   | 'warehouse'
   | 'admin'
   | 'other'
-  | 'payroll_management';
+  | 'payroll_management'
+  | 'donation_entry';
 
 export interface Staff {
   id: number;

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Staff accounts may include any of the following access roles:
 - `admin`
 - `other`
 - `payroll_management`
+- `donation_entry` – volunteer-only access for the warehouse donation log
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 


### PR DESCRIPTION
## Summary
- create donation-entry volunteer role and seed via migration
- allow donation-entry volunteers to log donations
- show donation log page for volunteers with donation-entry access and add related help content

## Testing
- `npm test` (backend) *(fails: Test Suites: 16 failed, 87 passed)*
- `npm test` (frontend) *(inconclusive: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbe4800b4832d879183ce709e8fc1