### PR TITLE
Include client details in volunteer search results

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -372,6 +372,7 @@ export async function searchVolunteers(req: Request, res: Response, next: NextFu
 
     const result = await pool.query(
       `SELECT v.id, v.first_name, v.last_name, v.user_id,
+              v.password IS NOT NULL AS has_password,
               ARRAY_REMOVE(ARRAY_AGG(vtr.role_id), NULL) AS role_ids
        FROM volunteers v
        LEFT JOIN volunteer_trained_roles vtr ON v.id = vtr.volunteer_id
@@ -389,6 +390,8 @@ export async function searchVolunteers(req: Request, res: Response, next: NextFu
       name: `${v.first_name} ${v.last_name}`.trim(),
       trainedAreas: (v.role_ids || []).map(Number),
       hasShopper: Boolean(v.user_id),
+      ...(v.user_id && { clientId: Number(v.user_id) }),
+      hasPassword: v.has_password,
     }));
 
     res.json(formatted);

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -180,6 +180,45 @@ describe('Volunteer routes role ID validation', () => {
   });
 });
 
+describe('Search volunteers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns clientId and hasPassword when shopper profile linked', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({
+      rowCount: 1,
+      rows: [
+        {
+          id: 1,
+          first_name: 'Jane',
+          last_name: 'Doe',
+          user_id: 7,
+          has_password: true,
+          role_ids: [2],
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/volunteers/search')
+      .query({ search: 'Jane' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: 1,
+        name: 'Jane Doe',
+        trainedAreas: [2],
+        hasShopper: true,
+        clientId: 7,
+        hasPassword: true,
+      },
+    ]);
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('SELECT v.id'), ['%Jane%']);
+  });
+});
+
 describe('Volunteer shopper profile', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -30,7 +30,13 @@ jest.mock('../api/volunteers', () => ({
   createVolunteer: jest.fn(),
 }));
 
-let mockVolunteer: any = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+let mockVolunteer: any = {
+  id: 1,
+  name: 'Test Vol',
+  trainedAreas: [],
+  hasShopper: false,
+  hasPassword: false,
+};
 
 jest.mock('../components/EntitySearch', () => (props: any) => (
   <button onClick={() => props.onSelect(mockVolunteer)}>Select Volunteer</button>
@@ -143,7 +149,13 @@ describe('VolunteerManagement create volunteer', () => {
 
 describe('VolunteerManagement shopper profile', () => {
   it('creates shopper profile for volunteer', async () => {
-    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: false,
+      hasPassword: false,
+    };
     (searchVolunteers as jest.Mock)
       .mockResolvedValueOnce([mockVolunteer])
       .mockResolvedValueOnce([{ ...mockVolunteer, hasShopper: true }]);
@@ -177,7 +189,14 @@ describe('VolunteerManagement shopper profile', () => {
   });
 
   it('removes shopper profile for volunteer', async () => {
-    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: true };
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: true,
+      hasPassword: false,
+      clientId: 123,
+    };
     (searchVolunteers as jest.Mock)
       .mockResolvedValueOnce([mockVolunteer])
       .mockResolvedValueOnce([{ ...mockVolunteer, hasShopper: false }]);
@@ -203,11 +222,47 @@ describe('VolunteerManagement shopper profile', () => {
       expect(screen.getByLabelText(/shopper profile/i)).not.toBeChecked()
     );
   });
+
+  it('shows captions for linked shopper profile and online account', async () => {
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: true,
+      hasPassword: true,
+      clientId: 456,
+    };
+    (searchVolunteers as jest.Mock).mockResolvedValue([mockVolunteer]);
+
+    render(
+      <MemoryRouter initialEntries={['/volunteers/search']}>
+        <Routes>
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText('Select Volunteer'));
+    expect(
+      await screen.findByText('Volunteer has an online account'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This profile has a shopper profile attached to it. Client ID: 456',
+      ),
+    ).toBeInTheDocument();
+  });
 });
 
 describe('VolunteerManagement search reset', () => {
   it('clears selected volunteer when leaving search tab', async () => {
-    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: false,
+      hasPassword: false,
+    };
     (searchVolunteers as jest.Mock).mockResolvedValue([mockVolunteer]);
 
     let navigateFn: (path: string) => void = () => {};
@@ -241,7 +296,13 @@ describe('VolunteerManagement search reset', () => {
 
 describe('VolunteerManagement role updates', () => {
   it('saves trained roles for volunteer', async () => {
-    mockVolunteer = { id: 1, name: 'Test Vol', trainedAreas: [], hasShopper: false };
+    mockVolunteer = {
+      id: 1,
+      name: 'Test Vol',
+      trainedAreas: [],
+      hasShopper: false,
+      hasPassword: false,
+    };
     (searchVolunteers as jest.Mock).mockResolvedValue([mockVolunteer]);
     (getVolunteerRoles as jest.Mock).mockResolvedValue([
       {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -80,6 +80,8 @@ interface VolunteerResult {
   name: string;
   trainedAreas: number[];
   hasShopper: boolean;
+  clientId?: number;
+  hasPassword: boolean;
 }
 
 interface VolunteerManagementProps {
@@ -346,7 +348,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
     } catch {
       // ignore
     }
-    return { id, name, trainedAreas: [], hasShopper: false };
+    return { id, name, trainedAreas: [], hasShopper: false, hasPassword: false };
   }
 
   async function refreshVolunteer() {
@@ -683,11 +685,25 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
             onSelect={selectVolunteer}
           />
           {selectedVolunteer && (
-            <Stack
-              direction={{ xs: 'column', md: 'row' }}
-              spacing={2}
-              mt={2}
-            >
+            <>
+              <Typography variant="h6" mt={2}>
+                {selectedVolunteer.name}
+              </Typography>
+              {selectedVolunteer.hasPassword && (
+                <Typography variant="caption">
+                  Volunteer has an online account
+                </Typography>
+              )}
+              {selectedVolunteer.clientId && (
+                <Typography variant="caption">
+                  This profile has a shopper profile attached to it. Client ID: {selectedVolunteer.clientId}
+                </Typography>
+              )}
+              <Stack
+                direction={{ xs: 'column', md: 'row' }}
+                spacing={2}
+                mt={2}
+              >
               <Box sx={{ width: { xs: 1, md: '33%' } }}>
                 <Stack spacing={2} sx={{ width: 1 }}>
                   <PageCard sx={{ width: 1 }}>
@@ -830,6 +846,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                 </PageCard>
               </Box>
             </Stack>
+          </>
           )}
         </>
       )}


### PR DESCRIPTION
## Summary
- Extend volunteer search to return linked client ID and password flag
- Display linked client and account status on volunteer management page
- Add unit tests for volunteer search and UI captions

## Testing
- `npm test` (backend) *(fails: 18 failed, 93 passed)*
- `npm test` (frontend) *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bdc2558d38832d85e78968c7c34578