### PR TITLE
Return booking history dates as plain strings

### DIFF
--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -14,6 +14,7 @@
 - Requires Node.js 22+ for native `fetch`; development is pinned via `.nvmrc`, and `.npmrc` sets `engine-strict=true` to prevent using other Node versions. GitHub Actions reads `.nvmrc` to keep CI builds and tests on the same runtime.
 - The `clients` table uses `client_id` as its primary key; do not reference an `id` column for clients.
 - The `volunteers` table no longer includes a `username` column, and `email` must be unique though it can be null.
+- PostgreSQL `DATE` fields are returned as plain strings (`YYYY-MM-DD`) via a custom type parser; avoid converting them to JS `Date` objects unless a time-of-day is required.
 
 ## Email & Jobs
 

--- a/MJ_FB_Backend/src/db.ts
+++ b/MJ_FB_Backend/src/db.ts
@@ -1,9 +1,12 @@
 // src/db.ts
-import { Pool } from 'pg';
+import { Pool, types } from 'pg';
 import fs from 'fs';
 import path from 'path';
 import config from './config';
 import logger from './utils/logger';
+
+// Ensure DATE columns are returned as plain strings (YYYY-MM-DD)
+types.setTypeParser(1082, (val) => val);
 
 const isLocal = ['localhost', '127.0.0.1'].includes(config.pgHost);
 

--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -203,7 +203,7 @@ export async function fetchBookingHistory(
     ? `CASE WHEN b.status IN ('visited','no_show') THEN NULL ELSE b.note END AS client_note,`
     : 'NULL AS client_note,';
   const res = await client.query(
-    `SELECT b.id, b.status, b.date, b.slot_id, b.request_data AS reason,
+    `SELECT b.id, b.status, to_char(b.date, 'YYYY-MM-DD') AS date, b.slot_id, b.request_data AS reason,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.start_time END AS start_time,
             CASE WHEN b.slot_id IS NULL THEN NULL ELSE s.end_time END AS end_time,
             b.created_at, b.is_staff_booking, b.reschedule_token, ${clientNoteSelect}
@@ -222,7 +222,7 @@ export async function fetchBookingHistory(
       visitWhere.push('v.date < CURRENT_DATE');
     }
     const visitRes = await client.query(
-      `SELECT v.id, 'visited' AS status, v.date, NULL AS slot_id, NULL AS reason, NULL AS start_time, NULL AS end_time, v.date AS created_at, false AS is_staff_booking, NULL AS reschedule_token, v.note AS staff_note
+      `SELECT v.id, 'visited' AS status, to_char(v.date, 'YYYY-MM-DD') AS date, NULL AS slot_id, NULL AS reason, NULL AS start_time, NULL AS end_time, to_char(v.date, 'YYYY-MM-DD') AS created_at, false AS is_staff_booking, NULL AS reschedule_token, v.note AS staff_note
          FROM client_visits v
          INNER JOIN clients c ON c.client_id = v.client_id
          LEFT JOIN bookings b ON b.user_id = c.client_id AND b.date = v.date

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -195,4 +195,20 @@ describe('bookingRepository', () => {
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/NULL AS client_note/);
   });
+
+  it('fetchBookingHistory formats booking dates as YYYY-MM-DD', async () => {
+    setQueryResults({ rows: [] });
+    await fetchBookingHistory([1], false, undefined, false);
+    const call = (mockPool.query as jest.Mock).mock.calls[0];
+    expect(call[0]).toMatch(/to_char\(b.date, 'YYYY-MM-DD'\) AS date/);
+  });
+
+  it('fetchBookingHistory formats visit dates as YYYY-MM-DD', async () => {
+    (mockPool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    await fetchBookingHistory([1], false, undefined, true);
+    const visitCall = (mockPool.query as jest.Mock).mock.calls[1];
+    expect(visitCall[0]).toMatch(/to_char\(v.date, 'YYYY-MM-DD'\) AS date/);
+  });
 });

--- a/MJ_FB_Backend/tests/dbDateParser.test.ts
+++ b/MJ_FB_Backend/tests/dbDateParser.test.ts
@@ -1,0 +1,10 @@
+import { types } from 'pg';
+import '../src/db';
+
+describe('pg date parser', () => {
+  it('returns DATE fields as raw YYYY-MM-DD strings', () => {
+    const parser = types.getTypeParser(1082);
+    expect(parser('2024-05-06')).toBe('2024-05-06');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Ensure pg date columns are parsed as raw strings
- Format booking history and visit dates as YYYY-MM-DD
- Add tests covering date formatting and parser behavior

## Testing
- `npm test` *(fails: Expected 200 but received 404 in several slot tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd277720c0832d98bd08615e7689c3