### PR TITLE
refactor staff dashboard grid layout

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import {
   List,
   ListItem,
   ListItemText,
+  Box,
 } from '@mui/material';
 import CalendarToday from '@mui/icons-material/CalendarToday';
 import People from '@mui/icons-material/People';
@@ -125,146 +126,127 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
   };
 
   return (
-    <Grid container spacing={2}>
-      <Grid size={{ xs: 12, md: 6 }}>
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+        gridAutoFlow: 'row dense',
+        gap: 2,
+      }}
+    >
+      <SectionCard title="Today at a Glance" sx={{ order: 0 }}>
         <Grid container spacing={2}>
-          <Grid size={12}>
-            <SectionCard title="Today at a Glance">
-              <Grid container spacing={2}>
-                <Grid size={{ xs: 12, md: 4 }}>
-                  <Stat
-                    icon={<CalendarToday color="primary" />}
-                    label="Appointments Today"
-                    value={stats.appointments}
-                  />
-                </Grid>
-                <Grid size={{ xs: 12, md: 4 }}>
-                  <Stat
-                    icon={<People color="primary" />}
-                    label="Volunteers Scheduled"
-                    value={stats.volunteers}
-                  />
-                </Grid>
-                <Grid size={{ xs: 12, md: 4 }}>
-                  <Stat
-                    icon={<CancelIcon color="error" />}
-                    label="Cancellations"
-                    value={stats.cancellations}
-                  />
-                </Grid>
-              </Grid>
-            </SectionCard>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Stat
+              icon={<CalendarToday color="primary" />}
+              label="Appointments Today"
+              value={stats.appointments}
+            />
           </Grid>
