### PR TITLE
Limit booking cancellation emails to staff and drop no‑show notices

### DIFF
--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -8,7 +8,7 @@ parameters supplied to each template.
 | `PASSWORD_SETUP_TEMPLATE_ID` | Account invitations and password reset emails | `link`, `token` | `authController.ts`, `agencyController.ts`, `admin/staffController.ts`, `admin/adminStaffController.ts`, `volunteerController.ts`, `userController.ts` |
 | `BOOKING_CONFIRMATION_TEMPLATE_ID` | Booking approval confirmations for clients | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` | `bookingController.ts` |
 | `BOOKING_REMINDER_TEMPLATE_ID` | Next-day booking reminders for clients | `body`, `cancelLink`, `rescheduleLink`, `type` | `bookingReminderJob.ts` |
-| `templateId: 1` | Booking cancellations, reschedules, and no-show notices | `body`, `type` | `bookingController.ts` |
+| `templateId: 1` | Booking cancellations and reschedules | `body`, `type` | `bookingController.ts` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` | `volunteerBookingController.ts` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts` |
 | `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` | `volunteerBookingController.ts` |
@@ -25,6 +25,8 @@ dynamic content.
 - **Params:**
   - `body` (string) – message body describing the booking status update.
   - `type` (string) – booking type, e.g., `shopping appointment`.
+
+No-show emails are no longer sent.
 
 ## Volunteer booking confirmation and reminder emails
 


### PR DESCRIPTION
## Summary
- Only queue cancellation emails when staff cancel a booking and include the provided reason
- Stop sending emails when bookings are marked as no-show
- Document removal of no-show emails and test staff-only behavior

## Testing
- `npm test` *(fails: Timesheet not found, slot tests expecting 200 but received 404, and other failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6ffcf784832dbff9dd98022a3032