### PR TITLE
Handle Date objects in toDayjs

### DIFF
--- a/MJ_FB_Frontend/src/utils/__tests__/date.test.ts
+++ b/MJ_FB_Frontend/src/utils/__tests__/date.test.ts
@@ -1,0 +1,8 @@
+import { formatReginaDate } from '../date';
+
+describe('toDayjs with Date input', () => {
+  test('preserves original day', () => {
+    const d = new Date('2024-09-02');
+    expect(formatReginaDate(d)).toBe('2024-09-02');
+  });
+});

--- a/MJ_FB_Frontend/src/utils/date.ts
+++ b/MJ_FB_Frontend/src/utils/date.ts
@@ -15,6 +15,10 @@ export function toDayjs(input?: ConfigType) {
   if (input === undefined || input === null || input === '') {
     return dayjs();
   }
+  if (input instanceof Date) {
+    const parsed = dayjs(input).tz(REGINA_TIMEZONE, true);
+    return parsed.isValid() ? parsed : dayjs(NaN);
+  }
   const isLocalString =
     typeof input === 'string' && !/([zZ]|[+-]\d{2}:?\d{2})$/.test(input);
   const parsed = dayjs(input).tz(REGINA_TIMEZONE, isLocalString);


### PR DESCRIPTION
## Summary
- Preserve day when converting Date objects in toDayjs
- Add test for Date formatting in Regina timezone

## Testing
- `npm test` *(fails: Missing elements, navigation not implemented errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd22e68398832db23621da1404004c