### PR TITLE
Fix client dashboard cards width responsiveness

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/SectionCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/SectionCard.tsx
@@ -12,7 +12,7 @@ interface SectionCardProps {
 export default function SectionCard({ title, icon, children, sx }: SectionCardProps) {
   return (
     <PageCard
-      sx={{ width: 1, ...sx }}
+      sx={{ width: '100%', ...sx }}
       header={<CardHeader title={title} avatar={icon} />}
     >
       {children}


### PR DESCRIPTION
## Summary
- Ensure SectionCard spans full width so client dashboard cards are responsive on small screens

## Testing
- `nvm use`
- `npm test` *(fails: RecurringBookings.test.tsx, PantryVisits.test.tsx, VolunteerManagement.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9cc163e8832d9e721eb620db8896