### PR TITLE
Send volunteer cancellation emails only for staff actions

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
@@ -4,6 +4,7 @@ import Dashboard from '../components/dashboard/Dashboard';
 import { getBookings } from '../api/bookings';
 import { getEvents } from '../api/events';
 import { getVisitStats } from '../api/clientVisits';
+import { getVolunteerBookings } from '../api/volunteers';
 
 jest.mock('../api/bookings', () => ({
   getBookings: jest.fn(),
@@ -17,9 +18,14 @@ jest.mock('../api/clientVisits', () => ({
   getVisitStats: jest.fn(),
 }));
 
+jest.mock('../api/volunteers', () => ({
+  getVolunteerBookings: jest.fn(),
+}));
+
 describe('StaffDashboard', () => {
   it('does not display no-show rankings card', async () => {
     (getBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVisitStats as jest.Mock).mockResolvedValue([
       { date: '2024-01-01', total: 2, adults: 1, children: 1 },
       { date: '2024-01-02', total: 3, adults: 2, children: 1 },
@@ -40,6 +46,7 @@ describe('StaffDashboard', () => {
 
   it('shows events returned by the API', async () => {
     (getBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVisitStats as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({
       today: [

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -322,6 +322,12 @@ export async function getVolunteerBookingsByRole(roleId: number) {
   return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
 }
 
+export async function getVolunteerBookings(): Promise<VolunteerBooking[]> {
+  const res = await apiFetch(`${API_BASE}/volunteer-bookings`);
+  const data = await handleResponse(res);
+  return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
+}
+
 export async function getUnmarkedVolunteerBookings(): Promise<VolunteerBooking[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/unmarked`);
   const data = await handleResponse(res);


### PR DESCRIPTION
## Summary
- send volunteer booking cancellation emails only when staff triggers the cancel and include the reason
- display volunteer shift cancellations on staff dashboard instead of relying on email
- test staff vs volunteer cancellation scenarios

## Testing
- `npm test tests/volunteerBookingStatusEmail.test.ts` *(pass)*
- `npm test` *(backend: fails: Timesheet not found, etc.)*
- `npm test` *(frontend: multiple spec failures such as StaffDashboard test)*

------
https://chatgpt.com/codex/tasks/task_e_68bc72dcd2c0832d966a892777ece5a7