### PR TITLE
Show new client option when search empty in pantry schedule

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -409,7 +409,17 @@ export default function PantrySchedule({
                     </li>
                   ))}
                   {assignSlot && searchTerm.length >= 3 && userResults.length === 0 && (
-                    <li>No search results.</li>
+                    <li>
+                      No search results.
+                      <Button
+                        size="small"
+                        variant="text"
+                        onClick={() => setIsNewClient(true)}
+                        sx={{ ml: 1 }}
+                      >
+                        Create new client
+                      </Button>
+                    </li>
                   )}
                 </ul>
               </>


### PR DESCRIPTION
## Summary
- display a **Create new client** button in Pantry Schedule's assign user modal when searches return no results
- test the new button and stabilize PantrySchedule tests with fixed dates

## Testing
- `npm test` *(fails: jsdom/undici runtime errors such as `ReferenceError: clearImmediate is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_68bccf1a6b80832db483826f4b247d7b