### PR TITLE
feat: add optional volunteer password setup

### DIFF
--- a/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
@@ -12,6 +12,8 @@ import {
   deleteVolunteer,
 } from '../../controllers/volunteer/volunteerController';
 import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
+import { validate } from '../../middleware/validate';
+import { createVolunteerSchema } from '../../schemas/volunteer/volunteerSchemas';
 
 const router = express.Router();
 
@@ -27,6 +29,7 @@ router.post(
   '/',
   authMiddleware,
   authorizeRoles('staff'),
+  validate(createVolunteerSchema),
   createVolunteer
 );
 

--- a/MJ_FB_Backend/src/schemas/volunteer/volunteerSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/volunteer/volunteerSchemas.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { passwordSchema } from '../../utils/passwordUtils';
+
+export const createVolunteerSchema = z
+  .object({
+    firstName: z.string().min(1),
+    lastName: z.string().min(1),
+    email: z.string().email().optional(),
+    phone: z.string().optional(),
+    roleIds: z.array(z.number().int().positive()).nonempty(),
+    onlineAccess: z.boolean().optional(),
+    password: passwordSchema.optional(),
+    sendPasswordLink: z.boolean().optional(),
+  })
+  .refine(data => !data.onlineAccess || !!data.email, {
+    message: 'Email required for online account',
+    path: ['email'],
+  })
+  .refine(data => !(data.password && data.sendPasswordLink), {
+    message: 'Cannot provide password and sendPasswordLink',
+    path: ['password'],
+  })
+  .refine(data => !data.password || !!data.email, {
+    message: 'Email required when providing password',
+    path: ['email'],
+  })
+  .refine(data => !data.sendPasswordLink || !!data.email, {
+    message: 'Email required to send password link',
+    path: ['email'],
+  });


### PR DESCRIPTION
## Summary
- add createVolunteerSchema with optional password and setup link flags
- hash volunteer password if provided and only send setup email when requested
- cover volunteer creation flows with new tests

## Testing
- `npm test tests/volunteers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bdb19ea580832d9a34cdf20d63e055