### PR TITLE
feat: include uid and sequence in calendar invites

### DIFF
--- a/MJ_FB_Backend/src/utils/calendarLinks.ts
+++ b/MJ_FB_Backend/src/utils/calendarLinks.ts
@@ -1,9 +1,14 @@
+import { randomUUID } from 'crypto';
+
 interface CalendarEvent {
   title: string;
   start: Date | string;
   end: Date | string;
   description?: string;
   location?: string;
+  uid?: string;
+  method?: 'REQUEST' | 'CANCEL';
+  sequence?: number;
 }
 
 function formatDate(date: Date | string): string {
@@ -40,6 +45,9 @@ export function buildIcsFile({
   end,
   description,
   location,
+  uid,
+  method = 'REQUEST',
+  sequence = 0,
 }: CalendarEvent): string {
   const startStr = formatDate(start);
   const endStr = formatDate(end);
@@ -47,7 +55,10 @@ export function buildIcsFile({
   const lines = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
+    `METHOD:${method}`,
     'BEGIN:VEVENT',
+    `UID:${uid || randomUUID()}`,
+    `SEQUENCE:${sequence}`,
     `SUMMARY:${title}`,
     `DTSTART:${startStr}`,
     `DTEND:${endStr}`,

--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -54,16 +54,23 @@ export async function sendEmail(
   }
 }
 
+interface Attachment {
+  name: string;
+  content: string;
+}
+
 interface TemplatedEmailOptions {
   to: string;
   templateId: number;
   params?: Record<string, unknown>;
+  attachments?: Attachment[];
 }
 
 export async function sendTemplatedEmail({
   to,
   templateId,
   params,
+  attachments,
 }: TemplatedEmailOptions): Promise<void | { skipped: true }> {
   if (process.env.EMAIL_ENABLED !== 'true') {
     return { skipped: true };
@@ -93,6 +100,7 @@ export async function sendTemplatedEmail({
         to: [{ email: to }],
         templateId,
         params: params || undefined,
+        attachment: attachments && attachments.length > 0 ? attachments : undefined,
       }),
     });
 

--- a/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
+++ b/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
@@ -81,5 +81,14 @@ describe('rescheduleBooking', () => {
     expect(params.newTime).toBe('11:00 to 12:00');
     expect(params.cancelLink).toBe('#cancel');
     expect(params.rescheduleLink).toBe('#resched');
+    const attachments = enqueueEmailMock.mock.calls[0][0].attachments;
+    expect(Array.isArray(attachments)).toBe(true);
+    expect(attachments).toHaveLength(2);
+    const cancel = Buffer.from(attachments[0].content, 'base64').toString('utf-8');
+    const updated = Buffer.from(attachments[1].content, 'base64').toString('utf-8');
+    expect(cancel).toContain('METHOD:CANCEL');
+    expect(cancel).toContain('UID:1');
+    expect(updated).toContain('METHOD:REQUEST');
+    expect(updated).toContain('SEQUENCE:1');
   });
 });

--- a/MJ_FB_Backend/tests/calendarLinks.test.ts
+++ b/MJ_FB_Backend/tests/calendarLinks.test.ts
@@ -22,15 +22,35 @@ describe('calendar link utilities', () => {
       end: new Date('2024-09-01T11:00:00Z'),
       description: 'Bring snacks & drinks',
       location: '123 Main St',
+      uid: 'abc123',
+      sequence: 0,
     });
 
     expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('METHOD:REQUEST');
+    expect(ics).toContain('UID:abc123');
+    expect(ics).toContain('SEQUENCE:0');
     expect(ics).toContain('SUMMARY:Food & Fun');
     expect(ics).toContain('DTSTART:20240901T100000Z');
     expect(ics).toContain('DTEND:20240901T110000Z');
     expect(ics).toContain('DESCRIPTION:Bring snacks & drinks');
     expect(ics).toContain('LOCATION:123 Main St');
     expect(ics).toContain('END:VCALENDAR');
+  });
+
+  it('creates a cancellation ICS referencing the same UID', () => {
+    const ics = buildIcsFile({
+      title: 'Food & Fun',
+      start: new Date('2024-09-01T10:00:00Z'),
+      end: new Date('2024-09-01T11:00:00Z'),
+      uid: 'abc123',
+      method: 'CANCEL',
+      sequence: 0,
+    });
+
+    expect(ics).toContain('METHOD:CANCEL');
+    expect(ics).toContain('UID:abc123');
+    expect(ics).toContain('SEQUENCE:0');
   });
 
   it('builds links from a booking object', () => {

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -62,5 +62,14 @@ describe('rescheduleVolunteerBooking', () => {
     expect(params.oldTime).toBe('08:00 to 09:00');
     expect(params.newDate).toBe('Thu, Sep 5, 2030');
     expect(params.newTime).toBe('09:00 to 12:00');
+    const attachments = enqueueEmailMock.mock.calls[0][0].attachments;
+    expect(Array.isArray(attachments)).toBe(true);
+    expect(attachments).toHaveLength(2);
+    const cancel = Buffer.from(attachments[0].content, 'base64').toString('utf-8');
+    const updated = Buffer.from(attachments[1].content, 'base64').toString('utf-8');
+    expect(cancel).toContain('METHOD:CANCEL');
+    expect(cancel).toContain('UID:1');
+    expect(updated).toContain('METHOD:REQUEST');
+    expect(updated).toContain('SEQUENCE:1');
   });
 });


### PR DESCRIPTION
## Summary
- extend ICS builder with uid, method, and sequence
- attach cancellation and updated ICS files when rescheduling bookings and volunteer shifts
- support email attachments in queue and sender utilities
- add tests for ICS generator and reschedule attachments

## Testing
- `npm test` *(fails: Timesheet not found, etc.)*
- `npm test tests/calendarLinks.test.ts tests/bookingRescheduleEmail.test.ts tests/volunteerReschedule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bcba917150832da4a9ba7923250fdd