### PR TITLE
refactor: drop unused email templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/
 
 ## Email templates
 
+Agency membership change and milestone badge emails have been discontinued under the revised email policy; only the templates below remain active.
+
 | Template reference | Purpose | Params |
 | ------------------- | ------- | ------ |
 | `PASSWORD_SETUP_TEMPLATE_ID` | Account invitations and password reset emails | `link`, `token` |
@@ -34,5 +36,3 @@ See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` |
 | `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` |
 | `VOLUNTEER_NO_SHOW_NOTIFICATION_TEMPLATE_ID` | Nightly coordinator alerts for volunteer no-shows | `ids` |
-| `templateId: 1` | Agency membership additions or removals | `body` |
-| `BADGE_MILESTONE_TEMPLATE_ID` | Milestone badge emails with downloadable card | `body`, `cardUrl` |

--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -52,8 +52,6 @@ BOOKING_CONFIRMATION_TEMPLATE_ID=2
 BOOKING_REMINDER_TEMPLATE_ID=3
 # Brevo template ID used for booking status emails (cancellations, reschedules, no-shows)
 BOOKING_STATUS_TEMPLATE_ID=7
-# Brevo template ID used for agency client update emails
-AGENCY_CLIENT_UPDATE_TEMPLATE_ID=8
 # Brevo template ID used for volunteer booking confirmation emails
 VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID=4
 # Brevo template ID used for volunteer booking reminder emails
@@ -62,9 +60,6 @@ VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID=5
 VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID=8
 # Brevo template ID used for nightly volunteer no-show coordinator alerts
 VOLUNTEER_NO_SHOW_NOTIFICATION_TEMPLATE_ID=1
-
-# Brevo template ID used for milestone badge emails
-BADGE_MILESTONE_TEMPLATE_ID=1
 
 # Hours to wait before marking a volunteer shift as no-show
 VOLUNTEER_NO_SHOW_HOURS=24

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -25,11 +25,9 @@ const envSchema = z.object({
   BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
   BOOKING_STATUS_TEMPLATE_ID: z.coerce.number().default(0),
-  AGENCY_CLIENT_UPDATE_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID: z.coerce.number().default(0),
-  BADGE_MILESTONE_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_NO_SHOW_NOTIFICATION_TEMPLATE_ID: z.coerce.number().default(1),
   VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
@@ -67,11 +65,9 @@ export default {
   bookingConfirmationTemplateId: env.BOOKING_CONFIRMATION_TEMPLATE_ID,
   bookingReminderTemplateId: env.BOOKING_REMINDER_TEMPLATE_ID,
   bookingStatusTemplateId: env.BOOKING_STATUS_TEMPLATE_ID,
-  agencyClientUpdateTemplateId: env.AGENCY_CLIENT_UPDATE_TEMPLATE_ID,
   volunteerBookingConfirmationTemplateId: env.VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID,
   volunteerBookingReminderTemplateId: env.VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID,
   volunteerBookingNotificationTemplateId: env.VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID,
   volunteerNoShowNotificationTemplateId: env.VOLUNTEER_NO_SHOW_NOTIFICATION_TEMPLATE_ID,
-  badgeMilestoneTemplateId: env.BADGE_MILESTONE_TEMPLATE_ID,
   volunteerNoShowHours: env.VOLUNTEER_NO_SHOW_HOURS,
 };

--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -1,20 +1,17 @@
 import { Request, Response, NextFunction } from 'express';
 import {
   addAgencyClient,
-    removeAgencyClient,
-    getAgencyClients as fetchAgencyClients,
-    createAgency as insertAgency,
-    getAgencyByEmail,
-    getAgencyForClient,
-    clientExists,
-    searchAgencies as findAgencies,
-    getAgencyEmail,
-    getClientName,
-  } from '../models/agency';
+  removeAgencyClient,
+  getAgencyClients as fetchAgencyClients,
+  createAgency as insertAgency,
+  getAgencyByEmail,
+  getAgencyForClient,
+  clientExists,
+  searchAgencies as findAgencies,
+} from '../models/agency';
 import { createAgencySchema } from '../schemas/agencySchemas';
 import { generatePasswordSetupToken } from '../utils/passwordSetupUtils';
 import { sendTemplatedEmail } from '../utils/emailUtils';
-import { enqueueEmail } from '../utils/emailQueue';
 import config from '../config';
 import { parseIdParam } from '../utils/parseIdParam';
 
@@ -105,19 +102,6 @@ export async function addClientToAgency(
       });
     }
     await addAgencyClient(agencyId, clientId);
-    const [agencyEmail, client] = await Promise.all([
-      getAgencyEmail(agencyId),
-      getClientName(clientId),
-    ]);
-    if (agencyEmail && client) {
-      const fullName = `${client.first_name} ${client.last_name}`;
-      const body = `${fullName} has been added to your agency.`;
-      enqueueEmail({
-        to: agencyEmail,
-        templateId: config.agencyClientUpdateTemplateId,
-        params: { body },
-      });
-    }
     res.status(204).send();
   } catch (err) {
     next(err);
@@ -145,19 +129,6 @@ export async function removeClientFromAgency(
       return res.status(403).json({ message: 'Forbidden' });
     }
     await removeAgencyClient(agencyId, clientId);
-    const [agencyEmail, client] = await Promise.all([
-      getAgencyEmail(agencyId),
-      getClientName(clientId),
-    ]);
-    if (agencyEmail && client) {
-      const fullName = `${client.first_name} ${client.last_name}`;
-      const body = `${fullName} has been removed from your agency.`;
-      enqueueEmail({
-        to: agencyEmail,
-        templateId: config.agencyClientUpdateTemplateId,
-        params: { body },
-      });
-    }
     res.status(204).send();
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/src/utils/badgeUtils.ts
+++ b/MJ_FB_Backend/src/utils/badgeUtils.ts
@@ -1,16 +1,7 @@
-import config from '../config';
-import { enqueueEmail } from './emailQueue';
-
 const badgeCardMap = new Map<string, string>();
 
 export function awardMilestoneBadge(email: string, badge: string): string {
   const cardUrl = `/cards/${badge}-thank-you-card.pdf`;
-  const body = `Thanks for helping us reach the ${badge} milestone.\nDownload your card: ${cardUrl}`;
-  enqueueEmail({
-    to: email,
-    templateId: config.badgeMilestoneTemplateId,
-    params: { body, cardUrl },
-  });
   badgeCardMap.set(email, cardUrl);
   return cardUrl;
 }

--- a/MJ_FB_Backend/tests/agency.test.ts
+++ b/MJ_FB_Backend/tests/agency.test.ts
@@ -34,8 +34,6 @@ jest.doMock('../src/models/agency', () => ({
   removeAgencyClient: jest.fn(),
   clientExists: jest.fn(),
   getAgencyForClient: jest.fn(),
-  getAgencyEmail: jest.fn(),
-  getClientName: jest.fn(),
   getAgencyClientSet: jest.fn(),
 }));
 jest.doMock('../src/middleware/authMiddleware', () => ({
@@ -81,15 +79,12 @@ const {
   removeAgencyClient,
   clientExists,
   getAgencyForClient,
-  getAgencyEmail,
-  getClientName,
   getAgencyClientSet,
 } = require('../src/models/agency');
 const bookingUtils = require('../src/utils/bookingUtils');
 const pool = require('../src/db').default;
 const { enqueueEmail } = require('../src/utils/emailQueue');
 const { formatReginaDate } = require('../src/utils/dateUtils');
-const config = require('../src/config').default;
 
 test('does not query database on import', () => {
   expect(pool.query).not.toHaveBeenCalled();
@@ -309,42 +304,26 @@ describe('Agency client notifications', () => {
     jest.clearAllMocks();
   });
 
-  it('notifies agency when client added', async () => {
+  it('adds client without sending email', async () => {
     (clientExists as jest.Mock).mockResolvedValue(true);
     (getAgencyForClient as jest.Mock).mockResolvedValue(null);
     (addAgencyClient as jest.Mock).mockResolvedValue(undefined);
-    (getAgencyEmail as jest.Mock).mockResolvedValue('agency@example.com');
-    (getClientName as jest.Mock).mockResolvedValue({ first_name: 'John', last_name: 'Doe' });
 
     const res = await request(app)
       .post('/agencies/add-client')
       .send({ agencyId: 1, clientId: 5 });
 
     expect(res.status).toBe(204);
-    expect(enqueueEmail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: 'agency@example.com',
-        templateId: config.agencyClientUpdateTemplateId,
-        params: expect.objectContaining({ body: 'John Doe has been added to your agency.' }),
-      }),
-    );
+    expect(enqueueEmail).not.toHaveBeenCalled();
   });
 
-  it('notifies agency when client removed', async () => {
+  it('removes client without sending email', async () => {
     (removeAgencyClient as jest.Mock).mockResolvedValue(undefined);
-    (getAgencyEmail as jest.Mock).mockResolvedValue('agency@example.com');
-    (getClientName as jest.Mock).mockResolvedValue({ first_name: 'John', last_name: 'Doe' });
 
     const res = await request(app).delete('/agencies/1/clients/5');
 
     expect(res.status).toBe(204);
-    expect(enqueueEmail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: 'agency@example.com',
-        templateId: config.agencyClientUpdateTemplateId,
-        params: expect.objectContaining({ body: 'John Doe has been removed from your agency.' }),
-      }),
-    );
+    expect(enqueueEmail).not.toHaveBeenCalled();
   });
 });
 

--- a/MJ_FB_Backend/tests/badgeUtils.test.ts
+++ b/MJ_FB_Backend/tests/badgeUtils.test.ts
@@ -15,18 +15,9 @@ test('does not query database on import', () => {
 });
 
 describe('awardMilestoneBadge', () => {
-  it('queues a thank-you email and returns a card url', () => {
+  it('returns a card url without sending email', () => {
     const cardUrl = awardMilestoneBadge('user@example.com', 'gold');
-    expect(enqueueEmail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: 'user@example.com',
-        templateId: expect.any(Number),
-        params: expect.objectContaining({
-          body: expect.stringContaining('Download your card'),
-          cardUrl: expect.stringContaining('gold'),
-        }),
-      }),
-    );
+    expect(enqueueEmail).not.toHaveBeenCalled();
     expect(cardUrl).toContain('gold');
   });
 });

--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` |
 | `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` |
 | `VOLUNTEER_NO_SHOW_NOTIFICATION_TEMPLATE_ID` | Nightly coordinator alerts for volunteer no-shows | `ids` |
