### PR TITLE
feat: add milestone badge email template id

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -56,6 +56,8 @@ BOOKING_STATUS_TEMPLATE_ID=7
 VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID=4
 # Brevo template ID used for volunteer booking reminder emails
 VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID=5
+# Brevo template ID used for milestone badge emails
+BADGE_MILESTONE_TEMPLATE_ID=1
 
 # Hours to wait before marking a volunteer shift as no-show
 VOLUNTEER_NO_SHOW_HOURS=24

--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -53,6 +53,8 @@ Authentication cookies are scoped to the `/` path and use the same options when 
 
 `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` – Brevo template ID for volunteer shift reminder emails.
 
+`BADGE_MILESTONE_TEMPLATE_ID` – Brevo template ID for milestone badge emails.
+
 `VOLUNTEER_NO_SHOW_HOURS` – Hours to wait before marking a volunteer shift as no-show (default 24).
 
 Booking confirmation and reminder templates can surface Google and Outlook calendar links by

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -27,6 +27,7 @@ const envSchema = z.object({
   BOOKING_STATUS_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
+  BADGE_MILESTONE_TEMPLATE_ID: z.coerce.number().default(1),
   VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
 
@@ -65,5 +66,6 @@ export default {
   bookingStatusTemplateId: env.BOOKING_STATUS_TEMPLATE_ID,
   volunteerBookingConfirmationTemplateId: env.VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID,
   volunteerBookingReminderTemplateId: env.VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID,
+  badgeMilestoneTemplateId: env.BADGE_MILESTONE_TEMPLATE_ID,
   volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/MJ_FB_Backend/src/utils/badgeUtils.ts
+++ b/MJ_FB_Backend/src/utils/badgeUtils.ts
@@ -1,11 +1,12 @@
 import { enqueueEmail } from './emailQueue';
+import config from '../config';
 
 const badgeCardMap = new Map<string, string>();
 
 export function awardMilestoneBadge(email: string, badge: string): string {
   const cardUrl = `/cards/${badge}-thank-you-card.pdf`;
   const body = `Thanks for helping us reach the ${badge} milestone.\nDownload your card: ${cardUrl}`;
-  enqueueEmail({ to: email, templateId: 1, params: { body, cardUrl } });
+  enqueueEmail({ to: email, templateId: config.badgeMilestoneTemplateId, params: { body, cardUrl } });
   badgeCardMap.set(email, cardUrl);
   return cardUrl;
 }

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Before merging a pull request, confirm the following:
 - A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.
 - A nightly volunteer no-show cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours and emails coordinators about the changes.
 - Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.
-- Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
+- Milestone badge awards send a template-based thank-you card via email using the `BADGE_MILESTONE_TEMPLATE_ID` and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Backend email queue retries failed sends with exponential backoff and persists jobs in an `email_queue` table so retries survive restarts. The maximum retries and initial delay are configurable.
 - Accounts for clients, volunteers, staff, and agencies are created without passwords; a one-time setup link directs them to `/set-password` for initial password creation.

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -35,3 +35,12 @@ Brevo templates can reference these `params.*` values to display actionable link
   - `body` (string) – message body describing the booking status update.
   - `type` (string) – booking type, e.g., `shopping appointment`.
 
+## Milestone badge email
+
+- **Template ID variable:** `BADGE_MILESTONE_TEMPLATE_ID` (exposed as `config.badgeMilestoneTemplateId`)
+- **Used in:**
+  - `MJ_FB_Backend/src/utils/badgeUtils.ts` (`awardMilestoneBadge`)
+- **Params:**
+  - `body` (string) – message body describing the milestone.
+  - `cardUrl` (string) – link to download the thank-you card.
+


### PR DESCRIPTION
## Summary
- add `BADGE_MILESTONE_TEMPLATE_ID` config and document it
- use configured template id in milestone badge emails
- document badge email template params

## Testing
- `npm test` *(fails: 18 failed, 86 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6666a744832dba5057fee7c941fa