### PR TITLE
feat: include booking type in email params

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -65,7 +65,12 @@ export async function createVolunteerBooking(
   next: NextFunction,
 ) {
   const user = req.user;
-  const { roleId, date } = req.body as { roleId?: number; date?: string };
+  const { roleId, date, type } = req.body as {
+    roleId?: number;
+    date?: string;
+    type?: string;
+  };
+  const emailType = type || 'volunteer shift';
   if (!user) return res.status(401).json({ message: 'Unauthorized' });
   if (!roleId || !date) {
     return res.status(400).json({ message: 'roleId and date are required' });
@@ -215,6 +220,7 @@ export async function createVolunteerBooking(
             rescheduleLink,
             googleCalendarLink,
             outlookCalendarLink,
+            type: emailType,
           },
         });
       } else {
@@ -432,10 +438,12 @@ export async function resolveVolunteerBookingConflict(
     rawRoleId !== undefined && rawRoleId !== null
       ? Number(rawRoleId)
       : undefined;
-  const { date, keep } = req.body as {
+  const { date, keep, type } = req.body as {
     date?: string;
     keep?: 'existing' | 'new';
+    type?: string;
   };
+  const emailType = type || 'volunteer shift';
 
   if (!user) return res.status(401).json({ message: 'Unauthorized' });
   if (
@@ -576,6 +584,7 @@ export async function resolveVolunteerBookingConflict(
           rescheduleLink,
           googleCalendarLink,
           outlookCalendarLink,
+          type: emailType,
         },
       });
     } else {

--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -24,7 +24,7 @@ export async function sendNextDayBookingReminders(): Promise<void> {
       await enqueueEmail({
         to: b.user_email,
         templateId: 1,
-        params: { body, cancelLink, rescheduleLink },
+        params: { body, cancelLink, rescheduleLink, type: 'shopping appointment' },
       });
     }
   } catch (err) {

--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -31,7 +31,7 @@ export async function sendNextDayVolunteerShiftReminders(): Promise<void> {
       enqueueEmail({
         to: row.email,
         templateId: 1,
-        params: { body, cancelLink, rescheduleLink },
+        params: { body, cancelLink, rescheduleLink, type: 'volunteer shift' },
       });
     }
   } catch (err) {

--- a/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
@@ -21,7 +21,7 @@ describe('bookings api', () => {
     await markBookingNoShow(5, 'reason');
     expect(apiFetch).toHaveBeenCalledWith('/api/bookings/5/no-show', expect.objectContaining({
       method: 'POST',
-      body: JSON.stringify({ reason: 'reason' }),
+      body: JSON.stringify({ reason: 'reason', type: 'shopping appointment' }),
     }));
   });
 
@@ -37,7 +37,7 @@ describe('bookings api', () => {
     await createBooking('3', '2024-05-01', 'note');
     expect(apiFetch).toHaveBeenCalledWith('/api/bookings', expect.objectContaining({
       method: 'POST',
-      body: JSON.stringify({ slotId: 3, date: '2024-05-01', note: 'note' }),
+      body: JSON.stringify({ slotId: 3, date: '2024-05-01', note: 'note', type: 'shopping appointment' }),
     }));
   });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -33,6 +33,7 @@ interface CreateBookingBody {
   date: string;
   note: string;
   userId?: number;
+  type: string;
 }
 
 const mapSlot = (s: SlotResponse): Slot => ({
@@ -86,6 +87,7 @@ export async function createBooking(
     slotId: Number(slotId),
     date,
     note,
+    type: 'shopping appointment',
   };
   if (note) body.note = note;
   if (userId) body.userId = userId;
@@ -277,7 +279,7 @@ export async function cancelBooking(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(reason ? { reason } : {}),
+    body: JSON.stringify(reason ? { reason, type: 'shopping appointment' } : { type: 'shopping appointment' }),
   });
   await handleResponse<void>(res);
 }
@@ -289,7 +291,7 @@ export async function markBookingNoShow(
   const res = await apiFetch(`${API_BASE}/bookings/${bookingId}/no-show`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(reason ? { reason } : {}),
+    body: JSON.stringify(reason ? { reason, type: 'shopping appointment' } : { type: 'shopping appointment' }),
   });
   await handleResponse<void>(res);
 }
@@ -321,7 +323,7 @@ export async function createBookingForUser(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ userId, slotId, date, isStaffBooking }),
+    body: JSON.stringify({ userId, slotId, date, isStaffBooking, type: 'shopping appointment' }),
   });
   await handleResponse<void>(res);
 }
@@ -336,7 +338,7 @@ export async function createBookingForNewClient(
   const res = await apiFetch(`${API_BASE}/bookings/new-client`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, email, phone, slotId, date }),
+    body: JSON.stringify({ name, email, phone, slotId, date, type: 'shopping appointment' }),
   });
   await handleResponse<void>(res);
 }
@@ -350,7 +352,7 @@ export async function rescheduleBookingByToken(
   const res = await apiFetch(`${API_BASE}/bookings/reschedule/${rescheduleToken}`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ slotId, date }),
+    body: JSON.stringify({ slotId, date, type: 'shopping appointment' }),
   });
   await handleResponse<void>(res);
 }

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -79,7 +79,7 @@ export async function requestVolunteerBooking(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ roleId, date }),
+    body: JSON.stringify({ roleId, date, type: 'volunteer shift' }),
   });
   const data = await handleResponse(res);
   return normalizeVolunteerBooking(data);
@@ -91,7 +91,7 @@ export async function resolveVolunteerBookingConflict(
   date: string,
   keep: 'existing' | 'new'
 ): Promise<VolunteerBooking> {
-  const body: any = { existingBookingId, keep };
+  const body: any = { existingBookingId, keep, type: 'volunteer shift' };
   if (roleId !== undefined) body.roleId = roleId;
   if (date !== undefined) body.date = date;
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/resolve-conflict`, {
@@ -121,6 +121,7 @@ export async function createRecurringVolunteerBooking(
       pattern: frequency,
       daysOfWeek: weekdays,
       endDate,
+      type: 'volunteer shift',
     }),
   });
   await handleResponse(res);
@@ -144,7 +145,7 @@ export async function cancelVolunteerBooking(
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ reason }),
+      body: JSON.stringify({ reason, type: 'volunteer shift' }),
     },
   );
   await handleResponse(res);


### PR DESCRIPTION
## Summary
- send booking type from frontend for clients and volunteers
- forward booking type to backend email utilities
- include type in reminder job emails

## Testing
- `npm test` (failed: timesheet, booking, and other suites)
- `npm test` (frontend; failed: jsdom location error)


------
https://chatgpt.com/codex/tasks/task_e_68bc5edecf60832d91592f651f068d6c