### PR TITLE
Remove sticky headers from schedule tables

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -35,9 +35,10 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   return (
     <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
-      <Table
-        size="small"
-        sx={{
+        <Table
+          size="small"
+          stickyHeader={false}
+          sx={{
           tableLayout: 'fixed',
           width: '100%',
           '& .MuiTableCell-root': {
@@ -55,7 +56,15 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
             <col key={i} style={{ width: slotWidth }} />
           ))}
         </colgroup>
-        <TableHead>
+        <TableHead
+          sx={{
+            '& .MuiTableCell-head': {
+              position: 'static',
+              top: 'auto',
+              zIndex: 'auto',
+            },
+          }}
+        >
           <TableRow>
             <TableCell>Time</TableCell>
             {Array.from({ length: safeMaxSlots }).map((_, i) => (


### PR DESCRIPTION
## Summary
- avoid sticky headers for pantry and volunteer schedules

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe7d20c78832daf6d6a092d6abe04