### PR TITLE
Add internal login guidance to client login modal

### DIFF
--- a/MJ_FB_Frontend/src/locales/am.json
+++ b/MJ_FB_Frontend/src/locales/am.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/ar.json
+++ b/MJ_FB_Frontend/src/locales/ar.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/en.json
+++ b/MJ_FB_Frontend/src/locales/en.json
@@ -313,6 +313,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/es.json
+++ b/MJ_FB_Frontend/src/locales/es.json
@@ -306,6 +306,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/fa.json
+++ b/MJ_FB_Frontend/src/locales/fa.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/fr.json
+++ b/MJ_FB_Frontend/src/locales/fr.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/hi.json
+++ b/MJ_FB_Frontend/src/locales/hi.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/ml.json
+++ b/MJ_FB_Frontend/src/locales/ml.json
@@ -309,6 +309,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/pa.json
+++ b/MJ_FB_Frontend/src/locales/pa.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/ps.json
+++ b/MJ_FB_Frontend/src/locales/ps.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/so.json
+++ b/MJ_FB_Frontend/src/locales/so.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/sw.json
+++ b/MJ_FB_Frontend/src/locales/sw.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/ta.json
+++ b/MJ_FB_Frontend/src/locales/ta.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/ti.json
+++ b/MJ_FB_Frontend/src/locales/ti.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/tl.json
+++ b/MJ_FB_Frontend/src/locales/tl.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/uk.json
+++ b/MJ_FB_Frontend/src/locales/uk.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/locales/zh.json
+++ b/MJ_FB_Frontend/src/locales/zh.json
@@ -304,6 +304,7 @@
   "reschedule_failed": "Failed to reschedule booking",
   "select_date_time": "Please select date and time",
   "client_login_notice_id": "Please use your client ID to login. If you don't know your client ID or don't have an account created by us, please email harvestpantry@mjfoodbank.org to get an account created.",
+  "client_login_notice_internal": "If you are staff, volunteer, or agency, use the internal login button in the menu to log in.",
   "client_login_notice_password": "If your password is not working, please use the forgot password link below to set a new password.",
   "client_login_notice_volunteer": "Are you a volunteer looking to shop? Please contact harvestpantry@mjfoodbank.org to enable booking shopping in your volunteer account. After that please login to your volunteer account to book your shopping appointments.",
   "client_login_notice_close": "Close this modal to sign in."

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -28,6 +28,7 @@ export default function Login({
   const { t } = useTranslation();
   const notices: { message: ReactNode; severity: AlertColor }[] = [
     { message: <span style={{ fontSize: '0.75rem' }}>{t('client_login_notice_id')}</span>, severity: 'info' },
+    { message: <span style={{ fontSize: '0.75rem' }}>{t('client_login_notice_internal')}</span>, severity: 'info' },
     { message: <span style={{ fontSize: '0.75rem' }}>{t('client_login_notice_password')}</span>, severity: 'warning' },
     { message: <span style={{ fontSize: '0.75rem' }}>{t('client_login_notice_volunteer')}</span>, severity: 'info' },
   ];
@@ -115,6 +116,9 @@ export default function Login({
           </IconButton>
           <Typography variant="body2" paragraph>
             {t('client_login_notice_id')}
+          </Typography>
+          <Typography variant="body2" paragraph>
+            {t('client_login_notice_internal')}
           </Typography>
           <Typography variant="body2" paragraph>
             {t('client_login_notice_password')}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Password fields include a visibility toggle so users can verify what they type.
 - Booking confirmation emails include links to public pages for cancelling or rescheduling
   bookings at `/cancel/:token` and `/reschedule/:token`.
-- Client login page reminds users to sign in with their client ID and provides contact and password reset guidance.
+- Client login page reminds users to sign in with their client ID, provides contact and password reset guidance, and directs staff, volunteers, and agencies to use the internal login button from the menu.
 
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 `/leave-requests` from the profile menu once logged in. Admin users also see

--- a/docs/login.md
+++ b/docs/login.md
@@ -5,6 +5,7 @@
 Add the following translation strings to locale files:
 
 - `client_login_notice_id` – instructs clients to email harvestpantry@mjfoodbank.org if they don't know their client ID or need an account created
+- `client_login_notice_internal` – tells staff, volunteers, and agencies to use the internal login button in the menu
 - `client_login_notice_password` – advises clients to use the forgot password link if their password is not working
 - `client_login_notice_volunteer` – tells volunteers who want to shop to email harvestpantry@mjfoodbank.org so booking can be enabled from their volunteer account
 - `client_login_notice_close` – instructs users to close the modal to sign in


### PR DESCRIPTION
## Summary
- expand client login notice to direct staff, volunteers, and agencies to the internal login
- document new translation key

## Testing
- `npm test` *(fails: RecurringBookings.test.tsx, PantryVisits.test.tsx, BookingUI.test.tsx, VolunteerManagement.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb28e6234832da876975e8f583bfa