### PR TITLE
Add nightly cleanup for expired tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Booking notes consist of **client notes** (entered when booking) and **staff notes** (recorded during visits). Staff users automatically receive staff notes in booking history responses, while agency users can include them with `includeStaffNotes=true`.
 - Keep `docs/timesheets.md` current with setup steps, API usage, payroll CSV export details, UI screenshots, and translation keys whenever the timesheet feature changes.
 - A cron job seeds pay periods for the upcoming year every **Nov 30** using `seedPayPeriods`.
+- Expired password setup and email verification tokens are purged nightly once they are more than 10 days past `expires_at`.
 - Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to Azure".
 - Always document new environment variables in the repository README and `.env.example` files.
 - Implement all database schema changes via migrations in `MJ_FB_Backend/src/migrations`; do not modify `src/setupDatabase.ts` for schema updates.

--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -31,6 +31,7 @@
 - A volunteer shift reminder job (`src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue. It also uses `node-cron` with the same schedule and exposes `startVolunteerShiftReminderJob`/`stopVolunteerShiftReminderJob`.
 - A nightly no-show cleanup job (`src/utils/noShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved bookings as `no_show`. It exposes `startNoShowCleanupJob`/`stopNoShowCleanupJob`.
 - A nightly volunteer no-show cleanup job (`src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results, emails coordinators, and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
+- An expired token cleanup job (`src/utils/expiredTokenCleanupJob.ts`) runs nightly at 3:00 AM Regina time to delete `password_setup_tokens` and `client_email_verifications` rows with `expires_at` more than 10 days ago. It exposes `startExpiredTokenCleanupJob`/`stopExpiredTokenCleanupJob`.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -14,6 +14,10 @@ import {
   startVolunteerNoShowCleanupJob,
   stopVolunteerNoShowCleanupJob,
 } from './utils/volunteerNoShowCleanupJob';
+import {
+  startExpiredTokenCleanupJob,
+  stopExpiredTokenCleanupJob,
+} from './utils/expiredTokenCleanupJob';
 import { startPayPeriodCronJob, stopPayPeriodCronJob } from './utils/payPeriodCronJob';
 import { initEmailQueue, shutdownQueue } from './utils/emailQueue';
 import seedPayPeriods from './utils/payPeriodSeeder';
@@ -43,6 +47,7 @@ async function init() {
     startVolunteerShiftReminderJob();
     startNoShowCleanupJob();
     startVolunteerNoShowCleanupJob();
+    startExpiredTokenCleanupJob();
     startPayPeriodCronJob();
     await seedPayPeriods('2025-08-03', '2025-12-31');
     await seedTimesheets();
@@ -59,6 +64,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   stopVolunteerShiftReminderJob();
   stopNoShowCleanupJob();
   stopVolunteerNoShowCleanupJob();
+  stopExpiredTokenCleanupJob();
   stopTimesheetSeedJob();
   stopPayPeriodCronJob();
   shutdownQueue();

--- a/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
@@ -1,0 +1,33 @@
+import pool from '../db';
+import logger from './logger';
+import scheduleDailyJob from './scheduleDailyJob';
+
+/**
+ * Remove expired password setup and email verification tokens.
+ */
+export async function cleanupExpiredTokens(): Promise<void> {
+  try {
+    await pool.query(
+      "DELETE FROM password_setup_tokens WHERE expires_at < (CURRENT_DATE - INTERVAL '10 days')",
+    );
+    await pool.query(
+      "DELETE FROM client_email_verifications WHERE expires_at < (CURRENT_DATE - INTERVAL '10 days')",
+    );
+  } catch (err) {
+    logger.error('Failed to clean up expired tokens', err);
+  }
+}
+
+/**
+ * Schedule the cleanup job to run nightly at 3:00 AM Regina time.
+ */
+const expiredTokenCleanupJob = scheduleDailyJob(
+  cleanupExpiredTokens,
+  '0 3 * * *',
+  true,
+  true,
+);
+
+export const startExpiredTokenCleanupJob = expiredTokenCleanupJob.start;
+export const stopExpiredTokenCleanupJob = expiredTokenCleanupJob.stop;
+

--- a/MJ_FB_Backend/tests/expiredTokenCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/expiredTokenCleanupJob.test.ts
@@ -1,0 +1,62 @@
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+jest.mock('../src/utils/scheduleDailyJob', () => {
+  const actual = jest.requireActual('../src/utils/scheduleDailyJob');
+  return {
+    __esModule: true,
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
+  };
+});
+const job = require('../src/utils/expiredTokenCleanupJob');
+const {
+  cleanupExpiredTokens,
+  startExpiredTokenCleanupJob,
+  stopExpiredTokenCleanupJob,
+} = job;
+import pool from '../src/db';
+
+describe('cleanupExpiredTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes expired password setup and email verification tokens', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1 }).mockResolvedValueOnce({ rowCount: 1 });
+    await cleanupExpiredTokens();
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      "DELETE FROM password_setup_tokens WHERE expires_at < (CURRENT_DATE - INTERVAL '10 days')",
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      "DELETE FROM client_email_verifications WHERE expires_at < (CURRENT_DATE - INTERVAL '10 days')",
+    );
+  });
+});
+
+describe('startExpiredTokenCleanupJob/stopExpiredTokenCleanupJob', () => {
+  let scheduleMock: jest.Mock;
+  let stopMock: jest.Mock;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    scheduleMock = require('node-cron').schedule as jest.Mock;
+    stopMock = jest.fn();
+    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+  });
+
+  afterEach(() => {
+    stopExpiredTokenCleanupJob();
+    jest.useRealTimers();
+    scheduleMock.mockReset();
+  });
+
+  it('schedules and stops the cron job', () => {
+    startExpiredTokenCleanupJob();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '0 3 * * *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+    stopExpiredTokenCleanupJob();
+    expect(stopMock).toHaveBeenCalled();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Before merging a pull request, confirm the following:
 - Booking confirmation and reminder emails include Cancel and Reschedule buttons so users can manage their appointments directly from the message.
 - A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.
 - A nightly volunteer no-show cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours.
+- A nightly token cleanup job runs at `0 3 * * *` Regina time to delete expired password setup and email verification tokens more than 10 days past `expires_at`.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Backend email queue retries failed sends with exponential backoff and persists jobs in an `email_queue` table so retries survive restarts. The maximum retries and initial delay are configurable.

--- a/docs/dataRetention.md
+++ b/docs/dataRetention.md
@@ -1,0 +1,3 @@
+# Data Retention
+
+Expired password setup tokens and client email verification records are automatically removed. A nightly job deletes any rows whose `expires_at` is more than 10 days in the past, keeping these tables compact without affecting active tokens.


### PR DESCRIPTION
## Summary
- delete expired password setup and email verification tokens with a nightly cron job
- register expired token cleanup with server startup/shutdown
- document token retention policy

## Testing
- ⚠️ `npm test` (fails: 17 failed, 96 passed)


------
https://chatgpt.com/codex/tasks/task_e_68be074e9504832db42361d048770476