### PR TITLE
feat(backend): configure badge milestone email template

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -55,5 +55,8 @@ VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID=4
 # Brevo template ID used for volunteer booking reminder emails
 VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID=5
 
+# Brevo template ID used for badge milestone emails
+BADGE_MILESTONE_TEMPLATE_ID=1
+
 # Hours to wait before marking a volunteer shift as no-show
 VOLUNTEER_NO_SHOW_HOURS=24

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -26,6 +26,7 @@ const envSchema = z.object({
   BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
+  BADGE_MILESTONE_TEMPLATE_ID: z.coerce.number().default(1),
   VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
 
@@ -63,5 +64,6 @@ export default {
   bookingReminderTemplateId: env.BOOKING_REMINDER_TEMPLATE_ID,
   volunteerBookingConfirmationTemplateId: env.VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID,
   volunteerBookingReminderTemplateId: env.VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID,
+  badgeMilestoneTemplateId: env.BADGE_MILESTONE_TEMPLATE_ID,
   volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/MJ_FB_Backend/src/utils/badgeUtils.ts
+++ b/MJ_FB_Backend/src/utils/badgeUtils.ts
@@ -1,11 +1,12 @@
 import { enqueueEmail } from './emailQueue';
+import config from '../config';
 
 const badgeCardMap = new Map<string, string>();
 
 export function awardMilestoneBadge(email: string, badge: string): string {
   const cardUrl = `/cards/${badge}-thank-you-card.pdf`;
   const body = `Thanks for helping us reach the ${badge} milestone.\nDownload your card: ${cardUrl}`;
-  enqueueEmail({ to: email, templateId: 1, params: { body, cardUrl } });
+  enqueueEmail({ to: email, templateId: config.badgeMilestoneTemplateId, params: { body, cardUrl } });
   badgeCardMap.set(email, cardUrl);
   return cardUrl;
 }

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `BOOKING_REMINDER_TEMPLATE_ID`               | Brevo template ID for booking reminder emails                                                                                             |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                                                                                     |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`     | Brevo template ID for volunteer shift reminder emails                                                                                     |
+| `BADGE_MILESTONE_TEMPLATE_ID`                | Brevo template ID for badge milestone emails
+                                                           |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS`             | Hours until password setup tokens expire (default 24)                                                                                     |
 
 See [docs/emailTemplates.md](docs/emailTemplates.md) for a list of email templates and parameters.

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -28,3 +28,12 @@ This document catalogs Brevo email templates used by the backend and the paramet
 
 Brevo templates can reference these `params.*` values to display actionable links such as “Add to Google Calendar” or “Add to Outlook Calendar”.
 
+## Badge milestone email
+
+- **Template ID variable:** `BADGE_MILESTONE_TEMPLATE_ID` (exposed as `config.badgeMilestoneTemplateId`)
+- **Used in:**
+  - `MJ_FB_Backend/src/utils/badgeUtils.ts` (`awardMilestoneBadge`)
+- **Params:**
+  - `body` (string) – message body describing the milestone.
+  - `cardUrl` (string) – URL to download the thank-you card.
+


### PR DESCRIPTION
## Summary
- add `BADGE_MILESTONE_TEMPLATE_ID` to environment config and documentation
- use configured template when awarding milestone badges
- document badge milestone email template parameters

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6328ee64832dbb37ee07fc75c55b