### PR TITLE
Display client login guidance in separate alerts

### DIFF
--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -19,7 +19,6 @@
   "tamil": "ታሚልኛ",
   "login": "ግባ",
   "client_login": "የደንበኛ መግቢያ",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "የደንበኛ መለያ",
   "password": "የሚስጥር ቃል",
   "forgot_password": "የሚስጥር ቃልህን ረሳህ?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -19,7 +19,6 @@
   "tamil": "التاميلية",
   "login": "تسجيل الدخول",
   "client_login": "تسجيل دخول العميل",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "معرف العميل",
   "password": "كلمة المرور",
   "forgot_password": "هل نسيت كلمة المرور؟",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -19,7 +19,6 @@
   "tamil": "Tamil",
   "login": "Login",
   "client_login": "Client Login",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "Client ID",
   "password": "Password",
   "forgot_password": "Forgot password?",
@@ -312,5 +311,8 @@
   },
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -19,7 +19,6 @@
   "tamil": "Tamil",
   "login": "Iniciar sesión",
   "client_login": "Acceso de cliente",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "ID del cliente",
   "password": "Contraseña",
   "forgot_password": "¿Olvidó su contraseña?",
@@ -305,5 +304,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -19,7 +19,6 @@
   "tamil": "تامیل",
   "login": "ورود",
   "client_login": "ورود مشتری",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "شناسه مشتری",
   "password": "گذرواژه",
   "forgot_password": "گذرواژه را فراموش کرده‌اید؟",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -19,7 +19,6 @@
   "tamil": "Tamoul",
   "login": "Connexion",
   "client_login": "Connexion client",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "Identifiant client",
   "password": "Mot de passe",
   "forgot_password": "Mot de passe oublié ?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -19,7 +19,6 @@
   "tamil": "तमिल",
   "login": "लॉगिन",
   "client_login": "क्लाइंट लॉगिन",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "क्लाइंट आईडी",
   "password": "पासवर्ड",
   "forgot_password": "पासवर्ड भूल गए?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -19,7 +19,6 @@
   "tamil": "തമിഴ്",
   "login": "ലോഗിൻ",
   "client_login": "ഉപഭോക്തൃ ലോഗിൻ",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "ക്ലയന്റ് ഐഡി",
   "password": "രഹസ്യവാക്ക്",
   "forgot_password": "രഹസ്യവാക്ക് മറന്നോ?",
@@ -308,5 +307,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -19,7 +19,6 @@
   "tamil": "ਤਾਮਿਲ",
   "login": "ਲੌਗਿਨ",
   "client_login": "ਗਾਹਕ ਲੌਗਿਨ",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "ਕਲਾਇੰਟ ID",
   "password": "ਪਾਸਵਰਡ",
   "forgot_password": "ਕੀ ਤੁਸੀਂ ਪਾਸਵਰਡ ਭੁੱਲ ਗਏ?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -19,7 +19,6 @@
   "tamil": "تامیل",
   "login": "ورود",
   "client_login": "د پېرېدونکي ننوتل",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "د پېرېدونکي پېژند",
   "password": "پاسورډ",
   "forgot_password": "پاسورډ مو هیر کړی؟",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -19,7 +19,6 @@
   "tamil": "Taamili",
   "login": "Gal",
   "client_login": "Galitaanka macmiilka",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "Aqoonsiga macmiilka",
   "password": "Ereyga sirta ah",
   "forgot_password": "Ma hilmaantay erayga sirta ah?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -19,7 +19,6 @@
   "tamil": "Kitamil",
   "login": "Ingia",
   "client_login": "Ingia ya mteja",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "Kitambulisho cha mteja",
   "password": "Nenosiri",
   "forgot_password": "Umesahau nenosiri?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -19,7 +19,6 @@
   "tamil": "தமிழ்",
   "login": "உள்நுழை",
   "client_login": "வாடிக்கையாளர் உள்நுழைவு",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "வாடிக்கையாளர் ஐடி",
   "password": "கடவுச்சொல்",
   "forgot_password": "கடவுச்சொல்லை மறந்துவிட்டீர்களா?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -19,7 +19,6 @@
   "tamil": "ታሚልኛ",
   "login": "መእተዊ",
   "client_login": "መእተዊ ደንበኛ",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "መለያ ደንበኛ",
   "password": "መለለይ",
   "forgot_password": "መለለይካ ረሲዕካ?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -19,7 +19,6 @@
   "tamil": "Tamil",
   "login": "Mag-login",
   "client_login": "Pag-login ng kliyente",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "ID ng kliyente",
   "password": "Password",
   "forgot_password": "Nakalimutan ang password?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -19,7 +19,6 @@
   "tamil": "тамільська",
   "login": "Вхід",
   "client_login": "Вхід клієнта",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "ID клієнта",
   "password": "Пароль",
   "forgot_password": "Забули пароль?",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -19,7 +19,6 @@
   "tamil": "泰米尔语",
   "login": "登录",
   "client_login": "客户登录",
-  "client_login_notice": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created. If your password is not working, please use the forgot password link below to set a new password. Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_id": "客户ID",
   "password": "密码",
   "forgot_password": "忘记密码？",
@@ -303,5 +302,8 @@
   "children_label": "Children",
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",
-  "select_date_time": "Please select date and time"
+  "select_date_time": "Please select date and time",
+  "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
 }

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -50,7 +50,13 @@ export default function Login({
   return (
     <Page title={t('client_login')}>
       <Alert severity="info" sx={{ mb: 2 }}>
-        {t('client_login_notice')}
+        {t('client_login_notice_id')}
+      </Alert>
+      <Alert severity="warning" sx={{ mb: 2 }}>
+        {t('client_login_notice_password')}
+      </Alert>
+      <Alert severity="info" sx={{ mb: 2 }}>
+        {t('client_login_notice_volunteer')}
       </Alert>
       <FormCard
         onSubmit={handleSubmit}

--- a/docs/login.md
+++ b/docs/login.md
@@ -4,4 +4,6 @@
 
 Add the following translation strings to locale files:
 
-- `client_login_notice` – tells clients to email harvestpantry@mjfoodbank.org if they don't know their client ID or need an account created and instructs volunteers who want to shop to email to enable booking from their volunteer account
+- `client_login_notice_id` – instructs clients to email harvestpantry@mjfoodbank.org if they don't know their client ID or need an account created
+- `client_login_notice_password` – advises clients to use the forgot password link if their password is not working
+- `client_login_notice_volunteer` – tells volunteers who want to shop to email harvestpantry@mjfoodbank.org so booking can be enabled from their volunteer account


### PR DESCRIPTION
## Summary
- split long client login notice into three alerts above the form
- add translation strings for each notice
- document new translation keys for login page

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68bcaa213150832d98249119acb056b3