### PR TITLE
Use timezone-aware parsing in reschedule page

### DIFF
--- a/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
@@ -10,7 +10,7 @@ import FormCard from '../components/FormCard';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
 import { getSlots, rescheduleBookingByToken } from '../api/bookings';
 import { formatTime } from '../utils/time';
-import { formatReginaDate } from '../utils/date';
+import { formatReginaDate, toDayjs } from '../utils/date';
 import type { Slot } from '../types';
 import { useTranslation } from 'react-i18next';
 
@@ -29,9 +29,9 @@ export default function RescheduleBooking() {
       getSlots(date)
         .then(s => {
           if (date === todayStr) {
-            const now = new Date();
+            const now = toDayjs().toDate();
             s = s.filter(
-              slot => new Date(`${date}T${slot.startTime}`) > now,
+              slot => toDayjs(`${date}T${slot.startTime}`).toDate() > now,
             );
           }
           s = s.filter(


### PR DESCRIPTION
## Summary
- use `toDayjs` for timezone-aware date comparisons in RescheduleBooking

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bdd15c44f8832da11b5e88670d83ab