### PR TITLE
Move client dashboard quick actions to top

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
@@ -103,4 +103,24 @@ describe('ClientDashboard', () => {
     await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
     expect(screen.queryByText('bring bag')).not.toBeInTheDocument();
   });
+
+  it('renders quick actions card first', async () => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([]);
+    (getSlots as jest.Mock).mockResolvedValue([]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+
+    render(
+      <MemoryRouter>
+        <ClientDashboard />
+      </MemoryRouter>,
+    );
+
+    const quick = await screen.findByText(/quick actions/i);
+    const news = await screen.findByText(/news & events/i);
+    const next = await screen.findByText(/next available slots/i);
+
+    expect(quick.compareDocumentPosition(news) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(quick.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -227,6 +227,35 @@ export default function ClientDashboard() {
 
         <Grid size={{ xs: 12, md: 6 }}>
           <Stack spacing={2}>
+            <SectionCard title={t('quick_actions')}>
+              <Stack direction="row" spacing={1} flexWrap="wrap">
+                <Button
+                  size="small"
+                  variant="contained"
+                  sx={{ textTransform: 'none' }}
+                  onClick={() => navigate('/book-appointment')}
+                >
+                  {t('book_appointment')}
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  sx={{ textTransform: 'none' }}
+                  onClick={() => navigate('/booking-history')}
+                >
+                  {t('reschedule')}
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  sx={{ textTransform: 'none' }}
+                  onClick={() => navigate('/booking-history')}
+                >
+                  {t('cancel')}
+                </Button>
+              </Stack>
+            </SectionCard>
+
             <SectionCard
               title={
                 <Stack direction="row" spacing={1} alignItems="center">
@@ -282,35 +311,6 @@ export default function ClientDashboard() {
                   </ListItem>
                 )}
               </List>
-            </SectionCard>
-
-            <SectionCard title={t('quick_actions')}>
-              <Stack direction="row" spacing={1} flexWrap="wrap">
-                <Button
-                  size="small"
-                  variant="contained"
-                  sx={{ textTransform: 'none' }}
-                  onClick={() => navigate('/book-appointment')}
-                >
-                  {t('book_appointment')}
-                </Button>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  sx={{ textTransform: 'none' }}
-                  onClick={() => navigate('/booking-history')}
-                >
-                  {t('reschedule')}
-                </Button>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  sx={{ textTransform: 'none' }}
-                  onClick={() => navigate('/booking-history')}
-                >
-                  {t('cancel')}
-                </Button>
-              </Stack>
             </SectionCard>
           </Stack>
         </Grid>


### PR DESCRIPTION
## Summary
- show quick actions card at top of client dashboard
- test quick actions appear before other sections

## Testing
- `npm test` *(fails: RecurringBookings, PantryVisits and others with act warnings and missing elements)*

------
https://chatgpt.com/codex/tasks/task_e_68bc951065e0832d95791d1557bd318c