### PR TITLE
Exclude anonymous visits from family size summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/src/locales` when client-visible text is added.
 - Pantry visits track daily sunshine bag weights via the `sunshine_bag_log` table.
+- Anonymous pantry visits display "(ANONYMOUS)" after the client ID and their family size is excluded from the summary counts.
 - Bulk pantry visit imports use the `POST /client-visits/import` endpoint (also available at `/visits/import`) and overwrite existing visits when client/date duplicates are found; see `docs/pantryVisits.md` for sheet naming and dry-run options.
 - Booking notes consist of **client notes** (entered when booking) and **staff notes** (recorded during visits). Staff users automatically receive staff notes in booking history responses, while agency users can include them with `includeStaffNotes=true`.
 - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes.

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -240,7 +240,8 @@ export function getHelpContent(
     {
       title: 'Look up past visits',
       body: {
-        description: 'View client visits for a specific day.',
+        description:
+          'View client visits for a specific day. Anonymous visits show (ANONYMOUS) after the client ID and are excluded from family counts in the summary.',
         steps: [
           'Open the Pantry Visits page.',
           'Choose a date in the lookup field.',

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -231,8 +231,11 @@ export default function PantryVisits() {
     const clients = visits.filter(v => !v.anonymous).length;
     const totalWeight =
       visits.reduce((sum, v) => sum + v.weightWithoutCart, 0) + sunshineBagWeight;
-    const adults = visits.reduce((sum, v) => sum + v.adults, 0);
-    const children = visits.reduce((sum, v) => sum + v.children, 0);
+    const adults = visits.reduce((sum, v) => sum + (v.anonymous ? 0 : v.adults), 0);
+    const children = visits.reduce(
+      (sum, v) => sum + (v.anonymous ? 0 : v.children),
+      0,
+    );
     return { clients, totalWeight, adults, children };
   }, [visits, sunshineBagWeight]);
 
@@ -352,7 +355,10 @@ export default function PantryVisits() {
             filteredVisits.map(v => (
               <TableRow key={v.id}>
                 <TableCell>{formatDisplay(v.date)}</TableCell>
-                <TableCell>{v.clientId ?? 'N/A'}</TableCell>
+                <TableCell>
+                  {v.clientId ?? 'N/A'}
+                  {v.anonymous ? ' (ANONYMOUS)' : ''}
+                </TableCell>
                 <TableCell>{v.clientName ?? ''}</TableCell>
                 <TableCell>
                   {v.clientId ? (

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -162,7 +162,7 @@ describe('PantryVisits', () => {
         date: '2024-01-01',
         clientId: 222,
         clientName: 'Bob',
-        anonymous: false,
+        anonymous: true,
         weightWithCart: 20,
         weightWithoutCart: 15,
         petItem: 1,
@@ -175,10 +175,12 @@ describe('PantryVisits', () => {
 
     renderVisits();
 
-    expect(await screen.findByText('Clients: 2')).toBeInTheDocument();
-    expect(screen.getByText('Total Weight: 20')).toBeInTheDocument();
-    expect(screen.getByText('Adults: 4')).toBeInTheDocument();
-    expect(screen.getByText('Children: 6')).toBeInTheDocument();
+    expect(await screen.findByText('111')).toBeInTheDocument();
+    expect(screen.getByText('222 (ANONYMOUS)')).toBeInTheDocument();
+    expect(screen.getByText('Clients: 1')).toBeInTheDocument();
+    expect(screen.getByText('Total Weight: 32')).toBeInTheDocument();
+    expect(screen.getByText('Adults: 1')).toBeInTheDocument();
+    expect(screen.getByText('Children: 2')).toBeInTheDocument();
     expect(screen.getByText('Sunshine Bag Weight: 12')).toBeInTheDocument();
   });
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Pantry pages include quick links for Pantry Schedule, Record a Visit, and Search Client.
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 - Pantry Visits can log daily sunshine bag weights, shown in the summary above the visit table.
+- Anonymous Pantry Visits show "(ANONYMOUS)" after the client ID and their family size is excluded from summary counts.
 - Pantry Visits support bulk importing visits from spreadsheets via `POST /client-visits/import` (also `/visits/import`) and overwrite existing visits on client/date conflicts (see `docs/pantryVisits.md`).
 - Pantry Visits allow selecting any date to view visits beyond the current week.
 

--- a/docs/pantryVisits.md
+++ b/docs/pantryVisits.md
@@ -20,6 +20,10 @@ Add the following translation strings to locale files:
 - `pantry_visits.sheet_rows`
 - `pantry_visits.sheet_errors`
 
+## Anonymous visits
+
+Anonymous visits display `(ANONYMOUS)` after the client ID in the Pantry Visits table, and their adults and children counts are excluded from summary totals.
+
 ## Bulk import format
  
 Pantry visits support bulk importing from an `.xlsx` spreadsheet. Upload the file via `POST /client-visits/import` (also available at `/visits/import`). Each sheet represents visits for a single day and must be named using the visit date in `YYYY-MM-DD` format. Because the sheet name holds the date, rows omit a `date` column.


### PR DESCRIPTION
## Summary
- exclude anonymous pantry visits from adult/child summary totals
- flag anonymous visits with "(ANONYMOUS)" next to the client ID
- document anonymous visit behavior in help, docs, and README

## Testing
- `npm test src/pages/staff/__tests__/PantryVisits.test.tsx` *(fails: Unable to find a label with the text of: Update)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd478c460832da83024ec764264a6