### PR TITLE
Use config for volunteer shift reminder template

### DIFF
--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -1,4 +1,5 @@
 import pool from '../db';
+import config from '../config';
 import { enqueueEmail } from './emailQueue';
 import { formatReginaDate } from './dateUtils';
 import logger from './logger';
@@ -28,11 +29,11 @@ export async function sendNextDayVolunteerShiftReminders(): Promise<void> {
         row.reschedule_token,
       );
       const body = `This is a reminder for your volunteer shift on ${nextDate}${time}.`;
-      enqueueEmail({
-        to: row.email,
-        templateId: 1,
-        params: { body, cancelLink, rescheduleLink, type: 'volunteer shift' },
-      });
+        enqueueEmail({
+          to: row.email,
+          templateId: config.volunteerBookingReminderTemplateId,
+          params: { body, cancelLink, rescheduleLink, type: 'volunteer shift' },
+        });
     }
   } catch (err) {
     logger.error('Failed to send volunteer shift reminders', err);

--- a/MJ_FB_Backend/tests/volunteerShiftReminderJobSend.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShiftReminderJobSend.test.ts
@@ -1,0 +1,56 @@
+jest.mock('../src/db', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+jest.mock('../src/utils/emailQueue', () => ({
+  enqueueEmail: jest.fn(),
+}));
+
+jest.mock('../src/config', () => ({
+  __esModule: true,
+  default: {
+    volunteerBookingReminderTemplateId: 99,
+    frontendOrigins: ['http://localhost:5173'],
+  },
+}));
+
+const { sendNextDayVolunteerShiftReminders } = require('../src/utils/volunteerShiftReminderJob');
+const db = require('../src/db').default;
+const { enqueueEmail } = require('../src/utils/emailQueue');
+
+describe('sendNextDayVolunteerShiftReminders', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('queues reminder emails with the configured template ID', async () => {
+    (db.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          email: 'vol@example.com',
+          start_time: '09:00:00',
+          end_time: '11:00:00',
+          reschedule_token: 'tok',
+        },
+      ],
+    });
+
+    await sendNextDayVolunteerShiftReminders();
+
+    expect(db.query).toHaveBeenCalledWith(expect.any(String), ['2024-01-02']);
+    expect(enqueueEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'vol@example.com',
+        templateId: 99,
+      }),
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- Use `config.volunteerBookingReminderTemplateId` instead of hardcoding template IDs in volunteer shift reminder job
- Add test ensuring volunteer shift reminders use the configured template ID

## Testing
- `npm test` *(fails: 18 failed, 87 passed, 105 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6326a240832da268bed11a5d24de