### PR TITLE
feat: add agency client update email template

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -54,6 +54,8 @@ BOOKING_REMINDER_TEMPLATE_ID=3
 VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID=4
 # Brevo template ID used for volunteer booking reminder emails
 VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID=5
+# Brevo template ID used for agency client update emails
+AGENCY_CLIENT_UPDATE_TEMPLATE_ID=1
 
 # Hours to wait before marking a volunteer shift as no-show
 VOLUNTEER_NO_SHOW_HOURS=24

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -26,6 +26,7 @@ const envSchema = z.object({
   BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
+  AGENCY_CLIENT_UPDATE_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
 
@@ -63,5 +64,6 @@ export default {
   bookingReminderTemplateId: env.BOOKING_REMINDER_TEMPLATE_ID,
   volunteerBookingConfirmationTemplateId: env.VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID,
   volunteerBookingReminderTemplateId: env.VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID,
+  agencyClientUpdateTemplateId: env.AGENCY_CLIENT_UPDATE_TEMPLATE_ID,
   volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -112,7 +112,11 @@ export async function addClientToAgency(
     if (agencyEmail && client) {
       const fullName = `${client.first_name} ${client.last_name}`;
       const body = `${fullName} has been added to your agency.`;
-      enqueueEmail({ to: agencyEmail, templateId: 1, params: { body } });
+      enqueueEmail({
+        to: agencyEmail,
+        templateId: config.agencyClientUpdateTemplateId,
+        params: { body },
+      });
     }
     res.status(204).send();
   } catch (err) {
@@ -148,7 +152,11 @@ export async function removeClientFromAgency(
     if (agencyEmail && client) {
       const fullName = `${client.first_name} ${client.last_name}`;
       const body = `${fullName} has been removed from your agency.`;
-      enqueueEmail({ to: agencyEmail, templateId: 1, params: { body } });
+      enqueueEmail({
+        to: agencyEmail,
+        templateId: config.agencyClientUpdateTemplateId,
+        params: { body },
+      });
     }
     res.status(204).send();
   } catch (err) {

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `BOOKING_REMINDER_TEMPLATE_ID`               | Brevo template ID for booking reminder emails                                                                                             |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                                                                                     |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`     | Brevo template ID for volunteer shift reminder emails                                                                                     |
+| `AGENCY_CLIENT_UPDATE_TEMPLATE_ID`           | Brevo template ID for agency client update emails                                                           |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS`             | Hours until password setup tokens expire (default 24)                                                                                     |
 
 See [docs/emailTemplates.md](docs/emailTemplates.md) for a list of email templates and parameters.

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -28,3 +28,11 @@ This document catalogs Brevo email templates used by the backend and the paramet
 
 Brevo templates can reference these `params.*` values to display actionable links such as “Add to Google Calendar” or “Add to Outlook Calendar”.
 
+## Agency client update email
+
+- **Template ID variable:** `AGENCY_CLIENT_UPDATE_TEMPLATE_ID` (exposed as `config.agencyClientUpdateTemplateId`)
+- **Used in:**
+  - `MJ_FB_Backend/src/controllers/agencyController.ts` (`addClientToAgency`, `removeClientFromAgency`)
+- **Params:**
+  - `body` (string) – message body describing the client update.
+


### PR DESCRIPTION
## Summary
- add AGENCY_CLIENT_UPDATE_TEMPLATE_ID env variable and config
- document agency client update email template
- use config.agencyClientUpdateTemplateId in agencyController

## Testing
- `npm test` *(fails: Test Suites: 18 failed, 86 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6327d89c832d8f99e85c9982a145