### PR TITLE
Use template 10 for reschedule emails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/
 | `CLIENT_RESCHEDULE_TEMPLATE_ID` | Booking reschedule notifications for clients | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `type` |
 | `VOLUNTEER_RESCHEDULE_TEMPLATE_ID` | Volunteer shift reschedule emails | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `type` |
 
+Client and volunteer reschedule emails currently use Brevo template ID **10**.
+
 Cancellation, no-show, volunteer booking notification, and agency membership emails are no longer sent.
 
 Cancel and reschedule links in booking emails point to public pages at `/cancel/:token` and `/reschedule/:token`.

--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -24,10 +24,10 @@ const envSchema = z.object({
   PASSWORD_SETUP_TEMPLATE_ID: z.coerce.number().default(6),
   BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
-  CLIENT_RESCHEDULE_TEMPLATE_ID: z.coerce.number().default(0),
+  CLIENT_RESCHEDULE_TEMPLATE_ID: z.coerce.number().default(10),
   VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID: z.coerce.number().default(0),
   VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID: z.coerce.number().default(0),
-  VOLUNTEER_RESCHEDULE_TEMPLATE_ID: z.coerce.number().default(0),
+  VOLUNTEER_RESCHEDULE_TEMPLATE_ID: z.coerce.number().default(10),
   VOLUNTEER_NO_SHOW_HOURS: z.coerce.number().default(24),
 });
 

--- a/MJ_FB_Backend/tests/config.test.ts
+++ b/MJ_FB_Backend/tests/config.test.ts
@@ -5,6 +5,8 @@ describe('config', () => {
   const originalJwt = process.env.JWT_SECRET;
   const originalRefresh = process.env.JWT_REFRESH_SECRET;
   const originalPasswordTemplate = process.env.PASSWORD_SETUP_TEMPLATE_ID;
+  const originalClientRescheduleTemplate = process.env.CLIENT_RESCHEDULE_TEMPLATE_ID;
+  const originalVolunteerRescheduleTemplate = process.env.VOLUNTEER_RESCHEDULE_TEMPLATE_ID;
 
   afterEach(() => {
     if (originalFrontend === undefined) {
@@ -26,6 +28,16 @@ describe('config', () => {
       delete process.env.PASSWORD_SETUP_TEMPLATE_ID;
     } else {
       process.env.PASSWORD_SETUP_TEMPLATE_ID = originalPasswordTemplate;
+    }
+    if (originalClientRescheduleTemplate === undefined) {
+      delete process.env.CLIENT_RESCHEDULE_TEMPLATE_ID;
+    } else {
+      process.env.CLIENT_RESCHEDULE_TEMPLATE_ID = originalClientRescheduleTemplate;
+    }
+    if (originalVolunteerRescheduleTemplate === undefined) {
+      delete process.env.VOLUNTEER_RESCHEDULE_TEMPLATE_ID;
+    } else {
+      process.env.VOLUNTEER_RESCHEDULE_TEMPLATE_ID = originalVolunteerRescheduleTemplate;
     }
     jest.resetModules();
   });
@@ -73,5 +85,19 @@ describe('config', () => {
     jest.resetModules();
     const config = require('../src/config').default;
     expect(config.passwordSetupTemplateId).toBe(6);
+  });
+
+  it('defaults CLIENT_RESCHEDULE_TEMPLATE_ID to 10 when missing', () => {
+    delete process.env.CLIENT_RESCHEDULE_TEMPLATE_ID;
+    jest.resetModules();
+    const config = require('../src/config').default;
+    expect(config.clientRescheduleTemplateId).toBe(10);
+  });
+
+  it('defaults VOLUNTEER_RESCHEDULE_TEMPLATE_ID to 10 when missing', () => {
+    delete process.env.VOLUNTEER_RESCHEDULE_TEMPLATE_ID;
+    jest.resetModules();
+    const config = require('../src/config').default;
+    expect(config.volunteerRescheduleTemplateId).toBe(10);
   });
 });

--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ Booking confirmation and reminder email bodies include the weekday and time for 
 | `BOOKING_REMINDER_TEMPLATE_ID`               | Brevo template ID for booking reminder emails                         |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Brevo template ID for volunteer booking confirmations                 |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID`     | Brevo template ID for volunteer shift reminder emails                 |
-| `CLIENT_RESCHEDULE_TEMPLATE_ID`              | Brevo template ID for client reschedule emails                        |
-| `VOLUNTEER_RESCHEDULE_TEMPLATE_ID`           | Brevo template ID for volunteer reschedule emails                     |
+| `CLIENT_RESCHEDULE_TEMPLATE_ID`              | Brevo template ID for client reschedule emails (default 10)           |
+| `VOLUNTEER_RESCHEDULE_TEMPLATE_ID`           | Brevo template ID for volunteer reschedule emails (default 10)        |
 | `PASSWORD_SETUP_TOKEN_TTL_HOURS`             | Hours until password setup tokens expire (default 24)                 |
 
 

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -10,6 +10,10 @@ parameters supplied to each template.
 | `BOOKING_REMINDER_TEMPLATE_ID` | Next-day booking reminders for clients | `body`, `cancelLink`, `rescheduleLink`, `type` | `bookingReminderJob.ts` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `type` | `volunteerBookingController.ts` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts` |
+| `CLIENT_RESCHEDULE_TEMPLATE_ID` | Booking reschedule notifications for clients | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `type` | `bookingController.ts` |
+| `VOLUNTEER_RESCHEDULE_TEMPLATE_ID` | Volunteer shift reschedule emails | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `type` | `volunteerBookingController.ts` |
+
+Client and volunteer reschedule notifications share Brevo template ID **10**.
 
 Brevo templates can reference these `params.*` values to display links and other
 dynamic content. The `body` parameter includes the booking date with the weekday and time range.


### PR DESCRIPTION
## Summary
- default client and volunteer reschedule emails to Brevo template 10
- document shared template and new defaults
- test configuration defaults for template 10

## Testing
- `npm test tests/config.test.ts tests/bookingRescheduleEmail.test.ts tests/volunteerReschedule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bcaa96046c832da1971f59eb0ec6fb