### PR TITLE
Exclude anonymous visits from volunteer family count

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerStatsController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerStatsController.ts
@@ -76,10 +76,10 @@ export async function getVolunteerGroupStats(
                    ELSE 0
                  END
                ), 0) AS month_lbs,
-               COALESCE(COUNT(DISTINCT CASE
-                   WHEN date_trunc('month', date) = date_trunc('month', CURRENT_DATE)
-                   THEN client_id
-                 END), 0) AS month_families
+               COALESCE(COUNT(DISTINCT client_id) FILTER (
+                   WHERE date_trunc('month', date) = date_trunc('month', CURRENT_DATE)
+                     AND is_anonymous = false
+               ), 0) AS month_families
         FROM client_visits
       ),
       goal AS (


### PR DESCRIPTION
## Summary
- ignore anonymous client visits when calculating `month_families` in volunteer group stats

## Testing
- `npm test` *(fails: Test Suites: 15 failed, 88 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcc897c94832d8c7e657506830eb3