### PR TITLE
Align pantry quick links with breadcrumbs

### DIFF
--- a/MJ_FB_Frontend/src/components/Page.tsx
+++ b/MJ_FB_Frontend/src/components/Page.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography, type BoxProps } from '@mui/material';
 import { type ReactNode } from 'react';
-import { usePageTitle } from './layout/MainLayout';
+import { usePageTitle, useBreadcrumbActions } from './layout/MainLayout';
 
 interface PageProps extends BoxProps {
   title: string;
@@ -10,10 +10,10 @@ interface PageProps extends BoxProps {
 
 export default function Page({ title, header, children, ...boxProps }: PageProps) {
   usePageTitle(title);
+  useBreadcrumbActions(header ?? null);
 
   return (
     <Box {...boxProps}>
-      {header}
       <Typography variant="h4" gutterBottom>
         {title}
       </Typography>

--- a/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
@@ -2,12 +2,17 @@ import { Stack, Button } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 
 export default function PantryQuickLinks() {
+  const buttonSx = {
+    textTransform: 'none',
+    '&:hover': { color: 'primary.main' },
+  };
+
   return (
-    <Stack direction="row" spacing={2} mb={2}>
+    <Stack direction="row" spacing={2}>
       <Button
         size="small"
-        variant="contained"
-        sx={{ textTransform: 'none' }}
+        variant="outlined"
+        sx={buttonSx}
         component={RouterLink}
         to="/pantry/schedule"
       >
@@ -15,8 +20,8 @@ export default function PantryQuickLinks() {
       </Button>
       <Button
         size="small"
-        variant="contained"
-        sx={{ textTransform: 'none' }}
+        variant="outlined"
+        sx={buttonSx}
         component={RouterLink}
         to="/pantry/visits"
       >
@@ -24,8 +29,8 @@ export default function PantryQuickLinks() {
       </Button>
       <Button
         size="small"
-        variant="contained"
-        sx={{ textTransform: 'none' }}
+        variant="outlined"
+        sx={buttonSx}
         component={RouterLink}
         to="/pantry/client-management?tab=history"
       >

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -24,6 +24,8 @@ import EventList from '../EventList';
 import SectionCard from './SectionCard';
 import VolunteerCoverageCard from './VolunteerCoverageCard';
 import { useTranslation } from 'react-i18next';
+import PantryQuickLinks from '../PantryQuickLinks';
+import { useBreadcrumbActions } from '../layout/MainLayout';
 
 export interface DashboardProps {
   role: Role;
@@ -374,6 +376,7 @@ function UserDashboard() {
 }
 
 export default function Dashboard({ role, masterRoleFilter }: DashboardProps) {
+  useBreadcrumbActions(role === 'staff' ? <PantryQuickLinks /> : null);
   if (role === 'staff')
     return <StaffDashboard masterRoleFilter={masterRoleFilter} />;
   return <UserDashboard />;

--- a/MJ_FB_Frontend/src/components/layout/MainLayout.tsx
+++ b/MJ_FB_Frontend/src/components/layout/MainLayout.tsx
@@ -3,7 +3,13 @@ import { useTheme } from '@mui/material/styles';
 import Navbar, { type NavGroup, type NavLink } from '../Navbar';
 import Breadcrumbs from '../Breadcrumbs';
 import PageContainer from './PageContainer';
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
 
 interface MainLayoutProps {
   groups: NavGroup[];
@@ -20,6 +26,9 @@ const setDocumentTitle = (title: string) => {
 };
 
 const PageTitleContext = createContext<(title: string) => void>(setDocumentTitle);
+const BreadcrumbActionsContext = createContext<
+  (actions: ReactNode | null) => void
+>(() => {});
 
 export function usePageTitle(title: string) {
   const setTitle = useContext(PageTitleContext);
@@ -28,8 +37,17 @@ export function usePageTitle(title: string) {
   }, [setTitle, title]);
 }
 
+export function useBreadcrumbActions(actions: ReactNode | null) {
+  const setActions = useContext(BreadcrumbActionsContext);
+  useEffect(() => {
+    setActions(actions);
+    return () => setActions(null);
+  }, [actions, setActions]);
+}
+
 export default function MainLayout({ children, ...navbarProps }: MainLayoutProps) {
   const [title, setTitle] = useState('');
+  const [actions, setActions] = useState<ReactNode | null>(null);
   const theme = useTheme();
 
   useEffect(() => {
@@ -46,13 +64,25 @@ export default function MainLayout({ children, ...navbarProps }: MainLayoutProps
 
   return (
     <PageTitleContext.Provider value={setTitle}>
-      <Box sx={{ bgcolor: 'background.default', minHeight: '100vh' }}>
-        <Navbar {...navbarProps} />
-        <PageContainer component="main">
-          <Breadcrumbs />
-          {children}
-        </PageContainer>
-      </Box>
+      <BreadcrumbActionsContext.Provider value={setActions}>
+        <Box sx={{ bgcolor: 'background.default', minHeight: '100vh' }}>
+          <Navbar {...navbarProps} />
+          <PageContainer component="main">
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                mb: 2,
+              }}
+            >
+              <Breadcrumbs />
+              {actions}
+            </Box>
+            {children}
+          </PageContainer>
+        </Box>
+      </BreadcrumbActionsContext.Provider>
     </PageTitleContext.Provider>
   );
 }

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -460,64 +460,62 @@ export default function PantryVisits() {
     <Page
       title="Pantry Visits"
       header={
-        <>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => {
+              setForm({
+                date: format(selectedDate),
+                anonymous: false,
+                sunshineBag: false,
+                sunshineWeight: '',
+                clientId: '',
+                weightWithCart: '',
+                weightWithoutCart: '',
+                adults: '',
+                children: '',
+                petItem: '0',
+                note: '',
+              });
+              setAutoWeight(true);
+              setEditing(null);
+              setRecordOpen(true);
+            }}
+          >
+            Record Visit
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => setImportOpen(true)}
+          >
+            {t('pantry_visits.import_visits')}
+          </Button>
+          <TextField
+            size="small"
+            label="Search"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          <TextField
+            size="small"
+            label="Lookup Date"
+            type="date"
+            value={lookupDate}
+            onChange={e => setLookupDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => navigate(`/pantry/visits?date=${lookupDate}`)}
+            disabled={!lookupDate}
+          >
+            Go
+          </Button>
           <PantryQuickLinks />
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Button
-              size="small"
-              variant="contained"
-              onClick={() => {
-                setForm({
-                  date: format(selectedDate),
-                  anonymous: false,
-                  sunshineBag: false,
-                  sunshineWeight: '',
-                  clientId: '',
-                  weightWithCart: '',
-                  weightWithoutCart: '',
-                  adults: '',
-                  children: '',
-                  petItem: '0',
-                  note: '',
-                });
-                setAutoWeight(true);
-                setEditing(null);
-                setRecordOpen(true);
-              }}
-            >
-              Record Visit
-            </Button>
-            <Button
-              size="small"
-              variant="contained"
-              onClick={() => setImportOpen(true)}
-            >
-              {t('pantry_visits.import_visits')}
-            </Button>
-            <TextField
-              size="small"
-              label="Search"
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-            />
-            <TextField
-              size="small"
-              label="Lookup Date"
-              type="date"
-              value={lookupDate}
-              onChange={e => setLookupDate(e.target.value)}
-              InputLabelProps={{ shrink: true }}
-            />
-            <Button
-              size="small"
-              variant="contained"
-              onClick={() => navigate(`/pantry/visits?date=${lookupDate}`)}
-              disabled={!lookupDate}
-            >
-              Go
-            </Button>
-          </Stack>
-        </>
+        </Stack>
       }
     >
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />


### PR DESCRIPTION
## Summary
- Place pantry quick links alongside breadcrumbs and right-align them
- Switch pantry quick link buttons to outlined style without hover color change
- Allow dashboards and pages to inject breadcrumb actions

## Testing
- `npm test` *(fails: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbc7deaa60832d9501dbef7c388eb6