### PR TITLE
Add monthly visit stats and interactive trend chart

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientVisitTrendChart.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientVisitTrendChart.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import ClientVisitTrendChart from '../components/dashboard/ClientVisitTrendChart';
+
+jest.mock('recharts', () => {
+  const Recharts = jest.requireActual('recharts');
+  return {
+    ...Recharts,
+    ResponsiveContainer: ({ children }: any) => (
+      <div className="recharts-wrapper" style={{ width: 800, height: 300 }}>
+        {React.cloneElement(children, { width: 800, height: 300 })}
+      </div>
+    ),
+  };
+});
+
+test('renders three lines for clients, adults, and children', () => {
+  const data = [
+    { month: '2024-01', clients: 5, adults: 3, children: 2 },
+    { month: '2024-02', clients: 6, adults: 4, children: 2 },
+  ];
+  const { container } = render(
+    <ThemeProvider theme={createTheme()}>
+      <ClientVisitTrendChart data={data} />
+    </ThemeProvider>,
+  );
+  expect(container.querySelectorAll('path.recharts-line-curve').length).toBe(3);
+});

--- a/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
@@ -4,7 +4,7 @@ import Dashboard from '../components/dashboard/Dashboard';
 import { getBookings } from '../api/bookings';
 import { getEvents } from '../api/events';
 import { getVisitStats } from '../api/clientVisits';
-import { getVolunteerBookings } from '../api/volunteers';
+import { getVolunteerBookings, getVolunteerRoles } from '../api/volunteers';
 
 jest.mock('../api/bookings', () => ({
   getBookings: jest.fn(),
@@ -20,15 +20,17 @@ jest.mock('../api/clientVisits', () => ({
 
 jest.mock('../api/volunteers', () => ({
   getVolunteerBookings: jest.fn(),
+  getVolunteerRoles: jest.fn(),
 }));
 
 describe('StaffDashboard', () => {
   it('does not display no-show rankings card', async () => {
     (getBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
     (getVisitStats as jest.Mock).mockResolvedValue([
-      { date: '2024-01-01', total: 2, adults: 1, children: 1 },
-      { date: '2024-01-02', total: 3, adults: 2, children: 1 },
+      { month: '2024-01', clients: 2, adults: 1, children: 1 },
+      { month: '2024-02', clients: 3, adults: 2, children: 1 },
     ]);
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
 
@@ -39,14 +41,14 @@ describe('StaffDashboard', () => {
     );
 
     await screen.findByText('Pantry Visit Trend');
-    const chart = screen.getByTestId('visit-trend-chart');
-    expect(chart.querySelectorAll('path.recharts-line-curve').length).toBe(3);
+    expect(getVisitStats).toHaveBeenCalled();
     expect(screen.queryByText('Pantry Schedule (This Week)')).toBeNull();
   });
 
   it('shows events returned by the API', async () => {
     (getBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
     (getVisitStats as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({
       today: [

--- a/MJ_FB_Frontend/src/api/clientVisits.ts
+++ b/MJ_FB_Frontend/src/api/clientVisits.ts
@@ -60,15 +60,23 @@ export interface VisitImportPreview {
 }
 
 export interface VisitStat {
-  date: string;
-  total: number;
+  month: string;
+  clients: number;
   adults: number;
   children: number;
 }
 
-export async function getVisitStats(days?: number): Promise<VisitStat[]> {
+interface VisitStatParams {
+  months?: number;
+  group?: string;
+}
+
+export async function getVisitStats(
+  params: VisitStatParams = {},
+): Promise<VisitStat[]> {
   const url = new URL(`${API_BASE}/client-visits/stats`);
-  if (days != null) url.searchParams.set('days', String(days));
+  if (params.months != null) url.searchParams.set('months', String(params.months));
+  if (params.group != null) url.searchParams.set('group', params.group);
   const res = await apiFetch(url.toString());
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/components/dashboard/ClientVisitTrendChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/ClientVisitTrendChart.tsx
@@ -7,6 +7,7 @@ import {
   YAxis,
   CartesianGrid,
   Legend,
+  Tooltip,
 } from 'recharts';
 import type { VisitStat } from '../../api/clientVisits';
 
@@ -20,31 +21,32 @@ export default function ClientVisitTrendChart({ data }: Props) {
     <ResponsiveContainer width="100%" height={300} data-testid="visit-trend-chart">
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
+        <XAxis dataKey="month" />
         <YAxis allowDecimals={false} />
+        <Tooltip trigger="click" />
         <Legend />
         <Line
           type="monotone"
-          dataKey="total"
-          stroke={theme.palette.primary.main}
+          dataKey="clients"
+          stroke={theme.palette.error.main}
           strokeWidth={2}
-          dot={false}
+          dot={{ r: 4, cursor: 'pointer' }}
           name="Total"
         />
         <Line
           type="monotone"
           dataKey="adults"
-          stroke={theme.palette.info.main}
+          stroke={theme.palette.success.main}
           strokeWidth={2}
-          dot={false}
+          dot={{ r: 4, cursor: 'pointer' }}
           name="Adults"
         />
         <Line
           type="monotone"
           dataKey="children"
-          stroke={theme.palette.success.main}
+          stroke={theme.palette.info.main}
           strokeWidth={2}
-          dot={false}
+          dot={{ r: 4, cursor: 'pointer' }}
           name="Children"
         />
       </LineChart>

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -99,7 +99,7 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
         setEvents({ today: [], upcoming: [], past: [] }),
       );
 
-    getVisitStats()
+    getVisitStats({ group: 'month', months: 12 })
       .then(data => setVisitStats(data ?? []))
       .catch(() => setVisitStats([]));
   }, []);


### PR DESCRIPTION
## Summary
- support monthly client visit stats via `months`/`group` parameters
- display monthly stats in dashboard and update trend chart colors
- add unit tests for staff dashboard and visit trend chart

## Testing
- `npm test src/__tests__/StaffDashboard.test.tsx src/__tests__/ClientVisitTrendChart.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc77d84aa0832d8067fa17e080128b