### PR TITLE
Make volunteer coverage card scrollable

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -66,7 +66,7 @@ export default function VolunteerCoverageCard({
   return (
     <>
       <SectionCard title="Volunteer Coverage" sx={sx}>
-        <List>
+        <List sx={{ maxHeight: '200px', overflowY: 'auto' }}>
           {coverage.map(c => {
             const ratio = c.filled / c.total;
             let color: 'success' | 'warning' | 'error' | 'default' = 'default';


### PR DESCRIPTION
## Summary
- Limit volunteer coverage card list height and enable scrolling for long lists

## Testing
- `npm test` *(fails: RecurringBookings.test.tsx, BookingUI.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9be5c7b0832da2c5232e7d574749