### PR TITLE
refactor: manage indexes via migrations

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000008_add_password_setup_tokens_token_hash_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000008_add_password_setup_tokens_token_hash_index.ts
@@ -1,0 +1,17 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('password_setup_tokens', [
+  "token_hash"
+], {
+    unique: true,
+    ifNotExists: true,
+    name: 'password_setup_tokens_token_hash_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('password_setup_tokens', [
+  "token_hash"
+], { name: 'password_setup_tokens_token_hash_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000009_add_slots_start_end_unique_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000009_add_slots_start_end_unique_index.ts
@@ -1,0 +1,19 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('slots', [
+  "start_time",
+  "end_time"
+], {
+    unique: true,
+    ifNotExists: true,
+    name: 'slots_unique_start_end'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('slots', [
+  "start_time",
+  "end_time"
+], { name: 'slots_unique_start_end' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000010_add_volunteer_slots_role_time_unique_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000010_add_volunteer_slots_role_time_unique_index.ts
@@ -1,0 +1,21 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('volunteer_slots', [
+  "role_id",
+  "start_time",
+  "end_time"
+], {
+    unique: true,
+    ifNotExists: true,
+    name: 'volunteer_slots_unique_role_time'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('volunteer_slots', [
+  "role_id",
+  "start_time",
+  "end_time"
+], { name: 'volunteer_slots_unique_role_time' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000011_add_volunteer_bookings_unique_volunteer_slot_date_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000011_add_volunteer_bookings_unique_volunteer_slot_date_index.ts
@@ -1,0 +1,22 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('volunteer_bookings', [
+  "volunteer_id",
+  "slot_id",
+  "date"
+], {
+    unique: true,
+    ifNotExists: true,
+    where: "status <> 'cancelled'",
+    name: 'volunteer_bookings_unique_volunteer_slot_date'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('volunteer_bookings', [
+  "volunteer_id",
+  "slot_id",
+  "date"
+], { name: 'volunteer_bookings_unique_volunteer_slot_date' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000012_add_bookings_user_id_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000012_add_bookings_user_id_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('bookings', [
+  "user_id"
+], {
+    ifNotExists: true,
+    name: 'bookings_user_id_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('bookings', [
+  "user_id"
+], { name: 'bookings_user_id_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000013_add_bookings_new_client_id_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000013_add_bookings_new_client_id_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('bookings', [
+  "new_client_id"
+], {
+    ifNotExists: true,
+    name: 'bookings_new_client_id_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('bookings', [
+  "new_client_id"
+], { name: 'bookings_new_client_id_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000014_add_bookings_slot_date_status_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000014_add_bookings_slot_date_status_index.ts
@@ -1,0 +1,20 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('bookings', [
+  "slot_id",
+  "date",
+  "status"
+], {
+    ifNotExists: true,
+    name: 'bookings_slot_date_status_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('bookings', [
+  "slot_id",
+  "date",
+  "status"
+], { name: 'bookings_slot_date_status_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000015_add_bookings_reschedule_token_unique_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000015_add_bookings_reschedule_token_unique_index.ts
@@ -1,0 +1,17 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('bookings', [
+  "reschedule_token"
+], {
+    unique: true,
+    ifNotExists: true,
+    name: 'bookings_reschedule_token_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('bookings', [
+  "reschedule_token"
+], { name: 'bookings_reschedule_token_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000016_add_volunteer_bookings_volunteer_id_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000016_add_volunteer_bookings_volunteer_id_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('volunteer_bookings', [
+  "volunteer_id"
+], {
+    ifNotExists: true,
+    name: 'volunteer_bookings_volunteer_id_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('volunteer_bookings', [
+  "volunteer_id"
+], { name: 'volunteer_bookings_volunteer_id_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000017_add_volunteer_bookings_slot_date_status_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000017_add_volunteer_bookings_slot_date_status_index.ts
@@ -1,0 +1,20 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('volunteer_bookings', [
+  "slot_id",
+  "date",
+  "status"
+], {
+    ifNotExists: true,
+    name: 'volunteer_bookings_slot_date_status_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('volunteer_bookings', [
+  "slot_id",
+  "date",
+  "status"
+], { name: 'volunteer_bookings_slot_date_status_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000018_add_volunteer_bookings_reschedule_token_unique_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000018_add_volunteer_bookings_reschedule_token_unique_index.ts
@@ -1,0 +1,17 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('volunteer_bookings', [
+  "reschedule_token"
+], {
+    unique: true,
+    ifNotExists: true,
+    name: 'volunteer_bookings_reschedule_token_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('volunteer_bookings', [
+  "reschedule_token"
+], { name: 'volunteer_bookings_reschedule_token_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000019_add_new_clients_created_at_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000019_add_new_clients_created_at_index.ts
@@ -1,0 +1,12 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('new_clients', [{ name: 'created_at', sort: 'DESC' }], {
+    ifNotExists: true,
+    name: 'new_clients_created_at_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('new_clients', ['created_at'], { name: 'new_clients_created_at_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000020_add_donations_donor_id_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000020_add_donations_donor_id_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('donations', [
+  "donor_id"
+], {
+    ifNotExists: true,
+    name: 'donations_donor_id_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('donations', [
+  "donor_id"
+], { name: 'donations_donor_id_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000021_add_donations_date_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000021_add_donations_date_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('donations', [
+  "date"
+], {
+    ifNotExists: true,
+    name: 'donations_date_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('donations', [
+  "date"
+], { name: 'donations_date_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000022_add_client_visits_date_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000022_add_client_visits_date_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('client_visits', [
+  "date"
+], {
+    ifNotExists: true,
+    name: 'client_visits_date_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('client_visits', [
+  "date"
+], { name: 'client_visits_date_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000023_add_client_visits_client_id_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000023_add_client_visits_client_id_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('client_visits', [
+  "client_id"
+], {
+    ifNotExists: true,
+    name: 'client_visits_client_id_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('client_visits', [
+  "client_id"
+], { name: 'client_visits_client_id_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000024_add_events_start_date_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000024_add_events_start_date_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('events', [
+  "start_date"
+], {
+    ifNotExists: true,
+    name: 'events_start_date_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('events', [
+  "start_date"
+], { name: 'events_start_date_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000025_add_surplus_log_date_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000025_add_surplus_log_date_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('surplus_log', [
+  "date"
+], {
+    ifNotExists: true,
+    name: 'surplus_log_date_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('surplus_log', [
+  "date"
+], { name: 'surplus_log_date_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000026_add_pig_pound_log_date_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000026_add_pig_pound_log_date_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('pig_pound_log', [
+  "date"
+], {
+    ifNotExists: true,
+    name: 'pig_pound_log_date_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('pig_pound_log', [
+  "date"
+], { name: 'pig_pound_log_date_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000027_add_outgoing_donation_log_receiver_date_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000027_add_outgoing_donation_log_receiver_date_index.ts
@@ -1,0 +1,18 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('outgoing_donation_log', [
+  "receiver_id",
+  "date"
+], {
+    ifNotExists: true,
+    name: 'outgoing_donation_log_receiver_date_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('outgoing_donation_log', [
+  "receiver_id",
+  "date"
+], { name: 'outgoing_donation_log_receiver_date_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000028_add_warehouse_overall_year_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000028_add_warehouse_overall_year_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('warehouse_overall', [
+  "year"
+], {
+    ifNotExists: true,
+    name: 'warehouse_overall_year_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('warehouse_overall', [
+  "year"
+], { name: 'warehouse_overall_year_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000029_add_donor_aggregations_year_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000029_add_donor_aggregations_year_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('donor_aggregations', [
+  "year"
+], {
+    ifNotExists: true,
+    name: 'donor_aggregations_year_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('donor_aggregations', [
+  "year"
+], { name: 'donor_aggregations_year_idx' });
+}

--- a/MJ_FB_Backend/src/migrations/1700000000030_add_email_queue_next_attempt_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000030_add_email_queue_next_attempt_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('email_queue', [
+  "next_attempt"
+], {
+    ifNotExists: true,
+    name: 'email_queue_next_attempt_idx'
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('email_queue', [
+  "next_attempt"
+], { name: 'email_queue_next_attempt_idx' });
+}

--- a/MJ_FB_Backend/src/setupDatabase.ts
+++ b/MJ_FB_Backend/src/setupDatabase.ts
@@ -474,11 +474,9 @@ CREATE TABLE IF NOT EXISTS email_queue (
     $$ LANGUAGE plpgsql;
   `);
 
-  await client.query(
-    `CREATE UNIQUE INDEX IF NOT EXISTS password_setup_tokens_token_hash_idx ON password_setup_tokens (token_hash);`
-  );
+  // Indexes are managed via migrations
 
-  // Remove duplicate slots and enforce uniqueness
+  // Remove duplicate slots; uniqueness enforced via migrations
   await client.query(`
     DELETE FROM slots a
     USING slots b
@@ -486,11 +484,8 @@ CREATE TABLE IF NOT EXISTS email_queue (
       AND a.start_time = b.start_time
       AND a.end_time = b.end_time;
   `);
-  await client.query(
-    `CREATE UNIQUE INDEX IF NOT EXISTS slots_unique_start_end ON slots (start_time, end_time);`
-  );
 
-  // Remove duplicate volunteer slots and enforce uniqueness
+  // Remove duplicate volunteer slots; uniqueness enforced via migrations
   await client.query(`
     DELETE FROM volunteer_slots a
     USING volunteer_slots b
@@ -499,11 +494,8 @@ CREATE TABLE IF NOT EXISTS email_queue (
       AND a.start_time = b.start_time
       AND a.end_time = b.end_time;
   `);
-  await client.query(
-    `CREATE UNIQUE INDEX IF NOT EXISTS volunteer_slots_unique_role_time ON volunteer_slots (role_id, start_time, end_time);`
-  );
 
-    // Remove duplicate volunteer bookings and enforce uniqueness
+    // Remove duplicate volunteer bookings; uniqueness enforced via migrations
     await client.query(`
       DELETE FROM volunteer_bookings a
       USING volunteer_bookings b
@@ -514,73 +506,6 @@ CREATE TABLE IF NOT EXISTS email_queue (
         AND a.status <> 'cancelled'
         AND b.status <> 'cancelled';
     `);
-    await client.query(
-      `CREATE UNIQUE INDEX IF NOT EXISTS volunteer_bookings_unique_volunteer_slot_date ON volunteer_bookings (volunteer_id, slot_id, date) WHERE status <> 'cancelled';`
-    );
-
-  // Create indexes for faster lookups on bookings and volunteer_bookings
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS bookings_user_id_idx ON bookings (user_id);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS bookings_new_client_id_idx ON bookings (new_client_id);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS bookings_slot_date_status_idx ON bookings (slot_id, date, status);`
-  );
-  await client.query(
-    `CREATE UNIQUE INDEX IF NOT EXISTS bookings_reschedule_token_idx ON bookings (reschedule_token);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS volunteer_bookings_volunteer_id_idx ON volunteer_bookings (volunteer_id);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS volunteer_bookings_slot_date_status_idx ON volunteer_bookings (slot_id, date, status);`
-  );
-  await client.query(
-    `CREATE UNIQUE INDEX IF NOT EXISTS volunteer_bookings_reschedule_token_idx ON volunteer_bookings (reschedule_token);`
-  );
-
-  // Create index for new_clients creation date
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS new_clients_created_at_idx ON new_clients (created_at DESC);`
-  );
-
-  // Create indexes for donation and warehouse log tables
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS donations_donor_id_idx ON donations (donor_id);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS donations_date_idx ON donations (date);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS client_visits_date_idx ON client_visits (date);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS client_visits_client_id_idx ON client_visits (client_id);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS events_start_date_idx ON events (start_date);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS surplus_log_date_idx ON surplus_log (date);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS pig_pound_log_date_idx ON pig_pound_log (date);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS outgoing_donation_log_receiver_date_idx ON outgoing_donation_log (receiver_id, date);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS warehouse_overall_year_idx ON warehouse_overall (year);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS donor_aggregations_year_idx ON donor_aggregations (year);`
-  );
-  await client.query(
-    `CREATE INDEX IF NOT EXISTS email_queue_next_attempt_idx ON email_queue (next_attempt);`
-  );
-
   // Insert master data
   await client.query(`
 INSERT INTO slots (start_time, end_time, max_capacity) VALUES


### PR DESCRIPTION
## Summary
- remove inline index creation from setupDatabase
- add migrations for all indexes including bookings, volunteer bookings, and logs

## Testing
- `npm test` *(fails: 19 failed, 92 passed)*
- `npm run migrate` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d483f38832db1996b2f4d6d5398