### PR TITLE
test: ensure reschedule shows only available volunteer slots

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerBookingHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBookingHistory.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerBookingHistory from '../pages/volunteer-management/VolunteerBookingHistory';
+import { getMyVolunteerBookings, getVolunteerRolesForVolunteer } from '../api/volunteers';
+import { formatTime } from '../utils/time';
+
+jest.mock('../api/volunteers', () => ({
+  getMyVolunteerBookings: jest.fn(),
+  cancelVolunteerBooking: jest.fn(),
+  cancelRecurringVolunteerBooking: jest.fn(),
+  rescheduleVolunteerBookingByToken: jest.fn(),
+  getVolunteerRolesForVolunteer: jest.fn(),
+}));
+
+describe('VolunteerBookingHistory', () => {
+  beforeEach(() => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'approved',
+        role_id: 1,
+        date: '2024-02-01',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        role_name: 'Pantry',
+        reschedule_token: 'abc',
+      },
+    ]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
+      {
+        id: 2,
+        role_id: 1,
+        name: 'Pantry',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        max_volunteers: 1,
+        booked: 1,
+        available: 0,
+        status: 'open',
+        date: '2024-02-02',
+        category_id: 1,
+        category_name: 'Pantry',
+        is_wednesday_slot: false,
+      },
+      {
+        id: 3,
+        role_id: 1,
+        name: 'Pantry',
+        start_time: '12:00:00',
+        end_time: '15:00:00',
+        max_volunteers: 1,
+        booked: 0,
+        available: 1,
+        status: 'open',
+        date: '2024-02-02',
+        category_id: 1,
+        category_name: 'Pantry',
+        is_wednesday_slot: false,
+      },
+    ]);
+  });
+
+  it('shows only available slots in reschedule dialog', async () => {
+    render(
+      <MemoryRouter>
+        <VolunteerBookingHistory />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /reschedule/i }));
+
+    fireEvent.change(screen.getByLabelText(/date/i), {
+      target: { value: '2024-02-02' },
+    });
+
+    fireEvent.mouseDown(await screen.findByLabelText(/role/i));
+
+    expect(
+      screen.queryByText(
+        `Pantry ${formatTime('09:00:00')}–${formatTime('12:00:00')}`,
+      ),
+    ).toBeNull();
+    expect(
+      await screen.findByText(
+        `Pantry ${formatTime('12:00:00')}–${formatTime('15:00:00')}`,
+      ),
+    ).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- test VolunteerBookingHistory reschedule dialog filters out unavailable shifts

## Testing
- `npm test -- VolunteerBookingHistory.test.tsx ManageVolunteerShiftDialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc85dd92b0832d94047f5468f0a4c6