### PR TITLE
Document volunteer email-based sign-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 - Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to Azure".
 - Always document new environment variables in the repository README and `.env.example` files.
 - Implement all database schema changes via migrations in `MJ_FB_Backend/src/migrations`; do not modify `src/setupDatabase.ts` for schema updates.
-- Volunteer usernames have been removed and volunteer emails must be unique (email remains optional).
+- Volunteers sign in with their email address instead of a username, and volunteer emails must be unique (email remains optional).
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.
 - Use the shared `PasswordField` component for any password input so users can toggle visibility.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repository uses Git submodules for the backend and frontend components. Aft
 ## Volunteer Creation
 
 Create volunteers from the Volunteers page. Check **Online Access** to send an email invitation; the email field becomes required when enabled.
-Volunteer usernames have been removed and email addresses must be unique, though providing an email remains optional.
+Volunteers sign in with their email address instead of a username, and volunteer emails must be unique, though providing an email remains optional for volunteers without online access.
 
 ## Node Version
 

--- a/docs/volunteerAccounts.md
+++ b/docs/volunteerAccounts.md
@@ -1,0 +1,4 @@
+# Volunteer accounts
+
+Create volunteers from the Volunteers page. When **Online Access** is enabled, the email field becomes mandatory and an invitation email is sent.
+Volunteers sign in with their email address instead of a username. Volunteer emails must be unique, though volunteers without online access can be added without an email.


### PR DESCRIPTION
## Summary
- clarify in README that volunteers sign in with email addresses instead of usernames
- document volunteer account creation and email sign-in in `docs/volunteerAccounts.md`
- update development guide to note volunteer email sign-in

## Testing
- `npm run test:backend` *(fails: Test Suites: 19 failed, 85 passed)*
- `npm run test:frontend` *(fails: FAIL src/__tests__/RecurringBookings.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bc85eec3e4832db8355d38b0fadc35