### PR TITLE
Split pantry visit trends into separate charts

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientVisitTrendChart.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientVisitTrendChart.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ClientVisitTrendChart from '../components/dashboard/ClientVisitTrendChart';
+import ClientVisitBreakdownChart from '../components/dashboard/ClientVisitBreakdownChart';
 
 jest.mock('recharts', () => {
   const Recharts = jest.requireActual('recharts');
@@ -15,15 +16,25 @@ jest.mock('recharts', () => {
   };
 });
 
-test('renders three lines for clients, adults, and children', () => {
-  const data = [
-    { month: '2024-01', clients: 5, adults: 3, children: 2 },
-    { month: '2024-02', clients: 6, adults: 4, children: 2 },
-  ];
+const data = [
+  { month: '2024-01', clients: 5, adults: 3, children: 2 },
+  { month: '2024-02', clients: 6, adults: 4, children: 2 },
+];
+
+test('renders one line for total clients', () => {
   const { container } = render(
     <ThemeProvider theme={createTheme()}>
       <ClientVisitTrendChart data={data} />
     </ThemeProvider>,
   );
-  expect(container.querySelectorAll('path.recharts-line-curve').length).toBe(3);
+  expect(container.querySelectorAll('path.recharts-line-curve').length).toBe(1);
+});
+
+test('renders two lines for adults and children', () => {
+  const { container } = render(
+    <ThemeProvider theme={createTheme()}>
+      <ClientVisitBreakdownChart data={data} />
+    </ThemeProvider>,
+  );
+  expect(container.querySelectorAll('path.recharts-line-curve').length).toBe(2);
 });

--- a/MJ_FB_Frontend/src/components/dashboard/ClientVisitBreakdownChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/ClientVisitBreakdownChart.tsx
@@ -15,10 +15,10 @@ interface Props {
   data: VisitStat[];
 }
 
-export default function ClientVisitTrendChart({ data }: Props) {
+export default function ClientVisitBreakdownChart({ data }: Props) {
   const theme = useTheme();
   return (
-    <ResponsiveContainer width="100%" height={300} data-testid="visit-trend-chart">
+    <ResponsiveContainer width="100%" height={300} data-testid="visit-breakdown-chart">
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="month" />
@@ -27,11 +27,19 @@ export default function ClientVisitTrendChart({ data }: Props) {
         <Legend />
         <Line
           type="monotone"
-          dataKey="clients"
-          stroke={theme.palette.error.main}
+          dataKey="adults"
+          stroke={theme.palette.success.main}
           strokeWidth={2}
           dot={{ r: 4, cursor: 'pointer' }}
-          name="Total"
+          name="Adults"
+        />
+        <Line
+          type="monotone"
+          dataKey="children"
+          stroke={theme.palette.info.main}
+          strokeWidth={2}
+          dot={{ r: 4, cursor: 'pointer' }}
+          name="Children"
         />
       </LineChart>
     </ResponsiveContainer>

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -25,6 +25,7 @@ import EventList from '../EventList';
 import SectionCard from './SectionCard';
 import VolunteerCoverageCard from './VolunteerCoverageCard';
 import ClientVisitTrendChart from './ClientVisitTrendChart';
+import ClientVisitBreakdownChart from './ClientVisitBreakdownChart';
 import { useTranslation } from 'react-i18next';
 import PantryQuickLinks from '../PantryQuickLinks';
 import { useBreadcrumbActions } from '../layout/MainLayout';
@@ -174,9 +175,14 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
               />
             </SectionCard>
           </Grid>
-          <Grid size={12}>
-            <SectionCard title="Pantry Visit Trend">
+          <Grid size={{ xs: 12, md: 6 }}>
+            <SectionCard title="Total Pantry Visits">
               <ClientVisitTrendChart data={visitStats} />
+            </SectionCard>
+          </Grid>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <SectionCard title="Adults vs Children">
+              <ClientVisitBreakdownChart data={visitStats} />
             </SectionCard>
           </Grid>
           <Grid size={12}>


### PR DESCRIPTION
## Summary
- Separate pantry visit trend into total vs breakdown cards
- Add chart for adult and child visits
- Update staff dashboard layout to show both charts side by side

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bc8bf82d48832db11687ff4aaec83f