### PR TITLE
feat: add bookings date status index

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000008_add_bookings_date_status_idx.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000008_add_bookings_date_status_idx.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction();
+  pgm.sql(`CREATE INDEX CONCURRENTLY bookings_date_status_idx ON bookings (date, status);`);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction();
+  pgm.sql('DROP INDEX CONCURRENTLY IF EXISTS bookings_date_status_idx;');
+}


### PR DESCRIPTION
## Summary
- add concurrent index on bookings date and status to speed up reminder queries

## Testing
- `npm test` (fails: 19 failed, 92 passed)
- `npm run migrate` (fails: missing JWT secrets)


------
https://chatgpt.com/codex/tasks/task_e_68bd2d429058832db90d55e3cbc45e9a