### PR TITLE
test: compute expected time string

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RescheduleDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RescheduleDialog.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RescheduleDialog from '../components/RescheduleDialog';
+import { formatTime } from '../utils/time';
 
 jest.mock('../api/bookings', () => ({
   getSlots: jest.fn(),
@@ -49,7 +50,8 @@ describe('RescheduleDialog', () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole('combobox', { name: /time/i }));
     const options = await screen.findAllByRole('option');
+    const expected = formatTime('13:00:00');
     expect(options).toHaveLength(1);
-    expect(options[0]).toHaveTextContent(/1:00 pm/i);
+    expect(options[0]).toHaveTextContent(expected);
   });
 });


### PR DESCRIPTION
## Summary
- use formatTime to create expected string in RescheduleDialog test

## Testing
- `npm test -- src/__tests__/RescheduleDialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be0242ae1c832d9bc4f32235832a6a