### PR TITLE
fix: convert Date inputs to Regina timezone

### DIFF
--- a/MJ_FB_Frontend/src/utils/__tests__/date.test.ts
+++ b/MJ_FB_Frontend/src/utils/__tests__/date.test.ts
@@ -1,8 +1,8 @@
 import { formatReginaDate } from '../date';
 
 describe('toDayjs with Date input', () => {
-  test('preserves original day', () => {
+  test('converts from system timezone to Regina', () => {
     const d = new Date('2024-09-02');
-    expect(formatReginaDate(d)).toBe('2024-09-02');
+    expect(formatReginaDate(d)).toBe('2024-09-01');
   });
 });

--- a/MJ_FB_Frontend/src/utils/date.ts
+++ b/MJ_FB_Frontend/src/utils/date.ts
@@ -16,7 +16,7 @@ export function toDayjs(input?: ConfigType) {
     return dayjs();
   }
   if (input instanceof Date) {
-    const parsed = dayjs(input).tz(REGINA_TIMEZONE, true);
+    const parsed = dayjs(input).tz(REGINA_TIMEZONE);
     return parsed.isValid() ? parsed : dayjs(NaN);
   }
   const isLocalString =


### PR DESCRIPTION
## Summary
- convert Date inputs from system timezone to Regina in `toDayjs`
- adjust date utility test for timezone conversion

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*


------
https://chatgpt.com/codex/tasks/task_e_68bdd67b9c08832d933bcc9945197082