### PR TITLE
feat: auto refresh pantry schedule on updates

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -117,7 +117,9 @@ export default function PantrySchedule({
 
   useEffect(() => {
     if (typeof EventSource === 'undefined') return;
-    const es = new EventSource(`${import.meta.env.VITE_API_BASE}/bookings/stream`, { withCredentials: true });
+    const es = new EventSource(`${import.meta.env.VITE_API_BASE}/bookings/stream`, {
+      withCredentials: true,
+    });
     es.onmessage = ev => {
       try {
         const data = JSON.parse(ev.data) as {
@@ -128,15 +130,14 @@ export default function PantrySchedule({
           time: string;
         };
         if (data.date === formatDate(currentDate)) {
-          const actionText = data.action === 'created' ? 'booked' : 'cancelled';
+          void loadData();
+          const actionText =
+            data.action === 'created' ? 'booked' : 'cancelled';
           setSnackbar({
-            message: `${data.name} (${data.role}) ${actionText} ${formatTime(data.time)}`,
+            message: `${data.name} (${data.role}) ${actionText} ${formatTime(
+              data.time,
+            )}`,
             severity: 'info',
-            action: (
-              <Button color="inherit" size="small" onClick={() => { loadData(); setSnackbar(null); }}>
-                Refresh
-              </Button>
-            ),
           });
         }
       } catch {


### PR DESCRIPTION
## Summary
- refresh pantry schedule automatically on SSE updates for selected date

## Testing
- `npm test` *(fails: UserHistory, RecurringBookings, BookingUI, PantrySchedule, PantryScheduleCapacity, ClientDashboard tests)*

------
https://chatgpt.com/codex/tasks/task_e_68be06519ee0832d949b35fe7a4ef09d