### PR TITLE
feat: add client login notice

### DIFF
--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -19,6 +19,7 @@
   "tamil": "ታሚልኛ",
   "login": "ግባ",
   "client_login": "የደንበኛ መግቢያ",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "የደንበኛ መለያ",
   "password": "የሚስጥር ቃል",
   "forgot_password": "የሚስጥር ቃልህን ረሳህ?",

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -19,6 +19,7 @@
   "tamil": "التاميلية",
   "login": "تسجيل الدخول",
   "client_login": "تسجيل دخول العميل",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "معرف العميل",
   "password": "كلمة المرور",
   "forgot_password": "هل نسيت كلمة المرور؟",

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -19,6 +19,7 @@
   "tamil": "Tamil",
   "login": "Login",
   "client_login": "Client Login",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "Client ID",
   "password": "Password",
   "forgot_password": "Forgot password?",

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -19,6 +19,7 @@
   "tamil": "Tamil",
   "login": "Iniciar sesión",
   "client_login": "Acceso de cliente",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "ID del cliente",
   "password": "Contraseña",
   "forgot_password": "¿Olvidó su contraseña?",

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -19,6 +19,7 @@
   "tamil": "تامیل",
   "login": "ورود",
   "client_login": "ورود مشتری",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "شناسه مشتری",
   "password": "گذرواژه",
   "forgot_password": "گذرواژه را فراموش کرده‌اید؟",

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -19,6 +19,7 @@
   "tamil": "Tamoul",
   "login": "Connexion",
   "client_login": "Connexion client",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "Identifiant client",
   "password": "Mot de passe",
   "forgot_password": "Mot de passe oublié ?",

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -19,6 +19,7 @@
   "tamil": "तमिल",
   "login": "लॉगिन",
   "client_login": "क्लाइंट लॉगिन",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "क्लाइंट आईडी",
   "password": "पासवर्ड",
   "forgot_password": "पासवर्ड भूल गए?",

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -19,6 +19,7 @@
   "tamil": "തമിഴ്",
   "login": "ലോഗിൻ",
   "client_login": "ഉപഭോക്തൃ ലോഗിൻ",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "ക്ലയന്റ് ഐഡി",
   "password": "രഹസ്യവാക്ക്",
   "forgot_password": "രഹസ്യവാക്ക് മറന്നോ?",

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -19,6 +19,7 @@
   "tamil": "ਤਾਮਿਲ",
   "login": "ਲੌਗਿਨ",
   "client_login": "ਗਾਹਕ ਲੌਗਿਨ",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "ਕਲਾਇੰਟ ID",
   "password": "ਪਾਸਵਰਡ",
   "forgot_password": "ਕੀ ਤੁਸੀਂ ਪਾਸਵਰਡ ਭੁੱਲ ਗਏ?",

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -19,6 +19,7 @@
   "tamil": "تامیل",
   "login": "ورود",
   "client_login": "د پېرېدونکي ننوتل",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "د پېرېدونکي پېژند",
   "password": "پاسورډ",
   "forgot_password": "پاسورډ مو هیر کړی؟",

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -19,6 +19,7 @@
   "tamil": "Taamili",
   "login": "Gal",
   "client_login": "Galitaanka macmiilka",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "Aqoonsiga macmiilka",
   "password": "Ereyga sirta ah",
   "forgot_password": "Ma hilmaantay erayga sirta ah?",

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -19,6 +19,7 @@
   "tamil": "Kitamil",
   "login": "Ingia",
   "client_login": "Ingia ya mteja",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "Kitambulisho cha mteja",
   "password": "Nenosiri",
   "forgot_password": "Umesahau nenosiri?",

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -19,6 +19,7 @@
   "tamil": "தமிழ்",
   "login": "உள்நுழை",
   "client_login": "வாடிக்கையாளர் உள்நுழைவு",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "வாடிக்கையாளர் ஐடி",
   "password": "கடவுச்சொல்",
   "forgot_password": "கடவுச்சொல்லை மறந்துவிட்டீர்களா?",

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -19,6 +19,7 @@
   "tamil": "ታሚልኛ",
   "login": "መእተዊ",
   "client_login": "መእተዊ ደንበኛ",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "መለያ ደንበኛ",
   "password": "መለለይ",
   "forgot_password": "መለለይካ ረሲዕካ?",

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -19,6 +19,7 @@
   "tamil": "Tamil",
   "login": "Mag-login",
   "client_login": "Pag-login ng kliyente",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "ID ng kliyente",
   "password": "Password",
   "forgot_password": "Nakalimutan ang password?",

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -19,6 +19,7 @@
   "tamil": "тамільська",
   "login": "Вхід",
   "client_login": "Вхід клієнта",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "ID клієнта",
   "password": "Пароль",
   "forgot_password": "Забули пароль?",

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -19,6 +19,7 @@
   "tamil": "泰米尔语",
   "login": "登录",
   "client_login": "客户登录",
+  "client_login_notice": "Please use your client ID to login. If you don't know your client ID, please email harvestpantry@mjfoodbank.org. If your password is not working, please use the forgot password link below to set a new password.",
   "client_id": "客户ID",
   "password": "密码",
   "forgot_password": "忘记密码？",

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { loginUser } from '../../api/users';
 import type { LoginResponse } from '../../api/users';
 import type { ApiError } from '../../api/client';
-import { Link, TextField, Button } from '@mui/material';
+import { Link, TextField, Button, Alert } from '@mui/material';
 import PasswordField from '../../components/PasswordField';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -49,6 +49,9 @@ export default function Login({
 
   return (
     <Page title={t('client_login')}>
+      <Alert severity="info" sx={{ mb: 2 }}>
+        {t('client_login_notice')}
+      </Alert>
       <FormCard
         onSubmit={handleSubmit}
         title={t('client_login')}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
   Admins can view requests for a specific staff member via
   `/api/timesheets/leave-requests/:staffId`.
 - Password fields include a visibility toggle so users can verify what they type.
+- Client login page reminds users to sign in with their client ID and provides contact and password reset guidance.
 
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 `/leave-requests` from the profile menu once logged in. Admin users also see

--- a/docs/login.md
+++ b/docs/login.md
@@ -1,0 +1,7 @@
+# Client login
+
+## Localization
+
+Add the following translation strings to locale files:
+
+- `client_login_notice`


### PR DESCRIPTION
## Summary
- add client login alert with contact and reset guidance
- document and localize client login notice
- note client login reminder in README

## Testing
- `npm test` *(fails: TypeError in jsdom and multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9dafa6a8832dbb77f686b472e972