### PR TITLE
Include cancel/reschedule links in staff booking email

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -606,17 +606,25 @@ export async function createBookingForUser(
     );
     const { start_time, end_time } = slotRes.rows[0] || {};
     if (clientEmail) {
+      const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
       const { googleCalendarLink, outlookCalendarLink } = buildCalendarLinks(
         date,
         start_time,
         end_time,
       );
       const body = `Your booking for ${date} has been automatically approved`;
-        enqueueEmail({
-          to: clientEmail,
-          templateId: config.bookingConfirmationTemplateId,
-          params: { body, googleCalendarLink, outlookCalendarLink, type: emailType },
-        });
+      enqueueEmail({
+        to: clientEmail,
+        templateId: config.bookingConfirmationTemplateId,
+        params: {
+          body,
+          cancelLink,
+          rescheduleLink,
+          googleCalendarLink,
+          outlookCalendarLink,
+          type: emailType,
+        },
+      });
     } else {
       logger.warn(
         'Booking approved email not sent. User %s has no email.',


### PR DESCRIPTION
## Summary
- ensure staff-created bookings send cancel and reschedule links

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'sendNextDayVolunteerShiftRemindersMock' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6c44185c832dbb18482902f8a973