### PR TITLE
Add helper to attach ICS files to calendar emails

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -19,6 +19,7 @@ import {
   buildCancelRescheduleLinks,
   buildCalendarLinks,
   saveIcsFile,
+  buildIcsAttachment,
 } from '../utils/emailUtils';
 import { buildIcsFile } from '../utils/calendarLinks';
 import logger from '../utils/logger';
@@ -152,11 +153,7 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
       const formattedDate = formatReginaDateWithDay(date);
       const body = `Date: ${formattedDate}${time}`;
       const attachments = [
-        {
-          name: 'booking.ics',
-          content: Buffer.from(icsContent, 'utf8').toString('base64'),
-          type: 'text/calendar',
-        },
+        buildIcsAttachment(icsContent, 'booking.ics'),
       ];
       enqueueEmail({
         to: user.email,
@@ -522,11 +519,7 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
       const cancelFileName = `${uid}-cancel.ics`;
       const appleCalendarCancelLink = saveIcsFile(cancelFileName, cancelIcs);
       const attachments = [
-        {
-          name: 'booking.ics',
-          content: Buffer.from(icsContent, 'utf8').toString('base64'),
-          type: 'text/calendar',
-        },
+        buildIcsAttachment(icsContent, 'booking.ics'),
         {
           name: 'booking-cancel.ics',
           content: cancelBase64,
@@ -745,11 +738,7 @@ export async function createBookingForUser(
         const formattedDate = formatReginaDateWithDay(date);
         const body = `Date: ${formattedDate}${time}`;
         const attachments = [
-          {
-            name: 'booking.ics',
-            content: Buffer.from(icsContent, 'utf8').toString('base64'),
-            type: 'text/calendar',
-          },
+          buildIcsAttachment(icsContent, 'booking.ics'),
         ];
       enqueueEmail({
         to: clientEmail,

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -6,6 +6,7 @@ import {
   buildCancelRescheduleLinks,
   buildCalendarLinks,
   saveIcsFile,
+  buildIcsAttachment,
 } from '../../utils/emailUtils';
 import { buildIcsFile } from '../../utils/calendarLinks';
 import { enqueueEmail } from '../../utils/emailQueue';
@@ -207,11 +208,7 @@ export async function createVolunteerBooking(
           slot.start_time,
         )} to ${formatTimeToAmPm(slot.end_time)}`;
         const attachments = [
-          {
-            name: 'shift.ics',
-            content: Buffer.from(icsContent, 'utf8').toString('base64'),
-            type: 'text/calendar',
-          },
+          buildIcsAttachment(icsContent, 'shift.ics'),
         ];
         enqueueEmail({
           to: user.email,
@@ -585,11 +582,7 @@ export async function resolveVolunteerBookingConflict(
         slot.start_time,
       )} to ${formatTimeToAmPm(slot.end_time)}`;
       const attachments = [
-        {
-          name: 'shift.ics',
-          content: Buffer.from(icsContent, 'utf8').toString('base64'),
-          type: 'text/calendar',
-        },
+        buildIcsAttachment(icsContent, 'shift.ics'),
       ];
       enqueueEmail({
         to: user.email,
@@ -999,11 +992,7 @@ export async function rescheduleVolunteerBooking(
       const cancelFileName = `${uid}-cancel.ics`;
       const appleCalendarCancelLink = saveIcsFile(cancelFileName, cancelIcs);
       const attachments = [
-        {
-          name: 'shift.ics',
-          content: Buffer.from(icsContent, 'utf8').toString('base64'),
-          type: 'text/calendar',
-        },
+        buildIcsAttachment(icsContent, 'shift.ics'),
         {
           name: 'shift-cancel.ics',
           content: cancelBase64,

--- a/MJ_FB_Backend/src/utils/emailUtils.ts
+++ b/MJ_FB_Backend/src/utils/emailUtils.ts
@@ -203,6 +203,14 @@ export function buildCalendarLinks(
   return { googleCalendarLink, outlookCalendarLink, appleCalendarLink, icsContent: ics };
 }
 
+export function buildIcsAttachment(icsContent: string, fileName: string) {
+  return {
+    name: fileName,
+    content: Buffer.from(icsContent, 'utf8').toString('base64'),
+    type: 'text/calendar' as const,
+  };
+}
+
 export function saveIcsFile(fileName: string, content: string): string {
   if (config.icsBaseUrl) {
     const dir = path.join(__dirname, '..', '..', 'public', 'ics');

--- a/MJ_FB_Backend/tests/agency.test.ts
+++ b/MJ_FB_Backend/tests/agency.test.ts
@@ -17,6 +17,7 @@ jest.doMock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.doMock('../src/utils/emailQueue', () => ({
   __esModule: true,

--- a/MJ_FB_Backend/tests/bookingController.test.ts
+++ b/MJ_FB_Backend/tests/bookingController.test.ts
@@ -64,8 +64,14 @@ describe('createBookingForUser', () => {
           outlookCalendarLink: expect.any(String),
           appleCalendarLink: expect.any(String),
         }),
+        attachments: [
+          expect.objectContaining({ name: 'booking.ics', type: 'text/calendar' }),
+        ],
       }),
     );
+    const call = enqueueEmail.mock.calls[0][0];
+    const decoded = Buffer.from(call.attachments[0].content, 'base64').toString();
+    expect(decoded).toContain('BEGIN:VCALENDAR');
   });
 
   it('returns 400 if booking date is a holiday', async () => {

--- a/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
+++ b/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
@@ -24,6 +24,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/models/bookingRepository');
 jest.mock('../src/utils/bookingUtils');
@@ -91,5 +92,7 @@ describe('rescheduleBooking', () => {
     expect(Buffer.from(cancelBase64, 'base64').toString()).toContain(
       'METHOD:CANCEL',
     );
+    const attachments = enqueueEmailMock.mock.calls[0][0].attachments;
+    expect(attachments[0]).toMatchObject({ name: 'event.ics', type: 'text/calendar' });
   });
 });

--- a/MJ_FB_Backend/tests/volunteerBookingConcurrency.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingConcurrency.test.ts
@@ -52,6 +52,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingConflict.test.ts
@@ -13,6 +13,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
@@ -13,6 +13,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerBookingInvalidDate.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingInvalidDate.test.ts
@@ -22,6 +22,7 @@ describe('volunteer booking date validation', () => {
           icsContent: '',
         }),
         saveIcsFile: () => '#',
+        buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
       }));
       jest.doMock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));
       jest.doMock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -15,6 +15,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 const sendTemplatedEmailMock = sendTemplatedEmail as jest.Mock;
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsList.test.ts
@@ -13,6 +13,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (

--- a/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsReview.test.ts
@@ -13,6 +13,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (

--- a/MJ_FB_Backend/tests/volunteerBookingsUnmarked.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingsUnmarked.test.ts
@@ -13,6 +13,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (

--- a/MJ_FB_Backend/tests/volunteerRebookCancelled.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRebookCancelled.test.ts
@@ -13,6 +13,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookings.test.ts
@@ -14,6 +14,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 const sendTemplatedEmailMock = sendTemplatedEmail as jest.Mock;
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRecurringBookingsStaff.test.ts
@@ -14,6 +14,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 const sendTemplatedEmailMock = sendTemplatedEmail as jest.Mock;
 jest.mock('../src/middleware/authMiddleware', () => ({

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -21,6 +21,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 const enqueueEmailMock = enqueueEmail as jest.Mock;
 jest.mock('../src/middleware/authMiddleware', () => ({
@@ -76,5 +77,7 @@ describe('rescheduleVolunteerBooking', () => {
     expect(Buffer.from(cancelBase64, 'base64').toString()).toContain(
       'METHOD:CANCEL',
     );
+    const attachments = enqueueEmailMock.mock.calls[0][0].attachments;
+    expect(attachments[0]).toMatchObject({ name: 'event.ics', type: 'text/calendar' });
   });
 });

--- a/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShopperBooking.test.ts
@@ -16,6 +16,7 @@ jest.mock('../src/utils/emailUtils', () => ({
     icsContent: '',
   }),
   saveIcsFile: () => '#',
+  buildIcsAttachment: () => ({ name: 'event.ics', content: '', type: 'text/calendar' }),
 }));
 jest.mock('../src/utils/emailQueue', () => ({ enqueueEmail: jest.fn() }));
 jest.mock('../src/models/bookingRepository', () => ({


### PR DESCRIPTION
## Summary
- add `buildIcsAttachment` utility to generate base64 ICS attachments
- use helper in booking and volunteer booking controllers to attach calendar files
- extend tests to confirm ICS attachments are enqueued with calendar emails

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: install did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc4668b18832da8cc0890a2684fbf