### PR TITLE
feat: shrink pantry visit buttons

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -479,6 +479,7 @@ export default function PantryVisits() {
                 setEditing(null);
                 setRecordOpen(true);
               }}
+              sx={{ typography: 'caption', textTransform: 'none' }}
             >
               Record Visit
             </Button>
@@ -486,6 +487,7 @@ export default function PantryVisits() {
               size="small"
               variant="contained"
               onClick={() => setImportOpen(true)}
+              sx={{ typography: 'caption', textTransform: 'none' }}
             >
               {t('pantry_visits.import_visits')}
             </Button>


### PR DESCRIPTION
## Summary
- shrink record/import visit buttons on pantry visit page

## Testing
- `npm test` (fails: loginAppreciation.test.tsx and many others)

------
https://chatgpt.com/codex/tasks/task_e_68bbc86b6660832d8fafd70ca1dbf656