### PR TITLE
Remove volunteer usernames and enforce unique volunteer email

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to Azure".
 - Always document new environment variables in the repository README and `.env.example` files.
 - Implement all database schema changes via migrations in `MJ_FB_Backend/src/migrations`; do not modify `src/setupDatabase.ts` for schema updates.
+- Volunteer usernames have been removed and volunteer emails must be unique (email remains optional).
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.
 - Use the shared `PasswordField` component for any password input so users can toggle visibility.
 

--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -13,6 +13,7 @@
 
 - Requires Node.js 22+ for native `fetch`; development is pinned via `.nvmrc`, and `.npmrc` sets `engine-strict=true` to prevent using other Node versions. GitHub Actions reads `.nvmrc` to keep CI builds and tests on the same runtime.
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
+- The `volunteers` table no longer includes a `username` column, and `email` must be unique though it can be null.
 
 ## Email & Jobs
 

--- a/MJ_FB_Backend/src/migrations/1700000000006_remove_username_add_unique_email_to_volunteers.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000006_remove_username_add_unique_email_to_volunteers.ts
@@ -1,0 +1,14 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('volunteers', 'username');
+  pgm.addConstraint('volunteers', 'volunteers_email_unique', { unique: ['email'] });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('volunteers', 'volunteers_email_unique');
+  pgm.addColumn('volunteers', {
+    username: { type: 'text', notNull: true },
+  });
+  pgm.addConstraint('volunteers', 'volunteers_username_unique', { unique: ['username'] });
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repository uses Git submodules for the backend and frontend components. Aft
 ## Volunteer Creation
 
 Create volunteers from the Volunteers page. Check **Online Access** to send an email invitation; the email field becomes required when enabled.
+Volunteer usernames have been removed and email addresses must be unique, though providing an email remains optional.
 
 ## Node Version
 


### PR DESCRIPTION
## Summary
- drop `username` column from `volunteers`
- enforce unique `email` on `volunteers`
- document volunteer schema change

## Testing
- `npm test` *(fails: 19 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7e330648832db9a5f3afa9678ff1