### PR TITLE
feat: allow setting client password on add

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/usersApi.test.ts
+++ b/MJ_FB_Frontend/src/__tests__/usersApi.test.ts
@@ -25,4 +25,34 @@ describe('users api', () => {
     expect(apiFetch).not.toHaveBeenCalled();
   });
 
+  it('sends password and flag to addUser', async () => {
+    await addUser(
+      'John',
+      'Doe',
+      '123',
+      'shopper',
+      true,
+      'john@example.com',
+      undefined,
+      'P@ssword1',
+      false,
+    );
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/users/add-client',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          firstName: 'John',
+          lastName: 'Doe',
+          clientId: 123,
+          role: 'shopper',
+          onlineAccess: true,
+          email: 'john@example.com',
+          password: 'P@ssword1',
+          sendPasswordLink: false,
+        }),
+      }),
+    );
+  });
+
 });

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -156,6 +156,8 @@ export async function addUser(
   onlineAccess: boolean,
   email?: string,
   phone?: string,
+  password?: string,
+  sendPasswordLink?: boolean,
 ): Promise<void> {
   const id = Number(clientId);
   if (!Number.isInteger(id)) {
@@ -174,6 +176,8 @@ export async function addUser(
       onlineAccess,
       email,
       phone,
+      password,
+      sendPasswordLink,
     }),
   });
   await handleResponse(res);

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/AddClient.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/AddClient.test.tsx
@@ -25,3 +25,23 @@ it('requires email when online access enabled', async () => {
   expect(await screen.findByText('First name, last name, client ID and email required')).toBeInTheDocument();
   expect(addUser).not.toHaveBeenCalled();
 });
+
+it('requires password when set password selected', async () => {
+  render(
+    <MemoryRouter>
+      <AddClient />
+    </MemoryRouter>,
+  );
+
+  fireEvent.click(screen.getByLabelText(/online access/i));
+  fireEvent.click(screen.getByRole('button', { name: /set password/i }));
+  fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'Jane' } });
+  fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'Doe' } });
+  fireEvent.change(screen.getByLabelText(/client id/i), { target: { value: '123' } });
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'jane@example.com' } });
+
+  fireEvent.click(screen.getByRole('button', { name: /add client/i }));
+
+  expect(await screen.findByText('Password required')).toBeInTheDocument();
+  expect(addUser).not.toHaveBeenCalled();
+});

--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -3,8 +3,20 @@ import { addUser } from '../../../api/users';
 import type { UserRole } from '../../../types';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import FeedbackModal from '../../../components/FeedbackModal';
-import { Box, Button, Stack, TextField, MenuItem, Typography, FormControlLabel, Checkbox } from '@mui/material';
+import {
+  Box,
+  Button,
+  Stack,
+  TextField,
+  MenuItem,
+  Typography,
+  FormControlLabel,
+  Checkbox,
+  ToggleButtonGroup,
+  ToggleButton,
+} from '@mui/material';
 import Page from '../../../components/Page';
+import PasswordField from '../../../components/PasswordField';
 
 export default function AddClient() {
   const [email, setEmail] = useState('');
@@ -17,11 +29,17 @@ export default function AddClient() {
   const [lastName, setLastName] = useState('');
   const [clientId, setClientId] = useState('');
   const [onlineAccess, setOnlineAccess] = useState(false);
+  const [sendPasswordLink, setSendPasswordLink] = useState(true);
+  const [password, setPassword] = useState('');
 
   async function submitUser() {
     if (onlineAccess) {
       if (!firstName || !lastName || !clientId || !email) {
         setError('First name, last name, client ID and email required');
+        return;
+      }
+      if (!sendPasswordLink && !password) {
+        setError('Password required');
         return;
       }
     } else if (!clientId) {
@@ -36,7 +54,9 @@ export default function AddClient() {
         role,
         onlineAccess,
         email || undefined,
-        phone || undefined
+        phone || undefined,
+        sendPasswordLink ? undefined : password || undefined,
+        sendPasswordLink
       );
       setSuccess('Client added successfully');
       setFirstName('');
@@ -45,6 +65,8 @@ export default function AddClient() {
       setEmail('');
       setPhone('');
       setOnlineAccess(false);
+      setSendPasswordLink(true);
+      setPassword('');
       setRole('shopper');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
@@ -59,13 +81,43 @@ export default function AddClient() {
           <FeedbackModal open={!!success} onClose={() => setSuccess('')} message={success} />
           <Stack spacing={2}>
           <FormControlLabel
-            control={<Checkbox checked={onlineAccess} onChange={e => setOnlineAccess(e.target.checked)} />}
+            control={
+              <Checkbox
+                checked={onlineAccess}
+                onChange={e => {
+                  setOnlineAccess(e.target.checked);
+                  if (!e.target.checked) {
+                    setSendPasswordLink(true);
+                    setPassword('');
+                  }
+                }}
+              />
+            }
             label="Online Access"
           />
           {onlineAccess && (
-            <Typography variant="body2" color="text.secondary">
-              An email invitation will be sent.
-            </Typography>
+            <>
+              <ToggleButtonGroup
+                size="small"
+                value={sendPasswordLink ? 'link' : 'password'}
+                exclusive
+                onChange={(_, v) => v && setSendPasswordLink(v === 'link')}
+              >
+                <ToggleButton value="link">Send link</ToggleButton>
+                <ToggleButton value="password">Set password</ToggleButton>
+              </ToggleButtonGroup>
+              {sendPasswordLink ? (
+                <Typography variant="body2" color="text.secondary">
+                  An email invitation will be sent.
+                </Typography>
+              ) : (
+                <PasswordField
+                  label="Password"
+                  value={password}
+                  onChange={e => setPassword(e.target.value)}
+                />
+              )}
+            </>
           )}
           <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
           <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />


### PR DESCRIPTION
## Summary
- allow setting client password when adding a client and toggle between sending link or direct password
- extend addUser API to accept password and sendPasswordLink options
- test addUser and AddClient for new password flow

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /search/i)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb1a37de4832daada397d9f033553