### PR TITLE
chore: add root build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ nvm use
 
 Run all backend and frontend tests on this runtime to match production behavior.
 
+To verify both backend and frontend compile successfully, run the root build script:
+
+```bash
+npm run build
+```
+
 To compile the backend for production, run:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "test:backend": "npm --prefix MJ_FB_Backend test",
-    "test:frontend": "npm --prefix MJ_FB_Frontend test"
+    "test:frontend": "npm --prefix MJ_FB_Frontend test",
+    "build": "npm --prefix MJ_FB_Backend run build && npm --prefix MJ_FB_Frontend run build"
   }
 }


### PR DESCRIPTION
## Summary
- add root build script to build backend and frontend
- document npm run build in README

## Testing
- `npm run test:backend` *(fails: 19 failed, 85 passed)*
- `npm run test:frontend` *(fails to complete)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc8581df70832dbe9afd5e70f4d921