### PR TITLE
Switch volunteer auth tests to email login

### DIFF
--- a/MJ_FB_Backend/tests/login.test.ts
+++ b/MJ_FB_Backend/tests/login.test.ts
@@ -32,7 +32,14 @@ describe('POST /api/users/login', () => {
   it('logs in staff with valid credentials', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({
       rowCount: 1,
-      rows: [{ id: 1, first_name: 'John', last_name: 'Doe', password: 'hashed', role: 'staff' }],
+      rows: [{
+        id: 1,
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john@example.com',
+        password: 'hashed',
+        role: 'staff',
+      }],
     });
     (bcrypt.compare as jest.Mock).mockResolvedValue(true);
     (jwt.sign as jest.Mock).mockReturnValue('token');
@@ -43,12 +50,13 @@ describe('POST /api/users/login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('role', 'staff');
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/WHERE email = \$1/);
   });
 
   it('returns 401 with invalid credentials', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({
       rowCount: 1,
-      rows: [{ password: 'hashed' }],
+      rows: [{ email: 'john@example.com', password: 'hashed' }],
     });
     (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -26,19 +26,19 @@ describe('requestPasswordReset', () => {
     jest.clearAllMocks();
   });
 
-  it('looks up by email across user tables', async () => {
+  it('looks up volunteer by email across user tables', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({
       rowCount: 1,
-      rows: [{ id: 7, email: 'user@example.com', user_type: 'staff' }],
+      rows: [{ id: 7, email: 'vol@example.com', user_type: 'volunteers' }],
     });
     (generatePasswordSetupToken as jest.Mock).mockResolvedValue('tok');
     const res = await request(app)
       .post('/auth/request-password-reset')
-      .send({ email: 'user@example.com' });
+      .send({ email: 'vol@example.com' });
     expect(res.status).toBe(204);
     expect(pool.query).toHaveBeenCalledTimes(1);
     expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/UNION ALL/);
-    expect(generatePasswordSetupToken).toHaveBeenCalledWith('staff', 7);
+    expect(generatePasswordSetupToken).toHaveBeenCalledWith('volunteers', 7);
     expect(sendTemplatedEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         templateId: config.passwordSetupTemplateId,

--- a/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
+++ b/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
@@ -24,7 +24,15 @@ describe('donation entry volunteer login', () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({
         rowCount: 1,
-        rows: [{ id: 1, first_name: 'Jane', last_name: 'Doe', password: 'hashed', user_id: null, user_role: null }],
+        rows: [{
+          id: 1,
+          first_name: 'Jane',
+          last_name: 'Doe',
+          email: 'jane@example.com',
+          password: 'hashed',
+          user_id: null,
+          user_role: null,
+        }],
       })
       .mockResolvedValueOnce({ rows: [{ name: 'Donation Entry' }] });
     (bcrypt.compare as jest.Mock).mockResolvedValue(true);
@@ -35,5 +43,6 @@ describe('donation entry volunteer login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.access).toEqual(['donation_entry']);
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/WHERE v.email = \$1/);
   });
 });

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -186,6 +186,7 @@ describe('Volunteer login with shopper profile', () => {
       refreshToken: 'token',
       access: [],
     });
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/WHERE v.email = \$1/);
     expect((jwt.sign as jest.Mock).mock.calls[0][0]).toMatchObject({
       id: 1,
       role: 'volunteer',


### PR DESCRIPTION
## Summary
- adjust volunteer login tests to assert email-based queries
- verify password reset looks up volunteers by email
- ensure donation entry and staff login tests send email credentials

## Testing
- `npm test -- tests/volunteers.test.ts tests/volunteerDonationEntry.test.ts tests/login.test.ts tests/passwordResetFlow.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc82387660832d8b145a63e6958509