### PR TITLE
refactor: drop volunteer coordinator emails

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -14,7 +14,6 @@ import {
 } from '../../types/volunteerBooking';
 import { formatReginaDate, reginaStartOfDayISO } from '../../utils/dateUtils';
 import config from '../../config';
-import coordinatorEmailsConfig from '../../config/coordinatorEmails.json';
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 function isValidDateString(date: string): boolean {
@@ -42,27 +41,6 @@ function mapBookingRow(b: any) {
   };
 }
 
-const coordinatorEmails: string[] = coordinatorEmailsConfig.coordinatorEmails || [];
-
-async function notifyCoordinators(subject: string, body: string) {
-  const results = await Promise.allSettled(
-    coordinatorEmails.map(email =>
-      sendTemplatedEmail({
-        to: email,
-        templateId: config.volunteerBookingNotificationTemplateId,
-        params: { subject, body },
-      }),
-    ),
-  );
-  results.forEach((result, idx) => {
-    if (result.status === 'rejected') {
-      logger.error('Failed to send coordinator email', {
-        email: coordinatorEmails[idx],
-        error: result.reason,
-      });
-    }
-  });
-}
 
 export async function createVolunteerBooking(
   req: Request,
@@ -947,10 +925,6 @@ export async function rescheduleVolunteerBooking(
       "UPDATE volunteer_bookings SET slot_id=$1, date=$2, reschedule_token=$3, status='approved', reason=NULL WHERE id=$4",
       [roleId, date, newToken, booking.id],
     );
-    await notifyCoordinators(
-      'Volunteer booking rescheduled',
-      `Volunteer booking ${booking.id} was rescheduled`,
-    );
     res.json({ message: 'Volunteer booking rescheduled', rescheduleToken: newToken });
   } catch (error) {
     logger.error('Error rescheduling volunteer booking:', error);
@@ -1099,10 +1073,6 @@ export async function createRecurringVolunteerBooking(
           user.id,
         );
       }
-      await notifyCoordinators(
-        subject,
-        `Volunteer ${user.id} booking confirmed for ${date} ${slot.start_time}-${slot.end_time}.`,
-      );
     }
     res.status(201).json({ recurringId, successes, skipped });
   } catch (error) {
@@ -1274,10 +1244,6 @@ export async function createRecurringVolunteerBookingForVolunteer(
           volunteerId,
         );
       }
-      await notifyCoordinators(
-        subject,
-        `Volunteer ${volunteerId} booking confirmed for ${date} ${slot.start_time}-${slot.end_time}.`,
-      );
     }
     res.status(201).json({ recurringId, successes, skipped });
   } catch (error) {
@@ -1392,10 +1358,6 @@ export async function cancelVolunteerBookingOccurrence(
         booking.volunteer_id,
       );
     }
-    await notifyCoordinators(
-      subject,
-      `Volunteer ${booking.volunteer_id} booking cancelled for ${dateStr} ${slot.start_time}-${slot.end_time}.`,
-    );
     booking.status = 'cancelled';
     booking.role_id = booking.slot_id;
     delete booking.slot_id;
@@ -1458,10 +1420,6 @@ export async function cancelRecurringVolunteerBooking(
         info.volunteer_id,
       );
     }
-    await notifyCoordinators(
-      subject,
-      `Volunteer ${info.volunteer_id} recurring bookings cancelled starting ${from} for ${info.start_time}-${info.end_time}.`,
-    );
     res.json({ message: 'Recurring bookings cancelled' });
   } catch (error) {
     logger.error('Error cancelling recurring volunteer bookings:', error);

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -4,7 +4,6 @@ import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import logger from '../src/utils/logger';
-import config from '../src/config';
 
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn().mockResolvedValue(undefined),
@@ -132,11 +131,9 @@ describe('cancelVolunteerBookingOccurrence', () => {
       .set('x-staff', '1')
       .send({ reason: 'sick' });
     expect(res.status).toBe(200);
-    const calls = sendTemplatedEmailMock.mock.calls.filter(
-      c => c[0].to === 'vol@example.com',
-    );
-    expect(calls).toHaveLength(1);
-    expect(calls[0][0].params.body).toContain('sick');
+    expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendTemplatedEmailMock.mock.calls[0][0].to).toBe('vol@example.com');
+    expect(sendTemplatedEmailMock.mock.calls[0][0].params.body).toContain('sick');
   });
 
   it('does not send email when volunteer cancels', async () => {
@@ -145,10 +142,7 @@ describe('cancelVolunteerBookingOccurrence', () => {
       .patch('/volunteer-bookings/1/cancel')
       .send({ reason: 'sick' });
     expect(res.status).toBe(200);
-    const calls = sendTemplatedEmailMock.mock.calls.filter(
-      c => c[0].to === 'vol@example.com',
-    );
-    expect(calls).toHaveLength(0);
+    expect(sendTemplatedEmailMock).not.toHaveBeenCalled();
   });
 });
 
