### PR TITLE
refactor: build volunteer reschedule labels with formatTime

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerRescheduleDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerRescheduleDialog.test.tsx
@@ -75,12 +75,13 @@ describe('VolunteerRescheduleDialog', () => {
 
     fireEvent.mouseDown(await screen.findByLabelText(/role/i));
 
-    const label = `Pantry ${formatTime('13:00:00')}–${formatTime('16:00:00')}`;
-    expect(screen.getByText(label)).toBeInTheDocument();
-    expect(
-      screen.queryByText(
-        `Pantry ${formatTime('09:00:00')}–${formatTime('12:00:00')}`,
-      ),
-    ).toBeNull();
+    {
+      const label = `Pantry ${formatTime('13:00:00')}–${formatTime('16:00:00')}`;
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    {
+      const label = `Pantry ${formatTime('09:00:00')}–${formatTime('12:00:00')}`;
+      expect(screen.queryByText(label)).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- refactor VolunteerRescheduleDialog test to build slot labels with `formatTime`

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68be02441808832d978fd41bbdf53726