### PR TITLE
Drop volunteer usernames in backend

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -23,9 +23,8 @@ export async function requestPasswordReset(
   res: Response,
   next: NextFunction,
 ) {
-  const { email, username, clientId } = req.body as {
+  const { email, clientId } = req.body as {
     email?: string;
-    username?: string;
     clientId?: number;
   };
   try {
@@ -51,15 +50,6 @@ export async function requestPasswordReset(
           id: result.rows[0].id,
           email: result.rows[0].email,
           table: result.rows[0].user_type,
-        };
-      }
-    } else if (username) {
-      const volRes = await pool.query('SELECT id, email FROM volunteers WHERE username=$1', [username]);
-      if ((volRes.rowCount ?? 0) > 0) {
-        user = {
-          id: volRes.rows[0].id,
-          email: volRes.rows[0].email,
-          table: 'volunteers',
         };
       }
     } else if (clientId) {

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -280,7 +280,7 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
 
     if (user.type === 'volunteer') {
       const profileRes = await pool.query(
-        `SELECT id, first_name, last_name, email, phone, username FROM volunteers WHERE id = $1`,
+        `SELECT id, first_name, last_name, email, phone FROM volunteers WHERE id = $1`,
         [user.id],
       );
       if ((profileRes.rowCount ?? 0) === 0) {
@@ -301,7 +301,6 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
         email: row.email,
         phone: row.phone,
         role: 'volunteer',
-        username: row.username,
         trainedAreas: trainedRes.rows.map(r => r.name),
       });
     }
@@ -383,7 +382,7 @@ export async function updateMyProfile(req: Request, res: Response, next: NextFun
          SET email = COALESCE($1, email),
              phone = COALESCE($2, phone)
          WHERE id = $3
-         RETURNING id, first_name, last_name, email, phone, username`,
+         RETURNING id, first_name, last_name, email, phone`,
         [email, phone, user.id],
       );
       if ((result.rowCount ?? 0) === 0) {
@@ -404,7 +403,6 @@ export async function updateMyProfile(req: Request, res: Response, next: NextFun
         email: row.email,
         phone: row.phone,
         role: 'volunteer',
-        username: row.username,
         trainedAreas: trainedRes.rows.map(r => r.name),
       });
     }

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -50,27 +50,6 @@ describe('requestPasswordReset', () => {
     );
   });
 
-  it('handles username lookup for volunteers', async () => {
-    (pool.query as jest.Mock).mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 5, email: 'vol@example.com' }],
-    });
-    (generatePasswordSetupToken as jest.Mock).mockResolvedValue('tok');
-    const res = await request(app)
-      .post('/auth/request-password-reset')
-      .send({ username: 'vol' });
-    expect(res.status).toBe(204);
-    expect(generatePasswordSetupToken).toHaveBeenCalledWith('volunteers', 5);
-    expect(sendTemplatedEmail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        templateId: config.passwordSetupTemplateId,
-        params: {
-          link: `${config.frontendOrigins[0]}/set-password?token=tok`,
-          token: 'tok',
-        },
-      }),
-    );
-  });
 
   it('handles clientId lookup for clients', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({

--- a/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
+++ b/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
@@ -24,14 +24,14 @@ describe('donation entry volunteer login', () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({
         rowCount: 1,
-        rows: [{ id: 1, first_name: 'Jane', last_name: 'Doe', username: 'jane', password: 'hashed', user_id: null, user_role: null }],
+        rows: [{ id: 1, first_name: 'Jane', last_name: 'Doe', password: 'hashed', user_id: null, user_role: null }],
       })
       .mockResolvedValueOnce({ rows: [{ name: 'Donation Entry' }] });
     (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
     const res = await request(app)
       .post('/volunteers/login')
-      .send({ username: 'jane', password: 'pw' });
+      .send({ email: 'jane@example.com', password: 'pw' });
 
     expect(res.status).toBe(200);
     expect(res.body.access).toEqual(['donation_entry']);


### PR DESCRIPTION
## Summary
- Authenticate volunteers by email instead of username
- Remove username from volunteer profile and creation APIs
- Simplify password reset to rely on email or client ID only

## Testing
- `npm test` *(fails: Test Suites: 19 failed, 85 passed, 104 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7fc51308832da7a8b97ad2383808