### PR TITLE
feat: include uid and method in calendar ICS

### DIFF
--- a/MJ_FB_Backend/src/utils/calendarLinks.ts
+++ b/MJ_FB_Backend/src/utils/calendarLinks.ts
@@ -1,9 +1,14 @@
+import { randomUUID } from 'crypto';
+
 interface CalendarEvent {
   title: string;
   start: Date | string;
   end: Date | string;
   description?: string;
   location?: string;
+  uid?: string;
+  method?: 'REQUEST' | 'CANCEL';
+  sequence?: number;
 }
 
 function formatDate(date: Date | string): string {
@@ -40,6 +45,9 @@ export function buildIcsFile({
   end,
   description,
   location,
+  uid = randomUUID(),
+  method = 'REQUEST',
+  sequence = 0,
 }: CalendarEvent): string {
   const startStr = formatDate(start);
   const endStr = formatDate(end);
@@ -47,7 +55,10 @@ export function buildIcsFile({
   const lines = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
+    `METHOD:${method}`,
     'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `SEQUENCE:${sequence}`,
     `SUMMARY:${title}`,
     `DTSTART:${startStr}`,
     `DTEND:${endStr}`,

--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -138,6 +138,8 @@ export function buildCalendarLinks(
   date: string,
   startTime?: string | null,
   endTime?: string | null,
+  uid?: string,
+  sequence = 0,
 ): {
   googleCalendarLink: string;
   outlookCalendarLink: string;
@@ -160,6 +162,9 @@ export function buildCalendarLinks(
     end,
     description: 'Your booking at the Harvest Pantry',
     location: 'Moose Jaw Food Bank',
+    uid,
+    method: 'REQUEST',
+    sequence,
   });
   const appleCalendarLink = `data:text/calendar;charset=utf-8,${encodeURIComponent(ics)}`;
   return { googleCalendarLink, outlookCalendarLink, appleCalendarLink };

--- a/MJ_FB_Backend/tests/bookingController.test.ts
+++ b/MJ_FB_Backend/tests/bookingController.test.ts
@@ -42,6 +42,7 @@ describe('createBookingForUser', () => {
   it('enqueues confirmation email after booking creation', async () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
       .mockResolvedValueOnce({ rows: [{ email: 'client@example.com' }] })
       .mockResolvedValueOnce({ rows: [{ start_time: '09:00:00', end_time: '09:30:00' }] });
     const req = {
@@ -88,7 +89,9 @@ describe('createBookingForUser', () => {
   it('passes note to insertBooking', async () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ start_time: '09:00:00', end_time: '09:30:00' }] });
     const req = {
       user: { role: 'staff', id: 99 },
       body: { userId: 1, slotId: 2, date: '2024-01-15', note: 'bring ID' },

--- a/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
+++ b/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
@@ -84,5 +84,6 @@ describe('rescheduleBooking', () => {
     expect(params.googleCalendarLink).toBe('#google');
     expect(params.outlookCalendarLink).toBe('#outlook');
     expect(params.appleCalendarLink).toBe('#apple');
+    expect(params.appleCalendarCancelLink).toContain('METHOD%3ACANCEL');
   });
 });

--- a/MJ_FB_Backend/tests/calendarLinks.test.ts
+++ b/MJ_FB_Backend/tests/calendarLinks.test.ts
@@ -22,15 +22,36 @@ describe('calendar link utilities', () => {
       end: new Date('2024-09-01T11:00:00Z'),
       description: 'Bring snacks & drinks',
       location: '123 Main St',
+      uid: 'abc',
+      method: 'REQUEST',
+      sequence: 1,
     });
 
     expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('METHOD:REQUEST');
+    expect(ics).toContain('UID:abc');
+    expect(ics).toContain('SEQUENCE:1');
     expect(ics).toContain('SUMMARY:Food & Fun');
     expect(ics).toContain('DTSTART:20240901T100000Z');
     expect(ics).toContain('DTEND:20240901T110000Z');
     expect(ics).toContain('DESCRIPTION:Bring snacks & drinks');
     expect(ics).toContain('LOCATION:123 Main St');
     expect(ics).toContain('END:VCALENDAR');
+  });
+
+  it('creates a cancellation ICS referencing a UID', () => {
+    const cancelIcs = buildIcsFile({
+      title: 'Food & Fun',
+      start: new Date('2024-09-01T10:00:00Z'),
+      end: new Date('2024-09-01T11:00:00Z'),
+      uid: 'abc',
+      method: 'CANCEL',
+      sequence: 2,
+    });
+
+    expect(cancelIcs).toContain('METHOD:CANCEL');
+    expect(cancelIcs).toContain('UID:abc');
+    expect(cancelIcs).toContain('SEQUENCE:2');
   });
 
   it('builds links from a booking object', () => {

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -70,5 +70,6 @@ describe('rescheduleVolunteerBooking', () => {
     expect(params.googleCalendarLink).toBe('#g');
     expect(params.outlookCalendarLink).toBe('#o');
     expect(params.appleCalendarLink).toBe('#a');
+    expect(params.appleCalendarCancelLink).toContain('METHOD%3ACANCEL');
   });
 });


### PR DESCRIPTION
## Summary
- add UID, METHOD and SEQUENCE fields to ICS generator
- send cancellation and updated ICS attachments on reschedule emails
- test ICS generator for request and cancel events

## Testing
- `npm test` *(fails: Timesheet tests, slot filtering, volunteer booking conflict, volunteer recurring bookings and others)*
- `npm test tests/calendarLinks.test.ts tests/bookingRescheduleEmail.test.ts tests/volunteerReschedule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bcbc43d1e4832daea45281fb19815b