-| `templateId: 1` | Agency membership additions or removals | `body` |
-| `BADGE_MILESTONE_TEMPLATE_ID` | Milestone badge emails with downloadable card | `body`, `cardUrl` |
+
+Agency membership change and milestone badge emails have been retired; only the templates above remain active under the revised email policy.
 
 See [docs/emailTemplates.md](docs/emailTemplates.md) for detailed usage notes.
 =======
@@ -291,11 +291,9 @@ See [docs/emailTemplates.md](docs/emailTemplates.md) for detailed usage notes.
 | `BOOKING_CONFIRMATION_TEMPLATE_ID`           | Brevo template ID for booking confirmation emails                     |
 | `BOOKING_REMINDER_TEMPLATE_ID`               | Brevo template ID for booking reminder emails                         |
 | `BOOKING_STATUS_TEMPLATE_ID`                | Brevo template ID for booking status emails (cancellations, reschedules, no-shows) |
-| `AGENCY_CLIENT_UPDATE_TEMPLATE_ID`         | Brevo template ID for agency client update emails                               |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                 |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`     | Brevo template ID for volunteer shift reminder emails                 |
 | `VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` | Brevo template ID for volunteer booking notifications (cancellations, coordinator alerts) |
-| `BADGE_MILESTONE_TEMPLATE_ID`              | Brevo template ID for milestone badge emails with downloadable card   |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS`             | Hours until password setup tokens expire (default 24)                 |
 
 

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -1,7 +1,7 @@
 # Email Templates
 
 This document catalogs Brevo email templates used by the backend and the
