### PR TITLE
Fix timezone handling for client visit xlsx import

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -361,7 +361,7 @@ export async function importVisitsFromXlsx(
     for (const sheet of sheets) {
       const rows = await readXlsxFile(req.file.buffer, { sheet: sheet.name });
       const sheetDate = sheet.name;
-      const formattedDate = formatReginaDate(new Date(sheetDate));
+      const formattedDate = formatReginaDate(sheetDate);
       const errors: string[] = [];
 
       const dataRows = rows.slice(1);
@@ -371,7 +371,6 @@ export async function importVisitsFromXlsx(
         const [familySize, weightWithCart, weightWithoutCart, petItem, clientId] = row;
         try {
           const parsed = importClientVisitsSchema.parse({
-            date: new Date(sheetDate),
             familySize: String(familySize ?? ''),
             weightWithCart:
               weightWithCart == null ? undefined : Number(weightWithCart),


### PR DESCRIPTION
## Summary
- ensure xlsx import treats sheet names as Regina-local dates
- add regression test confirming sheet names import visits with matching dates

## Testing
- `npm test` *(fails: cannot redefine property in agency.test.ts, and others)*
- `npm test tests/importClientVisits.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bbd2b14b5c832db8038c500d893fb4