### PR TITLE
Improve client edit error feedback

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import UpdateClientData from '../pages/staff/client-management/UpdateClientData';
+
+jest.mock('../api/users', () => ({
+  getIncompleteUsers: jest.fn().mockResolvedValue([
+    {
+      clientId: 1,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: '',
+      phone: '',
+      profileLink: 'link',
+    },
+  ]),
+  updateUserInfo: jest.fn().mockRejectedValue({
+    message: 'Update failed',
+    details: { errors: [{ message: 'Email already exists' }] },
+  }),
+}));
+
+describe('UpdateClientData', () => {
+  it('shows server error message when update fails', async () => {
+    render(<UpdateClientData />);
+
+    await screen.findByRole('button', { name: 'Edit' });
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Email already exists')
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -19,12 +19,13 @@ import {
 import Page from "../../../components/Page";
 import FeedbackSnackbar from "../../../components/FeedbackSnackbar";
 import DialogCloseButton from "../../../components/DialogCloseButton";
-import { 
+import {
   getIncompleteUsers,
   updateUserInfo,
   type IncompleteUser,
 } from "../../../api/users";
 import type { AlertColor } from "@mui/material";
+import type { ApiError } from "../../../api/client";
 import PasswordField from "../../../components/PasswordField";
 
 export default function UpdateClientData() {
@@ -85,9 +86,17 @@ export default function UpdateClientData() {
       setSelected(null);
       loadClients();
     } catch (err: unknown) {
+      let message = "Update failed";
+      const apiErr = err as ApiError;
+      const details = apiErr?.details as any;
+      if (details?.errors?.[0]?.message) {
+        message = details.errors[0].message as string;
+      } else if (err instanceof Error && err.message) {
+        message = err.message;
+      }
       setSnackbar({
         open: true,
-        message: err instanceof Error ? err.message : "Update failed",
+        message,
         severity: "error",
       });
     }


### PR DESCRIPTION
## Summary
- Show detailed error messages when client updates fail
- Test client edit dialog displays server validation errors

## Testing
- `npm test src/__tests__/UpdateClientData.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc5ddb7314832d85f5745b419ae5d1