### PR TITLE
test: verify Wednesday evening slot availability

### DIFF
--- a/MJ_FB_Backend/tests/slots.test.ts
+++ b/MJ_FB_Backend/tests/slots.test.ts
@@ -85,6 +85,30 @@ describe('GET /slots applies slot rules', () => {
     ]);
   });
 
+  it('lists Wednesday evening slot in range', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 1, start_time: '09:30:00', end_time: '10:00:00', max_capacity: 10 },
+          { id: 2, start_time: '18:30:00', end_time: '19:00:00', max_capacity: 10 },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get('/slots/range')
+      .query({ start: '2024-06-19', days: 1, includePast: 'true' });
+    expect(res.status).toBe(200);
+    expect(res.body[0].date).toBe('2024-06-19');
+    expect(res.body[0].slots.map((s: any) => s.startTime)).toEqual([
+      '09:30:00',
+      '18:30:00',
+    ]);
+  });
+
   it('marks slots blocked from recurring entries', async () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })

--- a/MJ_FB_Frontend/src/pages/__tests__/RescheduleBooking.test.tsx
+++ b/MJ_FB_Frontend/src/pages/__tests__/RescheduleBooking.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import RescheduleBooking from '../RescheduleBooking';
+import * as bookingApi from '../../api/bookings';
+
+jest.mock('../../api/bookings', () => ({
+  getSlots: jest.fn(),
+  rescheduleBookingByToken: jest.fn(),
+}));
+
+describe('RescheduleBooking Wednesday slot', () => {
+  beforeEach(() => {
+    (bookingApi.getSlots as jest.Mock).mockResolvedValue([
+      { id: '2', startTime: '18:30:00', endTime: '19:00:00', available: 1, maxCapacity: 1 },
+    ]);
+  });
+
+  it('lists evening slot on Wednesday', async () => {
+    render(
+      <MemoryRouter initialEntries={['/reschedule/abc']}>
+        <Routes>
+          <Route path="/reschedule/:token" element={<RescheduleBooking />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Date'), {
+      target: { value: '2024-06-19' },
+    });
+
+    expect(await screen.findByText('6:30 PM - 7:00 PM')).toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
@@ -134,3 +134,28 @@ describe('PantrySchedule status display', () => {
     expect(screen.queryByText('Cancel (3)')).toBeNull();
   });
 });
+
+describe('PantrySchedule Wednesday evening slot', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-06-19T00:00:00-06:00'));
+    (bookingApi.getSlots as jest.Mock).mockResolvedValue([
+      { id: '2', startTime: '18:30:00', endTime: '19:00:00', available: 1, maxCapacity: 1 },
+    ]);
+    (bookingApi.getBookings as jest.Mock).mockResolvedValue([]);
+    (bookingApi.getHolidays as jest.Mock).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows 6:30 PM–7:00 PM slot', async () => {
+    render(
+      <MemoryRouter>
+        <PantrySchedule />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText('6:30 PM - 7:00 PM')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add backend test confirming Wednesday slot range includes 6:30pm
- add frontend tests ensuring 6:30–7pm slot shows in pantry schedule and reschedule flow

## Testing
- `npm test` *(backend tests: 18 failed, 89 passed)*
- `npm test` *(frontend tests crashed with jsdom location error)*

------
https://chatgpt.com/codex/tasks/task_e_68bcccb57ea8832d838322af920e8031