### PR TITLE
Fix pantry schedule chips responsiveness

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -186,7 +186,7 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
           </Grid>
           <Grid size={12}>
             <SectionCard title="Pantry Schedule (This Week)">
-              <Grid container columns={7} spacing={2}>
+              <Grid container columns={{ xs: 3, sm: 7 }} spacing={2}>
                 {schedule.map((day, i) => (
                   <Grid size={1} key={i}>
                     <Stack alignItems="center" spacing={1}>


### PR DESCRIPTION
## Summary
- make pantry schedule dashboard chips wrap into fewer columns on small screens

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6b07ee8832db5ee787fa49287cb