### PR TITLE
Avoid deleting client when unlinking volunteer shopper

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -333,7 +333,15 @@ export async function removeVolunteerShopperProfile(
       return res.status(404).json({ message: 'Shopper profile not found' });
     }
     const userId = volRes.rows[0].user_id;
-    await pool.query(`DELETE FROM clients WHERE client_id = $1`, [userId]);
+    const clientRes = await pool.query(
+      `SELECT profile_link FROM clients WHERE client_id = $1`,
+      [userId],
+    );
+    const profileLink = clientRes.rows[0]?.profile_link;
+    const expectedLink = `https://portal.link2feed.ca/org/1605/intake/${userId}`;
+    if (profileLink === expectedLink) {
+      await pool.query(`DELETE FROM clients WHERE client_id = $1`, [userId]);
+    }
     await pool.query(`UPDATE volunteers SET user_id = NULL WHERE id = $1`, [id]);
     res.json({ message: 'Shopper profile removed' });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Check client profile before removing volunteer shopper links
- Only delete client record if it was created for the volunteer
- Test unlinking a volunteer from existing client without deleting client

## Testing
- `npm test` *(fails: 18 failed, 90 passed)*
- `npm test tests/volunteers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bcfcdab798832daa418bdd4acb5eda