### PR TITLE
feat: add pantry schedule today shortcut

### DIFF
--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -205,6 +205,12 @@ export function getHelpContent(
       },
     },
     {
+      title: 'Navigate schedule days',
+      body: {
+        description: 'Use the Previous, Today, and Next buttons to change the displayed date.',
+      },
+    },
+    {
       title: 'Manage availability',
       body: {
         description: 'Open or block pantry slots and adjust capacities.',

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -275,7 +275,9 @@ export default function PantrySchedule({
   return (
     <Page title="Pantry Schedule" header={<PantryQuickLinks />}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-        <Button onClick={() => changeDay(-1)} variant="outlined" color="primary">Previous</Button>
+        <Button onClick={() => changeDay(-1)} variant="outlined" color="primary">
+          Previous
+        </Button>
         <h3>
           {dateStr} - {dayName}
           {isHoliday
@@ -284,7 +286,23 @@ export default function PantrySchedule({
               ? ' (Weekend)'
               : ''}
         </h3>
-        <Button onClick={() => changeDay(1)} variant="outlined" color="primary">Next</Button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Button
+            onClick={() =>
+              setCurrentDate(
+                fromZonedTime(`${formatDate()}T00:00:00`, reginaTimeZone),
+              )
+            }
+            variant="outlined"
+            size="small"
+            color="primary"
+          >
+            Today
+          </Button>
+          <Button onClick={() => changeDay(1)} variant="outlined" color="primary">
+            Next
+          </Button>
+        </div>
       </div>
       <FeedbackSnackbar
         open={!!snackbar}


### PR DESCRIPTION
## Summary
- add a Today navigation button to Pantry Schedule that resets the view to the current date
- document new schedule navigation controls in the help content

## Testing
- `npm test` *(fails: UserHistory, RecurringBookings, BookingUI, PantrySchedule, ClientDashboard and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfc5b6360832dbd0ee2f1b886871b