### PR TITLE
Add volunteer booking notification template configuration

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -56,6 +56,8 @@ BOOKING_STATUS_TEMPLATE_ID=7
 VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID=4
 # Brevo template ID used for volunteer booking reminder emails
 VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID=5
+# Brevo template ID used for volunteer booking notification emails (cancellations, coordinator updates)
+VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID=8
 
 # Hours to wait before marking a volunteer shift as no-show
 VOLUNTEER_NO_SHOW_HOURS=24

--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -53,6 +53,8 @@ Authentication cookies are scoped to the `/` path and use the same options when 
 
 `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` – Brevo template ID for volunteer shift reminder emails.
 
+`VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` – Brevo template ID for volunteer booking notifications (cancellations, coordinator alerts).
+
 `VOLUNTEER_NO_SHOW_HOURS` – Hours to wait before marking a volunteer shift as no-show (default 24).
 
 Booking confirmation and reminder templates can surface Google and Outlook calendar links by

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -27,6 +27,7 @@ const envSchema = z.object({
   BOOKING_STATUS_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
+  VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
 
@@ -65,5 +66,7 @@ export default {
   bookingStatusTemplateId: env.BOOKING_STATUS_TEMPLATE_ID,
   volunteerBookingConfirmationTemplateId: env.VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID,
   volunteerBookingReminderTemplateId: env.VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID,
+   volunteerBookingNotificationTemplateId:
+    env.VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID,
   volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -13,6 +13,7 @@ import {
   CreateRecurringVolunteerBookingForVolunteerRequest,
 } from '../../types/volunteerBooking';
 import { formatReginaDate, reginaStartOfDayISO } from '../../utils/dateUtils';
+import config from '../../config';
 import coordinatorEmailsConfig from '../../config/coordinatorEmails.json';
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -46,7 +47,11 @@ const coordinatorEmails: string[] = coordinatorEmailsConfig.coordinatorEmails ||
 async function notifyCoordinators(subject: string, body: string) {
   const results = await Promise.allSettled(
     coordinatorEmails.map(email =>
-      sendTemplatedEmail({ to: email, templateId: 0, params: { subject, body } }),
+      sendTemplatedEmail({
+        to: email,
+        templateId: config.volunteerBookingNotificationTemplateId,
+        params: { subject, body },
+      }),
     ),
   );
   results.forEach((result, idx) => {
@@ -213,7 +218,7 @@ export async function createVolunteerBooking(
         );
         enqueueEmail({
           to: user.email,
-          templateId: 1,
+          templateId: config.volunteerBookingConfirmationTemplateId,
           params: {
             body: `Volunteer booking for role ${roleId} on ${date} has been confirmed.`,
             cancelLink,
@@ -577,7 +582,7 @@ export async function resolveVolunteerBookingConflict(
       );
       enqueueEmail({
         to: user.email,
-        templateId: 1,
+        templateId: config.volunteerBookingConfirmationTemplateId,
         params: {
           body: `Volunteer booking for role ${roleId} on ${date!} has been confirmed.`,
           cancelLink,
@@ -1083,7 +1088,7 @@ export async function createRecurringVolunteerBooking(
       if (user.email) {
         await sendTemplatedEmail({
           to: user.email,
-          templateId: 0,
+          templateId: config.volunteerBookingNotificationTemplateId,
           params: { subject, body },
         });
       } else {
@@ -1252,7 +1257,7 @@ export async function createRecurringVolunteerBookingForVolunteer(
       if (volunteerEmail) {
         await sendTemplatedEmail({
           to: volunteerEmail,
-          templateId: 0,
+          templateId: config.volunteerBookingNotificationTemplateId,
           params: { subject, body },
         });
       } else {
@@ -1367,7 +1372,7 @@ export async function cancelVolunteerBookingOccurrence(
     if (volunteerEmail) {
       await sendTemplatedEmail({
         to: volunteerEmail,
-        templateId: 0,
+        templateId: config.volunteerBookingNotificationTemplateId,
         params: { subject, body },
       });
     } else {
@@ -1431,7 +1436,7 @@ export async function cancelRecurringVolunteerBooking(
     if (info.email) {
       await sendTemplatedEmail({
         to: info.email,
-        templateId: 0,
+        templateId: config.volunteerBookingNotificationTemplateId,
         params: { subject, body },
       });
     } else {

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `BOOKING_STATUS_TEMPLATE_ID`                | Brevo template ID for booking status emails (cancellations, reschedules, no-shows) |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                 |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`     | Brevo template ID for volunteer shift reminder emails                 |
+| `VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` | Brevo template ID for volunteer booking notifications (cancellations, coordinator alerts) |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS`             | Hours until password setup tokens expire (default 24)                 |
 
 See [docs/emailTemplates.md](docs/emailTemplates.md) for a list of email templates and parameters.

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -35,3 +35,21 @@ Brevo templates can reference these `params.*` values to display actionable link
   - `body` (string) – message body describing the booking status update.
   - `type` (string) – booking type, e.g., `shopping appointment`.
 
+## Volunteer booking confirmation and reminder emails
+
+- **Template ID variables:** `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID`, `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`
+- **Params:**
+  - `body` (string) – message body describing the shift.
+  - `cancelLink` (string) – link for the recipient to cancel their shift.
+  - `rescheduleLink` (string) – link allowing rescheduling.
+  - `googleCalendarLink` (string) – URL to add the shift to Google Calendar.
+  - `outlookCalendarLink` (string) – URL to add the shift to Outlook Calendar.
+  - `type` (string) – booking type, e.g., `volunteer shift`.
+
+## Volunteer booking notification emails
+
+- **Template ID variable:** `VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID`
+- **Params:**
+  - `subject` (string) – email subject.
+  - `body` (string) – message body describing the update.
+


### PR DESCRIPTION
## Summary
- use configured template IDs for volunteer booking confirmations and notifications
- document new VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID env variable

## Testing
- `nvm use`
- `npm test` *(fails: Timesheet not found, Cannot edit stat holiday, Timesheet is locked, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bc662f170c832dbcbdf8f431b4aadb