### PR TITLE
feat: allow staff to delete clients and volunteers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.
 - Use the shared `PasswordField` component for any password input so users can toggle visibility.
 - Passwords must be at least 8 characters and include uppercase, lowercase, and special characters; numbers are optional.
+- Staff can delete client and volunteer accounts from their respective management pages; update help content when these features change.
 
 See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/AGENTS.md` for frontend-specific guidance.
 

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -576,3 +576,26 @@ export async function updateUserByClientId(
   }
 }
 
+export async function deleteUserByClientId(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (!req.user || req.user.role !== 'staff') {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+  const { clientId } = req.params;
+  try {
+    const result = await pool.query('DELETE FROM clients WHERE client_id = $1', [
+      clientId,
+    ]);
+    if ((result.rowCount ?? 0) === 0) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json({ message: 'User deleted' });
+  } catch (error) {
+    logger.error('Error deleting user:', error);
+    next(error);
+  }
+}
+

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -535,3 +535,26 @@ export async function awardVolunteerBadge(
     next(error);
   }
 }
+
+export async function deleteVolunteer(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (!req.user || req.user.role !== 'staff') {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+  const { id } = req.params;
+  try {
+    const result = await pool.query('DELETE FROM volunteers WHERE id = $1', [
+      id,
+    ]);
+    if ((result.rowCount ?? 0) === 0) {
+      return res.status(404).json({ message: 'Volunteer not found' });
+    }
+    res.json({ message: 'Volunteer deleted' });
+  } catch (error) {
+    logger.error('Error deleting volunteer:', error);
+    next(error);
+  }
+}

--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -8,6 +8,7 @@ import {
   listUsersMissingInfo,
   updateUserByClientId,
   updateMyProfile,
+  deleteUserByClientId,
 } from '../controllers/userController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
@@ -41,6 +42,12 @@ router.patch(
   authorizeRoles('staff'),
   validate(updateUserSchema),
   updateUserByClientId,
+);
+router.delete(
+  '/id/:clientId',
+  authMiddleware,
+  authorizeRoles('staff'),
+  deleteUserByClientId,
 );
 router.get(
   '/missing-info',

--- a/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
@@ -9,6 +9,7 @@ import {
   removeVolunteerShopperProfile,
   getVolunteerStats,
   awardVolunteerBadge,
+  deleteVolunteer,
 } from '../../controllers/volunteer/volunteerController';
 import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
 
@@ -55,6 +56,13 @@ router.delete(
   authMiddleware,
   authorizeRoles('staff'),
   removeVolunteerShopperProfile
+);
+
+router.delete(
+  '/:id',
+  authMiddleware,
+  authorizeRoles('staff'),
+  deleteVolunteer,
 );
 
 export default router;

--- a/MJ_FB_Backend/tests/deleteUser.test.ts
+++ b/MJ_FB_Backend/tests/deleteUser.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (req as any).user = { role: 'staff' };
+  next();
+});
+app.use('/users', usersRouter);
+
+describe('DELETE /users/id/:clientId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes existing user', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({ rowCount: 1 });
+    const res = await request(app).delete('/users/id/5');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'User deleted' });
+    expect(pool.query).toHaveBeenCalledWith('DELETE FROM clients WHERE client_id = $1', [ '5' ]);
+  });
+
+  it('returns 404 when user missing', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({ rowCount: 0 });
+    const res = await request(app).delete('/users/id/99');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: 'User not found' });
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/DeleteVolunteer.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DeleteVolunteer.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DeleteVolunteer from '../pages/volunteer-management/DeleteVolunteer';
+import { deleteVolunteer } from '../api/volunteers';
+
+jest.mock('../api/volunteers', () => ({ deleteVolunteer: jest.fn() }));
+
+jest.mock('../components/EntitySearch', () => (props: any) => (
+  <button onClick={() => props.onSelect({ id: 2, name: 'Jane' })}>Select Volunteer</button>
+));
+
+describe('DeleteVolunteer', () => {
+  it('deletes selected volunteer', async () => {
+    render(
+      <MemoryRouter>
+        <DeleteVolunteer />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(deleteVolunteer).toHaveBeenCalledWith(2);
+  });
+});

--- a/MJ_FB_Frontend/src/api/__tests__/usersApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/usersApi.test.ts
@@ -1,0 +1,20 @@
+import { apiFetch } from '../client';
+import { deleteUser } from '../users';
+
+jest.mock('../client', () => ({
+  API_BASE: '/api',
+  apiFetch: jest.fn(),
+  handleResponse: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('users api', () => {
+  beforeEach(() => {
+    (apiFetch as jest.Mock).mockResolvedValue(new Response(null));
+    jest.clearAllMocks();
+  });
+
+  it('calls delete endpoint', async () => {
+    await deleteUser(5);
+    expect(apiFetch).toHaveBeenCalledWith('/api/users/id/5', expect.objectContaining({ method: 'DELETE' }));
+  });
+});

--- a/MJ_FB_Frontend/src/api/__tests__/volunteersApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/volunteersApi.test.ts
@@ -1,0 +1,20 @@
+import { apiFetch } from '../client';
+import { deleteVolunteer } from '../volunteers';
+
+jest.mock('../client', () => ({
+  API_BASE: '/api',
+  apiFetch: jest.fn(),
+  handleResponse: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('volunteers api', () => {
+  beforeEach(() => {
+    (apiFetch as jest.Mock).mockResolvedValue(new Response(null));
+    jest.clearAllMocks();
+  });
+
+  it('calls delete volunteer endpoint', async () => {
+    await deleteVolunteer(3);
+    expect(apiFetch).toHaveBeenCalledWith('/api/volunteers/3', expect.objectContaining({ method: 'DELETE' }));
+  });
+});

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -241,3 +241,8 @@ export async function deleteNewClient(id: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/new-clients/${id}`, { method: "DELETE" });
   await handleResponse(res);
 }
