### PR TITLE
Show booking confirmation details on separate lines

### DIFF
--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -3,7 +3,7 @@
 This project is the React + Vite front end for the MJ Food Bank booking system. Volunteers can manage recurring bookings from `/volunteer/recurring`.
 Authenticated users can access a role-based help page at `/help`. Admins can view all help topics, including client and volunteer guidance.
 
-Client bookings include a confirmation step summarizing the selected date, time, and current-month visit count, with an optional client note field for staff.
+Client bookings include a confirmation step that lists the selected date, time, and current-month visit count on separate lines, with an optional client note field for staff.
 
 ## Node Version
 

--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -191,6 +191,30 @@ describe('Booking confirmation', () => {
     );
   });
 
+  it('shows summary fields on separate lines', async () => {
+    (getSlots as jest.Mock).mockResolvedValue([
+      { id: '1', startTime: '11:00:00', endTime: '11:30:00', available: 1 },
+    ]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getUserProfile as jest.Mock).mockResolvedValue({ bookingsThisMonth: 3 });
+
+    renderUI();
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      jest.runOnlyPendingTimers();
+    });
+    await waitFor(() => expect(getSlots).toHaveBeenCalled());
+    const slot = await screen.findByLabelText(/select .* time slot/i);
+    fireEvent.click(slot);
+    fireEvent.click(screen.getByText(/book selected slot/i));
+
+    await screen.findByText(/confirm booking/i);
+    screen.getByText(/^Date:/i);
+    screen.getByText(/^Time:/i);
+    screen.getByText(/^Visits this month:/i);
+  });
+
   it('shows calendar links after booking', async () => {
     (getSlots as jest.Mock).mockResolvedValue([
       { id: '1', startTime: '11:00:00', endTime: '11:30:00', available: 1 },

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -495,11 +495,13 @@ export default function BookingUI({
         <DialogTitle>{t('confirm_booking')}</DialogTitle>
         <DialogContent>
           <Typography>
-            {t('booking_summary', {
-              date: date.format('ddd, MMM D, YYYY'),
-              time: selectedLabel,
-              count: usage ?? 0,
-            })}
+            {t('date')}: {date.format('ddd, MMM D, YYYY')}
+          </Typography>
+          <Typography>
+            {t('time')}: {selectedLabel}
+          </Typography>
+          <Typography>
+            {t('visits_this_month')} {usage ?? 0}
           </Typography>
           <TextField
             fullWidth


### PR DESCRIPTION
## Summary
- Split booking confirmation dialog into separate lines for date, time, and monthly visit count
- Test that booking summary displays distinct fields
- Note in README that confirmation dialog presents each detail on its own line

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bc95c1b4a4832d991a447086000d8c