### PR TITLE
feat: add staff leave request endpoint

### DIFF
--- a/MJ_FB_Backend/src/controllers/leaveRequestController.ts
+++ b/MJ_FB_Backend/src/controllers/leaveRequestController.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import {
   insertLeaveRequest,
   selectLeaveRequests,
+  selectLeaveRequestsByStaffId,
   updateLeaveRequestStatus,
   countApprovedPersonalDaysThisQuarter,
   LeaveType,
@@ -47,6 +48,23 @@ export async function listLeaveRequests(
 ): Promise<void> {
   try {
     const rows = await selectLeaveRequests();
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listLeaveRequestsByStaff(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const staffId = parseIdParam(req.params.staffId);
+    if (staffId === null) {
+      return void res.status(400).json({ message: "Invalid staff ID" });
+    }
+    const rows = await selectLeaveRequestsByStaffId(staffId);
     res.json(rows);
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/src/models/leaveRequest.ts
+++ b/MJ_FB_Backend/src/models/leaveRequest.ts
@@ -50,6 +50,20 @@ export async function selectLeaveRequests(): Promise<LeaveRequest[]> {
   return res.rows;
 }
 
+export async function selectLeaveRequestsByStaffId(
+  staffId: number,
+): Promise<LeaveRequest[]> {
+  const res = await pool.query(
+    `SELECT lr.*, s.first_name || ' ' || s.last_name AS requester_name
+     FROM leave_requests lr
+     JOIN staff s ON s.id = lr.staff_id
+     WHERE lr.staff_id = $1
+     ORDER BY lr.start_date`,
+    [staffId],
+  );
+  return res.rows;
+}
+
 export async function updateLeaveRequestStatus(
   id: number,
   status: string,

--- a/MJ_FB_Backend/src/routes/timesheets.ts
+++ b/MJ_FB_Backend/src/routes/timesheets.ts
@@ -9,6 +9,7 @@ import {
   rejectTimesheet,
   processTimesheet,
 } from '../controllers/timesheetController';
+import { listLeaveRequestsByStaff } from '../controllers/leaveRequestController';
 
 const router = express.Router();
 
@@ -17,6 +18,12 @@ router.get('/mine', authMiddleware, authorizeRoles('staff', 'admin'), listMyTime
 // admin can list timesheets for any staff
 // optional query params: staffId, year, month
 router.get('/', authMiddleware, authorizeRoles('admin'), listTimesheets);
+router.get(
+  '/leave-requests/:staffId',
+  authMiddleware,
+  authorizeRoles('admin'),
+  listLeaveRequestsByStaff,
+);
 router.get(
   '/:id/days',
   authMiddleware,

--- a/MJ_FB_Backend/tests/leaveRequests.test.ts
+++ b/MJ_FB_Backend/tests/leaveRequests.test.ts
@@ -2,6 +2,7 @@ import "./setupTests";
 import {
   createLeaveRequest,
   approveLeaveRequest,
+  listLeaveRequestsByStaff,
 } from "../src/controllers/leaveRequestController";
 import mockPool from "./utils/mockDb";
 import { ensureTimesheetDay } from "../src/models/timesheet";
@@ -175,5 +176,43 @@ describe("leave requests controller", () => {
     });
     expect(ensureTimesheetDay).not.toHaveBeenCalled();
     expect(insertEvent).toHaveBeenCalled();
+  });
+
+  it("lists leave requests for a staff member", async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 3,
+          staff_id: 1,
+          start_date: "2024-03-01",
+          end_date: "2024-03-01",
+          type: "sick",
+          status: "pending",
+          reason: null,
+          requester_name: "Test User",
+          created_at: "now",
+          updated_at: "now",
+        },
+      ],
+      rowCount: 1,
+    });
+    const req: any = { params: { staffId: "1" } };
+    const res = makeRes();
+    await listLeaveRequestsByStaff(req, res as any, () => {});
+    expect(res.json).toHaveBeenCalledWith([
+      {
+        id: 3,
+        staff_id: 1,
+        start_date: "2024-03-01",
+        end_date: "2024-03-01",
+        type: "sick",
+        status: "pending",
+        reason: null,
+        requester_name: "Test User",
+        created_at: "now",
+        updated_at: "now",
+      },
+    ]);
+    expect(mockPool.query).toHaveBeenCalledWith(expect.any(String), [1]);
   });
 });

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - [docs](docs/) with setup notes and a [Timesheets guide](docs/timesheets.md).
 - Leave request API under `/api/leave/requests` for staff leave, supporting
   vacation, sick, or personal requests (one personal day per quarter) with optional reasons.
+  Admins can view requests for a specific staff member via
+  `/api/timesheets/leave-requests/:staffId`.
 - Password fields include a visibility toggle so users can verify what they type.
 
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -59,14 +59,14 @@ in `summary.ot_bank_remaining`.
 
 ## Leave approval workflow
 
-Staff can request vacation, sick, or personal leave by posting to
-`/timesheets/:id/leave-requests`. Personal days are limited to one per calendar
-quarter and approved requests do **not** prefill timesheets. Pending requests
-appear under the same path and globally via `/api/leave/requests` for admins.
-Approving a vacation or sick request adds default hours for each day in the
-request but leaves the entries editable. An approved request also creates a
-`staff_leave` event visible to clients and volunteers. Rejection simply removes
-the request.
+Staff can request vacation, sick, or personal leave via `/api/leave/requests`.
+Personal days are limited to one per calendar quarter and approved requests do
+**not** prefill timesheets. Admins can view requests for a specific staff member
+at `/api/timesheets/leave-requests/:staffId` or list all requests at
+`/api/leave/requests`. Approving a vacation or sick request adds default hours
+for each day in the request but leaves the entries editable. An approved request
+also creates a `staff_leave` event visible to clients and volunteers. Rejection
+simply removes the request.
 
 
 ## Email settings
@@ -90,13 +90,12 @@ TIMESHEET_APPROVER_EMAILS=admin1@example.com,admin2@example.com # optional
 - `POST /timesheets/:id/submit` – submit a pay period.
 - `POST /timesheets/:id/reject` – reject a submitted timesheet (admin only).
 - `POST /timesheets/:id/process` – mark a timesheet as processed and exportable (admin only).
-- `POST /timesheets/:id/leave-requests` – request leave for a day with `date`,
-  `hours`, and `type` (`vacation` or `sick`).
-- `GET /timesheets/:id/leave-requests` – list leave requests awaiting review.
-- `POST /timesheets/leave-requests/:requestId/approve` – approve a leave request, applying vacation hours and locking the day.
+- `GET /timesheets/leave-requests/:staffId` – list leave requests for a staff member (admin only).
 - `GET /api/leave/requests` – list all leave requests (admin only).
 - `POST /api/leave/requests` – submit a leave request for the logged in staff
   member with `startDate`, `endDate`, `type`, and optional `reason`.
+- `POST /api/leave/requests/:id/approve` – approve a leave request, applying vacation hours and locking the day.
+- `POST /api/leave/requests/:id/reject` – reject a leave request.
 
 ## UI walkthrough
 


### PR DESCRIPTION
## Summary
- support fetching leave requests for a specific staff member at `/api/timesheets/leave-requests/:staffId`
- document new endpoint in README and timesheets guide
- cover controller with tests

## Testing
- `nvm use`
- `npm test` *(fails: 18 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdbc3a150832db9a0919d618482b5