+
+export async function deleteUser(clientId: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/users/id/${clientId}`, { method: 'DELETE' });
+  await handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -505,6 +505,11 @@ export async function removeVolunteerShopperProfile(
   await handleResponse(res);
 }
 
+export async function deleteVolunteer(id: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/volunteers/${id}`, { method: 'DELETE' });
+  await handleResponse(res);
+}
+
 export interface VolunteerStats {
   badges: string[];
   lifetimeHours: number;

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -263,13 +263,24 @@ export function getHelpContent(
       },
     },
     {
+      title: 'Manage clients',
+      body: {
+        description: 'Search, add, update, and delete client accounts.',
+        steps: [
+          'Go to the Client Management page.',
+          'Search by name or client ID.',
+          'View, edit, or delete client information.',
+        ],
+      },
+    },
+    {
       title: 'Manage volunteers',
       body: {
-        description: 'Search, add, and review volunteers.',
+        description: 'Search, add, delete, and review volunteers.',
         steps: [
           'Go to the Volunteers page.',
           'Search by name.',
-          'View or edit volunteer information.',
+          'View, edit, or delete volunteer information.',
           'Check Online Access to email login details when creating a volunteer.',
         ],
       },

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -8,6 +8,7 @@ import UpdateClientData from './client-management/UpdateClientData';
 import UserHistory from './client-management/UserHistory';
 import NewClients from './client-management/NewClients';
 import NoShowWeek from './client-management/NoShowWeek';
+import DeleteClient from './client-management/DeleteClient';
 
 export default function ClientManagement() {
   const [searchParams] = useSearchParams();
@@ -41,6 +42,7 @@ export default function ClientManagement() {
     { label: 'Update', content: <UpdateClientData /> },
     { label: 'New Clients', content: <NewClients /> },
     { label: 'No Shows', content: <NoShowWeek /> },
+    { label: 'Delete', content: <DeleteClient /> },
   ];
 
   return (

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/DeleteClient.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/DeleteClient.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DeleteClient from '../client-management/DeleteClient';
+import { deleteUser } from '../../../api/users';
+
+jest.mock('../../../api/users', () => ({ deleteUser: jest.fn() }));
+
+jest.mock('../../../components/EntitySearch', () => (props: any) => (
+  <button onClick={() => props.onSelect({ name: 'John Doe', client_id: 1 })}>Select Client</button>
+));
+
+describe('DeleteClient', () => {
+  it('deletes selected client', async () => {
+    render(
+      <MemoryRouter>
+        <DeleteClient />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('Select Client'));
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(deleteUser).toHaveBeenCalledWith(1);
+  });
+});

--- a/MJ_FB_Frontend/src/pages/staff/client-management/DeleteClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/DeleteClient.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Button } from '@mui/material';
+import Page from '../../../components/Page';
+import EntitySearch from '../../../components/EntitySearch';
+import ConfirmDialog from '../../../components/ConfirmDialog';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import { deleteUser } from '../../../api/users';
+
+interface Client { name: string; client_id: number; }
+
+export default function DeleteClient() {
+  const [client, setClient] = useState<Client | null>(null);
+  const [confirm, setConfirm] = useState(false);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<'success' | 'error'>('success');
+
+  async function handleDelete() {
+    if (!client) return;
+    try {
+      await deleteUser(client.client_id);
+      setMessage('Client deleted');
+      setSeverity('success');
+      setClient(null);
+    } catch {
+      setMessage('Delete failed');
+      setSeverity('error');
+    }
+    setConfirm(false);
+  }
+
+  return (
+    <Page title="Delete Client">
+      <EntitySearch type="user" placeholder="Search client" onSelect={c => setClient(c as Client)} />
+      {client && (
+        <Button
+          size="small"
+          variant="contained"
+          color="error"
+          sx={{ mt: 2 }}
+          onClick={() => setConfirm(true)}
+        >
+          Delete
+        </Button>
+      )}
+      {confirm && (
+        <ConfirmDialog
+          message={`Delete ${client?.name}?`}
+          onConfirm={handleDelete}
+          onCancel={() => setConfirm(false)}
+        />
+      )}
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity={severity}
+      />
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/DeleteVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/DeleteVolunteer.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Button } from '@mui/material';
+import Page from '../../components/Page';
+import EntitySearch from '../../components/EntitySearch';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { deleteVolunteer } from '../../api/volunteers';
+
+interface Volunteer { id: number; name: string; }
+
+export default function DeleteVolunteer() {
+  const [volunteer, setVolunteer] = useState<Volunteer | null>(null);
+  const [confirm, setConfirm] = useState(false);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<'success' | 'error'>('success');
+
+  async function handleDelete() {
+    if (!volunteer) return;
+    try {
+      await deleteVolunteer(volunteer.id);
+      setMessage('Volunteer deleted');
+      setSeverity('success');
+      setVolunteer(null);
+    } catch {
+      setMessage('Delete failed');
+      setSeverity('error');
+    }
+    setConfirm(false);
+  }
+
+  return (
+    <Page title="Delete Volunteer">
+      <EntitySearch type="volunteer" placeholder="Search volunteer" onSelect={v => setVolunteer(v as Volunteer)} />
+      {volunteer && (
+        <Button
+          size="small"
+          variant="contained"
+          color="error"
+          sx={{ mt: 2 }}
+          onClick={() => setConfirm(true)}
+        >
+          Delete
+        </Button>
+      )}
+      {confirm && (
+        <ConfirmDialog
+          message={`Delete ${volunteer?.name}?`}
+          onConfirm={handleDelete}
+          onCancel={() => setConfirm(false)}
+        />
+      )}
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity={severity}
+      />
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerTabs.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerTabs.tsx
@@ -4,6 +4,7 @@ import Page from '../../components/Page';
 
 const VolunteerManagement = React.lazy(() => import('./VolunteerManagement'));
 const PendingReviews = React.lazy(() => import('./PendingReviews'));
+const DeleteVolunteer = React.lazy(() => import('./DeleteVolunteer'));
 
 export default function VolunteerTabs() {
   const [tab, setTab] = useState(0);
@@ -13,12 +14,14 @@ export default function VolunteerTabs() {
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="Search" />
         <Tab label="Add Volunteer" />
+        <Tab label="Delete Volunteer" />
         <Tab label="Pending Reviews" />
       </Tabs>
       <Suspense fallback={<CircularProgress />}>
         {tab === 0 && <VolunteerManagement initialTab="search" />}
         {tab === 1 && <VolunteerManagement initialTab="create" />}
-        {tab === 2 && <PendingReviews />}
+        {tab === 2 && <DeleteVolunteer />}
+        {tab === 3 && <PendingReviews />}
       </Suspense>
     </Page>
   );

--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Agency navigation offers Dashboard, Book Appointment, and Booking History pages, all behind an `AgencyGuard`.
 - Staff can add agencies, assign clients, and book appointments for those clients through the Harvest Pantry → Agency Management page. The **Add Client to Agency** tab initially shows only agency search; selecting an agency reveals a client search column and the agency's client list with Book buttons for scheduling on their behalf.
 - Staff can enter pay period timesheets with daily hour categories, request vacation leave, and submit periods for approval with admin review and processing.
+- Staff can delete client and volunteer accounts from the Client Management and Volunteer Management pages.
 - Pantry pages include quick links for Pantry Schedule, Record a Visit, and Search Client.
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 - Pantry Visits can log daily sunshine bag weights, shown in the summary above the visit table.


### PR DESCRIPTION
## Summary
- add backend endpoints for deleting client and volunteer accounts
- expose delete options in Client Management and Volunteer tabs
- document new deletion features and help content

## Testing
- `npx jest tests/deleteUser.test.ts tests/volunteers.test.ts`
- `npx jest src/pages/staff/__tests__/DeleteClient.test.tsx src/__tests__/DeleteVolunteer.test.tsx`
- `npm test` (backend) *(fails: TypeError: Cannot redefine property: isDateWithinCurrentOrNextMonth)*
- `npm test` (frontend) *(fails: An update to VolunteerSchedule inside a test was not wrapped in act(...))*

------
https://chatgpt.com/codex/tasks/task_e_68bcf9406fe4832db714864523229592