### PR TITLE
test: filter available volunteer slots

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -13,6 +13,7 @@ import {
   resolveVolunteerBookingConflict,
 } from '../api/volunteers';
 import { getHolidays } from '../api/bookings';
+import { formatTime } from '../utils/time';
 
 jest.mock('../api/volunteers', () => ({
   getVolunteerRolesForVolunteer: jest.fn(),
@@ -70,5 +71,95 @@ describe('VolunteerSchedule', () => {
     expect(prev).toBeDisabled();
 
     expect(await screen.findByText(i18n.t('no_bookings'))).toBeInTheDocument();
+  });
+
+  it('shows only available slots in reschedule dialog', async () => {
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        status: 'approved',
+        date: '2024-01-29',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        role_name: 'Greeter',
+      },
+    ]);
+    (getVolunteerRolesForVolunteer as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          role_id: 1,
+          name: 'Greeter',
+          start_time: '09:00:00',
+          end_time: '12:00:00',
+          max_volunteers: 1,
+          booked: 1,
+          available: 0,
+          status: 'open',
+          date: '2024-01-29',
+          category_id: 1,
+          category_name: 'Front',
+          is_wednesday_slot: false,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 2,
+          role_id: 1,
+          name: 'Greeter',
+          start_time: '09:00:00',
+          end_time: '12:00:00',
+          max_volunteers: 1,
+          booked: 1,
+          available: 0,
+          status: 'open',
+          date: '2024-02-02',
+          category_id: 1,
+          category_name: 'Front',
+          is_wednesday_slot: false,
+        },
+        {
+          id: 3,
+          role_id: 1,
+          name: 'Greeter',
+          start_time: '12:00:00',
+          end_time: '15:00:00',
+          max_volunteers: 1,
+          booked: 0,
+          available: 1,
+          status: 'open',
+          date: '2024-02-02',
+          category_id: 1,
+          category_name: 'Front',
+          is_wednesday_slot: false,
+        },
+      ]);
+
+    renderWithProviders(<VolunteerSchedule />);
+
+    fireEvent.mouseDown(screen.getByLabelText(i18n.t('role')));
+    fireEvent.click(await screen.findByText('Greeter'));
+
+    fireEvent.click(await screen.findByText('My Booking'));
+    fireEvent.click(await screen.findByRole('button', { name: /reschedule/i }));
+
+    fireEvent.change(screen.getByLabelText(/date/i), {
+      target: { value: '2024-02-02' },
+    });
+
+    fireEvent.mouseDown(await screen.findByLabelText(/role/i));
+
+    expect(
+      screen.queryByText(
+        `Greeter ${formatTime('09:00:00')}–${formatTime('12:00:00')}`,
+      ),
+    ).toBeNull();
+    expect(
+      await screen.findByText(
+        `Greeter ${formatTime('12:00:00')}–${formatTime('15:00:00')}`,
+      ),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- ensure reschedule dialog in VolunteerSchedule shows only available shifts

## Testing
- `npm test` *(fails: FAIL src/pages/staff/__tests__/PantryVisits.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8a365174832dab7b5702cd84b77f