### PR TITLE
Reduce button font size to fit small buttons

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ButtonTextFit.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ButtonTextFit.test.tsx
@@ -1,14 +1,14 @@
 import Button from '@mui/material/Button';
 import { renderWithProviders, screen } from '../../testUtils/renderWithProviders';
 
-// Ensure button labels wrap instead of overflowing their container
-it('wraps long button text when space is constrained', () => {
+// Ensure small buttons keep text within bounds by using a smaller font size
+it('uses reduced font size without wrapping text', () => {
   renderWithProviders(
     <div style={{ width: 40 }}>
       <Button>Really long button label</Button>
     </div>,
   );
   const btn = screen.getByRole('button');
-  expect(getComputedStyle(btn).whiteSpace).toBe('normal');
+  const style = getComputedStyle(btn);
+  expect(style.fontSize).toBe('0.875rem');
 });
-

--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -134,12 +134,10 @@ let theme = createTheme({
           fontWeight: 700,
           letterSpacing: '0.5px',
           padding: '0.7em 1.4em',
-          fontSize: '1rem',
+          fontSize: '0.875rem',
           border: '1px solid transparent',
           transition: 'border-color 0.25s, background-color 0.25s',
           '&:focus-visible': { boxShadow: `0 0 0 3px ${alpha(BRAND_PRIMARY, 0.25)}` },
-          whiteSpace: 'normal',
-          overflowWrap: 'anywhere',
           lineHeight: 1.2,
         },
         containedPrimary: {


### PR DESCRIPTION
## Summary
- shrink button font size to avoid overflow without increasing button dimensions
- update test to check for reduced button font size

## Testing
- `npm test -- src/__tests__/ButtonTextFit.test.tsx`
- `npm test -- src/__tests__/BookingUI.test.tsx` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc6883c20832d983f3ef8aca015f5