### PR TITLE
fix: remove manual chunking to prevent production runtime error

### DIFF
--- a/MJ_FB_Frontend/vite.config.ts
+++ b/MJ_FB_Frontend/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig, type PluginOption } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'node:path'
 
 // https://vite.dev/config/
 export default defineConfig(async ({ mode }) => {
@@ -31,26 +30,11 @@ export default defineConfig(async ({ mode }) => {
     build: {
       target: 'es2020',
       sourcemap: false,
-      rollupOptions: {
-        output: {
-          manualChunks(id: string) {
-            if (id.includes('@mui/icons-material/')) {
-              const [, name] = id.split('@mui/icons-material/')
-              const iconName = path.parse(name).name
-              if (iconName === 'createSvgIcon') return 'mui'
-              return `mui-${iconName}`
-            }
-            if (id.includes('/node_modules/@mui/material/')) return 'mui'
-            if (id.includes('/node_modules/react-router-dom/')) return 'router'
-            if (id.includes('/node_modules/recharts/')) return 'recharts'
-            if (
-              id.includes('/node_modules/react/') ||
-              id.includes('/node_modules/react-dom/')
-            )
-              return 'react'
-          },
-        },
-      },
+      // manualChunks previously split vendor libraries into bespoke chunks.
+      // This caused a circular dependency between the React and MUI chunks
+      // that triggered "Cannot access 'Mn' before initialization" during
+      // production builds. Removing the configuration lets Rollup determine
+      // optimal chunks and avoids the runtime error.
     },
   }
 })


### PR DESCRIPTION
## Summary
- remove custom manualChunks configuration to eliminate React/MUI circular dependency that caused `Cannot access 'Mn' before initialization` in production

## Testing
- `npm test` *(fails: Unable to find an element with the text: Clients: 1 and other test failures)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd179eebd4832da18a941d60601091