### PR TITLE
Format email type param

### DIFF
--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -2,6 +2,13 @@ import config from '../config';
 import logger from './logger';
 import { buildIcsFile } from './calendarLinks';
 
+function toTitleCase(value: string): string {
+  return value
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
 export async function sendEmail(
   to: string,
   subject: string,
@@ -78,6 +85,13 @@ export async function sendTemplatedEmail({
     return;
   }
 
+  const formattedParams: Record<string, unknown> | undefined = params
+    ? { ...params }
+    : undefined;
+  if (formattedParams && typeof formattedParams['type'] === 'string') {
+    formattedParams['type'] = toTitleCase(formattedParams['type'] as string);
+  }
+
   try {
     const response = await fetch('https://api.brevo.com/v3/smtp/email', {
       method: 'POST',
@@ -92,7 +106,7 @@ export async function sendTemplatedEmail({
         },
         to: [{ email: to }],
         templateId,
-        params: params || undefined,
+        params: formattedParams || undefined,
       }),
     });
 

--- a/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
+++ b/MJ_FB_Backend/tests/sendTemplatedEmail.test.ts
@@ -43,4 +43,15 @@ describe('sendTemplatedEmail', () => {
       params: { name: 'Tester' },
     });
   });
+
+  it('capitalizes the type param', async () => {
+    await sendTemplatedEmail({
+      to: 'user@example.com',
+      templateId: 123,
+      params: { type: 'shopping appointment' },
+    });
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.params.type).toBe('Shopping Appointment');
+  });
 });


### PR DESCRIPTION
## Summary
- Title-case Brevo email `type` parameter
- Add test covering `type` normalization

## Testing
- `npm test` *(fails: SyntaxError in tests/volunteers.test.ts, TypeError redefining properties, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2408f8f8832db1ab1c06a0de8c74