### PR TITLE
feat: add booking retention job and volunteer stats aggregation

### DIFF
--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -31,6 +31,7 @@
 - A volunteer shift reminder job (`src/utils/volunteerShiftReminderJob.ts`) runs at server startup and emails volunteers about next-day shifts using the same queue. It also uses `node-cron` with the same schedule and exposes `startVolunteerShiftReminderJob`/`stopVolunteerShiftReminderJob`.
 - A nightly no-show cleanup job (`src/utils/noShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved bookings as `no_show`. It exposes `startNoShowCleanupJob`/`stopNoShowCleanupJob`.
 - A nightly volunteer no-show cleanup job (`src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results, emails coordinators, and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
+- A nightly retention job (`src/utils/bookingRetentionJob.ts`) removes `bookings` and `volunteer_bookings` older than two years and aggregates volunteer stats into the `volunteers` table.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/src/migrations/1700000000024_add_volunteer_archived_stats.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000024_add_volunteer_archived_stats.ts
@@ -1,0 +1,21 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('volunteers', {
+    archived_hours: { type: 'numeric', notNull: true, default: 0 },
+    archived_shifts: { type: 'integer', notNull: true, default: 0 },
+    archived_bookings: { type: 'integer', notNull: true, default: 0 },
+    archived_no_shows: { type: 'integer', notNull: true, default: 0 },
+    has_early_bird: { type: 'boolean', notNull: true, default: false },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumns('volunteers', [
+    'archived_hours',
+    'archived_shifts',
+    'archived_bookings',
+    'archived_no_shows',
+    'has_early_bird',
+  ]);
+}

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -22,6 +22,7 @@ import {
   startTimesheetSeedJob,
   stopTimesheetSeedJob,
 } from './utils/timesheetSeedJob';
+import { startRetentionJob, stopRetentionJob } from './utils/bookingRetentionJob';
 
 const PORT = config.port;
 
@@ -47,6 +48,7 @@ async function init() {
     await seedPayPeriods('2025-08-03', '2025-12-31');
     await seedTimesheets();
     startTimesheetSeedJob();
+    startRetentionJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);
@@ -61,6 +63,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   stopVolunteerNoShowCleanupJob();
   stopTimesheetSeedJob();
   stopPayPeriodCronJob();
+  stopRetentionJob();
   shutdownQueue();
   if (server) {
     server.close();

--- a/MJ_FB_Backend/src/utils/bookingRetentionJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingRetentionJob.ts
@@ -1,0 +1,53 @@
+import pool from '../db';
+import logger from './logger';
+import scheduleDailyJob from './scheduleDailyJob';
+
+const RETENTION_YEARS = 2;
+
+export async function cleanupOldRecords(): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const cutoff = new Date();
+    cutoff.setFullYear(cutoff.getFullYear() - RETENTION_YEARS);
+
+    await client.query(
+      `UPDATE volunteers v
+       SET archived_hours = archived_hours + s.completed_hours,
+           archived_shifts = archived_shifts + s.completed_shifts,
+           archived_bookings = archived_bookings + s.total_bookings,
+           archived_no_shows = archived_no_shows + s.no_shows,
+           has_early_bird = has_early_bird OR s.early_bird
+       FROM (
+         SELECT vb.volunteer_id,
+                COALESCE(SUM(CASE WHEN vb.status='completed' THEN EXTRACT(EPOCH FROM (vs.end_time - vs.start_time)) / 3600 ELSE 0 END),0) AS completed_hours,
+                COUNT(*) FILTER (WHERE vb.status='completed') AS completed_shifts,
+                COUNT(*) FILTER (WHERE vb.status IN ('approved','completed','no_show')) AS total_bookings,
+                COUNT(*) FILTER (WHERE vb.status='no_show') AS no_shows,
+                BOOL_OR(vs.start_time < '09:00:00' AND vb.status='completed') AS early_bird
+         FROM volunteer_bookings vb
+         JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id
+         WHERE vb.date < $1
+         GROUP BY vb.volunteer_id
+       ) s
+       WHERE v.id = s.volunteer_id`,
+      [cutoff],
+    );
+
+    await client.query('DELETE FROM volunteer_bookings WHERE date < $1', [cutoff]);
+    await client.query('DELETE FROM bookings WHERE date < $1', [cutoff]);
+
+    await client.query('COMMIT');
+    logger.info('Old bookings cleaned up');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    logger.error('Failed to clean up old bookings', err);
+  } finally {
+    client.release();
+  }
+}
+
+const retentionJob = scheduleDailyJob(cleanupOldRecords, '0 1 * * *', true, true);
+
+export const startRetentionJob = retentionJob.start;
+export const stopRetentionJob = retentionJob.stop;

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Before merging a pull request, confirm the following:
 - Booking confirmation and reminder emails include Cancel and Reschedule buttons so users can manage their appointments directly from the message.
 - A nightly cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved bookings as `no_show`.
 - A nightly volunteer no-show cleanup job runs via `node-cron` at `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show` after `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours.
+- A nightly retention job deletes `bookings` and `volunteer_bookings` older than two years and rolls their volunteer hours and counts into aggregate fields.
 - Milestone badge awards send a template-based thank-you card via email and expose the card link through the stats endpoint.
 - Reusable Brevo email utility allows sending templated emails with custom properties and template IDs.
 - Backend email queue retries failed sends with exponential backoff and persists jobs in an `email_queue` table so retries survive restarts. The maximum retries and initial delay are configurable.
@@ -430,6 +431,7 @@ and cached on the server:
 - `CANS_WEIGHT_MULTIPLIER` (default `20`)
 
 The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) hours after a shift before marking it as `no_show`.
+A nightly retention job purges bookings older than two years and aggregates volunteer statistics.
 
 ### Frontend features
 


### PR DESCRIPTION
## Summary
- purge `bookings` and `volunteer_bookings` older than two years nightly
- roll deleted volunteer hours and booking counts into aggregate columns
- document new retention job

## Testing
- `npm test` *(fails: 18 failed, 94 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be08858ca4832d99fa8474314e2c18