### PR TITLE
Allow enabling online access without password

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -509,7 +509,7 @@ export async function updateUserByClientId(
     };
   try {
     if (onlineAccess) {
-      if (!password || !firstName || !lastName) {
+      if (!firstName || !lastName) {
         return res
           .status(400)
           .json({ message: 'Missing fields for online access' });
@@ -525,11 +525,11 @@ export async function updateUserByClientId(
         }
       }
 
-      const hashedPassword = await bcrypt.hash(password, 10);
+      const hashedPassword = password ? await bcrypt.hash(password, 10) : null;
       const result = await pool.query(
         `UPDATE clients
          SET first_name = $1, last_name = $2, email = $3, phone = $4,
-             online_access = true, password = $5
+             online_access = true, password = COALESCE($5, password)
          WHERE client_id = $6
          RETURNING client_id, first_name, last_name, email, phone, profile_link`,
         [

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -50,13 +50,7 @@ export const updateUserSchema = z.object({
   phone: z.string().optional(),
   onlineAccess: z.boolean().optional(),
   password: passwordSchema.optional(),
-}).refine(
-  data => !data.onlineAccess || (!!data.firstName && !!data.lastName),
-  {
-    message: 'firstName and lastName required for online access',
-    path: ['onlineAccess'],
-  },
-);
+});
 
 // Schema for users updating their own contact information. Either
 // email or phone must be provided, but both are optional.

--- a/MJ_FB_Backend/tests/updateUserByClientId.test.ts
+++ b/MJ_FB_Backend/tests/updateUserByClientId.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+import bcrypt from 'bcrypt';
+
+jest.mock('../src/db');
+jest.mock('bcrypt');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    (req as any).user = { role: 'staff' };
+    next();
+  },
+  authorizeRoles: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/users', usersRouter);
+
+describe('PATCH /users/id/:clientId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('enables online access without password', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{
+        client_id: 5,
+        first_name: 'Jane',
+        last_name: 'Doe',
+        email: null,
+        phone: null,
+        profile_link: 'link',
+      }],
+    });
+
+    const res = await request(app)
+      .patch('/users/id/5')
+      .send({
+        firstName: 'Jane',
+        lastName: 'Doe',
+        onlineAccess: true,
+      });
+    expect(res.status).toBe(200);
+    expect(bcrypt.hash).not.toHaveBeenCalled();
+    const params = (pool.query as jest.Mock).mock.calls[0][1];
+    expect(params).toEqual(['Jane', 'Doe', null, null, null, '5']);
+  });
+
+  it('enables online access with password', async () => {
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{
+        client_id: 5,
+        first_name: 'Jane',
+        last_name: 'Doe',
+        email: null,
+        phone: null,
+        profile_link: 'link',
+      }],
+    });
+
+    const res = await request(app)
+      .patch('/users/id/5')
+      .send({
+        firstName: 'Jane',
+        lastName: 'Doe',
+        onlineAccess: true,
+        password: 'Secret1!',
+      });
+    expect(res.status).toBe(200);
+    expect(bcrypt.hash).toHaveBeenCalledWith('Secret1!', 10);
+    const params = (pool.query as jest.Mock).mock.calls[0][1];
+    expect(params[4]).toBe('hashed');
+  });
+});


### PR DESCRIPTION
## Summary
- allow updating a client's online access without requiring a password
- permit optional password in update schema
- expose password field and reset-link button in staff client dialogs
- cover online access updates in backend and frontend tests

## Testing
- `npm test` *(backend: failures)*
- `npm test tests/updateUserByClientId.test.ts`
- `npm test` *(frontend: failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bd106947ac832d9442f57a85f69cbb