### PR TITLE
feat: make search client default tab in client management

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -13,31 +13,31 @@ export default function ClientManagement() {
   const initial = searchParams.get('tab');
   const [tab, setTab] = useState(() => {
     switch (initial) {
-      case 'update':
+      case 'add':
         return 1;
-      case 'history':
+      case 'update':
         return 2;
       case 'new':
         return 3;
       case 'noshow':
         return 4;
       default:
-        return 0;
+        return 0; // 'history' or unknown -> Search Client
     }
   });
 
   useEffect(() => {
     const t = searchParams.get('tab');
-    if (t === 'update') setTab(1);
-    else if (t === 'history') setTab(2);
+    if (t === 'add') setTab(1);
+    else if (t === 'update') setTab(2);
     else if (t === 'new') setTab(3);
     else if (t === 'noshow') setTab(4);
-    else setTab(0);
+    else setTab(0); // 'history' or undefined -> Search Client
   }, [searchParams]);
   const tabs = [
+    { label: 'Search Client', content: <UserHistory /> },
     { label: 'Add', content: <AddClient /> },
     { label: 'Update', content: <UpdateClientData /> },
-    { label: 'History', content: <UserHistory /> },
     { label: 'New Clients', content: <NewClients /> },
     { label: 'No Shows', content: <NoShowWeek /> },
   ];


### PR DESCRIPTION
## Summary
- rename history tab to "Search Client" and show first
- adjust query param logic for new tab order

## Testing
- `npm test` *(fails: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbc37ecde8832da3df89fbac564171