### PR TITLE
test: verify slot availability in volunteer flows

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerBookingHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBookingHistory.test.tsx
@@ -1,0 +1,83 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
+import VolunteerBookingHistory from '../pages/volunteer-management/VolunteerBookingHistory';
+import { formatTime } from '../utils/time';
+import {
+  getMyVolunteerBookings,
+  getVolunteerRolesForVolunteer,
+} from '../api/volunteers';
+
+jest.mock('../api/volunteers', () => ({
+  ...jest.requireActual('../api/volunteers'),
+  getMyVolunteerBookings: jest.fn(),
+  getVolunteerRolesForVolunteer: jest.fn(),
+}));
+
+const { getMyVolunteerBookings, getVolunteerRolesForVolunteer } = jest.requireMock('../api/volunteers');
+
+describe('VolunteerBookingHistory', () => {
+  beforeEach(() => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        role_name: 'Pantry',
+        volunteer_id: 1,
+        date: '2024-02-01',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        status: 'approved',
+        reschedule_token: 'abc',
+      },
+    ]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
+      {
+        id: 10,
+        role_id: 1,
+        name: 'Pantry',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        max_volunteers: 5,
+        booked: 5,
+        available: 0,
+        status: 'open',
+        date: '2024-02-02',
+        category_id: 1,
+        category_name: 'Pantry',
+        is_wednesday_slot: false,
+      },
+      {
+        id: 11,
+        role_id: 1,
+        name: 'Pantry',
+        start_time: '13:00:00',
+        end_time: '16:00:00',
+        max_volunteers: 5,
+        booked: 3,
+        available: 2,
+        status: 'open',
+        date: '2024-02-02',
+        category_id: 1,
+        category_name: 'Pantry',
+        is_wednesday_slot: false,
+      },
+    ]);
+  });
+
+  it('lists only available shifts when rescheduling', async () => {
+    renderWithProviders(<VolunteerBookingHistory />);
+
+    fireEvent.click(await screen.findByText(/reschedule/i));
+    fireEvent.change(screen.getByLabelText(/date/i), {
+      target: { value: '2024-02-02' },
+    });
+    fireEvent.mouseDown(await screen.findByLabelText(/role/i));
+    const availableLabel = `Pantry ${formatTime('13:00:00')}–${formatTime('16:00:00')}`;
+    expect(screen.getByText(availableLabel)).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        `Pantry ${formatTime('09:00:00')}–${formatTime('12:00:00')}`,
+      ),
+    ).toBeNull();
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -1,6 +1,7 @@
 import { screen, fireEvent } from '@testing-library/react';
 import VolunteerSchedule from '../pages/volunteer-management/VolunteerSchedule';
 import i18n from '../i18n';
+import { formatTime } from '../utils/time';
 import { renderWithProviders } from '../../testUtils/renderWithProviders';
 import {
   getVolunteerRolesForVolunteer,
@@ -70,5 +71,100 @@ describe('VolunteerSchedule', () => {
     expect(prev).toBeDisabled();
 
     expect(await screen.findByText(i18n.t('no_bookings'))).toBeInTheDocument();
+  });
+
+  it('shows only available shifts in reschedule dialog', async () => {
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        role_name: 'Pantry',
+        volunteer_id: 1,
+        date: '2024-01-29',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        status: 'approved',
+        reschedule_token: 'abc',
+      },
+    ]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockImplementation((date: string) => {
+      if (date === '2024-01-29') {
+        return Promise.resolve([
+          {
+            id: 1,
+            role_id: 1,
+            name: 'Pantry',
+            start_time: '09:00:00',
+            end_time: '12:00:00',
+            max_volunteers: 1,
+            booked: 1,
+            available: 0,
+            status: 'open',
+            date,
+            category_id: 1,
+            category_name: 'Pantry',
+            is_wednesday_slot: false,
+          },
+        ]);
+      }
+      if (date === '2024-02-02') {
+        return Promise.resolve([
+          {
+            id: 2,
+            role_id: 1,
+            name: 'Pantry',
+            start_time: '09:00:00',
+            end_time: '12:00:00',
+            max_volunteers: 1,
+            booked: 1,
+            available: 0,
+            status: 'open',
+            date,
+            category_id: 1,
+            category_name: 'Pantry',
+            is_wednesday_slot: false,
+          },
+          {
+            id: 3,
+            role_id: 1,
+            name: 'Pantry',
+            start_time: '13:00:00',
+            end_time: '16:00:00',
+            max_volunteers: 2,
+            booked: 0,
+            available: 2,
+            status: 'open',
+            date,
+            category_id: 1,
+            category_name: 'Pantry',
+            is_wednesday_slot: false,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    renderWithProviders(<VolunteerSchedule />);
+
+    fireEvent.mouseDown(screen.getByLabelText(i18n.t('role')));
+    fireEvent.click(await screen.findByText('Pantry'));
+
+    fireEvent.click(await screen.findByText('My Booking'));
+    fireEvent.click(screen.getByRole('button', { name: /reschedule/i }));
+
+    fireEvent.change(screen.getByLabelText(/date/i), {
+      target: { value: '2024-02-02' },
+    });
+
+    fireEvent.mouseDown(await screen.findByLabelText(/role/i));
+
+    const availableLabel = `Pantry ${formatTime('13:00:00')}–${formatTime('16:00:00')}`;
+    expect(screen.getByText(availableLabel)).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        `Pantry ${formatTime('09:00:00')}–${formatTime('12:00:00')}`,
+      ),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add VolunteerBookingHistory test confirming reschedule dropdown filters out full slots
- expand VolunteerSchedule tests to show only available shifts when rescheduling

## Testing
- `npm test` *(fails: clearImmediate is not defined / jsdom location errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc87d245a8832dbf4d78c0930d7342