### PR TITLE
Separate quick links from pantry visits toolbar and extend coverage

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyManagement.test.tsx
@@ -35,4 +35,15 @@ describe('AgencyManagement', () => {
       screen.getByRole('tab', { name: /add client to agency/i }),
     ).toBeInTheDocument();
   });
+
+  it('shows pantry quick links', async () => {
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test Staff');
+    localStorage.setItem('access', JSON.stringify(['pantry']));
+    window.history.pushState({}, '', '/pantry/agency-management');
+    renderWithProviders(<App />);
+    expect(
+      await screen.findByRole('link', { name: /record a visit/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/MJ_FB_Frontend/src/pages/staff/AgencyManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyManagement.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import StyledTabs from '../../components/StyledTabs';
 import Page from '../../components/Page';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
 import AddAgency from './AddAgency';
 import AgencyClientManager from './AgencyClientManager';
 
@@ -12,7 +13,7 @@ export default function AgencyManagement() {
   ];
 
   return (
-    <Page title="Agency Management">
+    <Page title="Agency Management" header={<PantryQuickLinks />}>
       <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />
     </Page>
   );

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -32,6 +32,7 @@ import type { AlertColor } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs, { type TabItem } from '../../components/StyledTabs';
 import Page from '../../components/Page';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
 import {
   getHolidays,
   addHoliday,
@@ -571,7 +572,7 @@ export default function ManageAvailability() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Page title="Manage Availability">
+      <Page title="Manage Availability" header={<PantryQuickLinks />}>
         <Box sx={{ maxWidth: 1000, mx: 'auto', pb: 6 }}>
           <StyledTabs tabs={tabs} />
           <FeedbackSnackbar

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -453,67 +453,62 @@ export default function PantryVisits() {
   }));
 
   return (
-    <Page
-      title="Pantry Visits"
-      header={
-        <Stack direction="row" spacing={2} alignItems="center">
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => {
-              setForm({
-                date: format(selectedDate),
-                anonymous: false,
-                sunshineBag: false,
-                sunshineWeight: '',
-                clientId: '',
-                weightWithCart: '',
-                weightWithoutCart: '',
-                adults: '',
-                children: '',
-                petItem: '0',
-                note: '',
-              });
-              setAutoWeight(true);
-              setEditing(null);
-              setRecordOpen(true);
-            }}
-          >
-            Record Visit
-          </Button>
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => setImportOpen(true)}
-          >
-            {t('pantry_visits.import_visits')}
-          </Button>
-          <TextField
-            size="small"
-            label="Search"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-          />
-          <TextField
-            size="small"
-            label="Lookup Date"
-            type="date"
-            value={lookupDate}
-            onChange={e => setLookupDate(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-          />
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => navigate(`/pantry/visits?date=${lookupDate}`)}
-            disabled={!lookupDate}
-          >
-            Go
-          </Button>
-          <PantryQuickLinks />
-        </Stack>
-      }
-    >
+    <Page title="Pantry Visits" header={<PantryQuickLinks />}>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => {
+            setForm({
+              date: format(selectedDate),
+              anonymous: false,
+              sunshineBag: false,
+              sunshineWeight: '',
+              clientId: '',
+              weightWithCart: '',
+              weightWithoutCart: '',
+              adults: '',
+              children: '',
+              petItem: '0',
+              note: '',
+            });
+            setAutoWeight(true);
+            setEditing(null);
+            setRecordOpen(true);
+          }}
+        >
+          Record Visit
+        </Button>
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => setImportOpen(true)}
+        >
+          {t('pantry_visits.import_visits')}
+        </Button>
+        <TextField
+          size="small"
+          label="Search"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <TextField
+          size="small"
+          label="Lookup Date"
+          type="date"
+          value={lookupDate}
+          onChange={e => setLookupDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => navigate(`/pantry/visits?date=${lookupDate}`)}
+          disabled={!lookupDate}
+        >
+          Go
+        </Button>
+      </Stack>
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
       <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>


### PR DESCRIPTION
## Summary
- Move visit management controls below breadcrumbs and keep quick links alone in header
- Add pantry quick links to Manage Availability and Agency Management pages
- Verify quick links presence on Agency Management page

## Testing
- `npm test -- src/__tests__/AgencyManagement.test.tsx src/pages/staff/__tests__/PantryVisits.test.tsx` *(fails: Unable to find element with text "Total Weight: 20" and label "Update")*

------
https://chatgpt.com/codex/tasks/task_e_68bbce5f29cc832daed52e699e70c540