### PR TITLE
Improve pantry quick links responsiveness

### DIFF
--- a/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
@@ -8,13 +8,18 @@ export default function PantryQuickLinks() {
   };
 
   return (
-    <Stack direction="row" spacing={2}>
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      spacing={{ xs: 1, sm: 2 }}
+      sx={{ width: '100%' }}
+    >
       <Button
         size="small"
         variant="outlined"
         sx={buttonSx}
         component={RouterLink}
         to="/pantry/schedule"
+        fullWidth
       >
         Pantry Schedule
       </Button>
@@ -24,6 +29,7 @@ export default function PantryQuickLinks() {
         sx={buttonSx}
         component={RouterLink}
         to="/pantry/visits"
+        fullWidth
       >
         Record a Visit
       </Button>
@@ -33,6 +39,7 @@ export default function PantryQuickLinks() {
         sx={buttonSx}
         component={RouterLink}
         to="/pantry/client-management?tab=history"
+        fullWidth
       >
         Search Client
       </Button>

--- a/MJ_FB_Frontend/src/components/layout/MainLayout.tsx
+++ b/MJ_FB_Frontend/src/components/layout/MainLayout.tsx
@@ -71,13 +71,17 @@ export default function MainLayout({ children, ...navbarProps }: MainLayoutProps
             <Box
               sx={{
                 display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
+                justifyContent: { xs: 'flex-start', sm: 'space-between' },
+                alignItems: { xs: 'stretch', sm: 'center' },
+                flexWrap: 'wrap',
+                gap: 1,
                 mb: 2,
               }}
             >
               <Breadcrumbs />
-              {actions}
+              {actions && (
+                <Box sx={{ width: { xs: '100%', sm: 'auto' } }}>{actions}</Box>
+              )}
             </Box>
             {children}
           </PageContainer>

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -454,7 +454,12 @@ export default function PantryVisits() {
 
   return (
     <Page title="Pantry Visits" header={<PantryQuickLinks />}>
-      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        sx={{ mb: 2 }}
+      >
         <Button
           size="small"
           variant="contained"
@@ -476,6 +481,7 @@ export default function PantryVisits() {
             setEditing(null);
             setRecordOpen(true);
           }}
+          fullWidth
         >
           Record Visit
         </Button>
@@ -483,6 +489,7 @@ export default function PantryVisits() {
           size="small"
           variant="contained"
           onClick={() => setImportOpen(true)}
+          fullWidth
         >
           {t('pantry_visits.import_visits')}
         </Button>
@@ -491,6 +498,7 @@ export default function PantryVisits() {
           label="Search"
           value={search}
           onChange={e => setSearch(e.target.value)}
+          fullWidth
         />
         <TextField
           size="small"
@@ -499,12 +507,14 @@ export default function PantryVisits() {
           value={lookupDate}
           onChange={e => setLookupDate(e.target.value)}
           InputLabelProps={{ shrink: true }}
+          fullWidth
         />
         <Button
           size="small"
           variant="contained"
           onClick={() => navigate(`/pantry/visits?date=${lookupDate}`)}
           disabled={!lookupDate}
+          fullWidth
         >
           Go
         </Button>


### PR DESCRIPTION
## Summary
- Wrap breadcrumb actions and allow wrapping so quick links stack on narrow screens
- Stack pantry quick links vertically on small viewports
- Make pantry visit controls stack vertically for mobile widths

## Testing
- `npm test` *(fails: e.g., TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbd36a0170832d9d42da10e2554cd3