### PR TITLE
Return booking id from insertBooking

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -48,9 +48,9 @@ export async function insertBooking(
   client: Queryable = pool,
 ) {
   const reginaDate = formatReginaDate(date);
-  await client.query(
+  const res = await client.query(
     `INSERT INTO bookings (user_id, new_client_id, slot_id, status, request_data, note, date, is_staff_booking, reschedule_token)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
     [
       userId,
       newClientId,
@@ -63,6 +63,7 @@ export async function insertBooking(
       rescheduleToken,
     ],
   );
+  return res.rows[0].id;
 }
 
 export async function fetchBookingById(id: number, client: Queryable = pool) {

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -41,8 +41,8 @@ describe('bookingRepository', () => {
   });
 
   it('insertBooking calls query with correct params', async () => {
-    setQueryResults({});
-    await insertBooking(1, 2, 'approved', '', '2024-01-01', false, 'token', null, 'note');
+    setQueryResults({ rows: [{ id: 1 }] });
+    const id = await insertBooking(1, 2, 'approved', '', '2024-01-01', false, 'token', null, 'note');
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/INSERT INTO bookings/);
     expect(call[1]).toEqual(
@@ -59,6 +59,7 @@ describe('bookingRepository', () => {
       ]),
     );
     expect(call[1]).toHaveLength(9);
+    expect(id).toBe(1);
   });
 
   it('updateBooking ignores disallowed keys', async () => {


### PR DESCRIPTION
## Summary
- return inserted booking id in `insertBooking` by adding `RETURNING id`
- update tests to expect returned id

## Testing
- `npm test` *(fails: Test Suites: 20 failed, 91 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d3e5d18832da42ef034b5ab700d