@@ -174,11 +168,9 @@ describe('cancelRecurringVolunteerBooking', () => {
       .set('x-staff', '1')
       .send({ reason: 'sick' });
     expect(res.status).toBe(200);
-    const calls = sendTemplatedEmailMock.mock.calls.filter(
-      c => c[0].to === 'vol@example.com',
-    );
-    expect(calls).toHaveLength(1);
-    expect(calls[0][0].params.body).toContain('sick');
+    expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendTemplatedEmailMock.mock.calls[0][0].to).toBe('vol@example.com');
+    expect(sendTemplatedEmailMock.mock.calls[0][0].params.body).toContain('sick');
   });
 
   it('does not send email when volunteer cancels recurring booking', async () => {
@@ -187,10 +179,7 @@ describe('cancelRecurringVolunteerBooking', () => {
       .delete('/volunteer-bookings/recurring/1')
       .send({ reason: 'sick' });
     expect(res.status).toBe(200);
-    const calls = sendTemplatedEmailMock.mock.calls.filter(
-      c => c[0].to === 'vol@example.com',
-    );
-    expect(calls).toHaveLength(0);
+    expect(sendTemplatedEmailMock).not.toHaveBeenCalled();
   });
 });
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ Before merging a pull request, confirm the following:
 - Booking confirmation and reminder emails include Cancel and Reschedule buttons so users can manage their appointments directly from the message.
 - A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.
 - A nightly volunteer no-show cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours.
-- Coordinator notification emails for volunteer booking changes are configured via `MJ_FB_Backend/src/config/coordinatorEmails.json`.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Backend email queue retries failed sends with exponential backoff and persists jobs in an `email_queue` table so retries survive restarts. The maximum retries and initial delay are configurable.
@@ -280,7 +279,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `templateId: 1` | Booking cancellations, reschedules, and no-show notices | `body`, `type` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` |
-| `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` |
+| `templateId: 0` | Volunteer booking notifications (cancellations, recurring bookings) | `subject`, `body` |
 | `templateId: 1` | Agency membership additions or removals | `body` |
 
 See [docs/emailTemplates.md](docs/emailTemplates.md) for detailed usage notes.
@@ -291,7 +290,7 @@ See [docs/emailTemplates.md](docs/emailTemplates.md) for detailed usage notes.
 | `BOOKING_STATUS_TEMPLATE_ID`                | Brevo template ID for booking status emails (cancellations, reschedules, no-shows) |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                 |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`     | Brevo template ID for volunteer shift reminder emails                 |
-| `VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` | Brevo template ID for volunteer booking notifications (cancellations, coordinator alerts) |
+| `VOLUNTEER_BOOKING_NOTIFICATION_TEMPLATE_ID` | Brevo template ID for volunteer booking notifications (cancellations, recurring bookings) |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS`             | Hours until password setup tokens expire (default 24)                 |
 
 

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -11,7 +11,7 @@ parameters supplied to each template.
 | `templateId: 1` | Booking cancellations and reschedules | `body`, `type` | `bookingController.ts` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` | `volunteerBookingController.ts` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts` |
-| `templateId: 0` | Volunteer booking notifications (cancellations, coordinator notices, recurring bookings) | `subject`, `body` 
+| `templateId: 0` | Volunteer booking notifications (cancellations, recurring bookings) | `subject`, `body`
 
 Brevo templates can reference these `params.*` values to display links and other
 dynamic content.


### PR DESCRIPTION
## Summary
- remove coordinator email notifications from volunteer booking controller
- adjust tests for volunteer booking status emails
- clean up coordinator notice references in docs and README

## Testing
- `npm test` *(fails: Test Suites: 20 failed, 84 passed, 104 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bc75732060832da436e1cb5175b40a