### PR TITLE
Filter unavailable shifts from ManageVolunteerShiftDialog

### DIFF
--- a/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
@@ -160,6 +160,8 @@ export default function ManageVolunteerShiftDialog({
     }
   }
 
+  const availableShifts = shifts.filter(s => !isShiftDisabled(s));
+
   return (
     <Dialog open={open} onClose={onClose} fullWidth>
       <DialogCloseButton onClose={onClose} />
@@ -212,15 +214,15 @@ export default function ManageVolunteerShiftDialog({
                 margin="normal"
                 disabled={!date}
               >
-                {shifts.map(s => (
-                  <MenuItem
-                    key={s.shiftId}
-                    value={s.shiftId.toString()}
-                    disabled={isShiftDisabled(s)}
-                  >
-                    {`${formatTime(s.startTime)} - ${formatTime(s.endTime)}`}
-                  </MenuItem>
-                ))}
+                {availableShifts.length > 0 ? (
+                  availableShifts.map(s => (
+                    <MenuItem key={s.shiftId} value={s.shiftId.toString()}>
+                      {`${formatTime(s.startTime)} - ${formatTime(s.endTime)}`}
+                    </MenuItem>
+                  ))
+                ) : (
+                  <MenuItem disabled>No shifts available</MenuItem>
+                )}
               </TextField>
             </>
           )}


### PR DESCRIPTION
## Summary
- Skip disabled volunteer shifts in ManageVolunteerShiftDialog and show placeholder when none are available
- Exclude unavailable shifts from shift dropdown in tests

## Testing
- `npm test src/__tests__/ManageVolunteerShiftDialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc848bce34832db6a9d611764f0749