### PR TITLE
Expose account status in client lookup

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -233,7 +233,7 @@ export async function getUserByClientId(req: Request, res: Response, next: NextF
   try {
     const { clientId } = req.params;
     const result = await pool.query(
-      `SELECT client_id, first_name, last_name, email, phone
+      `SELECT client_id, first_name, last_name, email, phone, online_access, password
        FROM clients WHERE client_id = $1`,
       [clientId]
     );
@@ -247,6 +247,8 @@ export async function getUserByClientId(req: Request, res: Response, next: NextF
       email: row.email,
       phone: row.phone,
       clientId: row.client_id,
+      onlineAccess: row.online_access,
+      hasPassword: row.password != null,
     });
   } catch (error) {
     logger.error('Error fetching user by client ID:', error);

--- a/MJ_FB_Backend/tests/getUserByClientId.test.ts
+++ b/MJ_FB_Backend/tests/getUserByClientId.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/users', usersRouter);
+
+describe('GET /users/id/:clientId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns user details with online access and password flag', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [
+        {
+          client_id: 5,
+          first_name: 'Jane',
+          last_name: 'Doe',
+          email: 'jane@example.com',
+          phone: '123',
+          online_access: true,
+          password: 'hash',
+        },
+      ],
+    });
+
+    const res = await request(app).get('/users/id/5');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      phone: '123',
+      clientId: 5,
+      onlineAccess: true,
+      hasPassword: true,
+    });
+    expect(pool.query).toHaveBeenCalledWith(
+      `SELECT client_id, first_name, last_name, email, phone, online_access, password\n       FROM clients WHERE client_id = $1`,
+      ['5'],
+    );
+  });
+});

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -186,7 +186,19 @@ export async function searchUsers(search: string) {
   return handleResponse(res);
 }
 
-export async function getUserByClientId(clientId: string) {
+export interface UserByClientId {
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+  clientId: number;
+  onlineAccess: boolean;
+  hasPassword: boolean;
+}
+
+export async function getUserByClientId(
+  clientId: string,
+): Promise<UserByClientId> {
   const res = await apiFetch(`${API_BASE}/users/id/${clientId}`);
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -71,6 +71,7 @@ export default function UserHistory({
     onlineAccess: false,
     password: '',
   });
+  const [hasPassword, setHasPassword] = useState(false);
   const { t } = useTranslation();
   const { role } = useAuth();
   const showNotes = role === 'staff' || role === 'agency';
@@ -174,9 +175,10 @@ export default function UserHistory({
         lastName: data.lastName || '',
         email: data.email || '',
         phone: data.phone || '',
-        onlineAccess: Boolean((data as any).onlineAccess),
+        onlineAccess: Boolean(data.onlineAccess),
         password: '',
       });
+      setHasPassword(Boolean(data.hasPassword));
       setEditOpen(true);
     } catch {
       setSeverity('error');
@@ -193,7 +195,7 @@ export default function UserHistory({
         email: form.email || undefined,
         phone: form.phone || undefined,
         onlineAccess: form.onlineAccess,
-        ...(form.onlineAccess ? { password: form.password } : {}),
+        ...(!hasPassword && form.onlineAccess ? { password: form.password } : {}),
       });
       setSelected(s =>
         s ? { ...s, name: `${form.firstName} ${form.lastName}` } : s
@@ -387,17 +389,21 @@ export default function UserHistory({
               <DialogTitle>Edit Client</DialogTitle>
               <DialogContent>
               <Stack spacing={2} mt={1}>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={form.onlineAccess}
-                      onChange={e =>
-                        setForm({ ...form, onlineAccess: e.target.checked })
-                      }
-                    />
-                  }
-                  label="Online Access"
-                />
+                {hasPassword ? (
+                  <Typography>Client already has an account</Typography>
+                ) : (
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={form.onlineAccess}
+                        onChange={e =>
+                          setForm({ ...form, onlineAccess: e.target.checked })
+                        }
+                      />
+                    }
+                    label="Online Access"
+                  />
+                )}
                 <TextField
                   label="First Name"
                   value={form.firstName}
@@ -420,7 +426,7 @@ export default function UserHistory({
                   value={form.phone}
                   onChange={e => setForm({ ...form, phone: e.target.value })}
                 />
-                {form.onlineAccess && (
+                {!hasPassword && form.onlineAccess && (
                   <PasswordField
                     label="Password"
                     value={form.password}
@@ -439,7 +445,7 @@ export default function UserHistory({
                     disabled={
                       !form.firstName ||
                       !form.lastName ||
-                      (form.onlineAccess && !form.password)
+                      (!hasPassword && form.onlineAccess && !form.password)
                     }
                   >
                     Save


### PR DESCRIPTION
## Summary
- Return `onlineAccess` and `hasPassword` from `GET /users/id/:clientId`
- Surface account status in frontend API
- Show "Client already has an account" and hide password fields when applicable

## Testing
- `cd MJ_FB_Backend && npm test` *(fails: Expected '}', got '<eof>')*
- `cd MJ_FB_Frontend && npm test` *(fails: Unable to find a label with the text of: /select .* time slot/i)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0ce7b58c832d930ba9c2fa217bbf