### PR TITLE
feat(frontend): make table headers sticky

### DIFF
--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -252,11 +252,26 @@ let theme = createTheme({
     },
 
     // Tables/lists
+    MuiTable: {
+      defaultProps: { stickyHeader: true },
+    },
     MuiListItem: {
-      styleOverrides: { root: { borderRadius: 5, '&:hover': { background: 'rgba(0,0,0,0.03)' } } },
+      styleOverrides: {
+        root: { borderRadius: 5, '&:hover': { background: 'rgba(0,0,0,0.03)' } },
+      },
     },
     MuiTableHead: {
-      styleOverrides: { root: { '& .MuiTableCell-head': { fontWeight: 700, background: '#fafafa' } } },
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-head': {
+            fontWeight: 700,
+            background: '#fafafa',
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+          },
+        },
+      },
     },
     MuiTableCell: { styleOverrides: { root: { borderBottomColor: '#eee' } } },
 


### PR DESCRIPTION
## Summary
- keep table headers visible when scrolling by enabling sticky headers

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd9d3178c832dbf2233abadb4e35b