### PR TITLE
Filter reschedule slots for availability

### DIFF
--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -78,6 +78,12 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
             const now = new Date();
             s = s.filter(slot => new Date(`${date}T${slot.startTime}`) > now);
           }
+          s = s.filter(
+            slot =>
+              (slot.available ?? 0) > 0 &&
+              slot.status !== 'blocked' &&
+              slot.status !== 'break',
+          );
           setSlots(s);
         })
         .catch(() => setSlots([]));

--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -47,6 +47,12 @@ export default function RescheduleDialog({
               slot => new Date(`${date}T${slot.startTime}`) > now,
             );
           }
+          s = s.filter(
+            slot =>
+              (slot.available ?? 0) > 0 &&
+              slot.status !== 'blocked' &&
+              slot.status !== 'break',
+          );
           setSlots(s);
         })
         .catch(() => setSlots([]));


### PR DESCRIPTION
## Summary
- filter out unavailable and blocked/break slots in client and staff reschedule dialogs
- add tests ensuring only available slots appear in reschedule dropdowns

## Testing
- `npm test src/__tests__/RescheduleDialog.test.tsx src/__tests__/ManageBookingDialog.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc802178ac832da91c6e95437540fa