-parameters supplied to each template.
+parameters supplied to each template. Agency membership and milestone badge emails were removed under the revised email policy.
 
 | Template reference | Purpose | Params | Used in |
 | ------------------- | ------- | ------ | ------- |
@@ -13,8 +13,6 @@ parameters supplied to each template.
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts` |
 | `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` | `volunteerBookingController.ts` |
 | `VOLUNTEER_NO_SHOW_NOTIFICATION_TEMPLATE_ID` | Nightly coordinator alerts for volunteer no-shows | `ids` | `volunteerNoShowCleanupJob.ts` |
-| `templateId: 1` | Agency membership additions or removals | `body` | `agencyController.ts` |
-| `BADGE_MILESTONE_TEMPLATE_ID` | Milestone badge emails with downloadable card | `body`, `cardUrl` | `badgeUtils.ts` |
 
 Brevo templates can reference these `params.*` values to display links and other
 dynamic content.
@@ -50,18 +48,4 @@ dynamic content.
 - **Params:**
   - `ids` (string) – comma-separated volunteer booking IDs marked as no-show.
 
-## Agency client update emails
-
-- **Template ID variable:** `AGENCY_CLIENT_UPDATE_TEMPLATE_ID`
-- **Used in:**
-  - `MJ_FB_Backend/src/controllers/agencyController.ts` (`addClientToAgency`, `removeClientFromAgency`)
-- **Params:**
-  - `body` (string) – message describing the client added to or removed from the agency.
-
-## Milestone badge emails
-
-- **Template ID variable:** `BADGE_MILESTONE_TEMPLATE_ID`
-- **Params:**
-  - `body` (string) – message body describing the milestone.
-  - `cardUrl` (string) – link to download the badge card.
 


### PR DESCRIPTION
## Summary
- remove agency client update and badge milestone templates from documentation and config
- stop sending emails for agency membership changes and milestone badges
- clean up example env vars and related tests

## Testing
- `npm test tests/agency.test.ts` (fails: Cannot redefine property)
- `npm test src/__tests__/App.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc701c8524832d91288ce0ead70552