### PR TITLE
fix: avoid transaction for client visits index

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000008_add_client_visits_client_date_idx.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000008_add_client_visits_client_date_idx.ts
@@ -1,9 +1,11 @@
 import type { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction();
   pgm.sql('CREATE INDEX CONCURRENTLY client_visits_client_date_idx ON client_visits (client_id, date);');
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction();
   pgm.sql('DROP INDEX CONCURRENTLY IF EXISTS client_visits_client_date_idx;');
 }


### PR DESCRIPTION
## Summary
- avoid wrapping `client_visits` index migration in a transaction so `CREATE INDEX CONCURRENTLY` can run

## Testing
- `npm test` *(fails: Test Suites: 19 failed, 92 passed, 111 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f5da2d8832da1abec0a95420064