### PR TITLE
fix volunteer coverage date handling

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
@@ -80,6 +80,30 @@ describe('ClientDashboard', () => {
     expect(chipLabel.closest('.MuiChip-colorSuccess')).toBeTruthy();
   });
 
+  it('displays visit dates without timezone shift', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-16T12:00:00Z'));
+    (getBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'visited',
+        date: '2024-01-15',
+      },
+    ]);
+    (getSlots as jest.Mock).mockResolvedValue([]);
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+
+    render(
+      <MemoryRouter>
+        <ClientDashboard />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
+    expect(screen.getByText('Mon, Jan 15, 2024')).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
   it('hides client note in booking history', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([
       {

--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -75,6 +75,31 @@ describe('UserHistory', () => {
     expect(screen.getByText(/bring ID/i)).toBeInTheDocument();
   });
 
+  it('displays visit dates without timezone shift', async () => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'visited',
+        date: '2024-01-15',
+        start_time: null,
+        end_time: null,
+        created_at: '2024-01-15',
+        slot_id: null,
+        is_staff_booking: false,
+        reschedule_token: null,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
+    expect(await screen.findByText('Jan 15, 2024')).toBeInTheDocument();
+  });
+
   it('hides edit client button when initialUser is provided', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([]);
     render(

--- a/MJ_FB_Frontend/src/__tests__/VolunteerCoverageCard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerCoverageCard.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import VolunteerCoverageCard from '../components/dashboard/VolunteerCoverageCard';
+import { getVolunteerRoles, getVolunteerBookingsByRole } from '../api/volunteers';
+
+jest.mock('../api/volunteers', () => ({
+  getVolunteerRoles: jest.fn(),
+  getVolunteerBookingsByRole: jest.fn(),
+}));
+
+describe('VolunteerCoverageCard', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('counts bookings for today without timezone shift', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-15T12:00:00Z'));
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'Greeter', category_name: 'Front', max_volunteers: 2 },
+    ]);
+    (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([
+      { status: 'approved', date: '2024-01-15' },
+      { status: 'approved', date: '2024-01-14' },
+    ]);
+
+    render(<VolunteerCoverageCard />);
+
+    await waitFor(() => expect(getVolunteerBookingsByRole).toHaveBeenCalled());
+    expect(await screen.findByText('1/2')).toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -3,6 +3,7 @@ import { List, ListItem, ListItemText, Chip, type SxProps, type Theme } from '@m
 import SectionCard from './SectionCard';
 import { getVolunteerRoles, getVolunteerBookingsByRole } from '../../api/volunteers';
 import { formatReginaDate } from '../../utils/time';
+import { toDate } from '../../utils/date';
 import FeedbackSnackbar from '../FeedbackSnackbar';
 
 interface CoverageItem {
@@ -27,7 +28,7 @@ export default function VolunteerCoverageCard({
   const [error, setError] = useState('');
 
   useEffect(() => {
-    const todayStr = formatReginaDate(new Date());
+    const todayStr = formatReginaDate(toDate());
 
     getVolunteerRoles()
       .then(roles =>
@@ -42,7 +43,7 @@ export default function VolunteerCoverageCard({
             const filled = bookings.filter(
               (b: any) =>
                 b.status === 'approved' &&
-                formatReginaDate(new Date(b.date)) === todayStr,
+                formatReginaDate(toDate(b.date)) === todayStr,
             ).length;
             return {
               roleName: r.name,


### PR DESCRIPTION
## Summary
- normalize volunteer coverage dates using `toDate` to avoid timezone shifts
- add regression tests for visit date display on client and user history pages
- test volunteer coverage date handling

## Testing
- `npm test` *(fails: ReferenceError clearImmediate not defined, markResourceTiming not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68bd22f1f8f0832d81bf2902d721d176