### PR TITLE
Use dated volunteer slots in reschedule dialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerRescheduleDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerRescheduleDialog.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VolunteerRescheduleDialog from '../components/VolunteerRescheduleDialog';
+import { formatTime } from '../utils/time';
+
+jest.mock('../api/volunteers', () => ({
+  ...jest.requireActual('../api/volunteers'),
+  getVolunteerRolesForVolunteer: jest.fn(),
+}));
+
+const { getVolunteerRolesForVolunteer } = jest.requireMock('../api/volunteers');
+
+describe('VolunteerRescheduleDialog', () => {
+  beforeAll(() => {
+    window.matchMedia =
+      window.matchMedia ||
+      ((query: string): MediaQueryList => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }));
+  });
+
+  beforeEach(() => {
+    (getVolunteerRolesForVolunteer as jest.Mock).mockReset();
+  });
+
+  it('omits slots with no availability', async () => {
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        name: 'Pantry',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        max_volunteers: 5,
+        booked: 5,
+        available: 0,
+        status: 'open',
+        date: '2024-02-02',
+        category_id: 1,
+        category_name: 'Pantry',
+        is_wednesday_slot: false,
+      },
+      {
+        id: 2,
+        role_id: 1,
+        name: 'Pantry',
+        start_time: '13:00:00',
+        end_time: '16:00:00',
+        max_volunteers: 5,
+        booked: 3,
+        available: 2,
+        status: 'open',
+        date: '2024-02-02',
+        category_id: 1,
+        category_name: 'Pantry',
+        is_wednesday_slot: false,
+      },
+    ]);
+
+    render(
+      <VolunteerRescheduleDialog open onClose={() => {}} onSubmit={() => {}} />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/date/i), {
+      target: { value: '2024-02-02' },
+    });
+
+    fireEvent.mouseDown(await screen.findByLabelText(/role/i));
+
+    const label = `Pantry ${formatTime('13:00:00')}–${formatTime('16:00:00')}`;
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        `Pantry ${formatTime('09:00:00')}–${formatTime('12:00:00')}`,
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- use getVolunteerRolesForVolunteer to load volunteer slots for chosen date
- show only available slots with role name and times
- add test ensuring filled slots are omitted

## Testing
- `npm test src/__tests__/RecurringBookings.test.tsx` *(fails: Unable to find role="listbox")*
- `npm test` *(fails: RecurringBookings.test.tsx and others due to act warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc81972e28832db98320d6b43eb757