### PR TITLE
feat: require email when enabling volunteer online access

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -164,6 +164,7 @@ export async function createVolunteer(
     email,
     phone,
     roleIds,
+    onlineAccess,
   } = req.body as {
     firstName?: string;
     lastName?: string;
@@ -171,6 +172,7 @@ export async function createVolunteer(
     email?: string;
     phone?: string;
     roleIds?: number[];
+    onlineAccess?: boolean;
   };
 
   if (
@@ -184,6 +186,12 @@ export async function createVolunteer(
     return res.status(400).json({
       message: 'First name, last name, username and roles required',
     });
+  }
+
+  if (onlineAccess && !email) {
+    return res
+      .status(400)
+      .json({ message: 'Email required for online account' });
   }
 
   try {

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -49,6 +49,7 @@ describe('Volunteer routes role ID validation', () => {
       email: 'john@example.com',
       phone: '123',
       roleIds: [1, 2],
+      onlineAccess: true,
     });
 
     expect(res.status).toBe(201);
@@ -84,9 +85,22 @@ describe('Volunteer routes role ID validation', () => {
       lastName: 'Doe',
       username: 'johndoe',
       roleIds: [1, 2],
+      onlineAccess: false,
     });
     expect(res.status).toBe(400);
     expect(res.body).toEqual({ message: 'Invalid roleIds', invalidIds: [2] });
+  });
+
+  it('requires email when online access enabled', async () => {
+    const res = await request(app).post('/volunteers').send({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      username: 'janedoe',
+      roleIds: [1],
+      onlineAccess: true,
+    });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ message: 'Email required for online account' });
   });
 
   it('returns invalid role IDs when updating trained areas', async () => {

--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.tsx
@@ -9,6 +9,7 @@ import {
   updateVolunteerBookingStatus,
   cancelVolunteerBooking,
   getUnmarkedVolunteerBookings,
+  createVolunteer,
 } from '../api/volunteers';
 
 jest.mock('../api/client', () => ({
@@ -71,6 +72,25 @@ describe('volunteers api', () => {
   it('fetches recurring volunteer bookings', async () => {
     await getMyRecurringVolunteerBookings();
     expect(apiFetch).toHaveBeenCalledWith('/api/volunteer-bookings/recurring');
+  });
+
+  it('creates a volunteer', async () => {
+    await createVolunteer('John', 'Doe', 'jdoe', [1, 2], true, 'a@b.com', '123');
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/volunteers',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          firstName: 'John',
+          lastName: 'Doe',
+          username: 'jdoe',
+          roleIds: [1, 2],
+          onlineAccess: true,
+          email: 'a@b.com',
+          phone: '123',
+        }),
+      }),
+    );
   });
 
   it('creates recurring volunteer booking for volunteer', async () => {

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -425,6 +425,7 @@ export async function createVolunteer(
   lastName: string,
   username: string,
   roleIds: number[],
+  onlineAccess: boolean,
   email?: string,
   phone?: string
 ): Promise<void> {
@@ -438,6 +439,7 @@ export async function createVolunteer(
       lastName,
       username,
       roleIds,
+      onlineAccess,
       email,
       phone,
     }),

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -269,6 +269,7 @@ export function getHelpContent(
           'Go to the Volunteers page.',
           'Search by name.',
           'View or edit volunteer information.',
+          'Check Online Access to email login details when creating a volunteer.',
         ],
       },
     },

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -144,6 +144,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
+  const [onlineAccess, setOnlineAccess] = useState(false);
   const [selectedCreateRoles, setSelectedCreateRoles] = useState<string[]>([]);
   const [createMsg, setCreateMsg] = useState('');
   const [createSeverity, setCreateSeverity] = useState<'success' | 'error'>('success');
@@ -528,6 +529,11 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
       );
       return;
     }
+    if (onlineAccess && !email) {
+      setCreateSeverity('error');
+      setCreateMsg('Email required for online access');
+      return;
+    }
     try {
       const ids = Array.from(
         new Set(
@@ -539,6 +545,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
         lastName,
         username,
         ids,
+        onlineAccess,
         email || undefined,
         phone || undefined
       );
@@ -549,6 +556,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
       setUsername('');
       setEmail('');
       setPhone('');
+      setOnlineAccess(false);
       setSelectedCreateRoles([]);
     } catch (e) {
       setCreateSeverity('error');
@@ -852,9 +860,24 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
               size="small"
               fullWidth
             />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={onlineAccess}
+                  onChange={e => setOnlineAccess(e.target.checked)}
+                />
+              }
+              label="Online Access"
+            />
+            {onlineAccess && (
+              <Typography variant="body2" color="text.secondary">
+                An email invitation will be sent.
+              </Typography>
+            )}
             <TextField
-              label="Email (optional)"
+              label={onlineAccess ? 'Email' : 'Email (optional)'}
               type="email"
+              required={onlineAccess}
               value={email}
               onChange={e => setEmail(e.target.value)}
               size="small"
@@ -868,9 +891,6 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
               size="small"
               fullWidth
             />
-            <Typography variant="body2" color="text.secondary">
-              An email invitation will be sent.
-            </Typography>
             <div ref={dropdownRef} style={{ position: 'relative' }}>
               <label>Role: </label>
               <Button type="button" onClick={() => setRoleDropdownOpen(o => !o)} variant="outlined" color="primary">

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Staff accounts may include any of the following access roles:
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 
+## Volunteer Creation
+
+Create volunteers from the Volunteers page. Check **Online Access** to send an email invitation; the email field becomes required when enabled.
+
 ## Node Version
 
 Requires **Node.js 22+**. The repo includes a `.nvmrc` file and installation is engine‑strict, so use the pinned version:


### PR DESCRIPTION
## Summary
- add Online Access checkbox when creating volunteers
- enforce email when Online Access is selected
- document volunteer creation option

## Testing
- `npm test` (MJ_FB_Backend) *(fails: ReferenceError in volunteerShiftReminderJob.test.ts)*
- `npm test` (MJ_FB_Frontend) *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bc6d26aa18832d8930f3ab8495cf43