### PR TITLE
Ensure booking history dates are plain strings

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -203,7 +203,7 @@ export async function fetchBookingHistory(
     ? `CASE WHEN b.status IN ('visited','no_show') THEN NULL ELSE b.note END AS client_note,`
     : 'NULL AS client_note,';
   const res = await client.query(
-    `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason,
+    `SELECT b.id, b.status, to_char(b.date, 'YYYY-MM-DD') AS date, b.slot_id, b.request_data AS reason,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.start_time END AS start_time,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.end_time END AS end_time,
             b.created_at, b.is_staff_booking, b.reschedule_token, ${clientNoteSelect}
@@ -222,7 +222,7 @@ export async function fetchBookingHistory(
       visitWhere.push('v.date < CURRENT_DATE');
     }
     const visitRes = await client.query(
-      `SELECT v.id, 'visited' AS status, v.date, NULL AS slot_id, NULL AS reason, NULL AS start_time, NULL AS end_time, v.date AS created_at, false AS is_staff_booking, NULL AS reschedule_token, v.note AS staff_note
+      `SELECT v.id, 'visited' AS status, to_char(v.date, 'YYYY-MM-DD') AS date, NULL AS slot_id, NULL AS reason, NULL AS start_time, NULL AS end_time, to_char(v.date, 'YYYY-MM-DD') AS created_at, false AS is_staff_booking, NULL AS reschedule_token, v.note AS staff_note
          FROM client_visits v
          INNER JOIN clients c ON c.client_id = v.client_id
          LEFT JOIN bookings b ON b.user_id = c.client_id AND b.date = v.date


### PR DESCRIPTION
## Summary
- Cast booking and visit dates to `YYYY-MM-DD` in booking history queries
- Cover date formatting with new repository tests

## Testing
- `npm test -- tests/bookingRepository.test.ts tests/bookingHistoryVisits.test.ts`
- `npm test` *(fails: 16 failed, 94 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd29cd044c832da8d5695fac994175