### PR TITLE
Add pantry quick links for pantry staff pages

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PantryQuickLinks from '../components/PantryQuickLinks';
+
+describe('PantryQuickLinks', () => {
+  it('renders links to pantry routes', () => {
+    render(
+      <MemoryRouter>
+        <PantryQuickLinks />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /Pantry Schedule/i })).toHaveAttribute(
+      'href',
+      '/pantry/schedule',
+    );
+    expect(screen.getByRole('link', { name: /Record a Visit/i })).toHaveAttribute(
+      'href',
+      '/pantry/visits',
+    );
+    expect(screen.getByRole('link', { name: /Search Client/i })).toHaveAttribute(
+      'href',
+      '/pantry/client-management?tab=history',
+    );
+  });
+});

--- a/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
@@ -1,0 +1,36 @@
+import { Stack, Button } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+
+export default function PantryQuickLinks() {
+  return (
+    <Stack direction="row" spacing={2} mb={2}>
+      <Button
+        size="small"
+        variant="contained"
+        sx={{ textTransform: 'none' }}
+        component={RouterLink}
+        to="/pantry/schedule"
+      >
+        Pantry Schedule
+      </Button>
+      <Button
+        size="small"
+        variant="contained"
+        sx={{ textTransform: 'none' }}
+        component={RouterLink}
+        to="/pantry/visits"
+      >
+        Record a Visit
+      </Button>
+      <Button
+        size="small"
+        variant="contained"
+        sx={{ textTransform: 'none' }}
+        component={RouterLink}
+        to="/pantry/client-management?tab=history"
+      >
+        Search Client
+      </Button>
+    </Stack>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/PantryScheduleCapacity.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/PantryScheduleCapacity.test.tsx
@@ -4,6 +4,7 @@ import PantrySchedule from '../../staff/PantrySchedule';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from '../../../theme';
+import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('../../../api/bookings', () => ({
   getSlots: jest.fn(),
@@ -62,11 +63,13 @@ describe('PantrySchedule status colors', () => {
 
     const queryClient = new QueryClient();
     render(
-      <ThemeProvider theme={theme}>
-        <QueryClientProvider client={queryClient}>
-          <PantrySchedule />
-        </QueryClientProvider>
-      </ThemeProvider>
+      <MemoryRouter>
+        <ThemeProvider theme={theme}>
+          <QueryClientProvider client={queryClient}>
+            <PantrySchedule />
+          </QueryClientProvider>
+        </ThemeProvider>
+      </MemoryRouter>
     );
 
     const approved = await screen.findByText('App (1)');
@@ -117,11 +120,13 @@ describe('PantrySchedule status colors', () => {
 
     const queryClient = new QueryClient();
     render(
-      <ThemeProvider theme={theme}>
-        <QueryClientProvider client={queryClient}>
-          <PantrySchedule />
-        </QueryClientProvider>
-      </ThemeProvider>,
+      <MemoryRouter>
+        <ThemeProvider theme={theme}>
+          <QueryClientProvider client={queryClient}>
+            <PantrySchedule />
+          </QueryClientProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
     );
 
     const over = await screen.findByText('Over (2)');

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -197,6 +197,13 @@ export function getHelpContent(
   ],
   pantry: [
     {
+      title: 'Pantry quick links',
+      body: {
+        description:
+          'Pantry pages include a quick-access bar with links to Pantry Schedule, Record a Visit, and Search Client.',
+      },
+    },
+    {
       title: 'Manage availability',
       body: {
         description: 'Open or block pantry slots and adjust capacities.',

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import StyledTabs from '../../components/StyledTabs';
 import Page from '../../components/Page';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
 import { useSearchParams } from 'react-router-dom';
 import AddClient from './client-management/AddClient';
 import UpdateClientData from './client-management/UpdateClientData';
@@ -43,7 +44,7 @@ export default function ClientManagement() {
   ];
 
   return (
-    <Page title="Client Management">
+    <Page title="Client Management" header={<PantryQuickLinks />}>
       <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />
     </Page>
   );

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -22,6 +22,7 @@ import {
   TextField,
 } from '@mui/material';
 import ManageBookingDialog from '../../components/ManageBookingDialog';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
 import Page from '../../components/Page';
 
 interface User {
@@ -272,7 +273,7 @@ export default function PantrySchedule({
   });
 
   return (
-    <Page title="Pantry Schedule">
+    <Page title="Pantry Schedule" header={<PantryQuickLinks />}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
         <Button onClick={() => changeDay(-1)} variant="outlined" color="primary">Previous</Button>
         <h3>

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -30,6 +30,7 @@ import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
 import {
   getClientVisits,
   createClientVisit,
@@ -459,61 +460,64 @@ export default function PantryVisits() {
     <Page
       title="Pantry Visits"
       header={
-        <Stack direction="row" spacing={2} alignItems="center">
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => {
-              setForm({
-                date: format(selectedDate),
-                anonymous: false,
-                sunshineBag: false,
-                sunshineWeight: '',
-                clientId: '',
-                weightWithCart: '',
-                weightWithoutCart: '',
-                adults: '',
-                children: '',
-                petItem: '0',
-                note: '',
-              });
-              setAutoWeight(true);
-              setEditing(null);
-              setRecordOpen(true);
-            }}
-          >
-            Record Visit
-          </Button>
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => setImportOpen(true)}
-          >
-            {t('pantry_visits.import_visits')}
-          </Button>
-          <TextField
-            size="small"
-            label="Search"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-          />
-          <TextField
-            size="small"
-            label="Lookup Date"
-            type="date"
-            value={lookupDate}
-            onChange={e => setLookupDate(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-          />
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => navigate(`/pantry/visits?date=${lookupDate}`)}
-            disabled={!lookupDate}
-          >
-            Go
-          </Button>
-        </Stack>
+        <>
+          <PantryQuickLinks />
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Button
+              size="small"
+              variant="contained"
+              onClick={() => {
+                setForm({
+                  date: format(selectedDate),
+                  anonymous: false,
+                  sunshineBag: false,
+                  sunshineWeight: '',
+                  clientId: '',
+                  weightWithCart: '',
+                  weightWithoutCart: '',
+                  adults: '',
+                  children: '',
+                  petItem: '0',
+                  note: '',
+                });
+                setAutoWeight(true);
+                setEditing(null);
+                setRecordOpen(true);
+              }}
+            >
+              Record Visit
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={() => setImportOpen(true)}
+            >
+              {t('pantry_visits.import_visits')}
+            </Button>
+            <TextField
+              size="small"
+              label="Search"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
+            <TextField
+              size="small"
+              label="Lookup Date"
+              type="date"
+              value={lookupDate}
+              onChange={e => setLookupDate(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+            <Button
+              size="small"
+              variant="contained"
+              onClick={() => navigate(`/pantry/visits?date=${lookupDate}`)}
+              disabled={!lookupDate}
+            >
+              Go
+            </Button>
+          </Stack>
+        </>
       }
     >
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ClientManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ClientManagement.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ClientManagement from '../ClientManagement';
 import { getNewClients, deleteNewClient } from '../../../api/users';
+import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
 
 jest.mock('../../../api/users', () => ({
   ...jest.requireActual('../../../api/users'),
@@ -26,7 +27,7 @@ describe('ClientManagement New Clients tab', () => {
   });
 
   it('displays new clients and handles deletion', async () => {
-    render(
+    renderWithProviders(
       <MemoryRouter>
         <ClientManagement />
       </MemoryRouter>,

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import PantrySchedule from '../PantrySchedule';
 import * as bookingApi from '../../../api/bookings';
+import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('../../../api/bookings', () => ({
   getSlots: jest.fn(),
@@ -36,13 +37,21 @@ describe('PantrySchedule new client workflow', () => {
         profile_link: '',
       },
     ]);
-    render(<PantrySchedule />);
+    render(
+      <MemoryRouter>
+        <PantrySchedule />
+      </MemoryRouter>,
+    );
     expect(await screen.findByText('[NEW CLIENT] New Person')).toBeInTheDocument();
   });
 
   it('creates booking for new client', async () => {
     (bookingApi.getBookings as jest.Mock).mockResolvedValue([]);
-    render(<PantrySchedule searchUsersFn={jest.fn()} />);
+    render(
+      <MemoryRouter>
+        <PantrySchedule searchUsersFn={jest.fn()} />
+      </MemoryRouter>,
+    );
 
     const rows = await screen.findAllByRole('row');
     const cells = within(rows[1]).getAllByRole('cell');
@@ -115,7 +124,11 @@ describe('PantrySchedule status display', () => {
         profile_link: '',
       },
     ]);
-    render(<PantrySchedule />);
+    render(
+      <MemoryRouter>
+        <PantrySchedule />
+      </MemoryRouter>,
+    );
     expect(await screen.findByText('Done (1)')).toBeInTheDocument();
     expect(await screen.findByText('Flake (2)')).toBeInTheDocument();
     expect(screen.queryByText('Cancel (3)')).toBeNull();

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import PantryVisits from '../PantryVisits';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from '../../../theme';
+import { MemoryRouter } from 'react-router-dom';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -37,6 +38,16 @@ const { getClientVisits, importVisitsXlsx } = jest.requireMock('../../../api/cli
 const { getAppConfig } = jest.requireMock('../../../api/appConfig');
 const { getSunshineBag } = jest.requireMock('../../../api/sunshineBags');
 
+function renderVisits() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <PantryVisits />
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
 describe('PantryVisits', () => {
   beforeAll(() => {
     window.matchMedia =
@@ -61,11 +72,7 @@ describe('PantryVisits', () => {
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
     (getSunshineBag as jest.Mock).mockResolvedValue(null);
 
-    render(
-      <ThemeProvider theme={theme}>
-        <PantryVisits />
-      </ThemeProvider>,
-    );
+    renderVisits();
 
     await screen.findByText('Record Visit');
     expect(screen.getByText('May 13')).toBeInTheDocument();
@@ -78,11 +85,7 @@ describe('PantryVisits', () => {
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 10 });
     (getSunshineBag as jest.Mock).mockResolvedValue(null);
 
-    render(
-      <ThemeProvider theme={theme}>
-        <PantryVisits />
-      </ThemeProvider>,
-    );
+    renderVisits();
 
     await waitFor(() => expect(getAppConfig).toHaveBeenCalled());
 
@@ -125,11 +128,7 @@ describe('PantryVisits', () => {
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
     (getSunshineBag as jest.Mock).mockResolvedValue(null);
 
-    render(
-      <ThemeProvider theme={theme}>
-        <PantryVisits />
-      </ThemeProvider>,
-    );
+    renderVisits();
 
     await screen.findByText('Alice');
     expect(screen.getByText('Bob')).toBeInTheDocument();
@@ -174,11 +173,7 @@ describe('PantryVisits', () => {
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
     (getSunshineBag as jest.Mock).mockResolvedValue({ date: '2024-01-01', weight: 12 });
 
-    render(
-      <ThemeProvider theme={theme}>
-        <PantryVisits />
-      </ThemeProvider>,
-    );
+    renderVisits();
 
     expect(await screen.findByText('Clients: 2')).toBeInTheDocument();
     expect(screen.getByText('Total Weight: 20')).toBeInTheDocument();
@@ -192,11 +187,7 @@ describe('PantryVisits', () => {
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
     (getSunshineBag as jest.Mock).mockResolvedValue(null);
 
-    render(
-      <ThemeProvider theme={theme}>
-        <PantryVisits />
-      </ThemeProvider>,
-    );
+    renderVisits();
 
     expect(await screen.findByText('No records')).toBeInTheDocument();
   });
@@ -209,11 +200,7 @@ describe('PantryVisits', () => {
       sheets: [{ date: '2024-02-01', rows: 2, errors: ['bad row'] }],
     });
 
-    render(
-      <ThemeProvider theme={theme}>
-        <PantryVisits />
-      </ThemeProvider>,
-    );
+    renderVisits();
 
     await screen.findByText('Record Visit');
 
@@ -244,11 +231,7 @@ describe('PantryVisits', () => {
     (getSunshineBag as jest.Mock).mockResolvedValue(null);
     (importVisitsXlsx as jest.Mock).mockResolvedValue(undefined);
 
-    render(
-      <ThemeProvider theme={theme}>
-        <PantryVisits />
-      </ThemeProvider>,
-    );
+    renderVisits();
 
     await screen.findByText('Record Visit');
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.
 - Staff can add agencies, assign clients, and book appointments for those clients through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list with Book buttons for scheduling on their behalf.
 - Staff can enter pay period timesheets with daily hour categories, request vacation leave, and submit periods for approval with admin review and processing.
+- Pantry pages include quick links for Pantry Schedule, Record a Visit, and Search Client.
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 - Pantry Visits can log daily sunshine bag weights, shown in the summary above the visit table.
 - Pantry Visits support bulk importing visits from spreadsheets via `POST /client-visits/import` (see `docs/pantryVisits.md`).


### PR DESCRIPTION
## Summary
- add PantryQuickLinks component with navigation to schedule, visits, and client search
- integrate quick links into Pantry Schedule, Pantry Visits, and Client Management pages
- document quick-access bar in help content and repository README
- test quick link targets and update existing pantry tests for router context

## Testing
- `npm test` *(fails: TypeError: Cannot destructure property 'basename' of 'React2.useContext(...)' as it is null)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc508ef74832da062511642a7cc5a