### PR TITLE
Parse PG DATE fields as plain strings

### DIFF
--- a/MJ_FB_Backend/src/db.ts
+++ b/MJ_FB_Backend/src/db.ts
@@ -1,9 +1,12 @@
 // src/db.ts
-import { Pool } from 'pg';
+import { Pool, types } from 'pg';
 import fs from 'fs';
 import path from 'path';
 import config from './config';
 import logger from './utils/logger';
+
+// Parse DATE (OID 1082) as YYYY-MM-DD strings to avoid timezone shifts
+types.setTypeParser(1082, (val) => val);
 
 const isLocal = ['localhost', '127.0.0.1'].includes(config.pgHost);
 

--- a/MJ_FB_Backend/tests/dateParser.test.ts
+++ b/MJ_FB_Backend/tests/dateParser.test.ts
@@ -1,0 +1,9 @@
+import { types } from 'pg';
+import '../src/db';
+
+describe('pg DATE type parser', () => {
+  it('returns YYYY-MM-DD strings without timezone conversion', () => {
+    const parser = types.getTypeParser(1082, 'text');
+    expect(parser('2024-03-10')).toBe('2024-03-10');
+  });
+});


### PR DESCRIPTION
## Summary
- Parse PostgreSQL DATE (OID 1082) values as raw `YYYY-MM-DD` strings in the backend
- Add test ensuring the pg driver returns DATE strings without timezone conversion

## Testing
- `npm test` *(fails: Test Suites: 17 failed, 94 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2b876c98832dae84a9010739f914