### PR TITLE
Make booking note optional in booking API

### DIFF
--- a/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
@@ -40,4 +40,12 @@ describe('bookings api', () => {
       body: JSON.stringify({ slotId: 3, date: '2024-05-01', note: 'note', type: 'shopping appointment' }),
     }));
   });
+
+  it('omits note when blank', async () => {
+    await createBooking('4', '2024-05-01', '   ');
+    expect(apiFetch).toHaveBeenCalledWith('/api/bookings', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ slotId: 4, date: '2024-05-01', type: 'shopping appointment' }),
+    }));
+  });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -31,7 +31,7 @@ interface SlotsByDateResponse {
 interface CreateBookingBody {
   slotId: number;
   date: string;
-  note: string;
+  note?: string;
   userId?: number;
   type: string;
 }
@@ -80,16 +80,15 @@ export async function getSlotsRange(
 export async function createBooking(
   slotId: string,
   date: string,
-  note: string,
+  note?: string,
   userId?: number,
 ) {
   const body: CreateBookingBody = {
     slotId: Number(slotId),
     date,
-    note,
     type: 'shopping appointment',
   };
-  if (note) body.note = note;
+  if (note && note.trim()) body.note = note;
   if (userId) body.userId = userId;
   const res = await apiFetch(`${API_BASE}/bookings`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Allow omitting booking notes when creating bookings
- Only include `note` in booking creation requests when it's non-empty
- Test that blank notes are excluded from booking requests

## Testing
- `npm test` *(fails: UserHistory.test.tsx, StaffRecurringBookings.test.tsx, HelpPage.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d53d3a0832db41a9472e0cbef21