### PR TITLE
Allow button text to wrap within small buttons

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ButtonTextWrap.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ButtonTextWrap.test.tsx
@@ -1,0 +1,14 @@
+import Button from '@mui/material/Button';
+import { renderWithProviders, screen } from '../../testUtils/renderWithProviders';
+
+// Ensure button labels wrap instead of overflowing their container
+it('wraps long button text when space is constrained', () => {
+  renderWithProviders(
+    <div style={{ width: 40 }}>
+      <Button>Really long button label</Button>
+    </div>,
+  );
+  const btn = screen.getByRole('button');
+  expect(getComputedStyle(btn).whiteSpace).toBe('normal');
+});
+

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -138,6 +138,9 @@ let theme = createTheme({
           border: '1px solid transparent',
           transition: 'border-color 0.25s, background-color 0.25s',
           '&:focus-visible': { boxShadow: `0 0 0 3px ${alpha(BRAND_PRIMARY, 0.25)}` },
+          whiteSpace: 'normal',
+          overflowWrap: 'anywhere',
+          lineHeight: 1.2,
         },
         containedPrimary: {
           '&:hover': { backgroundColor: darken(BRAND_PRIMARY, 0.08) },


### PR DESCRIPTION
## Summary
- let Material UI buttons wrap and break long text
- add test covering button text wrapping behavior

## Testing
- `npm test` *(fails: BookingUI.test.tsx, StaffRecurringBookings.test.tsx, EventForm.test.tsx, PasswordSetup.test.tsx, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc3f545ec832dbdeb20d89505f148