### PR TITLE
Fix record visit dialog to use exclusive visit types

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -17,7 +17,8 @@ import {
   Stack,
   IconButton,
   FormControlLabel,
-  Checkbox,
+  Radio,
+  RadioGroup,
   Typography,
 } from '@mui/material';
 import Edit from '@mui/icons-material/Edit';
@@ -539,16 +540,23 @@ export default function PantryVisits() {
               onChange={e => setForm({ ...form, date: e.target.value })}
               InputLabelProps={{ shrink: true }}
             />
-            <Stack direction="row" spacing={2}>
-              <FormControlLabel
-                control={<Checkbox checked={form.anonymous} onChange={e => setForm({ ...form, anonymous: e.target.checked })} />}
-                label="Anonymous"
-              />
-              <FormControlLabel
-                control={<Checkbox checked={form.sunshineBag} onChange={e => setForm({ ...form, sunshineBag: e.target.checked })} />}
-                label={t('sunshine_bag_label')}
-              />
-            </Stack>
+            <RadioGroup
+              row
+              value={form.sunshineBag ? 'sunshine' : form.anonymous ? 'anonymous' : 'regular'}
+              onChange={e => {
+                const v = e.target.value;
+                setForm({
+                  ...form,
+                  anonymous: v === 'anonymous',
+                  sunshineBag: v === 'sunshine',
+                });
+              }}
+              sx={{ gap: 2 }}
+            >
+              <FormControlLabel value="regular" control={<Radio />} label="Regular visit" />
+              <FormControlLabel value="anonymous" control={<Radio />} label="Anonymous visit" />
+              <FormControlLabel value="sunshine" control={<Radio />} label={t('sunshine_bag_label')} />
+            </RadioGroup>
             {form.sunshineBag ? (
               <TextField
                 label={t('sunshine_bag_weight_label')}


### PR DESCRIPTION
## Summary
- Replace anonymous/sunshine checkboxes with radio group including Regular visit option
- Adjust staff pantry visit tests to cover new visit type selection and import flow

## Testing
- `npm test src/pages/staff/__tests__/PantryVisits.test.tsx`
- `npm test` *(fails: BookingUI.test.tsx, PantrySchedule.test.tsx, PasswordSetup.test.tsx, NoShowWeek.test.tsx, HelpPage.test.tsx, ClientManagement.test.tsx, AdminLeaveRequests.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd73b8b70832d90e3d8b93b593fc7