### PR TITLE
refactor: streamline booking email bodies

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -216,11 +216,12 @@ export async function createVolunteerBooking(
           slot.start_time,
           slot.end_time,
         );
+        const body = `Date: ${date} from ${slot.start_time} to ${slot.end_time}`;
         enqueueEmail({
           to: user.email,
           templateId: config.volunteerBookingConfirmationTemplateId,
           params: {
-            body: `Volunteer booking for role ${roleId} on ${date} has been confirmed.`,
+            body,
             cancelLink,
             rescheduleLink,
             googleCalendarLink,
@@ -580,11 +581,12 @@ export async function resolveVolunteerBookingConflict(
         slot.start_time,
         slot.end_time,
       );
+      const body = `Date: ${date!} from ${slot.start_time} to ${slot.end_time}`;
       enqueueEmail({
         to: user.email,
         templateId: config.volunteerBookingConfirmationTemplateId,
         params: {
-          body: `Volunteer booking for role ${roleId} on ${date!} has been confirmed.`,
+          body,
           cancelLink,
           rescheduleLink,
           googleCalendarLink,
@@ -1080,7 +1082,7 @@ export async function createRecurringVolunteerBooking(
       successes.push(date);
 
       const subject = `Volunteer booking confirmed for ${date} ${slot.start_time}-${slot.end_time}`;
-      const body = `Your volunteer booking on ${date} from ${slot.start_time} to ${slot.end_time} has been confirmed.`;
+      const body = `Date: ${date} from ${slot.start_time} to ${slot.end_time}`;
       if (user.email) {
         const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
         await sendTemplatedEmail({
@@ -1255,7 +1257,7 @@ export async function createRecurringVolunteerBookingForVolunteer(
       successes.push(date);
 
       const subject = `Volunteer booking confirmed for ${date} ${slot.start_time}-${slot.end_time}`;
-      const body = `Your volunteer booking on ${date} from ${slot.start_time} to ${slot.end_time} has been confirmed.`;
+      const body = `Date: ${date} from ${slot.start_time} to ${slot.end_time}`;
       if (volunteerEmail) {
         const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
         await sendTemplatedEmail({
@@ -1376,7 +1378,7 @@ export async function cancelVolunteerBookingOccurrence(
         ? formatReginaDate(booking.date)
         : booking.date;
     const subject = `Volunteer booking cancelled for ${dateStr} ${slot.start_time}-${slot.end_time}`;
-    const body = `Your volunteer booking on ${dateStr} from ${slot.start_time} to ${slot.end_time} has been cancelled. Reason: ${cancelReason}.`;
+    const body = `Date: ${dateStr} from ${slot.start_time} to ${slot.end_time}. Reason: ${cancelReason}.`;
     if (volunteerEmail && req.user?.role === 'staff') {
       const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(
         booking.reschedule_token,
@@ -1445,7 +1447,7 @@ export async function cancelRecurringVolunteerBooking(
       [id, from],
     );
     const subject = `Recurring volunteer bookings cancelled starting ${from} ${info.start_time}-${info.end_time}`;
-    const body = `Your recurring volunteer bookings starting ${from} from ${info.start_time} to ${info.end_time} have been cancelled. Reason: ${cancelReason}.`;
+    const body = `Date: ${from} from ${info.start_time} to ${info.end_time}. Reason: ${cancelReason}.`;
     if (info.email && req.user?.role === 'staff') {
       await sendTemplatedEmail({
         to: info.email,

--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -17,11 +17,14 @@ export async function sendNextDayBookingReminders(): Promise<void> {
     const bookings = await fetchBookingsForReminder(nextDate);
     for (const b of bookings) {
       if (!b.user_email) continue;
-      const time = b.start_time && b.end_time ? ` from ${b.start_time} to ${b.end_time}` : '';
+      const time =
+        b.start_time && b.end_time
+          ? ` from ${b.start_time} to ${b.end_time}`
+          : '';
       const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(
         b.reschedule_token,
       );
-      const body = `This is a reminder for your booking on ${nextDate}${time}.`;
+      const body = `Date: ${nextDate}${time}`;
       await enqueueEmail({
         to: b.user_email,
         templateId: config.bookingReminderTemplateId,

--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -24,11 +24,14 @@ export async function sendNextDayVolunteerShiftReminders(): Promise<void> {
     );
     for (const row of res.rows) {
       if (!row.email) continue;
-      const time = row.start_time && row.end_time ? ` from ${row.start_time} to ${row.end_time}` : '';
+      const time =
+        row.start_time && row.end_time
+          ? ` from ${row.start_time} to ${row.end_time}`
+          : '';
       const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(
         row.reschedule_token,
       );
-      const body = `This is a reminder for your volunteer shift on ${nextDate}${time}.`;
+      const body = `Date: ${nextDate}${time}`;
       enqueueEmail({
         to: row.email,
         templateId: config.volunteerBookingReminderTemplateId,


### PR DESCRIPTION
## Summary
- remove leading sentences from booking and volunteer shift emails
- populate email bodies with only date/time details

## Testing
- `npm test` *(fails: ReferenceError in volunteerShiftReminderJob.test.ts and multiple suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7567fc60832d8a249f37b5e27c6b