### PR TITLE
Add calendar link helpers

### DIFF
--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -6,6 +6,8 @@
 - Always run tests through `npm test` so `.env.test` and `tests/setupTests.ts` load environment variables, polyfill `global.fetch` with `undici`, and mock the database.
 - Tests for invitation and password setup flows live in `tests/passwordResetFlow.test.ts`; run `npm test tests/passwordResetFlow.test.ts` when working on these features.
 - To customize the mocked database in backend tests, import `../tests/utils/mockDb`, which mocks `../src/db` and exports the mocked `pool` for custom query behavior.
+- Calendar link utilities live in `src/utils/calendarLinks.ts`; ensure tests in `tests/calendarLinks.test.ts` cover changes.
+
 
 ## Environment
 

--- a/MJ_FB_Backend/src/utils/calendarLinks.ts
+++ b/MJ_FB_Backend/src/utils/calendarLinks.ts
@@ -1,0 +1,87 @@
+interface CalendarEvent {
+  title: string;
+  start: Date | string;
+  end: Date | string;
+  description?: string;
+  location?: string;
+}
+
+function formatDate(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return d.toISOString().replace(/[-:]|\.\d{3}/g, '');
+}
+
+export function buildGoogleCalendarLink({
+  title,
+  start,
+  end,
+  description,
+  location,
+}: CalendarEvent): string {
+  const startStr = formatDate(start);
+  const endStr = formatDate(end);
+
+  const params = [
+    'action=TEMPLATE',
+    `text=${encodeURIComponent(title)}`,
+    `dates=${startStr}/${endStr}`,
+    description ? `details=${encodeURIComponent(description)}` : '',
+    location ? `location=${encodeURIComponent(location)}` : '',
+  ]
+    .filter(Boolean)
+    .join('&');
+
+  return `https://calendar.google.com/calendar/render?${params}`;
+}
+
+export function buildIcsFile({
+  title,
+  start,
+  end,
+  description,
+  location,
+}: CalendarEvent): string {
+  const startStr = formatDate(start);
+  const endStr = formatDate(end);
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'BEGIN:VEVENT',
+    `SUMMARY:${title}`,
+    `DTSTART:${startStr}`,
+    `DTEND:${endStr}`,
+  ];
+  if (description) lines.push(`DESCRIPTION:${description}`);
+  if (location) lines.push(`LOCATION:${location}`);
+  lines.push('END:VEVENT', 'END:VCALENDAR');
+
+  return lines.join('\r\n');
+}
+
+export function buildCalendarLinks(booking: {
+  date: string;
+  start_time: string | null;
+  end_time: string | null;
+}): { google: string; ics: string } {
+  if (!booking.start_time || !booking.end_time) {
+    throw new Error('Booking missing start or end time');
+  }
+
+  const start = new Date(`${booking.date}T${booking.start_time}-06:00`);
+  const end = new Date(`${booking.date}T${booking.end_time}-06:00`);
+  const title = 'Moose Jaw Food Bank Booking';
+  const description = 'Your booking at the Moose Jaw Food Bank';
+  const location = 'Moose Jaw Food Bank';
+
+  return {
+    google: buildGoogleCalendarLink({ title, start, end, description, location }),
+    ics: buildIcsFile({ title, start, end, description, location }),
+  };
+}
+
+export default {
+  buildGoogleCalendarLink,
+  buildIcsFile,
+  buildCalendarLinks,
+};

--- a/MJ_FB_Backend/tests/calendarLinks.test.ts
+++ b/MJ_FB_Backend/tests/calendarLinks.test.ts
@@ -1,0 +1,46 @@
+import { buildGoogleCalendarLink, buildIcsFile, buildCalendarLinks } from '../src/utils/calendarLinks';
+
+describe('calendar link utilities', () => {
+  it('builds a Google Calendar link with encoded parameters', () => {
+    const url = buildGoogleCalendarLink({
+      title: 'Food & Fun',
+      start: new Date('2024-09-01T10:00:00Z'),
+      end: new Date('2024-09-01T11:00:00Z'),
+      description: 'Bring snacks & drinks',
+      location: '123 Main St',
+    });
+
+    expect(url).toBe(
+      'https://calendar.google.com/calendar/render?action=TEMPLATE&text=Food%20%26%20Fun&dates=20240901T100000Z/20240901T110000Z&details=Bring%20snacks%20%26%20drinks&location=123%20Main%20St'
+    );
+  });
+
+  it('creates an ICS file string with event details', () => {
+    const ics = buildIcsFile({
+      title: 'Food & Fun',
+      start: new Date('2024-09-01T10:00:00Z'),
+      end: new Date('2024-09-01T11:00:00Z'),
+      description: 'Bring snacks & drinks',
+      location: '123 Main St',
+    });
+
+    expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('SUMMARY:Food & Fun');
+    expect(ics).toContain('DTSTART:20240901T100000Z');
+    expect(ics).toContain('DTEND:20240901T110000Z');
+    expect(ics).toContain('DESCRIPTION:Bring snacks & drinks');
+    expect(ics).toContain('LOCATION:123 Main St');
+    expect(ics).toContain('END:VCALENDAR');
+  });
+
+  it('builds links from a booking object', () => {
+    const links = buildCalendarLinks({
+      date: '2024-09-01',
+      start_time: '09:00:00',
+      end_time: '10:00:00',
+    });
+
+    expect(links.google).toContain('text=Moose%20Jaw%20Food%20Bank%20Booking');
+    expect(links.ics).toContain('SUMMARY:Moose Jaw Food Bank Booking');
+  });
+});


### PR DESCRIPTION
## Summary
- generate Google Calendar links and ICS file content
- expose buildCalendarLinks helper
- test calendar link utilities

## Testing
- `npm test tests/calendarLinks.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbef25a460832d8917490c92b685c2