### PR TITLE
Ensure client visit dates have no timezone

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -130,7 +130,11 @@ export async function listVisits(req: Request, res: Response, next: NextFunction
        ORDER BY v.id`,
       [date]
     );
-    res.json(result.rows);
+    const rows = result.rows.map(r => ({
+      ...r,
+      date: formatReginaDate(r.date),
+    }));
+    res.json(rows);
   } catch (error) {
     logger.error('Error listing client visits:', error);
     next(error);

--- a/MJ_FB_Backend/tests/clientVisitController.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitController.test.ts
@@ -176,6 +176,31 @@ describe('client visit notes', () => {
     expect(res.body[0].children).toBe(2);
   });
 
+  it('returns dates in YYYY-MM-DD format', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 9,
+          date: new Date('2024-05-13T06:00:00.000Z'),
+          clientId: 123,
+          weightWithCart: null,
+          weightWithoutCart: null,
+          petItem: 0,
+          anonymous: false,
+          note: null,
+          adults: 0,
+          children: 0,
+          clientName: '',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const res = await request(app).get('/client-visits?date=2024-05-13');
+    expect(res.status).toBe(200);
+    expect(res.body[0].date).toBe('2024-05-13');
+  });
+
   it('allows null weights on create', async () => {
     const queryMock = jest
       .fn()

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -219,6 +219,34 @@ describe('PantryVisits', () => {
     expect(screen.getByText('Sunshine Bag Weight: 12')).toBeInTheDocument();
   });
 
+  it('displays visit dates without timezone shift', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-05-13T12:00:00Z'));
+    (getClientVisits as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        date: '2024-05-13',
+        clientId: 111,
+        clientName: 'Alice',
+        anonymous: false,
+        weightWithCart: null,
+        weightWithoutCart: null,
+        petItem: 0,
+        adults: 1,
+        children: 0,
+      },
+    ]);
+    (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
+    (getSunshineBag as jest.Mock).mockResolvedValue(null);
+
+    renderVisits();
+
+    await screen.findByText('Alice');
+
+    expect(screen.getByText('Mon, May 13, 2024')).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
   it('shows "No records" when there are no visits', async () => {
     (getClientVisits as jest.Mock).mockResolvedValue([]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });


### PR DESCRIPTION
## Summary
- format dates in client visit list with `formatReginaDate`
- return visit dates as `YYYY-MM-DD`
- test client visit date formatting on backend and frontend

## Testing
- `npx jest tests/clientVisitController.test.ts -t 'returns dates in YYYY-MM-DD format'`
- `npm test` *(fails: An update to VolunteerSchedule inside a test was not wrapped in act(...))*

------
https://chatgpt.com/codex/tasks/task_e_68bd10d2d588832da0c15dc8fdc95cf9