### PR TITLE
Include clientId in password setup emails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/
 
 | Template reference | Purpose | Params |
 | ------------------- | ------- | ------ |
-| `PASSWORD_SETUP_TEMPLATE_ID` | Account invitations and password reset emails | `link`, `token` |
+| `PASSWORD_SETUP_TEMPLATE_ID` | Account invitations and password reset emails | `link`, `token`, `clientId` |
 | `BOOKING_CONFIRMATION_TEMPLATE_ID` | Booking approval confirmations for clients | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` |
 | `BOOKING_REMINDER_TEMPLATE_ID` | Next-day booking reminders for clients | `body`, `cancelLink`, `rescheduleLink`, `type` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` |

--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -65,14 +65,18 @@ export async function requestPasswordReset(
 
     if (user) {
       const token = await generatePasswordSetupToken(user.table, user.id);
-        await sendTemplatedEmail({
-          to: user.email,
-          templateId: config.passwordSetupTemplateId,
-          params: {
-            link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
-            token,
-          },
-        });
+      const params: Record<string, unknown> = {
+        link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
+        token,
+      };
+      if (user.table === 'clients') {
+        params.clientId = user.id;
+      }
+      await sendTemplatedEmail({
+        to: user.email,
+        templateId: config.passwordSetupTemplateId,
+        params,
+      });
       logger.info(`Password reset requested for ${user.email}`);
     }
     res.status(204).send();
@@ -138,14 +142,18 @@ export async function resendPasswordSetup(
 
     if (user) {
       const token = await generatePasswordSetupToken(user.table, user.id);
-        await sendTemplatedEmail({
-          to: user.email,
-          templateId: config.passwordSetupTemplateId,
-          params: {
-            link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
-            token,
-          },
-        });
+      const params: Record<string, unknown> = {
+        link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
+        token,
+      };
+      if (user.table === 'clients') {
+        params.clientId = user.id;
+      }
+      await sendTemplatedEmail({
+        to: user.email,
+        templateId: config.passwordSetupTemplateId,
+        params,
+      });
       logger.info(`Password setup link resent for ${user.email}`);
     }
     res.status(204).send();

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -177,14 +177,16 @@ export async function createUser(req: Request, res: Response, next: NextFunction
 
     const token = await generatePasswordSetupToken('clients', clientId);
     if (email) {
-        await sendTemplatedEmail({
-          to: email,
-          templateId: config.passwordSetupTemplateId,
-          params: {
-            link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
-            token,
-          },
-        });
+      const params: Record<string, unknown> = {
+        link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
+        token,
+        clientId,
+      };
+      await sendTemplatedEmail({
+        to: email,
+        templateId: config.passwordSetupTemplateId,
+        params,
+      });
     }
 
     res.status(201).json({ message: 'User created' });

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -306,13 +306,15 @@ export async function createVolunteerShopperProfile(
     ]);
     const token = await generatePasswordSetupToken('clients', clientId);
     if (volRes.rows[0].email) {
+      const params: Record<string, unknown> = {
+        link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
+        token,
+        clientId,
+      };
       await sendTemplatedEmail({
         to: volRes.rows[0].email,
         templateId: config.passwordSetupTemplateId,
-        params: {
-          link: `${config.frontendOrigins[0]}/set-password?token=${token}`,
-          token,
-        },
+        params,
       });
     }
     res.status(201).json({ userId });

--- a/MJ_FB_Backend/tests/createUser.test.ts
+++ b/MJ_FB_Backend/tests/createUser.test.ts
@@ -60,7 +60,14 @@ describe('POST /users/add-client', () => {
     expect(res.body).toEqual({ message: 'User created' });
     expect(generatePasswordSetupToken).toHaveBeenCalledWith('clients', 123);
     expect(sendTemplatedEmail).toHaveBeenCalledWith(
-      expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
+      expect.objectContaining({
+        templateId: config.passwordSetupTemplateId,
+        params: {
+          link: `${config.frontendOrigins[0]}/set-password?token=tok`,
+          token: 'tok',
+          clientId: 123,
+        },
+      }),
     );
   });
 

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -68,6 +68,7 @@ describe('requestPasswordReset', () => {
         params: {
           link: `${config.frontendOrigins[0]}/set-password?token=tok`,
           token: 'tok',
+          clientId: 3,
         },
       }),
     );

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -171,6 +171,7 @@ describe('Volunteer shopper profile', () => {
     expect(sendTemplatedEmail).toHaveBeenCalledWith(
       expect.objectContaining({ templateId: config.passwordSetupTemplateId }),
     );
+    expect((sendTemplatedEmail as jest.Mock).mock.calls[0][0].params.clientId).toBe(123);
   });
 
   it('links to existing client when email matches regardless of case', async () => {

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 
 | Template reference | Purpose | Params |
 | ------------------- | ------- | ------ |
-| `PASSWORD_SETUP_TEMPLATE_ID` | Account invitations and password reset emails | `link`, `token` |
+| `PASSWORD_SETUP_TEMPLATE_ID` | Account invitations and password reset emails | `link`, `token`, `clientId` |
 | `BOOKING_CONFIRMATION_TEMPLATE_ID` | Booking approval confirmations for clients | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` |
 | `BOOKING_REMINDER_TEMPLATE_ID` | Next-day booking reminders for clients | `body`, `cancelLink`, `rescheduleLink`, `type` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` |

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -5,7 +5,7 @@ parameters supplied to each template.
 
 | Template reference | Purpose | Params | Used in |
 | ------------------- | ------- | ------ | ------- |
-| `PASSWORD_SETUP_TEMPLATE_ID` | Account invitations and password reset emails | `link`, `token` | `authController.ts`, `agencyController.ts`, `admin/staffController.ts`, `admin/adminStaffController.ts`, `volunteerController.ts`, `userController.ts` |
+| `PASSWORD_SETUP_TEMPLATE_ID` | Account invitations and password reset emails | `link`, `token`, `clientId` | `authController.ts`, `agencyController.ts`, `admin/staffController.ts`, `admin/adminStaffController.ts`, `volunteerController.ts`, `userController.ts` |
 | `BOOKING_CONFIRMATION_TEMPLATE_ID` | Booking approval confirmations for clients | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` | `bookingController.ts` |
 | `BOOKING_REMINDER_TEMPLATE_ID` | Next-day booking reminders for clients | `body`, `cancelLink`, `rescheduleLink`, `type` | `bookingReminderJob.ts` |
 | `VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID` | Volunteer shift confirmation emails | `body`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `outlookCalendarLink`, `appleCalendarLink`, `type` | `volunteerBookingController.ts` |


### PR DESCRIPTION
## Summary
- include clientId in password setup email params for client accounts
- document clientId as parameter of PASSWORD_SETUP_TEMPLATE_ID
- update tests expecting clientId in password setup email params

## Testing
- `nvm use`
- `npm test tests/passwordResetFlow.test.ts`
- `npm test tests/createUser.test.ts`
- `npm test` *(fails: GET /slots with invalid dates › returns 400 for invalid date format, GET /slots applies slot rules › uses weekday rules, GET /slots applies slot rules › uses Wednesday rules, GET /slots applies slot rules › lists Wednesday evening slot in range, GET /slots applies slot rules › marks slots blocked from recurring entries, GET /slots applies slot rules › marks slot as overbooked when approved bookings exceed capacity, GET /slots closed days › returns empty array on weekends, GET /slots closed days › returns empty array on holidays, client visit notes › persists note on update, client visit stats › aggregates stats by month, Past slot filtering › omits past slots for current day, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd07f125a4832d963f5b7c2f3ee01c