-          <Grid size={12}>
-            <VolunteerCoverageCard
-              masterRoleFilter={masterRoleFilter}
-              onCoverageLoaded={data =>
-                setVolunteerCount(data.reduce((sum, c) => sum + c.filled, 0))
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Stat
+              icon={<People color="primary" />}
+              label="Volunteers Scheduled"
+              value={stats.volunteers}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Stat
+              icon={<CancelIcon color="error" />}
+              label="Cancellations"
+              value={stats.cancellations}
+            />
+          </Grid>
+        </Grid>
+      </SectionCard>
+      <VolunteerCoverageCard
+        masterRoleFilter={masterRoleFilter}
+        onCoverageLoaded={data =>
+          setVolunteerCount(data.reduce((sum, c) => sum + c.filled, 0))
+        }
+        sx={{ order: 0 }}
+      />
+      <SectionCard
+        title="News & Events"
+        icon={<Announcement color="primary" />}
+        sx={{ order: 0 }}
+      >
+        <EventList events={[...events.today, ...events.upcoming]} limit={5} />
+      </SectionCard>
+      <SectionCard title="Total Clients" sx={{ order: 1 }}>
+        <ClientVisitTrendChart data={visitStats} />
+      </SectionCard>
+      <SectionCard title="Adults vs Children" sx={{ order: 1 }}>
+        <ClientVisitBreakdownChart data={visitStats} />
+      </SectionCard>
+      <SectionCard title="Quick Search" sx={{ order: 2 }}>
+        <Stack spacing={2}>
+          <EntitySearch
+            type={searchType}
+            placeholder="Search"
+            onSelect={res => {
+              if (searchType === 'user') {
+                navigate(
+                  `/pantry/client-management?tab=history&id=${res.id}&name=${encodeURIComponent(
+                    res.name,
+                  )}&clientId=${res.client_id}`,
+                );
+              } else {
+                navigate(
+                  `/volunteer-management/search?id=${res.id}&name=${encodeURIComponent(
+                    res.name,
+                  )}`,
+                );
               }
-            />
-          </Grid>
-        </Grid>
-      </Grid>
-      <Grid size={{ xs: 12, md: 6 }}>
-        <Grid container spacing={2}>
-          <Grid size={12}>
-            <SectionCard title="News & Events" icon={<Announcement color="primary" />}>
-              <EventList
-                events={[...events.today, ...events.upcoming]}
-                limit={5}
-              />
-            </SectionCard>
-          </Grid>
-        </Grid>
-      </Grid>
-      <Grid size={12}>
-        <Grid container spacing={2}>
-          <Grid size={{ xs: 12, md: 6 }}>
-            <SectionCard title="Total Clients">
-              <ClientVisitTrendChart data={visitStats} />
-            </SectionCard>
-          </Grid>
-          <Grid size={{ xs: 12, md: 6 }}>
-            <SectionCard title="Adults vs Children">
-              <ClientVisitBreakdownChart data={visitStats} />
-            </SectionCard>
-          </Grid>
-        </Grid>
-      </Grid>
-      <Grid size={12}>
-        <SectionCard title="Quick Search">
-          <Stack spacing={2}>
-            <EntitySearch
-              type={searchType}
-              placeholder="Search"
-              onSelect={res => {
-                if (searchType === 'user') {
-                  navigate(
-                    `/pantry/client-management?tab=history&id=${res.id}&name=${encodeURIComponent(
-                      res.name,
-                    )}&clientId=${res.client_id}`,
-                  );
-                } else {
-                  navigate(
-                    `/volunteer-management/search?id=${res.id}&name=${encodeURIComponent(
-                      res.name,
-                    )}`,
-                  );
-                }
-              }}
-            />
-            <Stack direction="row" spacing={1}>
-              <Button
-                size="small"
-                variant={searchType === 'user' ? 'contained' : 'outlined'}
-                sx={{ textTransform: 'none' }}
-                onClick={() => setSearchType('user')}
-              >
-                Find Client
-              </Button>
-              <Button
-                size="small"
-                variant={searchType === 'volunteer' ? 'contained' : 'outlined'}
-                sx={{ textTransform: 'none' }}
-                onClick={() => setSearchType('volunteer')}
-              >
-                Find Volunteer
-              </Button>
-            </Stack>
+            }}
+          />
+          <Stack direction="row" spacing={1}>
+            <Button
+              size="small"
+              variant={searchType === 'user' ? 'contained' : 'outlined'}
+              sx={{ textTransform: 'none' }}
+              onClick={() => setSearchType('user')}
+            >
+              Find Client
+            </Button>
+            <Button
+              size="small"
+              variant={searchType === 'volunteer' ? 'contained' : 'outlined'}
+              sx={{ textTransform: 'none' }}
+              onClick={() => setSearchType('volunteer')}
+            >
+              Find Volunteer
+            </Button>
           </Stack>
-        </SectionCard>
-      </Grid>
-      <Grid size={12}>
-        <SectionCard title="Recent Cancellations">
-          <List>
-            {cancellations.slice(0, 5).map(c => (
-              <ListItem key={c.id}>
-                <ListItemText
-                  primary={`${c.user_name || 'Unknown'} - ${formatTime(
-                    c.start_time || '',
-                  )}`}
-                />
-              </ListItem>
-            ))}
-          </List>
-        </SectionCard>
-      </Grid>
-      <Grid size={12}>
-        <SectionCard title="Volunteer Shift Changes">
-          <List>
-            {volCancellations.slice(0, 5).map(c => (
-              <ListItem key={c.id}>
-                <ListItemText
-                  primary={`${c.volunteer_name || 'Unknown'} - ${formatTime(
-                    c.start_time || '',
-                  )}`}
-                />
-              </ListItem>
-            ))}
-          </List>
-        </SectionCard>
-      </Grid>
-    </Grid>
+        </Stack>
+      </SectionCard>
+      <SectionCard title="Recent Cancellations" sx={{ order: 3 }}>
+        <List>
+          {cancellations.slice(0, 5).map(c => (
+            <ListItem key={c.id}>
+              <ListItemText
+                primary={`${c.user_name || 'Unknown'} - ${formatTime(
+                  c.start_time || '',
+                )}`}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </SectionCard>
+      <SectionCard title="Volunteer Shift Changes" sx={{ order: 4 }}>
+        <List>
+          {volCancellations.slice(0, 5).map(c => (
+            <ListItem key={c.id}>
+              <ListItemText
+                primary={`${c.volunteer_name || 'Unknown'} - ${formatTime(
+                  c.start_time || '',
+                )}`}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </SectionCard>
+    </Box>
   );
 }
 

--- a/MJ_FB_Frontend/src/components/dashboard/SectionCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/SectionCard.tsx
@@ -1,4 +1,4 @@
-import { CardHeader } from '@mui/material';
+import { CardHeader, type SxProps, type Theme } from '@mui/material';
 import type { ReactNode } from 'react';
 import PageCard from '../layout/PageCard';
 
@@ -6,10 +6,16 @@ interface SectionCardProps {
   title: ReactNode;
   icon?: ReactNode;
   children: ReactNode;
+  sx?: SxProps<Theme>;
 }
 
-export default function SectionCard({ title, icon, children }: SectionCardProps) {
+export default function SectionCard({ title, icon, children, sx }: SectionCardProps) {
   return (
-    <PageCard header={<CardHeader title={title} avatar={icon} />}>{children}</PageCard>
+    <PageCard
+      sx={sx}
+      header={<CardHeader title={title} avatar={icon} />}
+    >
+      {children}
+    </PageCard>
   );
 }

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { List, ListItem, ListItemText, Chip } from '@mui/material';
+import { List, ListItem, ListItemText, Chip, type SxProps, type Theme } from '@mui/material';
 import SectionCard from './SectionCard';
 import { getVolunteerRoles, getVolunteerBookingsByRole } from '../../api/volunteers';
 import { formatReginaDate } from '../../utils/time';
@@ -15,11 +15,13 @@ interface CoverageItem {
 interface VolunteerCoverageCardProps {
   masterRoleFilter?: string[];
   onCoverageLoaded?: (data: CoverageItem[]) => void;
+  sx?: SxProps<Theme>;
 }
 
 export default function VolunteerCoverageCard({
   masterRoleFilter,
   onCoverageLoaded,
+  sx,
 }: VolunteerCoverageCardProps) {
   const [coverage, setCoverage] = useState<CoverageItem[]>([]);
   const [error, setError] = useState('');
@@ -63,7 +65,7 @@ export default function VolunteerCoverageCard({
 
   return (
     <>
-      <SectionCard title="Volunteer Coverage">
+      <SectionCard title="Volunteer Coverage" sx={sx}>
         <List>
           {coverage.map(c => {
             const ratio = c.filled / c.total;


### PR DESCRIPTION
## Summary
- replace nested grids in staff dashboard with a single CSS grid container
- allow SectionCard and VolunteerCoverageCard to accept sx so items can be ordered
- assign order to dashboard cards to keep priority info on top

## Testing
- `npm test` *(fails: act warnings and several failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bc955e38d0832d98f9f02e273bfa30