### PR TITLE
refactor: remove volunteer username

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Profile.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Profile.test.tsx
@@ -34,15 +34,14 @@ describe('Profile password reset', () => {
     (getVolunteerProfile as jest.Mock).mockResolvedValue({
       firstName: 'V',
       lastName: 'Olunteer',
-      email: null,
+      email: 'v@example.com',
       phone: null,
       role: 'volunteer',
-      username: 'vol1',
     } as UserProfile);
     render(<Profile role="volunteer" />);
     const btn = await screen.findByRole('button', { name: /Reset Password/i });
     fireEvent.click(btn);
     await screen.findByText(/reset link/i);
-    expect(requestPasswordReset).toHaveBeenCalledWith({ username: 'vol1' });
+    expect(requestPasswordReset).toHaveBeenCalledWith({ email: 'v@example.com' });
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/VolunteerLogin.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerLogin.test.tsx
@@ -22,15 +22,15 @@ describe('VolunteerLogin component', () => {
         <VolunteerLogin onLogin={onLogin} />
       </MemoryRouter>
     );
-    fireEvent.change(screen.getByLabelText(/username/i), {
-      target: { value: 'user' },
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'user@example.com' },
     });
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'pass' },
     });
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
     expect(
-      await screen.findByText('Incorrect username or password')
+      await screen.findByText('Incorrect email or password')
     ).toBeInTheDocument();
     expect(onLogin).not.toHaveBeenCalled();
   });

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -76,9 +76,6 @@ describe('VolunteerManagement create volunteer', () => {
     fireEvent.change(screen.getByLabelText('Last Name'), {
       target: { value: 'Doe' },
     });
-    fireEvent.change(screen.getByLabelText('Username'), {
-      target: { value: 'jdoe' },
-    });
     fireEvent.click(screen.getByRole('button', { name: /select roles/i }));
     fireEvent.click(await screen.findByLabelText('Greeter'));
     fireEvent.click(screen.getByLabelText(/online access/i));

--- a/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
@@ -28,7 +28,7 @@ describe('Volunteer with shopper profile', () => {
 
     fireEvent.click(screen.getByText(/volunteer login/i));
 
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'vol' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'vol@example.com' } });
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), { target: { value: 'pass' } });
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
 

