### PR TITLE
chore: split mui icons for smaller chunks

### DIFF
--- a/MJ_FB_Frontend/src/components/PasswordField.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordField.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import TextField, { type TextFieldProps } from '@mui/material/TextField';
 import { IconButton, InputAdornment } from '@mui/material';
-import { Visibility, VisibilityOff } from '@mui/icons-material';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { useTranslation } from 'react-i18next';
 
 export default function PasswordField({ InputProps, ...props }: TextFieldProps) {

--- a/MJ_FB_Frontend/vite.config.ts
+++ b/MJ_FB_Frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, type PluginOption } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
 
 // https://vite.dev/config/
 export default defineConfig(async ({ mode }) => {
@@ -32,11 +33,21 @@ export default defineConfig(async ({ mode }) => {
       sourcemap: false,
       rollupOptions: {
         output: {
-          manualChunks: {
-            react: ['react', 'react-dom'],
-            mui: ['@mui/material', '@mui/icons-material'],
-            router: ['react-router-dom'],
-            recharts: ['recharts'],
+          manualChunks(id: string) {
+            if (id.includes('@mui/icons-material/')) {
+              const [, name] = id.split('@mui/icons-material/')
+              const iconName = path.parse(name).name
+              if (iconName === 'createSvgIcon') return 'mui'
+              return `mui-${iconName}`
+            }
+            if (id.includes('/node_modules/@mui/material/')) return 'mui'
+            if (id.includes('/node_modules/react-router-dom/')) return 'router'
+            if (id.includes('/node_modules/recharts/')) return 'recharts'
+            if (
+              id.includes('/node_modules/react/') ||
+              id.includes('/node_modules/react-dom/')
+            )
+              return 'react'
           },
         },
       },


### PR DESCRIPTION
## Summary
- remove icons from mui manual chunk
- dynamically chunk individual MUI icons
- import PasswordField icons directly

## Testing
- `npm test` *(fails: multiple failing tests including StaffRecurringBookings.test.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd004784c0832d907ac1d57cf98b9d