### PR TITLE
feat: add calendar links to booking confirmation

### DIFF
--- a/MJ_FB_Frontend/src/components/FeedbackSnackbar.tsx
+++ b/MJ_FB_Frontend/src/components/FeedbackSnackbar.tsx
@@ -8,6 +8,7 @@ interface FeedbackSnackbarProps {
   message: ReactNode;
   severity?: AlertColor;
   duration?: number;
+  action?: ReactNode;
 }
 
 export default function FeedbackSnackbar({
@@ -16,6 +17,7 @@ export default function FeedbackSnackbar({
   message,
   severity = 'success',
   duration = 6000,
+  action,
 }: FeedbackSnackbarProps) {
   function handleClose(_?: SyntheticEvent | Event, reason?: string) {
     if (reason === 'clickaway') return;
@@ -29,7 +31,13 @@ export default function FeedbackSnackbar({
       onClose={handleClose}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
     >
-      <Alert onClose={handleClose} severity={severity} variant="filled" sx={{ width: '100%' }}>
+      <Alert
+        onClose={handleClose}
+        severity={severity}
+        variant="filled"
+        action={action}
+        sx={{ width: '100%' }}
+      >
         {message}
       </Alert>
     </Snackbar>

--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "የመንገድ ምልክት",
   "home": "መነሻ ገጽ",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "مسار التنقل",
   "home": "الصفحة الرئيسية",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -57,7 +57,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -122,6 +122,8 @@
   "breadcrumb": "breadcrumb",
   "home": "Home",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -57,7 +57,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -122,6 +122,8 @@
   "breadcrumb": "miga de pan",
   "home": "Inicio",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "ردیف راهبری",
   "home": "خانه",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "fil d'Ariane",
   "home": "Accueil",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "ब्रेडक्रम्ब",
   "home": "मुखपृष्ठ",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "ബ്രെഡ് ക്രംബ്",
   "home": "ഹോം",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "ਬ੍ਰੇਡਕ੍ਰੰਬ",
   "home": "ਘਰ",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "د لورلارې نښه",
   "home": "کور",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "raadraac",
   "home": "Bogga hore",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "alama ya njia",
   "home": "Nyumbani",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "பிரெட்கிரம்",
   "home": "முகப்பு",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "ትካል መንገዲ",
   "home": "ገዛ",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "mga mumo ng tinapay",
   "home": "Bahay",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "навігаційний ланцюжок",
   "home": "Головна",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -55,7 +55,7 @@
         "steps": [
           "Open your dashboard.",
           "Choose an available date.",
-          "Select a time, add a client note for staff if needed, and confirm the booking."
+          "Select a time, add a client note for staff if needed, confirm the booking, and add it to your calendar."
         ]
       },
       "rescheduling_or_canceling": {
@@ -120,6 +120,8 @@
   "breadcrumb": "面包屑导航",
   "home": "首页",
   "slot_booked_success": "Slot booked successfully",
+  "add_to_google_calendar": "Add to Google Calendar",
+  "download_ics": "Download ICS",
   "booking_failed": "Booking failed",
   "full": "Full",
   "choose_this_time": "Choose this time",

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -64,7 +64,7 @@ function bookSlot(payload: {
   slotId: string;
   note: string;
   userId?: number;
-}): Promise<void> {
+}): Promise<any> {
   return createBooking(payload.slotId, payload.date, payload.note, payload.userId);
 }
 
@@ -119,6 +119,7 @@ export default function BookingUI({
     open: boolean;
     message: string;
     severity: 'success' | 'error';
+    action?: ReactNode;
   }>({ open: false, message: '', severity: 'success' });
   const [modal, setModal] = useState<{ open: boolean; message: ReactNode }>({
     open: false,
@@ -183,7 +184,7 @@ export default function BookingUI({
     if (!selectedSlotId || !visibleSlots.some(s => s.id === selectedSlotId)) return;
     setBooking(true);
     try {
-      await bookSlot({
+      const res = await bookSlot({
         date: date.format('YYYY-MM-DD'),
         slotId: selectedSlotId,
         note,
@@ -193,6 +194,33 @@ export default function BookingUI({
         open: true,
         message: t('slot_booked_success'),
         severity: 'success',
+        action:
+          res?.googleCalendarUrl || res?.icsUrl ? (
+            <Stack direction="row" spacing={1}>
+              {res?.googleCalendarUrl && (
+                <Button
+                  size="small"
+                  variant="contained"
+                  component="a"
+                  href={res.googleCalendarUrl}
+                  target="_blank"
+                  rel="noopener"
+                >
+                  {t('add_to_google_calendar')}
+                </Button>
+              )}
+              {res?.icsUrl && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  component="a"
+                  href={res.icsUrl}
+                >
+                  {t('download_ics')}
+                </Button>
+              )}
+            </Stack>
+          ) : undefined,
       });
       setSelectedSlotId(null);
       setNote('');
@@ -495,6 +523,7 @@ export default function BookingUI({
         message={snackbar.message}
         severity={snackbar.severity}
         duration={4000}
+        action={snackbar.action}
       />
       <FeedbackModal
         open={modal.open}

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - A shared dashboard component lives in `src/components/dashboard`.
 - Staff dashboard dates display weekday, month, day, and year (e.g., 'Tue, Jan 2, 2024').
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
+- Booking confirmations include links to add appointments to Google Calendar or download an ICS file.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.
 - Warehouse Aggregations page provides yearly totals and supports exporting them via `/warehouse-overall/export`.
 - Page and form titles render in uppercase with a lighter font weight for clarity.

--- a/docs/bookings.md
+++ b/docs/bookings.md
@@ -7,3 +7,5 @@ Translations apply only to client-visible booking messages (e.g., `no_reschedule
 - `adults_label`
 - `children_label`
 - `no_reschedule_token`
+- `add_to_google_calendar`
+- `download_ics`


### PR DESCRIPTION
## Summary
- show Google Calendar and ICS download links when booking succeeds
- localize calendar actions and update booking help text
- document new translation keys

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbef434d7c832d88e42852a966e749