### PR TITLE
fix: remove schedule table row hover

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -39,17 +39,20 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
           size="small"
           stickyHeader={false}
           sx={{
-          tableLayout: 'fixed',
-          width: '100%',
-          '& .MuiTableCell-root': {
-            p: isSmall ? 0.5 : 1,
-            fontSize: isSmall ? '0.75rem' : 'inherit',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          },
-        }}
-      >
+            tableLayout: 'fixed',
+            width: '100%',
+            '& .MuiTableCell-root': {
+              p: isSmall ? 0.5 : 1,
+              fontSize: isSmall ? '0.75rem' : 'inherit',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            },
+            '& tbody tr:hover td, & tbody tr:hover th': {
+              backgroundColor: 'inherit',
+            },
+          }}
+        >
         <colgroup>
           <col style={{ width: 160 }} />
           {Array.from({ length: safeMaxSlots }).map((_, i) => (
@@ -87,6 +90,9 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
                       textAlign: 'center',
                       cursor: cell.onClick ? 'pointer' : 'default',
                       backgroundColor: cell.backgroundColor,
+                      ...(cell.backgroundColor && {
+                        '&:hover': { backgroundColor: cell.backgroundColor },
+                      }),
                     }}
                   >
                     {cell.content}


### PR DESCRIPTION
## Summary
- prevent schedule rows from changing background color on hover
- keep slot colors when hovering schedule cells

## Testing
- `npm test` *(fails: RecurringBookings.test.tsx, PantryVisits.test.tsx, VolunteerManagement.test.tsx, StaffRecurringBookings.test.tsx, PasswordSetup.test.tsx, NoShowWeek.test.tsx, HelpPage.test.tsx, AgencyAccess.test.tsx, loginAppreciation.test.tsx, VolunteerShopperAccess.test.tsx, LeaveManagement.test.tsx, EventForm.test.tsx, PendingReviews.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8b80b034832da3dbd813c636280e