### PR TITLE
Add password token cleanup job

### DIFF
--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -31,6 +31,7 @@
 - A volunteer shift reminder job (`src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue. It also uses `node-cron` with the same schedule and exposes `startVolunteerShiftReminderJob`/`stopVolunteerShiftReminderJob`.
 - A nightly no-show cleanup job (`src/utils/noShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved bookings as `no_show`. It exposes `startNoShowCleanupJob`/`stopNoShowCleanupJob`.
 - A nightly volunteer no-show cleanup job (`src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results, emails coordinators, and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
+- A daily password token cleanup job (`src/utils/passwordTokenCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 1 * * *` Regina time to delete used or expired password setup tokens. It exposes `startPasswordTokenCleanupJob`/`stopPasswordTokenCleanupJob`.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -22,6 +22,10 @@ import {
   startTimesheetSeedJob,
   stopTimesheetSeedJob,
 } from './utils/timesheetSeedJob';
+import {
+  startPasswordTokenCleanupJob,
+  stopPasswordTokenCleanupJob,
+} from './utils/passwordTokenCleanupJob';
 
 const PORT = config.port;
 
@@ -47,6 +51,7 @@ async function init() {
     await seedPayPeriods('2025-08-03', '2025-12-31');
     await seedTimesheets();
     startTimesheetSeedJob();
+    startPasswordTokenCleanupJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);
@@ -61,6 +66,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   stopVolunteerNoShowCleanupJob();
   stopTimesheetSeedJob();
   stopPayPeriodCronJob();
+  stopPasswordTokenCleanupJob();
   shutdownQueue();
   if (server) {
     server.close();

--- a/MJ_FB_Backend/src/utils/passwordTokenCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/passwordTokenCleanupJob.ts
@@ -1,0 +1,30 @@
+import pool from '../db';
+import logger from './logger';
+import scheduleDailyJob from './scheduleDailyJob';
+
+/**
+ * Remove used or expired password setup tokens.
+ */
+export async function cleanupPasswordTokens(): Promise<void> {
+  try {
+    await pool.query(
+      "DELETE FROM password_setup_tokens WHERE used=true OR expires_at < CURRENT_DATE - INTERVAL '10 days'",
+    );
+  } catch (err) {
+    logger.error('Failed to clean up password setup tokens', err);
+  }
+}
+
+/**
+ * Schedule the cleanup job to run daily at 1:00 AM Regina time.
+ */
+const passwordTokenCleanupJob = scheduleDailyJob(
+  cleanupPasswordTokens,
+  '0 1 * * *',
+  true,
+  true,
+);
+
+export const startPasswordTokenCleanupJob = passwordTokenCleanupJob.start;
+export const stopPasswordTokenCleanupJob = passwordTokenCleanupJob.stop;
+

--- a/MJ_FB_Backend/tests/passwordTokenCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/passwordTokenCleanupJob.test.ts
@@ -1,0 +1,57 @@
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+jest.mock('../src/utils/scheduleDailyJob', () => {
+  const actual = jest.requireActual('../src/utils/scheduleDailyJob');
+  return {
+    __esModule: true,
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
+  };
+});
+const job = require('../src/utils/passwordTokenCleanupJob');
+const {
+  cleanupPasswordTokens,
+  startPasswordTokenCleanupJob,
+  stopPasswordTokenCleanupJob,
+} = job;
+import pool from '../src/db';
+
+describe('cleanupPasswordTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes used or expired tokens', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1 });
+    await cleanupPasswordTokens();
+    expect(pool.query).toHaveBeenCalledWith(
+      "DELETE FROM password_setup_tokens WHERE used=true OR expires_at < CURRENT_DATE - INTERVAL '10 days'",
+    );
+  });
+});
+
+describe('startPasswordTokenCleanupJob/stopPasswordTokenCleanupJob', () => {
+  let scheduleMock: jest.Mock;
+  let stopMock: jest.Mock;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    scheduleMock = require('node-cron').schedule as jest.Mock;
+    stopMock = jest.fn();
+    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+  });
+
+  afterEach(() => {
+    stopPasswordTokenCleanupJob();
+    jest.useRealTimers();
+    scheduleMock.mockReset();
+  });
+
+  it('schedules and stops the cron job', () => {
+    startPasswordTokenCleanupJob();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '0 1 * * *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+    stopPasswordTokenCleanupJob();
+    expect(stopMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add cron job to purge used or stale password setup tokens
- start the cleanup job at server boot and stop during shutdown
- test token cleanup scheduling and SQL deletion

## Testing
- `npm test` *(fails: Timesheet not found, client visit xlsx import, volunteer booking tests, etc.)*
- `npm test tests/passwordTokenCleanupJob.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68be06f67ab8832da16b3965f4167864