### PR TITLE
Use reminder template for recurring volunteer bookings

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -1086,10 +1086,16 @@ export async function createRecurringVolunteerBooking(
       const subject = `Volunteer booking confirmed for ${date} ${slot.start_time}-${slot.end_time}`;
       const body = `Your volunteer booking on ${date} from ${slot.start_time} to ${slot.end_time} has been confirmed.`;
       if (user.email) {
+        const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
         await sendTemplatedEmail({
           to: user.email,
-          templateId: config.volunteerBookingNotificationTemplateId,
-          params: { subject, body },
+          templateId: config.volunteerBookingReminderTemplateId,
+          params: {
+            body,
+            cancelLink,
+            rescheduleLink,
+            type: 'volunteer shift',
+          },
         });
       } else {
         logger.warn(
@@ -1255,10 +1261,16 @@ export async function createRecurringVolunteerBookingForVolunteer(
       const subject = `Volunteer booking confirmed for ${date} ${slot.start_time}-${slot.end_time}`;
       const body = `Your volunteer booking on ${date} from ${slot.start_time} to ${slot.end_time} has been confirmed.`;
       if (volunteerEmail) {
+        const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
         await sendTemplatedEmail({
           to: volunteerEmail,
-          templateId: config.volunteerBookingNotificationTemplateId,
-          params: { subject, body },
+          templateId: config.volunteerBookingReminderTemplateId,
+          params: {
+            body,
+            cancelLink,
+            rescheduleLink,
+            type: 'volunteer shift',
+          },
         });
       } else {
         logger.warn(
@@ -1334,7 +1346,7 @@ export async function cancelVolunteerBookingOccurrence(
   const cancelReason = reason || 'volunteer_cancelled';
   try {
     const bookingRes = await pool.query(
-      `SELECT id, slot_id, volunteer_id, date, status, recurring_id
+      `SELECT id, slot_id, volunteer_id, date, status, recurring_id, reschedule_token
        FROM volunteer_bookings WHERE id=$1`,
       [id],
     );
@@ -1370,10 +1382,13 @@ export async function cancelVolunteerBookingOccurrence(
     const subject = `Volunteer booking cancelled for ${dateStr} ${slot.start_time}-${slot.end_time}`;
     const body = `Your volunteer booking on ${dateStr} from ${slot.start_time} to ${slot.end_time} has been cancelled.`;
     if (volunteerEmail) {
+      const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(
+        booking.reschedule_token,
+      );
       await sendTemplatedEmail({
         to: volunteerEmail,
-        templateId: config.volunteerBookingNotificationTemplateId,
-        params: { subject, body },
+        templateId: config.volunteerBookingReminderTemplateId,
+        params: { body, cancelLink, rescheduleLink, type: 'volunteer shift' },
       });
     } else {
       logger.warn(

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -4,6 +4,7 @@ import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import logger from '../src/utils/logger';
+import config from '../src/config';
 
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn().mockResolvedValue(undefined),
@@ -144,6 +145,7 @@ describe('cancelVolunteerBookingOccurrence', () => {
       date: '2025-09-01',
       status: 'approved',
       recurring_id: null,
+      reschedule_token: 'token',
     };
     const slot = { start_time: '09:00:00', end_time: '12:00:00' };
     (pool.query as jest.Mock)
@@ -158,7 +160,7 @@ describe('cancelVolunteerBookingOccurrence', () => {
     expect(sendTemplatedEmailMock.mock.calls).toHaveLength(3);
     expect(sendTemplatedEmailMock.mock.calls[0][0]).toMatchObject({
       to: 'vol@example.com',
-      templateId: 0,
+      templateId: config.volunteerBookingReminderTemplateId,
     });
   });
 });

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -10,8 +10,8 @@ parameters supplied to each template.
 | `BOOKING_REMINDER_TEMPLATE_ID` | Next-day booking reminders for clients | `body`, `cancelLink`, `rescheduleLink`, `type` | `bookingReminderJob.ts` |
 | `templateId: 1` | Booking cancellations, reschedules, and no-show notices | `body`, `type` | `bookingController.ts` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` | `volunteerBookingController.ts` |
-| `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts` |
-| `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` | `volunteerBookingController.ts` |
+| `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts`, `volunteerBookingController.ts` |
+| `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices) | `subject`, `body` | `volunteerBookingController.ts` |
 | `VOLUNTEER_NO_SHOW_NOTIFICATION_TEMPLATE_ID` | Nightly coordinator alerts for volunteer no-shows | `ids` | `volunteerNoShowCleanupJob.ts` |
 | `templateId: 1` | Agency membership additions or removals | `body` | `agencyController.ts` |
 | `BADGE_MILESTONE_TEMPLATE_ID` | Milestone badge emails with downloadable card | `body`, `cardUrl` | `badgeUtils.ts` |
@@ -36,6 +36,8 @@ dynamic content.
   - `googleCalendarLink` (string) – URL to add the shift to Google Calendar.
   - `outlookCalendarLink` (string) – URL to add the shift to Outlook Calendar.
   - `type` (string) – booking type, e.g., `volunteer shift`.
+
+Recurring volunteer bookings also reuse the reminder template so volunteers receive cancel and reschedule links.
 
 ## Volunteer booking notification emails
 


### PR DESCRIPTION
## Summary
- Send recurring volunteer booking confirmations via reminder template with cancel/reschedule links
- Align cancellation emails and tests with reminder template
- Document that recurring volunteer bookings reuse the reminder template

## Testing
- `npm test` *(fails: Test Suites: 19 failed, 85 passed, 104 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bc70086b1c832db5c0fc229ab677b3