### PR TITLE
feat: prevent duplicate volunteer shopper profiles

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -251,11 +251,14 @@ export async function createVolunteerShopperProfile(
   };
   try {
     const volRes = await pool.query(
-      `SELECT first_name, last_name, email, phone FROM volunteers WHERE id = $1`,
+      `SELECT first_name, last_name, email, phone, user_id FROM volunteers WHERE id = $1`,
       [id],
     );
     if ((volRes.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'Volunteer not found' });
+    }
+    if (volRes.rows[0].user_id) {
+      return res.status(409).json({ message: 'Shopper profile already exists' });
     }
     const email = volRes.rows[0].email;
     if (email) {

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -157,6 +157,29 @@ describe('Volunteer shopper profile', () => {
     expect(sendTemplatedEmail).not.toHaveBeenCalled();
   });
 
+  it('returns 409 when shopper profile already exists', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [
+        {
+          first_name: 'John',
+          last_name: 'Doe',
+          email: 'j@e.com',
+          phone: '123',
+          user_id: 9,
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post('/volunteers/1/shopper')
+      .send({ clientId: 123 });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ message: 'Shopper profile already exists' });
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+
   it('removes a shopper profile for a volunteer', async () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ user_id: 9 }] })


### PR DESCRIPTION
## Summary
- avoid creating duplicate shopper profile for volunteer
- test duplicate volunteer shopper profile creation returns HTTP 409

## Testing
- `npm test tests/volunteers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bcfce6bcb4832d842a0fff03b5c0d6