### PR TITLE
Add index for client visits monthly lookups

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000008_add_client_visits_client_date_idx.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000008_add_client_visits_client_date_idx.ts
@@ -1,0 +1,9 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('CREATE INDEX CONCURRENTLY client_visits_client_date_idx ON client_visits (client_id, date);');
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('DROP INDEX CONCURRENTLY IF EXISTS client_visits_client_date_idx;');
+}


### PR DESCRIPTION
## Summary
- add migration creating an index on client_visits (client_id, date) using CREATE INDEX CONCURRENTLY

## Testing
- `npm test` (fails: Test Suites: 20 failed, 91 passed)
- `npm run migrate` (fails: could not connect to postgres)


------
https://chatgpt.com/codex/tasks/task_e_68bd2d4559ac832dae1b94126275dee4