### PR TITLE
Remove volunteer coordinator email notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,5 +32,5 @@ See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/
 | `templateId: 1` | Booking cancellations, reschedules, and no-show notices | `body`, `type` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` |
-| `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` |
+| `templateId: 0` | Volunteer booking notifications (cancellations, recurring bookings) | `subject`, `body` |
 | `templateId: 1` | Agency membership additions or removals | `body` |

--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -23,13 +23,12 @@
 - Use the `sendTemplatedEmail` utility to send Brevo template emails by providing a `templateId` and `params` object.
 - `POST /auth/resend-password-setup` regenerates password setup links using `generatePasswordSetupToken`; requests are rate limited per email or client ID.
 - Profile pages send a password reset link without requiring current or new password fields.
-- Coordinator notification addresses for volunteer booking updates live in `src/config/coordinatorEmails.json`.
 - Staff or agency users can create bookings for unregistered individuals via `POST /bookings/new-client`; staff may review or delete these records through `/new-clients` routes.
 - The `new_clients.email` field is nullable; `POST /bookings/new-client` accepts requests without an email address.
 - A daily reminder job (`src/utils/bookingReminderJob.ts`) runs at server startup and emails clients about next-day bookings using the `enqueueEmail` queue. It uses `node-cron` with schedule `0 9 * * *` Regina time and exposes `startBookingReminderJob`/`stopBookingReminderJob`.
 - A volunteer shift reminder job (`src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue. It also uses `node-cron` with the same schedule and exposes `startVolunteerShiftReminderJob`/`stopVolunteerShiftReminderJob`.
 - A nightly no-show cleanup job (`src/utils/noShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved bookings as `no_show`. It exposes `startNoShowCleanupJob`/`stopNoShowCleanupJob`.
-- A nightly volunteer no-show cleanup job (`src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results, emails coordinators, and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
+- A nightly volunteer no-show cleanup job (`src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -53,7 +53,7 @@ Authentication cookies are scoped to the `/` path and use the same options when 
 
 `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` – Brevo template ID for volunteer shift reminder emails.
 
-`VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` – Brevo template ID for volunteer booking notifications (cancellations, coordinator alerts).
+`VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` – Brevo template ID for volunteer booking notifications (cancellations).
 
 `VOLUNTEER_NO_SHOW_HOURS` – Hours to wait before marking a volunteer shift as no-show (default 24).
 

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -4,7 +4,6 @@ import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import logger from '../src/utils/logger';
-import config from '../src/config';
 
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn().mockResolvedValue(undefined),

--- a/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
@@ -54,7 +54,7 @@ describe('recurring volunteer bookings', () => {
       '2025-01-03',
     ]);
     expect(res.body.skipped).toEqual([]);
-    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(9);
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(3);
     expect(sendTemplatedEmailMock.mock.calls[0][0]).toMatchObject({
       to: 'test@example.com',
       templateId: 0,
@@ -88,7 +88,7 @@ describe('recurring volunteer bookings', () => {
       { date: '2025-01-04', reason: 'Role not bookable on holidays or weekends' },
       { date: '2025-01-05', reason: 'Role not bookable on holidays or weekends' },
     ]);
-    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(3);
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(1);
   });
 
   it('cancels future recurring bookings', async () => {
@@ -110,7 +110,7 @@ describe('recurring volunteer bookings', () => {
       '/volunteer-bookings/recurring/10?from=2025-01-02',
     );
     expect(res.status).toBe(200);
-    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(3);
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(1);
   });
 
   it('lists recurring bookings', async () => {

--- a/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
@@ -51,7 +51,7 @@ describe('staff recurring volunteer bookings', () => {
     expect(res.body.recurringId).toBe(30);
     expect(res.body.successes).toEqual(['2025-01-01', '2025-01-02', '2025-01-03']);
     expect(res.body.skipped).toEqual([]);
-    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(9);
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(3);
     expect(sendTemplatedEmailMock.mock.calls[0][0]).toMatchObject({
       to: 'vol@example.com',
       templateId: 0,
@@ -107,6 +107,6 @@ describe('staff recurring volunteer bookings', () => {
     );
 
     expect(res.status).toBe(200);
-    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(3);
+    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(1);
   });
 });

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -52,14 +52,6 @@ describe('rescheduleVolunteerBooking', () => {
     expect(res.status).toBe(200);
     const updateCall = (pool.query as jest.Mock).mock.calls[6];
     expect(updateCall[0]).toContain("status='approved'");
-    expect(sendTemplatedEmailMock.mock.calls).toHaveLength(2);
-    expect(sendTemplatedEmailMock.mock.calls[0][0]).toMatchObject({
-      to: 'coordinator1@example.com',
-      templateId: 0,
-    });
-    expect(sendTemplatedEmailMock.mock.calls[1][0]).toMatchObject({
-      to: 'coordinator2@example.com',
-      templateId: 0,
-    });
+    expect(sendTemplatedEmailMock).not.toHaveBeenCalled();
   });
 });

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ Before merging a pull request, confirm the following:
 - Booking confirmation and reminder emails include Cancel and Reschedule buttons so users can manage their appointments directly from the message.
 - A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.
 - A nightly volunteer no-show cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours.
-- Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Backend email queue retries failed sends with exponential backoff and persists jobs in an `email_queue` table so retries survive restarts. The maximum retries and initial delay are configurable.
@@ -280,7 +279,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `templateId: 1` | Booking cancellations, reschedules, and no-show notices | `body`, `type` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` |
-| `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` |
+| `templateId: 0` | Volunteer booking notifications (cancellations, recurring bookings) | `subject`, `body` |
 | `templateId: 1` | Agency membership additions or removals | `body` |
 
 See [docs/emailTemplates.md](docs/emailTemplates.md) for detailed usage notes.
@@ -291,7 +290,7 @@ See [docs/emailTemplates.md](docs/emailTemplates.md) for detailed usage notes.
 | `BOOKING_STATUS_TEMPLATE_ID`                | Brevo template ID for booking status emails (cancellations, reschedules, no-shows) |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                 |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`     | Brevo template ID for volunteer shift reminder emails                 |
-| `VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` | Brevo template ID for volunteer booking notifications (cancellations, coordinator alerts) |
+| `VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` | Brevo template ID for volunteer booking notifications (cancellations) |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS`             | Hours until password setup tokens expire (default 24)                 |
 
 

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -11,7 +11,7 @@ parameters supplied to each template.
 | `templateId: 1` | Booking cancellations and reschedules | `body`, `type` | `bookingController.ts` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` | `volunteerBookingController.ts` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts` |
-| `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` 
+| `templateId: 0` | Volunteer booking notifications (cancellations, recurring bookings) | `subject`, `body`
 
 Brevo templates can reference these `params.*` values to display links and other
 dynamic content.


### PR DESCRIPTION
## Summary
- remove coordinator notification helper and usage in volunteer booking controller
- update tests after dropping coordinator emails
- strip coordinator notice references from docs and guidelines

## Testing
- `npm test` *(fails: Timesheet not found; Cannot edit stat holiday; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc72c77cf0832dadd17920433ac615