--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.tsx
@@ -75,7 +75,7 @@ describe('volunteers api', () => {
   });
 
   it('creates a volunteer', async () => {
-    await createVolunteer('John', 'Doe', 'jdoe', [1, 2], true, 'a@b.com', '123');
+    await createVolunteer('John', 'Doe', [1, 2], true, 'a@b.com', '123');
     expect(apiFetch).toHaveBeenCalledWith(
       '/api/volunteers',
       expect.objectContaining({
@@ -83,7 +83,6 @@ describe('volunteers api', () => {
         body: JSON.stringify({
           firstName: 'John',
           lastName: 'Doe',
-          username: 'jdoe',
           roleIds: [1, 2],
           onlineAccess: true,
           email: 'a@b.com',

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -56,7 +56,6 @@ export async function logout(): Promise<void> {
 
 export async function requestPasswordReset(data: {
   email?: string;
-  username?: string;
   clientId?: string;
 }): Promise<void> {
   const res = await apiFetch(`${API_BASE}/auth/request-password-reset`, {

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -25,13 +25,13 @@ function normalizeVolunteerBooking(b: any): VolunteerBooking {
 }
 
 export async function loginVolunteer(
-  username: string,
+  email: string,
   password: string
 ): Promise<LoginResponse> {
   const res = await apiFetch(`${API_BASE}/volunteers/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify({ email, password }),
   });
   const data = await handleResponse(res);
   return data;
@@ -429,7 +429,6 @@ export async function getVolunteerBookingHistory(
 export async function createVolunteer(
   firstName: string,
   lastName: string,
-  username: string,
   roleIds: number[],
   onlineAccess: boolean,
   email?: string,
@@ -443,7 +442,6 @@ export async function createVolunteer(
     body: JSON.stringify({
       firstName,
       lastName,
-      username,
       roleIds,
       onlineAccess,
       email,

--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -23,17 +23,15 @@ export default function PasswordResetDialog({
   const { t } = useTranslation();
 
   const label =
-    type === 'staff' ? t('email') : type === 'volunteer' ? t('username') : t('client_id');
+    type === 'staff' || type === 'volunteer' ? t('email') : t('client_id');
   const formTitle = t('reset_password');
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
       const body: any =
-        type === 'staff'
+        type === 'staff' || type === 'volunteer'
           ? { email: identifier }
-          : type === 'volunteer'
-          ? { username: identifier }
           : { clientId: identifier };
       await requestPasswordReset(body);
       setSnackbarSeverity('success');
@@ -62,20 +60,10 @@ export default function PasswordResetDialog({
               autoFocus
               margin="dense"
               label={label}
-              type={type === 'staff' ? 'email' : 'text'}
-              name={
-                type === 'staff'
-                  ? 'email'
-                  : type === 'volunteer'
-                  ? 'username'
-                  : 'clientId'
-              }
+              type={type === 'staff' || type === 'volunteer' ? 'email' : 'text'}
+              name={type === 'staff' || type === 'volunteer' ? 'email' : 'clientId'}
               autoComplete={
-                type === 'staff'
-                  ? 'email'
-                  : type === 'volunteer'
-                  ? 'username'
-                  : 'off'
+                type === 'staff' || type === 'volunteer' ? 'email' : 'off'
               }
               fullWidth
               value={identifier}

--- a/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/VolunteerLogin.tsx
@@ -15,27 +15,27 @@ export default function VolunteerLogin({
 }: {
   onLogin: (u: LoginResponse) => Promise<void>;
 }) {
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [resetOpen, setResetOpen] = useState(false);
   const [resendOpen, setResendOpen] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
-  const usernameError = submitted && username === '';
+  const emailError = submitted && email === '';
   const passwordError = submitted && password === '';
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     setSubmitted(true);
-    if (username === '' || password === '') return;
+    if (email === '' || password === '') return;
     try {
-      const user = await loginVolunteer(username, password);
+      const user = await loginVolunteer(email, password);
       await onLogin(user);
     } catch (err: unknown) {
       const apiErr = err as ApiError;
       if (apiErr?.status === 401) {
-        setError('Incorrect username or password');
+        setError('Incorrect email or password');
       } else if (apiErr?.status === 403) {
         setError('Password setup link expired');
         setResendOpen(true);
@@ -62,15 +62,15 @@ export default function VolunteerLogin({
         }
       >
         <TextField
-          name="username"
-          autoComplete="username"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
-          label="Username"
+          name="email"
+          autoComplete="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          label="Email"
           fullWidth
           required
-          error={usernameError}
-          helperText={usernameError ? 'Username is required' : ''}
+          error={emailError}
+          helperText={emailError ? 'Email is required' : ''}
         />
         <PasswordField
           name="password"

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -60,9 +60,7 @@ export default function Profile({ role }: { role: Role }) {
     setSubmitting(true);
     try {
       const body =
-        profile.role === 'volunteer'
-          ? { username: profile.username ?? '' }
-          : profile.role === 'shopper' || profile.role === 'delivery'
+        profile.role === 'shopper' || profile.role === 'delivery'
           ? { clientId: String(profile.clientId) }
           : { email: profile.email ?? '' };
       await requestPasswordReset(body);
@@ -141,11 +139,6 @@ export default function Profile({ role }: { role: Role }) {
               {profile.roles && profile.roles.length > 0 && (
                 <Typography>
                   <strong>{t('profile_page.roles')}</strong> {profile.roles.join(', ')}
-                </Typography>
-              )}
-              {profile.username && (
-                <Typography>
-                  <strong>{t('profile_page.username')}</strong> {profile.username}
                 </Typography>
               )}
               {profile.trainedAreas && profile.trainedAreas.length > 0 && (

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -141,7 +141,6 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
 
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-  const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
   const [onlineAccess, setOnlineAccess] = useState(false);
@@ -520,13 +519,10 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
     if (
       !firstName ||
       !lastName ||
-      !username ||
       selectedCreateRoles.length === 0
     ) {
       setCreateSeverity('error');
-      setCreateMsg(
-        'First name, last name, username and at least one role required'
-      );
+      setCreateMsg('First name, last name and at least one role required');
       return;
     }
     if (onlineAccess && !email) {
@@ -543,7 +539,6 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
       await createVolunteer(
         firstName,
         lastName,
-        username,
         ids,
         onlineAccess,
         email || undefined,
@@ -553,7 +548,6 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
       setCreateMsg('Volunteer created');
       setFirstName('');
       setLastName('');
-      setUsername('');
       setEmail('');
       setPhone('');
       setOnlineAccess(false);
@@ -850,13 +844,6 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
               label="Last Name"
               value={lastName}
               onChange={e => setLastName(e.target.value)}
-              size="small"
-              fullWidth
-            />
-            <TextField
-              label="Username"
-              value={username}
-              onChange={e => setUsername(e.target.value)}
               size="small"
               fullWidth
             />

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -176,7 +176,6 @@ export interface UserProfile {
   clientId?: number;
   bookingsThisMonth?: number;
   roles?: StaffAccess[];
-  username?: string;
   trainedAreas?: string[];
 }
 


### PR DESCRIPTION
## Summary
- use email for volunteer login and password resets
- drop username from volunteer creation and user profile types
- update components, pages, and tests to reflect removal

## Testing
- `npm test src/__tests__/VolunteerManagement.test.tsx` *(fails: Unable to find a label with the text of: Greeter)*

------
https://chatgpt.com/codex/tasks/task_e_68bc824d9f88832daa2bf40284bddb46