### PR TITLE
Expose password presence in search results

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -219,7 +219,7 @@ export async function searchUsers(req: Request, res: Response, next: NextFunctio
     }
 
     const usersResult = await pool.query(
-      `SELECT client_id, first_name, last_name, email, phone
+      `SELECT client_id, first_name, last_name, email, phone, password
        FROM clients
        WHERE (first_name || ' ' || last_name) ILIKE $1
           OR email ILIKE $1
@@ -235,6 +235,7 @@ export async function searchUsers(req: Request, res: Response, next: NextFunctio
       email: u.email,
       phone: u.phone,
       client_id: u.client_id,
+      hasPassword: u.password != null,
     }));
 
     res.json(formatted);

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -371,7 +371,7 @@ export async function searchVolunteers(req: Request, res: Response, next: NextFu
     }
 
     const result = await pool.query(
-      `SELECT v.id, v.first_name, v.last_name, v.user_id,
+      `SELECT v.id, v.first_name, v.last_name, v.user_id, v.password,
               ARRAY_REMOVE(ARRAY_AGG(vtr.role_id), NULL) AS role_ids
        FROM volunteers v
        LEFT JOIN volunteer_trained_roles vtr ON v.id = vtr.volunteer_id
@@ -389,6 +389,8 @@ export async function searchVolunteers(req: Request, res: Response, next: NextFu
       name: `${v.first_name} ${v.last_name}`.trim(),
       trainedAreas: (v.role_ids || []).map(Number),
       hasShopper: Boolean(v.user_id),
+      hasPassword: v.password != null,
+      clientId: v.user_id,
     }));
 
     res.json(formatted);

--- a/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
@@ -11,7 +11,11 @@ jest.mock('../api/bookings', () => ({
 }));
 
 jest.mock('../components/EntitySearch', () => (props: any) => (
-  <button onClick={() => props.onSelect({ name: 'Client One', client_id: 1 })}>
+  <button
+    onClick={() =>
+      props.onSelect({ name: 'Client One', client_id: 1, hasPassword: false })
+    }
+  >
     select client
   </button>
 ));

--- a/MJ_FB_Frontend/src/__tests__/AgencyClientManager.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyClientManager.test.tsx
@@ -12,7 +12,7 @@ jest.mock('../components/EntitySearch', () =>
     if (type === 'agency') {
       return <button onClick={() => onSelect({ id: 1, name: 'Agency A' })}>select agency</button>;
     }
-    const user = { id: 2, name: 'Client C', client_id: 2 };
+    const user = { id: 2, name: 'Client C', client_id: 2, hasPassword: false };
     return <div>{renderResult(user, () => onSelect(user))}</div>;
   },
 );

