### PR TITLE
Handle single data point in visit charts

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientVisitTrendChart.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientVisitTrendChart.test.tsx
@@ -21,6 +21,8 @@ const data = [
   { month: '2024-02', clients: 6, adults: 4, children: 2 },
 ];
 
+const singleMonthData = [{ month: '2024-01', clients: 5, adults: 3, children: 2 }];
+
 test('renders one line for total clients', () => {
   const { container } = render(
     <ThemeProvider theme={createTheme()}>
@@ -37,4 +39,22 @@ test('renders two lines for adults and children', () => {
     </ThemeProvider>,
   );
   expect(container.querySelectorAll('path.recharts-line-curve').length).toBe(2);
+});
+
+test('renders dots for single-month trend data', () => {
+  const { container } = render(
+    <ThemeProvider theme={createTheme()}>
+      <ClientVisitTrendChart data={singleMonthData} />
+    </ThemeProvider>,
+  );
+  expect(container.querySelectorAll('circle.recharts-line-dot').length).toBeGreaterThan(0);
+});
+
+test('renders dots for single-month breakdown data', () => {
+  const { container } = render(
+    <ThemeProvider theme={createTheme()}>
+      <ClientVisitBreakdownChart data={singleMonthData} />
+    </ThemeProvider>,
+  );
+  expect(container.querySelectorAll('circle.recharts-line-dot').length).toBeGreaterThan(0);
 });

--- a/MJ_FB_Frontend/src/components/dashboard/ClientVisitBreakdownChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/ClientVisitBreakdownChart.tsx
@@ -17,9 +17,13 @@ interface Props {
 
 export default function ClientVisitBreakdownChart({ data }: Props) {
   const theme = useTheme();
+  const chartData =
+    data.length === 1
+      ? [...data, { month: '', clients: 0, adults: 0, children: 0 }]
+      : data;
   return (
     <ResponsiveContainer width="100%" height={300} data-testid="visit-breakdown-chart">
-      <LineChart data={data}>
+      <LineChart data={chartData}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="month" />
         <YAxis allowDecimals={false} />

--- a/MJ_FB_Frontend/src/components/dashboard/ClientVisitTrendChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/ClientVisitTrendChart.tsx
@@ -17,9 +17,13 @@ interface Props {
 
 export default function ClientVisitTrendChart({ data }: Props) {
   const theme = useTheme();
+  const chartData =
+    data.length === 1
+      ? [...data, { month: '', clients: 0, adults: 0, children: 0 }]
+      : data;
   return (
     <ResponsiveContainer width="100%" height={300} data-testid="visit-trend-chart">
-      <LineChart data={data}>
+      <LineChart data={chartData}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="month" />
         <YAxis allowDecimals={false} />


### PR DESCRIPTION
## Summary
- Ensure client visit trend and breakdown charts render a dot when only one month of data is present by appending a zero-valued month
- Add unit tests covering single-month datasets for both charts

## Testing
- `npm test src/__tests__/ClientVisitTrendChart.test.tsx`
- `npm test` *(fails: UserHistory.test.tsx, PantryVisits.test.tsx, RecurringBookings.test.tsx, PantrySchedule.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd205eedac832d9008ac943e7bedd8