### PR TITLE
docs: document password setup options in help page

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/HelpPage.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/HelpPage.test.tsx
@@ -95,5 +95,24 @@ describe('HelpPage', () => {
       screen.getByText(/Fill in hours for each day\./i),
     ).toBeInTheDocument();
   });
+
+  it('mentions password setup choices in management sections', () => {
+    mockUseAuth.mockReturnValue({
+      role: 'staff',
+      access: ['pantry'],
+      token: '',
+      name: '',
+      userRole: '',
+      login: jest.fn(),
+      logout: jest.fn(),
+      cardUrl: '',
+      ready: true,
+      id: null,
+    } as any);
+    renderPage();
+    expect(
+      screen.getAllByText(/Set Password or Send Setup Link/i),
+    ).toHaveLength(2);
+  });
 });
 

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -265,23 +265,26 @@ export function getHelpContent(
     {
       title: 'Manage clients',
       body: {
-        description: 'Search, add, update, and delete client accounts.',
+        description:
+          'Search, add, update, and delete client accounts. Choose Set Password or Send Setup Link for online access.',
         steps: [
           'Go to the Client Management page.',
           'Search by name or client ID.',
           'View, edit, or delete client information.',
+          'Choose Set Password or Send Setup Link when enabling online access.',
         ],
       },
     },
     {
       title: 'Manage volunteers',
       body: {
-        description: 'Search, add, delete, and review volunteers.',
+        description:
+          'Search, add, delete, and review volunteers. Choose Set Password or Send Setup Link for online access.',
         steps: [
           'Go to the Volunteers page.',
           'Search by name.',
           'View, edit, or delete volunteer information.',
-          'Check Online Access to email login details when creating a volunteer.',
+          'Choose Set Password or Send Setup Link when creating a volunteer.',
         ],
       },
     },


### PR DESCRIPTION
## Summary
- document Set Password vs Send Setup Link choices for client and volunteer management help sections
- test that Help page includes password setup guidance

## Testing
- `npm test` *(fails: UserHistory allows staff to delete visits, RecurringBookings, ClientDashboard, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb3ff80ac832d8147ae49eaabb6b9