### PR TITLE
fix: allow relative API base URLs

### DIFF
--- a/MJ_FB_Frontend/.env.example
+++ b/MJ_FB_Frontend/.env.example
@@ -1,4 +1,5 @@
 # Backend API base URL (required; build fails if missing)
+# May be absolute (http://localhost:4000/api) or relative (/api)
 VITE_API_BASE=http://localhost:4000/api
 # Origin used in invitation links; should match the first entry in BACKEND `FRONTEND_ORIGIN`
 VITE_FRONTEND_ORIGIN=http://localhost:5173

--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -29,7 +29,13 @@ Run tests with `npm test` so `.env.test` and `jest.setup.ts` execute, providing 
 
 ## Environment Variables
 
-The frontend requires `VITE_API_BASE` to be defined. Create a `.env` file in this directory with:
+The frontend requires `VITE_API_BASE` to be defined. Create a `.env` file in this directory with either an absolute or relative URL:
+
+```
+VITE_API_BASE=/api
+```
+
+or
 
 ```
 VITE_API_BASE=http://localhost:4000/api

--- a/MJ_FB_Frontend/src/api/clientVisits.ts
+++ b/MJ_FB_Frontend/src/api/clientVisits.ts
@@ -63,10 +63,10 @@ export async function importVisitsXlsx(
   formData: FormData,
   dryRun?: boolean,
 ): Promise<VisitImportPreview | void> {
-  const url = new URL(`${API_BASE}/visits/import/xlsx`);
-  if (dryRun) url.searchParams.set('dryRun', 'true');
+  let url = `${API_BASE}/visits/import/xlsx`;
+  if (dryRun) url += '?dryRun=true';
 
-  const res = await apiFetch(url.toString(), {
+  const res = await apiFetch(url, {
     method: 'POST',
     body: formData,
   });

--- a/MJ_FB_Frontend/src/api/timesheets.ts
+++ b/MJ_FB_Frontend/src/api/timesheets.ts
@@ -40,11 +40,13 @@ export async function listAllTimesheets(
   year?: number,
   month?: number,
 ): Promise<TimesheetSummary[]> {
-  const url = new URL(`${API_BASE}/timesheets`);
-  if (staffId) url.searchParams.set('staffId', String(staffId));
-  if (year) url.searchParams.set('year', String(year));
-  if (month) url.searchParams.set('month', String(month));
-  const res = await apiFetch(url.toString());
+  const params = new URLSearchParams();
+  if (staffId) params.set('staffId', String(staffId));
+  if (year) params.set('year', String(year));
+  if (month) params.set('month', String(month));
+  const query = params.toString();
+  const url = `${API_BASE}/timesheets${query ? `?${query}` : ''}`;
+  const res = await apiFetch(url);
   return handleResponse(res);
 }
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,13 @@ npm start   # or npm run dev
 
 ### Environment variables
 
-The frontend requires `VITE_API_BASE` to point to the backend API. Create a `.env` file in `MJ_FB_Frontend` with:
+The frontend requires `VITE_API_BASE` to point to the backend API. Create a `.env` file in `MJ_FB_Frontend` with either a relative or absolute URL:
+
+```
+VITE_API_BASE=/api
+```
+
+or
 
 ```
 VITE_API_BASE=http://localhost:4000/api


### PR DESCRIPTION
## Summary
- build client visits import URL with string instead of `new URL`
- avoid `new URL` in timesheet API helper
- document absolute and relative formats for `VITE_API_BASE`

## Testing
- `npm test` *(fails: BookingUI.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe386060c832d80349818c51a431d