### PR TITLE
Allow staff to delete recorded visits

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Before merging a pull request, confirm the following:
 - Adding a client visit automatically updates any approved booking for that client on the same date to `visited`.
 - The Manage Booking dialog now displays the client's name, a link to their profile, and their visit count for the current month to assist staff decisions.
 - Client booking history tables can filter bookings by `visited` and `no_show` statuses.
+- Staff can delete visit records from booking history if they were recorded in error; clients cannot remove visits.
 - Booking requests are automatically approved; the submitted state has been removed.
 - Booking confirmations display "Shift booked"; the volunteer dashboard shows only approved bookings.
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.


### PR DESCRIPTION
## Summary
- Allow staff to delete pantry visit records from booking history and revert related bookings
- Provide UI and confirmation dialog for staff-only visit deletion
- Document staff-only visit deletion capability in README

## Testing
- `npm test` (backend) *(fails: Cannot redefine property: isDateWithinCurrentOrNextMonth, etc.)*
- `npm test` (frontend) *(fails: Unable to find element, jsdom location errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc476fa7c832dad1f7f0a2b50df62