### PR TITLE
Show dates in pantry visits tabs

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -421,7 +421,16 @@ export default function PantryVisits() {
   );
 
   const tabs = weekDates.map(d => ({
-    label: formatLocaleDate(d, { weekday: 'short' }),
+    label: (
+      <Stack spacing={0} alignItems="center">
+        <Typography variant="body2">
+          {formatLocaleDate(d, { weekday: 'short' })}
+        </Typography>
+        <Typography variant="caption">
+          {formatLocaleDate(d, { month: 'short', day: 'numeric' })}
+        </Typography>
+      </Stack>
+    ),
     content: (
       <>
         <Stack direction="row" spacing={2} sx={{ mb: 2 }}>

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -55,6 +55,24 @@ describe('PantryVisits', () => {
     mockNavigate.mockReset();
   });
 
+  it('shows date in weekday tabs', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-05-13'));
+    (getClientVisits as jest.Mock).mockResolvedValue([]);
+    (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
+    (getSunshineBag as jest.Mock).mockResolvedValue(null);
+
+    render(
+      <ThemeProvider theme={theme}>
+        <PantryVisits />
+      </ThemeProvider>,
+    );
+
+    await screen.findByText('Record Visit');
+    expect(screen.getByText('May 13')).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
   it('uses cart tare from config when calculating weight', async () => {
     (getClientVisits as jest.Mock).mockResolvedValue([]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 10 });


### PR DESCRIPTION
## Summary
- Display both weekday and date in staff Pantry Visits tabs
- Add test ensuring date renders in tab label

## Testing
- `npm test src/pages/staff/__tests__/PantryVisits.test.tsx`
- `npm test` *(fails: unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc3c731c8832d918f450060840bac