### PR TITLE
Fix event details field overflow

### DIFF
--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -198,8 +198,12 @@ let theme = createTheme({
         root: ({ theme }) => ({
           '& .MuiOutlinedInput-root': {
             borderRadius: theme.shape.borderRadius,
-            '&.MuiInputBase-sizeSmall': { height: theme.spacing(5) },
-            '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: alpha(BRAND_PRIMARY, 0.4) },
+            '&.MuiInputBase-sizeSmall:not(.MuiInputBase-multiline)': {
+              height: theme.spacing(5),
+            },
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: alpha(BRAND_PRIMARY, 0.4),
+            },
             '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
               borderColor: BRAND_PRIMARY,
               boxShadow: `0 0 0 3px ${alpha(BRAND_PRIMARY, 0.12)}`,


### PR DESCRIPTION
## Summary
- prevent global small TextField height from applying to multiline inputs

## Testing
- `npm test` *(fails: BookingUI.test.tsx, StaffRecurringBookings.test.tsx, PantrySchedule.test.tsx, PasswordSetup.test.tsx, EventForm.test.tsx, AgencyAccess.test.tsx and jsdom TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc4298940832da73b0672aa6bab41