### PR TITLE
docs: clarify staff dashboard monthly totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Profile pages provide a button to email a password reset link instead of changing passwords directly.
 - A shared dashboard component lives in `src/components/dashboard`.
 - Staff dashboard dates display weekday, month, day, and year (e.g., 'Tue, Jan 2, 2024').
-- Staff dashboard includes a pantry visit trend line chart showing daily totals for adults, children, and overall visits.
+- Staff dashboard includes a pantry visit trend line chart showing monthly totals for clients, adults, and children.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Booking confirmations include links to add appointments to Google Calendar or download an ICS file.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.

--- a/docs/staff.md
+++ b/docs/staff.md
@@ -1,3 +1,5 @@
 # Staff management
 
 Staff accounts can be granted access to different areas of the system.
+
+The staff dashboard includes a pantry visit trend line chart showing monthly totals for clients, adults, and children.


### PR DESCRIPTION
## Summary
- Clarify in README that staff dashboard displays monthly totals for clients, adults, and children
- Note staff dashboard's monthly totals in staff documentation

## Testing
- `npm run test:backend` *(fails: Test Suites: 20 failed, 84 passed)*
- `npm run test:frontend` *(fails: TypeError: Cannot read properties of null (reading '_location'))*


------
https://chatgpt.com/codex/tasks/task_e_68bc77db4174832da44728d8f426bb55