### PR TITLE
Remove staff selector from event creation

### DIFF
--- a/MJ_FB_Backend/src/schemas/eventSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/eventSchemas.ts
@@ -6,7 +6,6 @@ export const createEventSchema = z.object({
   category: z.string().min(1),
   startDate: z.string().min(1),
   endDate: z.string().min(1),
-  staffIds: z.array(z.number().int()).optional(),
   visibleToVolunteers: z.boolean().optional(),
   visibleToClients: z.boolean().optional(),
 }).refine((data) => data.endDate >= data.startDate, {

--- a/MJ_FB_Backend/tests/events.test.ts
+++ b/MJ_FB_Backend/tests/events.test.ts
@@ -59,7 +59,6 @@ describe('POST /events', () => {
     category: 'General',
     startDate: '2024-01-01',
     endDate: '2024-01-02',
-    staffIds: [2],
   };
 
   it('creates an event and commits the transaction', async () => {
@@ -73,7 +72,6 @@ describe('POST /events', () => {
         .fn()
         .mockResolvedValueOnce(undefined) // BEGIN
         .mockResolvedValueOnce({ rows: [{ id: 42 }] }) // insert event
-        .mockResolvedValueOnce(undefined) // insert event_staff
         .mockResolvedValueOnce(undefined), // COMMIT
       release: jest.fn(),
     };
@@ -94,7 +92,7 @@ describe('POST /events', () => {
     expect(client.release).toHaveBeenCalled();
   });
 
-  it('rolls back if inserting staff fails', async () => {
+  it('rolls back if inserting event fails', async () => {
     (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff' });
     (pool.query as jest.Mock).mockResolvedValueOnce({
       rowCount: 1,
@@ -104,8 +102,7 @@ describe('POST /events', () => {
       query: jest
         .fn()
         .mockResolvedValueOnce(undefined) // BEGIN
-        .mockResolvedValueOnce({ rows: [{ id: 1 }] }) // insert event
-        .mockRejectedValueOnce(new Error('fail')) // insert event_staff fails
+        .mockRejectedValueOnce(new Error('fail')) // insert event fails
         .mockResolvedValueOnce(undefined), // ROLLBACK
       release: jest.fn(),
     };

--- a/MJ_FB_Frontend/src/__tests__/EventForm.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/EventForm.test.tsx
@@ -2,14 +2,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import dayjs from 'dayjs';
 import EventForm from '../components/EventForm';
 import { createEvent } from '../api/events';
-import { searchStaff } from '../api/staff';
 
 jest.mock('../api/events', () => ({
   createEvent: jest.fn(),
-}));
-
-jest.mock('../api/staff', () => ({
-  searchStaff: jest.fn(),
 }));
 
 jest.mock('@mui/x-date-pickers', () => {
@@ -30,10 +25,9 @@ jest.mock('@mui/x-date-pickers', () => {
 describe('EventForm', () => {
   beforeEach(() => {
     (createEvent as jest.Mock).mockResolvedValue({});
-    (searchStaff as jest.Mock).mockResolvedValue([]);
   });
 
-  it('submits without staff selection', async () => {
+  it('submits event data', async () => {
     render(<EventForm open onClose={() => {}} onCreated={() => {}} />);
 
     fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: 'Test' } });
@@ -44,27 +38,15 @@ describe('EventForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /Create/i }));
 
     await waitFor(() => expect(createEvent).toHaveBeenCalled());
-    expect((createEvent as jest.Mock).mock.calls[0][0].staffIds).toEqual([]);
-  });
-
-  it('submits with selected staff', async () => {
-    (searchStaff as jest.Mock).mockResolvedValue([{ id: 1, name: 'Alice' }]);
-    render(<EventForm open onClose={() => {}} onCreated={() => {}} />);
-
-    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: 'Test' } });
-    fireEvent.change(screen.getByLabelText(/Category/i), { target: { value: 'harvest pantry' } });
-    fireEvent.change(screen.getByLabelText(/Start Date/i), { target: { value: '2024-01-01' } });
-    fireEvent.change(screen.getByLabelText(/End Date/i), { target: { value: '2024-01-02' } });
-
-    const staffInput = screen.getByLabelText(/Staff Involved/i);
-    fireEvent.change(staffInput, { target: { value: 'Ali' } });
-    await waitFor(() => expect(searchStaff).toHaveBeenCalledWith('Ali'));
-    const option = await screen.findByText('Alice');
-    fireEvent.click(option);
-
-    fireEvent.click(screen.getByRole('button', { name: /Create/i }));
-
-    await waitFor(() => expect(createEvent).toHaveBeenCalled());
-    expect((createEvent as jest.Mock).mock.calls[0][0].staffIds).toEqual([1]);
+    expect(createEvent).toHaveBeenCalledWith({
+      title: 'Test',
+      details: '',
+      category: 'harvest pantry',
+      startDate: '2024-01-01',
+      endDate: '2024-01-02',
+      visibleToVolunteers: false,
+      visibleToClients: false,
+    });
   });
 });
+

--- a/MJ_FB_Frontend/src/api/events.ts
+++ b/MJ_FB_Frontend/src/api/events.ts
@@ -7,7 +7,6 @@ export interface Event {
   endDate: string; // ISO string
   details?: string;
   category?: string;
-  staffIds?: number[];
   createdBy: number;
   createdByName: string;
   visibleToVolunteers?: boolean;
@@ -31,7 +30,6 @@ export async function createEvent(data: {
   category: string;
   startDate: string;
   endDate: string;
-  staffIds: number[];
   visibleToVolunteers?: boolean;
   visibleToClients?: boolean;
 }) {

--- a/MJ_FB_Frontend/src/components/EventForm.tsx
+++ b/MJ_FB_Frontend/src/components/EventForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -7,7 +7,6 @@ import {
   TextField,
   MenuItem,
   Button,
-  Autocomplete,
   FormControlLabel,
   Checkbox,
 } from '@mui/material';
@@ -18,7 +17,6 @@ import type { Dayjs } from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import { createEvent } from '../api/events';
-import { searchStaff, type StaffOption } from '../api/staff';
 import DialogCloseButton from './DialogCloseButton';
 
 interface EventFormProps {
@@ -42,35 +40,10 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
   const [category, setCategory] = useState('');
   const [startDate, setStartDate] = useState<Dayjs | null>(null);
   const [endDate, setEndDate] = useState<Dayjs | null>(null);
-  const [staffInput, setStaffInput] = useState('');
-  const [staffOptions, setStaffOptions] = useState<StaffOption[]>([]);
-  const [selectedStaff, setSelectedStaff] = useState<StaffOption[]>([]);
   const [visibleToVolunteers, setVisibleToVolunteers] = useState(false);
   const [visibleToClients, setVisibleToClients] = useState(false);
   const [success, setSuccess] = useState('');
   const [error, setError] = useState('');
-
-  useEffect(() => {
-    let active = true;
-    if (!staffInput) {
-      setStaffOptions([]);
-      return undefined;
-    }
-    searchStaff(staffInput)
-      .then(data => {
-        if (active) setStaffOptions(data);
-      })
-      .catch(() => {
-        if (active) setStaffOptions([]);
-      });
-    return () => {
-      active = false;
-    };
-  }, [staffInput]);
-
-  function handleStaffChange(_: any, value: StaffOption[]) {
-    setSelectedStaff(value);
-  }
 
   async function submit() {
     if (!title || !category || !startDate || !endDate) {
@@ -88,7 +61,6 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
         category,
         startDate: formatReginaDate(startDate),
         endDate: formatReginaDate(endDate),
-        staffIds: selectedStaff.map(s => s.id),
         visibleToVolunteers,
         visibleToClients,
       });
@@ -98,7 +70,6 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
       setCategory('');
       setStartDate(null);
       setEndDate(null);
-      setSelectedStaff([]);
       setVisibleToVolunteers(false);
       setVisibleToClients(false);
       onCreated();
@@ -158,17 +129,6 @@ export default function EventForm({ open, onClose, onCreated }: EventFormProps) 
               slotProps={{ textField: { fullWidth: true, margin: 'normal' } }}
             />
           </LocalizationProvider>
-          <Autocomplete
-            multiple
-            options={staffOptions}
-            value={selectedStaff}
-            onChange={handleStaffChange}
-            onInputChange={(_, val) => setStaffInput(val)}
-            getOptionLabel={option => option.name}
-            renderInput={params => (
-              <TextField {...params} label="Staff Involved" margin="normal" />
-            )}
-          />
           <FormControlLabel
             control={
               <Checkbox

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -33,7 +33,6 @@ import {
 } from 'recharts';
 import { useNavigate } from 'react-router-dom';
 import { formatLocaleDate, toDate } from '../../utils/date';
-import { useAuth } from '../../hooks/useAuth';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import VolunteerCoverageCard from '../../components/dashboard/VolunteerCoverageCard';
 import EventList from '../../components/EventList';
@@ -76,7 +75,6 @@ function kpiDelta(curr: number, prev?: number) {
 export default function WarehouseDashboard() {
   const theme = useTheme();
   const navigate = useNavigate();
-  const { id } = useAuth();
   const searchRef = useRef<HTMLInputElement>(null);
   const [years, setYears] = useState<number[]>([]);
   const [year, setYear] = useState<number>();
@@ -233,11 +231,8 @@ export default function WarehouseDashboard() {
   );
 
   const visibleEvents = useMemo(
-    () =>
-      [...events.today, ...events.upcoming].filter(
-        ev => !ev.staffIds || ev.staffIds.includes(id ?? -1),
-      ),
-    [events, id],
+    () => [...events.today, ...events.upcoming],
+    [events],
   );
 
   function go(path: string) {

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ Before merging a pull request, confirm the following:
 - **Volunteer Recurring Bookings** let volunteers schedule repeating shifts with start and end dates, choose daily, weekly, or weekday patterns, and cancel individual occurrences or the remaining series.
 - Staff can create recurring volunteer booking series for volunteers via `POST /volunteer-bookings/recurring/staff` and list active series with `GET /volunteer-bookings/recurring/volunteer/:volunteer_id`.
 - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts). Volunteers can create new series and manage existing ones from separate tabs on the **Recurring Bookings** page.
- - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)) with multi-day events supported via start and end dates.
+- Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)) with multi-day events supported via start and end dates.
+- Events are visible to all staff by default; the former "Staff Involved" selector has been removed.
 - Self-service client registration with email OTP verification (currently disabled pending further testing).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.
 - Staff can set a cart tare value and a single maximum booking capacity applied to all pantry time slots through the Admin → Settings → Pantry tab or `PUT /slots/capacity`.


### PR DESCRIPTION
## Summary
- remove staffIds support from backend events API
- drop staff selector from EventForm and WarehouseDashboard
- document that events are visible to all staff by default

## Testing
- `npm test` (backend) *(fails: Expected '}', got '<eof>' in tests/importClientVisits.test.ts, among other failures)*
- `npm test` (frontend) *(fails: jsdom navigation not implemented and multiple test assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc6d3b360832d93d8835f4e07d715