### PR TITLE
Handle missing new_clients table in reschedule

### DIFF
--- a/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
+++ b/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
@@ -58,6 +58,7 @@ fetchBookingByTokenMock.mockResolvedValue({
 poolQueryMock
   .mockResolvedValueOnce({ rows: [{ start_time: '09:00', end_time: '10:00' }] })
   .mockResolvedValueOnce({ rows: [{ start_time: '11:00', end_time: '12:00' }] })
+  .mockResolvedValueOnce({ rows: [{ exists: true }] })
   .mockResolvedValueOnce({ rows: [{ email: 'client@example.com' }] });
 
 describe('rescheduleBooking', () => {


### PR DESCRIPTION
## Summary
- avoid 42P01 errors when rescheduling by checking for the presence of the new_clients table before joining
- adjust backend tests to mock table existence and booking utils

## Testing
- `npm test tests/bookingRescheduleEmail.test.ts`
- `npm test tests/volunteerShopperBooking.test.ts`
- `npm test tests/agency.test.ts`
- `npm test` *(fails: 16 failed, 94 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd22c41ce8832d87b92bf43d87f4bc