### PR TITLE
Add type column to leave requests table

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000005_add_type_to_leave_requests.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000005_add_type_to_leave_requests.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('leave_requests', {
+    type: { type: 'varchar(20)', notNull: true, default: 'vacation' },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('leave_requests', 'type');
+}


### PR DESCRIPTION
## Summary
- add migration to include `type` field in `leave_requests`

## Testing
- `npm test`
- `npm test tests/leaveRequests.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbde2fe9a0832da05354f9d0da247e