### PR TITLE
Use appointment details in email bodies

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -131,7 +131,9 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
         start_time,
         end_time,
       );
-      const body = `Your booking for ${date} has been automatically approved.`;
+      const time =
+        start_time && end_time ? ` from ${start_time} to ${end_time}` : '';
+      const body = `Date: ${date}${time}`;
       enqueueEmail({
         to: user.email,
         templateId: config.bookingConfirmationTemplateId,
@@ -254,8 +256,19 @@ export async function cancelBooking(req: AuthRequest, res: Response, next: NextF
       email = emailRes.rows[0]?.email;
     }
     if (email) {
-        const body = `Booking ${bookingId} was cancelled`;
-        enqueueEmail({ to: email, templateId: config.bookingStatusTemplateId, params: { body, type } });
+      const slotRes = await pool.query(
+        'SELECT start_time, end_time FROM slots WHERE id=$1',
+        [booking.slot_id],
+      );
+      const { start_time, end_time } = slotRes.rows[0] || {};
+      const time =
+        start_time && end_time ? ` from ${start_time} to ${end_time}` : '';
+      const body = `Date: ${booking.date}${time}`;
+      enqueueEmail({
+        to: email,
+        templateId: config.bookingStatusTemplateId,
+        params: { body, type },
+      });
     } else {
       logger.warn(
         'Booking cancellation email not sent. Booking %s has no associated email.',
@@ -279,10 +292,11 @@ export async function markBookingNoShow(req: Request, res: Response, next: NextF
   const type = (req.body?.type as string) || 'shopping appointment';
   try {
     const result = await pool.query(
-      `SELECT COALESCE(c.email, nc.email) AS email, b.reschedule_token, b.date
+      `SELECT COALESCE(c.email, nc.email) AS email, b.reschedule_token, b.date, s.start_time, s.end_time
        FROM bookings b
        LEFT JOIN clients c ON b.user_id = c.client_id
        LEFT JOIN new_clients nc ON b.new_client_id = nc.id
+       JOIN slots s ON b.slot_id = s.id
        WHERE b.id = $1`,
       [bookingId],
     );
@@ -290,10 +304,17 @@ export async function markBookingNoShow(req: Request, res: Response, next: NextF
     await updateBooking(bookingId, { status: 'no_show', request_data: reason, note: null });
 
     const booking = result.rows[0];
-    if (booking?.email && booking?.reschedule_token) {
-      const link = `${config.frontendOrigins[0]}/reschedule/${booking.reschedule_token}`;
-        const body = `You missed your Harvest Pantry booking on ${booking.date}. You can reschedule here: ${link}`;
-        enqueueEmail({ to: booking.email, templateId: config.bookingStatusTemplateId, params: { body, type } });
+    if (booking?.email) {
+      const time =
+        booking.start_time && booking.end_time
+          ? ` from ${booking.start_time} to ${booking.end_time}`
+          : '';
+      const body = `Date: ${booking.date}${time}`;
+      enqueueEmail({
+        to: booking.email,
+        templateId: config.bookingStatusTemplateId,
+        params: { body, type },
+      });
     }
 
     res.json({ message: 'Booking marked as no-show' });
@@ -425,8 +446,19 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
       email = emailRes.rows[0]?.email;
     }
     if (email) {
-        const body = `Booking ${booking.id} was rescheduled`;
-        enqueueEmail({ to: email, templateId: config.bookingStatusTemplateId, params: { body, type: emailType } });
+      const slotRes = await pool.query(
+        'SELECT start_time, end_time FROM slots WHERE id=$1',
+        [slotId],
+      );
+      const { start_time, end_time } = slotRes.rows[0] || {};
+      const time =
+        start_time && end_time ? ` from ${start_time} to ${end_time}` : '';
+      const body = `Date: ${date}${time}`;
+      enqueueEmail({
+        to: email,
+        templateId: config.bookingStatusTemplateId,
+        params: { body, type: emailType },
+      });
     } else {
       logger.warn(
         'Booking rescheduled email not sent. Booking %s has no associated email.',
@@ -612,7 +644,9 @@ export async function createBookingForUser(
         start_time,
         end_time,
       );
-      const body = `Your booking for ${date} has been automatically approved`;
+      const time =
+        start_time && end_time ? ` from ${start_time} to ${end_time}` : '';
+      const body = `Date: ${date}${time}`;
       enqueueEmail({
         to: clientEmail,
         templateId: config.bookingConfirmationTemplateId,

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -1084,7 +1084,7 @@ export async function createRecurringVolunteerBooking(
       successes.push(date);
 
       const subject = `Volunteer booking confirmed for ${date} ${slot.start_time}-${slot.end_time}`;
-      const body = `Your volunteer booking on ${date} from ${slot.start_time} to ${slot.end_time} has been confirmed.`;
+      const body = `Date: ${date} from ${slot.start_time} to ${slot.end_time}`;
       if (user.email) {
         await sendTemplatedEmail({
           to: user.email,
@@ -1253,7 +1253,7 @@ export async function createRecurringVolunteerBookingForVolunteer(
       successes.push(date);
 
       const subject = `Volunteer booking confirmed for ${date} ${slot.start_time}-${slot.end_time}`;
-      const body = `Your volunteer booking on ${date} from ${slot.start_time} to ${slot.end_time} has been confirmed.`;
+      const body = `Date: ${date} from ${slot.start_time} to ${slot.end_time}`;
       if (volunteerEmail) {
         await sendTemplatedEmail({
           to: volunteerEmail,
@@ -1368,7 +1368,7 @@ export async function cancelVolunteerBookingOccurrence(
         ? formatReginaDate(booking.date)
         : booking.date;
     const subject = `Volunteer booking cancelled for ${dateStr} ${slot.start_time}-${slot.end_time}`;
-    const body = `Your volunteer booking on ${dateStr} from ${slot.start_time} to ${slot.end_time} has been cancelled.`;
+    const body = `Date: ${dateStr} from ${slot.start_time} to ${slot.end_time}`;
     if (volunteerEmail) {
       await sendTemplatedEmail({
         to: volunteerEmail,
@@ -1432,7 +1432,7 @@ export async function cancelRecurringVolunteerBooking(
       [id, from],
     );
     const subject = `Recurring volunteer bookings cancelled starting ${from} ${info.start_time}-${info.end_time}`;
-    const body = `Your recurring volunteer bookings starting ${from} from ${info.start_time} to ${info.end_time} have been cancelled.`;
+    const body = `Date: ${from} from ${info.start_time} to ${info.end_time}`;
     if (info.email) {
       await sendTemplatedEmail({
         to: info.email,

--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -17,11 +17,12 @@ export async function sendNextDayBookingReminders(): Promise<void> {
     const bookings = await fetchBookingsForReminder(nextDate);
     for (const b of bookings) {
       if (!b.user_email) continue;
-      const time = b.start_time && b.end_time ? ` from ${b.start_time} to ${b.end_time}` : '';
+      const time =
+        b.start_time && b.end_time ? ` from ${b.start_time} to ${b.end_time}` : '';
       const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(
         b.reschedule_token,
       );
-      const body = `This is a reminder for your booking on ${nextDate}${time}.`;
+      const body = `Date: ${nextDate}${time}`;
       await enqueueEmail({
         to: b.user_email,
         templateId: config.bookingReminderTemplateId,

--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -24,11 +24,14 @@ export async function sendNextDayVolunteerShiftReminders(): Promise<void> {
     );
     for (const row of res.rows) {
       if (!row.email) continue;
-      const time = row.start_time && row.end_time ? ` from ${row.start_time} to ${row.end_time}` : '';
+      const time =
+        row.start_time && row.end_time
+          ? ` from ${row.start_time} to ${row.end_time}`
+          : '';
       const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(
         row.reschedule_token,
       );
-      const body = `This is a reminder for your volunteer shift on ${nextDate}${time}.`;
+      const body = `Date: ${nextDate}${time}`;
       enqueueEmail({
         to: row.email,
         templateId: config.volunteerBookingReminderTemplateId,


### PR DESCRIPTION
## Summary
- Strip boilerplate text from booking and volunteer reminder emails, leaving only appointment details
- Update booking and volunteer controllers to send only date and time in email params

## Testing
- `npm test` *(fails: TypeError: Cannot redefine property: isDateWithinCurrentOrNextMonth, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc6f417c48832d9249793fb04dbd3a