### PR TITLE
Use readSheetNames for client visit imports and target ES2018

### DIFF
--- a/MJ_FB_Backend/tsconfig.json
+++ b/MJ_FB_Backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2018",
     "module": "CommonJS",
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- switch client visit XLSX imports to `readSheetNames` and type `PoolClient`
- compile to ES2018 to allow named regex groups

## Testing
- `npm run build`
- `npm test` *(fails: Test Suites: 19 failed, 84 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdd0c98ec832d94f386690da0e75f