### PR TITLE
Add calendar links to reschedule emails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/
 | `BOOKING_REMINDER_TEMPLATE_ID` | Next-day booking reminders for clients | `body`, `cancelLink`, `rescheduleLink`, `type` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` |
-| `CLIENT_RESCHEDULE_TEMPLATE_ID` | Booking reschedule notifications for clients | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `type` |
-| `VOLUNTEER_RESCHEDULE_TEMPLATE_ID` | Volunteer shift reschedule emails | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `type` |
+| `CLIENT_RESCHEDULE_TEMPLATE_ID` | Booking reschedule notifications for clients | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` |
+| `VOLUNTEER_RESCHEDULE_TEMPLATE_ID` | Volunteer shift reschedule emails | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` |
 
 Client and volunteer reschedule emails currently use Brevo template ID **10**.
 

--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -458,6 +458,15 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
       const newTime = newSlotRes.rows[0]
         ? `${newSlotRes.rows[0].start_time} to ${newSlotRes.rows[0].end_time}`
         : '';
+      const {
+        googleCalendarLink,
+        outlookCalendarLink,
+        appleCalendarLink,
+      } = buildCalendarLinks(
+        date,
+        newSlotRes.rows[0]?.start_time,
+        newSlotRes.rows[0]?.end_time,
+      );
       enqueueEmail({
         to: email,
         templateId:
@@ -469,6 +478,9 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
           newTime,
           cancelLink,
           rescheduleLink,
+          googleCalendarLink,
+          outlookCalendarLink,
+          appleCalendarLink,
           type: emailType,
         },
       });

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -949,6 +949,11 @@ export async function rescheduleVolunteerBooking(
       const oldTime = oldSlotRes.rows[0]
         ? `${oldSlotRes.rows[0].start_time} to ${oldSlotRes.rows[0].end_time}`
         : '';
+      const {
+        googleCalendarLink,
+        outlookCalendarLink,
+        appleCalendarLink,
+      } = buildCalendarLinks(date, slot.start_time, slot.end_time);
       enqueueEmail({
         to: email,
         templateId:
@@ -961,6 +966,9 @@ export async function rescheduleVolunteerBooking(
           newTime: `${slot.start_time} to ${slot.end_time}`,
           cancelLink,
           rescheduleLink,
+          googleCalendarLink,
+          outlookCalendarLink,
+          appleCalendarLink,
           type: 'Volunteer Shift',
         },
       });

--- a/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
+++ b/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
@@ -18,9 +18,9 @@ jest.mock('../src/utils/emailQueue', () => ({
 jest.mock('../src/utils/emailUtils', () => ({
   buildCancelRescheduleLinks: () => ({ cancelLink: '#cancel', rescheduleLink: '#resched' }),
   buildCalendarLinks: () => ({
-    googleCalendarLink: '',
-    outlookCalendarLink: '',
-    appleCalendarLink: '',
+    googleCalendarLink: '#google',
+    outlookCalendarLink: '#outlook',
+    appleCalendarLink: '#apple',
   }),
 }));
 jest.mock('../src/models/bookingRepository');
@@ -81,5 +81,8 @@ describe('rescheduleBooking', () => {
     expect(params.newTime).toBe('11:00 to 12:00');
     expect(params.cancelLink).toBe('#cancel');
     expect(params.rescheduleLink).toBe('#resched');
+    expect(params.googleCalendarLink).toBe('#google');
+    expect(params.outlookCalendarLink).toBe('#outlook');
+    expect(params.appleCalendarLink).toBe('#apple');
   });
 });

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -14,6 +14,11 @@ afterAll(() => {
 
 jest.mock('../src/utils/emailUtils', () => ({
   buildCancelRescheduleLinks: () => ({ cancelLink: '', rescheduleLink: '' }),
+  buildCalendarLinks: () => ({
+    googleCalendarLink: '#g',
+    outlookCalendarLink: '#o',
+    appleCalendarLink: '#a',
+  }),
 }));
 const enqueueEmailMock = enqueueEmail as jest.Mock;
 jest.mock('../src/middleware/authMiddleware', () => ({
@@ -62,5 +67,8 @@ describe('rescheduleVolunteerBooking', () => {
     expect(params.oldTime).toBe('08:00 to 09:00');
     expect(params.newDate).toBe('Thu, Sep 5, 2030');
     expect(params.newTime).toBe('09:00 to 12:00');
+    expect(params.googleCalendarLink).toBe('#g');
+    expect(params.outlookCalendarLink).toBe('#o');
+    expect(params.appleCalendarLink).toBe('#a');
   });
 });

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ EMAIL_ENABLED=true # set to 'true' to send emails
 TIMESHEET_APPROVER_EMAILS=admin1@example.com,admin2@example.com # optional
 ```
 
-Booking confirmation and reminder templates can surface "Add to Calendar" buttons by referencing
+Booking confirmation, reminder, and reschedule templates can surface "Add to Calendar" buttons by referencing
 `{{ params.googleCalendarLink }}`, `{{ params.outlookCalendarLink }}`, and `{{ params.appleCalendarLink }}` in the Brevo templates.
 The backend supplies these URLs automatically; no extra environment variables are required.
 

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -10,8 +10,8 @@ parameters supplied to each template.
 | `BOOKING_REMINDER_TEMPLATE_ID` | Next-day booking reminders for clients | `body`, `cancelLink`, `rescheduleLink`, `type` | `bookingReminderJob.ts` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` | `volunteerBookingController.ts` |
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts` |
-| `CLIENT_RESCHEDULE_TEMPLATE_ID` | Booking reschedule notifications for clients | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `type` | `bookingController.ts` |
-| `VOLUNTEER_RESCHEDULE_TEMPLATE_ID` | Volunteer shift reschedule emails | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `type` | `volunteerBookingController.ts` |
+| `CLIENT_RESCHEDULE_TEMPLATE_ID` | Booking reschedule notifications for clients | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` | `bookingController.ts` |
+| `VOLUNTEER_RESCHEDULE_TEMPLATE_ID` | Volunteer shift reschedule emails | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` | `volunteerBookingController.ts` |
 
 Client and volunteer reschedule notifications share Brevo template ID **10**.
 


### PR DESCRIPTION
## Summary
- Build calendar links when client or volunteer bookings are rescheduled
- Document new calendar link parameters for reschedule email templates
- Test reschedule flows include Google/Outlook/Apple calendar URLs

## Testing
- `npm test` *(fails: 18 failed, 89 passed)*
- `npm test -- tests/bookingRescheduleEmail.test.ts tests/volunteerReschedule.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bcba8cc8d0832d80b83eaa3cd8d7c1