### PR TITLE
Disable online access toggle when password exists

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
@@ -78,4 +78,24 @@ describe('UpdateClientData', () => {
     );
     expect(requestPasswordReset).toHaveBeenCalledWith({ clientId: '1' });
   });
+
+  it('disables online access checkbox when client has password', async () => {
+    (getUserByClientId as jest.Mock).mockResolvedValueOnce({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: '',
+      phone: '',
+      onlineAccess: true,
+      hasPassword: true,
+    });
+
+    render(<UpdateClientData />);
+
+    await screen.findByRole('button', { name: 'Edit' });
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const checkbox = await screen.findByLabelText('Online Access');
+    expect(checkbox).toBeDisabled();
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+  });
 });

--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -287,6 +287,32 @@ describe('UserHistory', () => {
     expect(requestPasswordReset).toHaveBeenCalledWith({ clientId: '1' });
   });
 
+  it('disables online access checkbox when client has password', async () => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([]);
+    (getUserByClientId as jest.Mock).mockResolvedValue({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: '',
+      phone: '',
+      onlineAccess: true,
+      hasPassword: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/?name=Jane%20Doe&clientId=1']}>
+        <UserHistory />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('button', { name: /edit client/i });
+    fireEvent.click(screen.getByRole('button', { name: /edit client/i }));
+    await waitFor(() => expect(getUserByClientId).toHaveBeenCalled());
+
+    const checkbox = await screen.findByLabelText('Online Access');
+    expect(checkbox).toBeDisabled();
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+  });
+
   it('saves password when provided', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([]);
     (getUserByClientId as jest.Mock).mockResolvedValue({

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -15,6 +15,7 @@ import {
   Link,
   FormControlLabel,
   Checkbox,
+  Tooltip,
 } from "@mui/material";
 import Page from "../../../components/Page";
 import FeedbackSnackbar from "../../../components/FeedbackSnackbar";
@@ -40,6 +41,7 @@ export default function UpdateClientData() {
     phone: "",
     onlineAccess: false,
     password: "",
+    hasPassword: false,
   });
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -68,6 +70,7 @@ export default function UpdateClientData() {
         phone: data.phone || "",
         onlineAccess: Boolean(data.onlineAccess),
         password: "",
+        hasPassword: data.hasPassword,
       });
     } catch {
       setForm({
@@ -77,6 +80,7 @@ export default function UpdateClientData() {
         phone: client.phone || "",
         onlineAccess: false,
         password: "",
+        hasPassword: false,
       });
     }
   }
@@ -89,7 +93,7 @@ export default function UpdateClientData() {
         lastName: form.lastName,
         email: form.email || undefined,
         phone: form.phone || undefined,
-        onlineAccess: form.onlineAccess,
+        onlineAccess: form.hasPassword ? true : form.onlineAccess,
         ...(form.onlineAccess && form.password
           ? { password: form.password }
           : {}),
@@ -193,20 +197,28 @@ export default function UpdateClientData() {
         </DialogTitle>
         <DialogContent>
           <Stack spacing={2} mt={1}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={form.onlineAccess}
-                  onChange={(e) =>
-                    setForm({
-                      ...form,
-                      onlineAccess: e.target.checked,
-                    })
+            <Tooltip
+              title="Client already has a password"
+              disableHoverListener={!form.hasPassword}
+            >
+              <span>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={form.onlineAccess}
+                      onChange={(e) =>
+                        setForm({
+                          ...form,
+                          onlineAccess: e.target.checked,
+                        })
+                      }
+                      disabled={form.hasPassword}
+                    />
                   }
+                  label="Online Access"
                 />
-              }
-              label="Online Access"
-            />
+              </span>
+            </Tooltip>
             <TextField
               label="First Name"
               value={form.firstName}
@@ -231,7 +243,7 @@ export default function UpdateClientData() {
               value={form.phone}
               onChange={(e) => setForm({ ...form, phone: e.target.value })}
             />
-            {form.onlineAccess && (
+            {form.onlineAccess && !form.hasPassword && (
               <PasswordField
                 label="Password"
                 value={form.password}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -24,6 +24,7 @@ import {
   FormControlLabel,
   Checkbox,
   Stack,
+  Tooltip,
   Table,
   TableBody,
   TableCell,
@@ -74,6 +75,7 @@ export default function UserHistory({
     phone: '',
     onlineAccess: false,
     password: '',
+    hasPassword: false,
   });
   const { t } = useTranslation();
   const { role } = useAuth();
@@ -180,6 +182,7 @@ export default function UserHistory({
         phone: data.phone || '',
         onlineAccess: Boolean(data.onlineAccess),
         password: '',
+        hasPassword: data.hasPassword,
       });
       setEditOpen(true);
     } catch {
@@ -196,7 +199,7 @@ export default function UserHistory({
         lastName: form.lastName,
         email: form.email || undefined,
         phone: form.phone || undefined,
-        onlineAccess: form.onlineAccess,
+        onlineAccess: form.hasPassword ? true : form.onlineAccess,
         ...(form.onlineAccess && form.password
           ? { password: form.password }
           : {}),
@@ -409,17 +412,28 @@ export default function UserHistory({
               <DialogTitle>Edit Client</DialogTitle>
               <DialogContent>
               <Stack spacing={2} mt={1}>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={form.onlineAccess}
-                      onChange={e =>
-                        setForm({ ...form, onlineAccess: e.target.checked })
+                <Tooltip
+                  title="Client already has a password"
+                  disableHoverListener={!form.hasPassword}
+                >
+                  <span>
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={form.onlineAccess}
+                          onChange={e =>
+                            setForm({
+                              ...form,
+                              onlineAccess: e.target.checked,
+                            })
+                          }
+                          disabled={form.hasPassword}
+                        />
                       }
+                      label="Online Access"
                     />
-                  }
-                  label="Online Access"
-                />
+                  </span>
+                </Tooltip>
                 <TextField
                   label="First Name"
                   value={form.firstName}
@@ -442,7 +456,7 @@ export default function UserHistory({
                   value={form.phone}
                   onChange={e => setForm({ ...form, phone: e.target.value })}
                 />
-                {form.onlineAccess && (
+                {form.onlineAccess && !form.hasPassword && (
                   <PasswordField
                     label="Password"
                     value={form.password}


### PR DESCRIPTION
## Summary
- Disable online access checkbox when a client already has a password
- Hide password field in that case and explain with tooltip
- Add tests for checkbox disabling logic

## Testing
- `npm test` *(fails: various test failures such as UserHistory.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1394c954832daaa0a075148a46ca