### PR TITLE
format date when updating booking

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -91,7 +91,10 @@ export async function updateBooking(
   const keys = Object.keys(fields).filter((k) => whitelist.includes(k));
   if (keys.length === 0) return;
   const setClause = keys.map((key, idx) => `${key}=$${idx + 2}`).join(', ');
-  const params = [id, ...keys.map((k) => fields[k])];
+  const params = [
+    id,
+    ...keys.map((k) => (k === 'date' ? formatReginaDate(fields[k]) : fields[k])),
+  ];
   await client.query(`UPDATE bookings SET ${setClause} WHERE id=$1`, params);
 }
 

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -8,6 +8,7 @@ import {
   fetchBookingsForReminder,
   fetchBookingHistory,
 } from '../src/models/bookingRepository';
+import { formatReginaDate } from '../src/utils/dateUtils';
 
 
 describe('bookingRepository', () => {
@@ -76,6 +77,17 @@ describe('bookingRepository', () => {
     expect(sql).toEqual(expect.stringContaining('WHERE id=$1'));
     expect(params).toEqual(expect.arrayContaining([1, 'cancelled', 'reason']));
     expect(params).toHaveLength(3);
+  });
+
+  it('updateBooking formats date field', async () => {
+    setQueryResults({});
+    const date = '2024-01-01T06:00:00Z';
+    await updateBooking(1, { date });
+    const params = (mockPool.query as jest.Mock).mock.calls[0][1];
+    expect(params).toEqual([
+      1,
+      formatReginaDate(date),
+    ]);
   });
 
   it('updateBooking returns early when only disallowed keys provided', async () => {


### PR DESCRIPTION
## Summary
- ensure booking updates format incoming dates using Regina timezone
- test date formatting in booking repository

## Testing
- `npm test tests/bookingRepository.test.ts`
- `npm test` *(fails: 19 failed, 92 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d376284832db243a60271153fdf