### PR TITLE
feat: handle volunteer email case-insensitivity

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -192,9 +192,10 @@ export async function createVolunteer(
 
   try {
     if (email) {
-      const emailCheck = await pool.query('SELECT id FROM volunteers WHERE email=$1', [
-        email,
-      ]);
+      const emailCheck = await pool.query(
+        'SELECT id FROM volunteers WHERE LOWER(email) = LOWER($1)',
+        [email],
+      );
       if ((emailCheck.rowCount ?? 0) > 0) {
         return res.status(400).json({ message: 'Email already exists' });
       }
@@ -260,7 +261,7 @@ export async function createVolunteerShopperProfile(
     const email = volRes.rows[0].email;
     if (email) {
       const emailCheck = await pool.query(
-        `SELECT client_id FROM clients WHERE email = $1`,
+        `SELECT client_id FROM clients WHERE LOWER(email) = LOWER($1)`,
         [email],
       );
       if (emailCheck.rowCount) {

--- a/MJ_FB_Backend/src/migrations/1700000000007_case_insensitive_email.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000007_case_insensitive_email.ts
@@ -1,0 +1,22 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('volunteers', 'volunteers_email_unique');
+  pgm.sql(
+    `CREATE UNIQUE INDEX volunteers_email_lower_idx ON volunteers (LOWER(email));`,
+  );
+
+  pgm.dropConstraint('clients', 'clients_email_key');
+  pgm.sql(
+    `CREATE UNIQUE INDEX clients_email_lower_idx ON clients (LOWER(email));`,
+  );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('DROP INDEX IF EXISTS clients_email_lower_idx;');
+  pgm.addConstraint('clients', 'clients_email_key', { unique: ['email'] });
+
+  pgm.sql('DROP INDEX IF EXISTS volunteers_email_lower_idx;');
+  pgm.addConstraint('volunteers', 'volunteers_email_unique', { unique: ['email'] });
+}
+


### PR DESCRIPTION
## Summary
- ensure volunteer creation query matches emails case-insensitively
- case-insensitive linking of volunteers to shopper profiles
- enforce lower-case unique indexes on client and volunteer emails
- test mixed-case emails for duplicate detection and profile linking

## Testing
- `npm test`
- `npm test tests/volunteers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bcfceeef90832d8221b83ffdb8df55