### PR TITLE
feat: stream booking updates via SSE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Ensure tests are added or updated for any code changes and run the relevant test suites after each task.
 - Use Node.js 22+; run `nvm use` to switch to the pinned version in `.nvmrc`.
 - Keep recurring-booking tests current in both the backend and frontend whenever this feature changes.
+- The pantry schedule receives live updates through an SSE endpoint at `/bookings/stream`.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/public/locales` when client-visible text is added.
 - Pantry visits track daily sunshine bag weights and client counts via the `sunshine_bag_log` table.

--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -4,6 +4,7 @@ import {
   authorizeRoles,
   optionalAuthMiddleware,
 } from '../middleware/authMiddleware';
+import { registerBookingStream } from '../utils/bookingEvents';
 import {
   createBooking,
   listBookings,
@@ -46,6 +47,21 @@ router.get(
   authMiddleware,
   authorizeRoles('staff', 'agency'),
   listBookings
+);
+
+// SSE stream of booking events
+router.get(
+  '/stream',
+  authMiddleware,
+  (req: Request, res: Response) => {
+    res.set({
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+    res.flushHeaders();
+    registerBookingStream(res);
+  }
 );
 
 // Booking history for user or staff lookup

--- a/MJ_FB_Backend/src/utils/bookingEvents.ts
+++ b/MJ_FB_Backend/src/utils/bookingEvents.ts
@@ -1,0 +1,25 @@
+import type { Response } from 'express';
+
+export interface BookingEvent {
+  action: 'created' | 'cancelled';
+  name: string;
+  role: 'client' | 'volunteer';
+  date: string;
+  time: string;
+}
+
+const clients = new Set<Response>();
+
+export function registerBookingStream(res: Response) {
+  clients.add(res);
+  res.on('close', () => {
+    clients.delete(res);
+  });
+}
+
+export function sendBookingEvent(event: BookingEvent) {
+  const data = `data: ${JSON.stringify(event)}\n\n`;
+  for (const res of clients) {
+    res.write(data);
+  }
+}

--- a/MJ_FB_Backend/tests/bookingController.test.ts
+++ b/MJ_FB_Backend/tests/bookingController.test.ts
@@ -216,7 +216,9 @@ describe('cancelBooking', () => {
       status: 'approved',
       date: futureDate,
     });
-    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ email: 'client@example.com' }] });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ email: 'client@example.com', first_name: 'A', last_name: 'B' }] })
+      .mockResolvedValueOnce({ rows: [{ start_time: '09:00:00' }] });
     const req = {
       params: { id: '1' },
       user: { role: 'staff', id: '99' },
@@ -245,7 +247,9 @@ describe('cancelBooking', () => {
       status: 'approved',
       date: futureDate,
     });
-    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ email: 'client@example.com' }] });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ email: 'client@example.com', first_name: 'A', last_name: 'B' }] })
+      .mockResolvedValueOnce({ rows: [{ start_time: '09:00:00' }] });
     const req = {
       params: { id: '1' },
       user: { role: 'client', id: '5' },

--- a/MJ_FB_Backend/tests/bookingEvents.test.ts
+++ b/MJ_FB_Backend/tests/bookingEvents.test.ts
@@ -1,0 +1,15 @@
+import { registerBookingStream, sendBookingEvent } from '../src/utils/bookingEvents';
+import type { Response } from 'express';
+
+describe('bookingEvents', () => {
+  it('delivers events to registered clients', () => {
+    const res = {
+      write: jest.fn(),
+      on: jest.fn(),
+    } as unknown as Response;
+    registerBookingStream(res);
+    const event = { action: 'created', name: 'Test', role: 'client', date: '2024-01-01', time: '09:00:00' } as const;
+    sendBookingEvent(event);
+    expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify(event)}\n\n`);
+  });
+});

