### PR TITLE
Add build workflow for backend and frontend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install and build backend
+        working-directory: MJ_FB_Backend
+        run: |
+          npm ci
+          npm run build
+      - name: Install and build frontend
+        working-directory: MJ_FB_Frontend
+        env:
+          VITE_API_BASE: 'https://example.com'
+        run: |
+          npm ci
+          npm run build


### PR DESCRIPTION
## Summary
- add build CI workflow

## Testing
- `npm test` (backend) *(fails: jest: not found)*
- `npm test` (frontend) *(fails: remains running; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc857f58b8832db0c4482f9b1c457a