--- a/MJ_FB_Frontend/src/__tests__/DeleteVolunteer.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DeleteVolunteer.test.tsx
@@ -6,7 +6,20 @@ import { deleteVolunteer } from '../api/volunteers';
 jest.mock('../api/volunteers', () => ({ deleteVolunteer: jest.fn() }));
 
 jest.mock('../components/EntitySearch', () => (props: any) => (
-  <button onClick={() => props.onSelect({ id: 2, name: 'Jane' })}>Select Volunteer</button>
+  <button
+    onClick={() =>
+      props.onSelect({
+        id: 2,
+        name: 'Jane',
+        trainedAreas: [],
+        hasShopper: false,
+        hasPassword: false,
+        clientId: null,
+      })
+    }
+  >
+    Select Volunteer
+  </button>
 ));
 
 describe('DeleteVolunteer', () => {

--- a/MJ_FB_Frontend/src/__tests__/EntitySearch.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/EntitySearch.test.tsx
@@ -3,7 +3,9 @@ import EntitySearch from '../components/EntitySearch';
 
 describe('EntitySearch', () => {
   it('clears query after selection when clearOnSelect is true', async () => {
-    const searchFn = jest.fn().mockResolvedValue([{ id: 1, name: 'Client 1', client_id: 1 }]);
+    const searchFn = jest
+      .fn()
+      .mockResolvedValue([{ id: 1, name: 'Client 1', client_id: 1, hasPassword: false }]);
     render(
       <EntitySearch
         type="user"

--- a/MJ_FB_Frontend/src/__tests__/StaffRecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffRecurringBookings.test.tsx
@@ -12,7 +12,18 @@ import {
 jest.mock('../components/EntitySearch', () => ({
   __esModule: true,
   default: ({ onSelect }: any) => (
-    <button onClick={() => onSelect({ id: 7, name: 'Test Vol' })}>
+    <button
+      onClick={() =>
+        onSelect({
+          id: 7,
+          name: 'Test Vol',
+          trainedAreas: [],
+          hasShopper: false,
+          hasPassword: false,
+          clientId: null,
+        })
+      }
+    >
       Select Volunteer
     </button>
   ),

--- a/MJ_FB_Frontend/src/__tests__/StaffRecurringBookingsSearch.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffRecurringBookingsSearch.test.tsx
@@ -23,7 +23,7 @@ jest.mock('../api/volunteers', () => ({
 describe('StaffRecurringBookings volunteer search', () => {
   beforeEach(() => {
     (searchVolunteers as jest.Mock).mockResolvedValue([
-      { id: 7, name: 'Test Vol' },
+      { id: 7, name: 'Test Vol', trainedAreas: [], hasShopper: false, hasPassword: false, clientId: null },
     ]);
     (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
     (getRecurringVolunteerBookingsForVolunteer as jest.Mock).mockResolvedValue([]);

--- a/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UserHistory.test.tsx
@@ -61,7 +61,7 @@ describe('UserHistory', () => {
 
     render(
       <MemoryRouter>
-        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1, hasPassword: false }} />
       </MemoryRouter>,
     );
 
@@ -92,7 +92,7 @@ describe('UserHistory', () => {
 
     render(
       <MemoryRouter>
-        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1, hasPassword: false }} />
       </MemoryRouter>,
     );
 
@@ -104,7 +104,7 @@ describe('UserHistory', () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([]);
     render(
       <MemoryRouter>
-        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1, hasPassword: false }} />
       </MemoryRouter>,
     );
 
@@ -120,7 +120,7 @@ describe('UserHistory', () => {
 
     render(
       <MemoryRouter>
-        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1, hasPassword: false }} />
       </MemoryRouter>,
     );
 
@@ -171,7 +171,7 @@ describe('UserHistory', () => {
 
     render(
       <MemoryRouter>
-        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1, hasPassword: false }} />
       </MemoryRouter>,
     );
 
@@ -203,7 +203,7 @@ describe('UserHistory', () => {
 
     render(
       <MemoryRouter>
-        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1, hasPassword: false }} />
       </MemoryRouter>,
     );
 
@@ -229,7 +229,7 @@ describe('UserHistory', () => {
 
     render(
       <MemoryRouter>
-        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1, hasPassword: false }} />
       </MemoryRouter>,
     );
 
@@ -262,7 +262,7 @@ describe('UserHistory', () => {
 
     render(
       <MemoryRouter>
-        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1 }} />
+        <UserHistory initialUser={{ id: 1, name: 'Test', client_id: 1, hasPassword: false }} />
       </MemoryRouter>,
     );
 

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -30,7 +30,14 @@ jest.mock('../api/volunteers', () => ({
   createVolunteer: jest.fn(),
 }));
 
-let mockVolunteer: any = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+let mockVolunteer: any = {
+  id: 1,
+  name: 'Test Vol',
+  trainedAreas: [],
+  hasShopper: false,
+  hasPassword: false,
+  clientId: null,
+};
 
 jest.mock('../components/EntitySearch', () => (props: any) => (
   <button onClick={() => props.onSelect(mockVolunteer)}>Select Volunteer</button>
@@ -143,7 +150,14 @@ describe('VolunteerManagement create volunteer', () => {
 
 describe('VolunteerManagement shopper profile', () => {
   it('creates shopper profile for volunteer', async () => {
-    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: false,
+      hasPassword: false,
+      clientId: null,
+    };
     (searchVolunteers as jest.Mock)
       .mockResolvedValueOnce([mockVolunteer])
       .mockResolvedValueOnce([{ ...mockVolunteer, hasShopper: true }]);
@@ -177,7 +191,14 @@ describe('VolunteerManagement shopper profile', () => {
   });
 
   it('removes shopper profile for volunteer', async () => {
-    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: true };
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: true,
+      hasPassword: false,
+      clientId: 5,
+    };
     (searchVolunteers as jest.Mock)
       .mockResolvedValueOnce([mockVolunteer])
       .mockResolvedValueOnce([{ ...mockVolunteer, hasShopper: false }]);
@@ -207,7 +228,14 @@ describe('VolunteerManagement shopper profile', () => {
 
 describe('VolunteerManagement search reset', () => {
   it('clears selected volunteer when leaving search tab', async () => {
-    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: false,
+      hasPassword: false,
+      clientId: null,
+    };
     (searchVolunteers as jest.Mock).mockResolvedValue([mockVolunteer]);
 
     let navigateFn: (path: string) => void = () => {};
@@ -241,7 +269,14 @@ describe('VolunteerManagement search reset', () => {
 
 describe('VolunteerManagement role updates', () => {
   it('saves trained roles for volunteer', async () => {
-    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: false,
+      hasPassword: false,
+      clientId: null,
+    };
     (searchVolunteers as jest.Mock).mockResolvedValue([mockVolunteer]);
     (getVolunteerRoles as jest.Mock).mockResolvedValue([
       {

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -183,11 +183,21 @@ export async function addUser(
   await handleResponse(res);
 }
 
-export async function searchUsers(search: string) {
+export async function searchUsers(
+  search: string,
+): Promise<UserSearchResult[]> {
   const res = await apiFetch(
     `${API_BASE}/users/search?search=${encodeURIComponent(search)}`,
   );
   return handleResponse(res);
+}
+
+export interface UserSearchResult {
+  name: string;
+  email: string | null;
+  phone: string | null;
+  client_id: number;
+  hasPassword: boolean;
 }
 
 export interface UserByClientId {

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -42,7 +42,18 @@ export async function getVolunteerProfile(): Promise<UserProfile> {
   return handleResponse(res);
 }
 
-export async function searchVolunteers(search: string) {
+export interface VolunteerSearchResult {
+  id: number;
+  name: string;
+  trainedAreas: number[];
+  hasShopper: boolean;
+  hasPassword: boolean;
+  clientId: number | null;
+}
+
+export async function searchVolunteers(
+  search: string,
+): Promise<VolunteerSearchResult[]> {
   const res = await apiFetch(
     `${API_BASE}/volunteers/search?search=${encodeURIComponent(search)}`,
   );

--- a/MJ_FB_Frontend/src/components/EntitySearch.tsx
+++ b/MJ_FB_Frontend/src/components/EntitySearch.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { TextField, Button } from '@mui/material';
+import { TextField, Button, Typography } from '@mui/material';
 import { searchUsers } from '../api/users';
 import { searchVolunteers } from '../api/volunteers';
 import { searchAgencies } from '../api/agencies';
@@ -8,6 +8,8 @@ interface SearchResultBase {
   id?: number | string;
   name: string;
   client_id?: number | string;
+  hasPassword?: boolean;
+  clientId?: number | string;
 }
 
 interface EntitySearchProps<T extends SearchResultBase> {
@@ -92,13 +94,22 @@ export default function EntitySearch<T extends SearchResultBase>({
               {renderResult ? (
                 renderResult(r, () => handleSelect(r))
               ) : (
-                <Button
-                  onClick={() => handleSelect(r)}
-                  variant="outlined"
-                  color="primary"
-                >
-                  {getLabel(r)}
-                </Button>
+                <div>
+                  <Button
+                    onClick={() => handleSelect(r)}
+                    variant="outlined"
+                    color="primary"
+                  >
+                    {getLabel(r)}
+                  </Button>
+                  {r.hasPassword && (
+                    <Typography variant="caption">
+                      {type === 'volunteer'
+                        ? 'Volunteer has an online account'
+                        : 'Client has an online account'}
+                    </Typography>
+                  )}
+                </div>
               )}
             </li>
           ))}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -80,6 +80,8 @@ interface VolunteerResult {
   name: string;
   trainedAreas: number[];
   hasShopper: boolean;
+  hasPassword: boolean;
+  clientId: number | null;
 }
 
 interface VolunteerManagementProps {
@@ -287,7 +289,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
     const id = searchParams.get('id');
     const name = searchParams.get('name');
     if (id && name) {
-      selectVolunteer({ id: Number(id), name, trainedAreas: [], hasShopper: false });
+      selectVolunteer({ id: Number(id), name, trainedAreas: [], hasShopper: false, hasPassword: false, clientId: null });
     }
   }, [tab, searchParams, selectedVolunteer]);
 
@@ -346,7 +348,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
     } catch {
       // ignore
     }
-    return { id, name, trainedAreas: [], hasShopper: false };
+    return { id, name, trainedAreas: [], hasShopper: false, hasPassword: false, clientId: null };
   }
 
   async function refreshVolunteer() {


### PR DESCRIPTION
## Summary
- Include `hasPassword` flag in user and volunteer search endpoints
- Surface linked client ID for volunteer search results
- Show caption in entity search when a result has an online account

## Testing
- `cd MJ_FB_Backend && npm test` *(fails: Timesheet not found, Cannot edit stat holiday, etc.)*
- `cd MJ_FB_Frontend && npm test` *(fails: various jsdom and act(...) warnings, timeout in fetchWithRetry.test, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc253e738832da32f5519fea00432