### PR TITLE
fix: close Stack in pantry visits header

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -510,64 +510,7 @@ export default function PantryVisits() {
             Go
           </Button>
           <PantryQuickLinks />
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Button
-              size="small"
-              variant="contained"
-              onClick={() => {
-                setForm({
-                  date: format(selectedDate),
-                  anonymous: false,
-                  sunshineBag: false,
-                  sunshineWeight: '',
-                  clientId: '',
-                  weightWithCart: '',
-                  weightWithoutCart: '',
-                  adults: '',
-                  children: '',
-                  petItem: '0',
-                  note: '',
-                });
-                setAutoWeight(true);
-                setEditing(null);
-                setRecordOpen(true);
-              }}
-              sx={{ typography: 'caption', textTransform: 'none' }}
-            >
-              Record Visit
-            </Button>
-            <Button
-              size="small"
-              variant="contained"
-              onClick={() => setImportOpen(true)}
-              sx={{ typography: 'caption', textTransform: 'none' }}
-            >
-              {t('pantry_visits.import_visits')}
-            </Button>
-            <TextField
-              size="small"
-              label="Search"
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-            />
-            <TextField
-              size="small"
-              label="Lookup Date"
-              type="date"
-              value={lookupDate}
-              onChange={e => setLookupDate(e.target.value)}
-              InputLabelProps={{ shrink: true }}
-            />
-            <Button
-              size="small"
-              variant="contained"
-              onClick={() => navigate(`/pantry/visits?date=${lookupDate}`)}
-              disabled={!lookupDate}
-            >
-              Go
-            </Button>
-          </Stack>
-        </>
+        </Stack>
       }
     >
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />


### PR DESCRIPTION
## Summary
- fix JSX structure in pantry visits header

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbcc07a220832d87bb07cd5e76e650