--- a/MJ_FB_Backend/tests/bookingNewClient.test.ts
+++ b/MJ_FB_Backend/tests/bookingNewClient.test.ts
@@ -18,6 +18,7 @@ jest.mock('../src/models/newClient', () => ({
 jest.mock('../src/utils/bookingUtils', () => ({
   isDateWithinCurrentOrNextMonth: jest.fn().mockReturnValue(true),
 }));
+jest.mock('../src/db', () => ({ __esModule: true, default: { connect: jest.fn(), query: jest.fn() } }));
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (
     req: any,
@@ -50,6 +51,7 @@ app.use((err: any, _req: express.Request, res: express.Response, _next: express.
 beforeEach(() => {
   jest.clearAllMocks();
   (pool.connect as jest.Mock).mockResolvedValue({ query: jest.fn(), release: jest.fn() });
+  (pool.query as jest.Mock).mockResolvedValue({ rows: [{ start_time: '09:00:00' }] });
   (bookingRepository.checkSlotCapacity as jest.Mock).mockResolvedValue(undefined);
   (bookingRepository.insertBooking as jest.Mock).mockResolvedValue(undefined);
   (newClientModel.insertNewClient as jest.Mock).mockResolvedValue(1);

--- a/MJ_FB_Backend/tests/volunteerBooking.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBooking.test.ts
@@ -20,6 +20,7 @@ jest.mock('../src/middleware/authMiddleware', () => ({
     next: express.NextFunction,
   ) => next(),
 }));
+jest.mock('../src/db', () => ({ __esModule: true, default: { query: jest.fn() } }));
 
 const app = express();
 app.use(express.json());

--- a/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
@@ -32,6 +32,7 @@ jest.mock('../src/middleware/authMiddleware', () => ({
     next: express.NextFunction,
   ) => next(),
 }));
+jest.mock('../src/db', () => ({ __esModule: true, default: { query: jest.fn(), connect: jest.fn() } }));
 
 const app = express();
 app.use(express.json());
@@ -64,7 +65,8 @@ describe('createVolunteerBookingForVolunteer force', () => {
       .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
-      .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rows: [{ first_name: 'A', last_name: 'B' }] });
 
     client.query
       .mockResolvedValueOnce({}) // BEGIN

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -37,6 +37,7 @@ jest.mock('../src/middleware/authMiddleware', () => ({
     next();
   },
 }));
+jest.mock('../src/db', () => ({ __esModule: true, default: { query: jest.fn() } }));
 
 const app = express();
 app.use(express.json());
@@ -123,7 +124,7 @@ describe('cancelVolunteerBookingOccurrence', () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 1, rows: [booking] })
       .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({ rows: [{ email: 'vol@example.com' }] })
+      .mockResolvedValueOnce({ rows: [{ email: 'vol@example.com', first_name: 'A', last_name: 'B' }] })
       .mockResolvedValueOnce({ rows: [{ start_time: '09:00', end_time: '10:00' }] });
   }
 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Admin navigation includes a Settings page with Pantry, Warehouse, and Volunteer tabs.
 - The Settings page's Pantry tab lets staff configure a cart tare value and one max booking capacity used for all pantry times.
 - Pantry schedule cells use color coding: rgb(228,241,228) for approved, rgb(255, 200, 200) for no-show, rgb(111,146,113) for visited, and the theme's warning light for capacity exceeded.
+- Pantry schedule listens for live booking updates via a Server‑Sent Events stream at `/bookings/stream`.
 - Filled pantry schedule slots display the client's ID in parentheses, or show `[NEW CLIENT] Name` when booked for an unregistered individual.
 - Staff can book new clients directly from the pantry schedule's **Assign User** modal by checking **New client** and entering a name (email and phone optional).
 - Wednesdays include an additional 6:30–7:00 PM pantry slot.


### PR DESCRIPTION
## Summary
- expose `/bookings/stream` SSE endpoint
- broadcast booking create/cancel events for clients and volunteers
- listen for booking stream in pantry schedule and prompt refresh

## Testing
- `npm test` *(backend, failed: Booking tests and others)*
- `npm test` *(frontend, failed: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfff811f0832db79e0323999ff44d