### PR TITLE
Prevent duplicate client visits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/src/locales` when client-visible text is added.
 - Pantry visits track daily sunshine bag weights via the `sunshine_bag_log` table.
 - Bulk pantry visit imports use the `POST /client-visits/import` endpoint (also available at `/visits/import`) and overwrite existing visits when client/date duplicates are found; see `docs/pantryVisits.md` for sheet naming and dry-run options.
+- Client visits enforce a unique client/date combination; attempts to record a second visit for the same client and day return a 409 error.
 - Booking notes consist of **client notes** (entered when booking) and **staff notes** (recorded during visits). Staff users automatically receive staff notes in booking history responses, while agency users can include them with `includeStaffNotes=true`.
 - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes.
 - A cron job seeds pay periods for the upcoming year every **Nov 30** using `seedPayPeriods`.

--- a/MJ_FB_Backend/src/migrations/1700000000003_add_unique_client_visit.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000003_add_unique_client_visit.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addConstraint('client_visits', 'client_visits_client_date_unique', {
+    unique: ['date', 'client_id'],
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('client_visits', 'client_visits_client_date_unique');
+}

--- a/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
+++ b/MJ_FB_Backend/tests/bookingStatusUpdate.test.ts
@@ -56,14 +56,16 @@ describe('booking status updates', () => {
   it('allows staff to mark booking as visited', async () => {
     (bookingRepo.updateBooking as jest.Mock).mockResolvedValue(undefined);
     (pool.query as jest.Mock)
-      .mockResolvedValueOnce({ rows: [{ client_id: 1 }] })
-      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      .mockResolvedValueOnce({ rowCount: 0 }) // duplicate check
+      .mockResolvedValueOnce({ rows: [{ client_id: 1 }], rowCount: 1 }) // insert
+      .mockResolvedValueOnce({}); // refresh count
     const res = await request(app)
       .post('/bookings/2/visited')
       .set('x-role', 'staff')
       .send({ requestData: 'note', note: 'remember ID', adults: 1, children: 2 });
     expect(res.status).toBe(200);
-    expect(pool.query).toHaveBeenCalledWith(
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
       expect.stringContaining('INSERT INTO client_visits'),
       [null, null, 0, 'remember ID', 1, 2, 2],
     );
@@ -72,6 +74,14 @@ describe('booking status updates', () => {
       request_data: 'note',
       note: null,
     });
+  });
+
+  it('rejects duplicate visit on booking', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1 });
+    const res = await request(app)
+      .post('/bookings/4/visited')
+      .set('x-role', 'staff');
+    expect(res.status).toBe(409);
   });
 
   it('rejects non-staff users', async () => {

--- a/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
@@ -62,6 +62,7 @@ describe('client visit booking integration', () => {
     const queryMock = jest
       .fn()
       .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // duplicate check
       .mockResolvedValueOnce({
         rows: [
           {
@@ -146,6 +147,7 @@ describe('client visit booking integration', () => {
     const queryMock = jest
       .fn()
       .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // duplicate check
       .mockResolvedValueOnce({
         rows: [
           {

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 - Pantry Visits can log daily sunshine bag weights, shown in the summary above the visit table.
 - Pantry Visits support bulk importing visits from spreadsheets via `POST /client-visits/import` (also `/visits/import`) and overwrite existing visits on client/date conflicts (see `docs/pantryVisits.md`).
+- Pantry Visits reject attempts to record more than one visit per client on the same day.
 - Pantry Visits allow selecting any date to view visits beyond the current week.
 
 ## Deploying to Azure

--- a/docs/pantryVisits.md
+++ b/docs/pantryVisits.md
@@ -20,6 +20,10 @@ Add the following translation strings to locale files:
 - `pantry_visits.sheet_rows`
 - `pantry_visits.sheet_errors`
 
+## Visit limits
+
+Staff can record only one visit per client per day. Attempts to add a second visit for the same client and date are rejected as duplicates.
+
 ## Bulk import format
  
 Pantry visits support bulk importing from an `.xlsx` spreadsheet. Upload the file via `POST /client-visits/import` (also available at `/visits/import`). Each sheet represents visits for a single day and must be named using the visit date in `YYYY-MM-DD` format. Because the sheet name holds the date, rows omit a `date` column.


### PR DESCRIPTION
## Summary
- prevent duplicate pantry visits by enforcing unique client/date
- reject duplicate visits in booking and visit controllers
- document single-visit limit for clients

## Testing
- `npm test` (backend) *(fails: Test Suites: 18 failed, 85 passed)*
- `npm test` (frontend) *(fails: PantryVisits.test.tsx, BookingUI.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd4f32820832d80bf9707275ec087