### PR TITLE
feat: poll pantry schedule when viewing today's date

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -101,6 +101,21 @@ export default function PantrySchedule({
   }, [loadData]);
 
   useEffect(() => {
+    if (formatDate(currentDate) !== formatDate()) return;
+    const reloadIfVisible = () => {
+      if (document.visibilityState === 'visible') {
+        loadData();
+      }
+    };
+    const interval = setInterval(reloadIfVisible, 60_000);
+    document.addEventListener('visibilitychange', reloadIfVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', reloadIfVisible);
+    };
+  }, [currentDate, loadData]);
+
+  useEffect(() => {
     if (assignSlot && !isNewClient && searchTerm.length >= 3) {
       const delay = setTimeout(() => {
         (searchUsersFn || searchUsers)(searchTerm)


### PR DESCRIPTION
## Summary
- poll pantry schedule every minute when viewing today's date
- pause polling when tab is hidden

## Testing
- `npm test` *(fails: UserHistory.test.tsx, RecurringBookings.test.tsx, PantrySchedule.test.tsx, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfc538a98832dbf3c4e91069306de