### PR TITLE
Show login notices in modal

### DIFF
--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -314,5 +314,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -307,5 +307,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -310,5 +310,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -305,5 +305,6 @@
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
-  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments."
+  "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
+  "client_login_notice_close": "Close this modal to sign in."
 }

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { loginUser } from '../../api/users';
 import type { LoginResponse } from '../../api/users';
 import type { ApiError } from '../../api/client';
-import { Link, TextField, Button, Box } from '@mui/material';
+import { Link, TextField, Button, Box, Dialog, DialogContent, IconButton, Typography } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 import PasswordField from '../../components/PasswordField';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -22,9 +23,7 @@ export default function Login({
   const [resetOpen, setResetOpen] = useState(false);
   const [resendOpen, setResendOpen] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const [idNoticeOpen, setIdNoticeOpen] = useState(true);
-  const [passwordNoticeOpen, setPasswordNoticeOpen] = useState(true);
-  const [volunteerNoticeOpen, setVolunteerNoticeOpen] = useState(true);
+  const [noticeOpen, setNoticeOpen] = useState(true);
   const { t } = useTranslation();
 
   const clientIdError = submitted && clientId === '';
@@ -98,24 +97,29 @@ export default function Login({
       </Box>
       <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="user" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-      <FeedbackSnackbar
-        open={idNoticeOpen}
-        onClose={() => setIdNoticeOpen(false)}
-        message={<span style={{ fontSize: '0.75rem' }}>{t('client_login_notice_id')}</span>}
-        severity="info"
-      />
-      <FeedbackSnackbar
-        open={passwordNoticeOpen}
-        onClose={() => setPasswordNoticeOpen(false)}
-        message={<span style={{ fontSize: '0.75rem' }}>{t('client_login_notice_password')}</span>}
-        severity="warning"
-      />
-      <FeedbackSnackbar
-        open={volunteerNoticeOpen}
-        onClose={() => setVolunteerNoticeOpen(false)}
-        message={<span style={{ fontSize: '0.75rem' }}>{t('client_login_notice_volunteer')}</span>}
-        severity="info"
-      />
+      <Dialog open={noticeOpen} onClose={() => setNoticeOpen(false)}>
+        <DialogContent sx={{ position: 'relative', pt: 4 }}>
+          <IconButton
+            aria-label="close"
+            onClick={() => setNoticeOpen(false)}
+            sx={{ position: 'absolute', right: 8, top: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+          <Typography variant="body2" paragraph>
+            {t('client_login_notice_id')}
+          </Typography>
+          <Typography variant="body2" paragraph>
+            {t('client_login_notice_password')}
+          </Typography>
+          <Typography variant="body2" paragraph>
+            {t('client_login_notice_volunteer')}
+          </Typography>
+          <Typography variant="body2" paragraph>
+            {t('client_login_notice_close')}
+          </Typography>
+        </DialogContent>
+      </Dialog>
       <ResendPasswordSetupDialog open={resendOpen} onClose={() => setResendOpen(false)} />
     </Page>
   );

--- a/docs/login.md
+++ b/docs/login.md
@@ -7,3 +7,4 @@ Add the following translation strings to locale files:
 - `client_login_notice_id` – instructs clients to email harvestpantry@mjfoodbank.org if they don't know their client ID or need an account created
 - `client_login_notice_password` – advises clients to use the forgot password link if their password is not working
 - `client_login_notice_volunteer` – tells volunteers who want to shop to email harvestpantry@mjfoodbank.org so booking can be enabled from their volunteer account
+- `client_login_notice_close` – instructs users to close the modal to sign in


### PR DESCRIPTION
## Summary
- replace stacked login snackbars with a modal that lists all notices and includes a close icon
- add translation key for closing notice modal and document it

## Testing
- `npm test` (fails: TypeError Cannot read properties of null (reading '_location'))

------
https://chatgpt.com/codex/tasks/task_e_68bcaf680ae0832d991d228cc2df154d