### PR TITLE
feat: purge past blocked slots nightly

### DIFF
--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -33,6 +33,7 @@
 - A nightly volunteer no-show cleanup job (`src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results, emails coordinators, and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
 - An expired token cleanup job (`src/utils/expiredTokenCleanupJob.ts`) runs nightly at 3:00 AM Regina time to delete `password_setup_tokens` and `client_email_verifications` rows with `expires_at` more than 10 days ago. It exposes `startExpiredTokenCleanupJob`/`stopExpiredTokenCleanupJob`.
 - A daily password token cleanup job (`src/utils/passwordTokenCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 1 * * *` Regina time to delete used or expired password setup tokens. It exposes `startPasswordTokenCleanupJob`/`stopPasswordTokenCleanupJob`.
+- A nightly blocked slot cleanup job (`src/utils/blockedSlotCleanupJob.ts`) runs at 2:00 AM Regina time to delete past non-recurring blocked slots. It exposes `startBlockedSlotCleanupJob`/`stopBlockedSlotCleanupJob` and can be triggered manually via `POST /blocked-slots/cleanup`.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/src/routes/blockedSlots.ts
+++ b/MJ_FB_Backend/src/routes/blockedSlots.ts
@@ -7,6 +7,7 @@ import {
   deleteBlockedSlotParamsSchema,
 } from '../schemas/blockedSlotSchemas';
 import { formatReginaDate, reginaStartOfDayISO } from '../utils/dateUtils';
+import { cleanupPastBlockedSlots } from '../utils/blockedSlotCleanupJob';
 
 const router = express.Router();
 
@@ -90,6 +91,16 @@ router.delete(
     const { date, slotId } = req.params;
     await pool.query('DELETE FROM blocked_slots WHERE date = $1 AND slot_id = $2', [date, slotId]);
     res.json({ message: 'Removed' });
+  },
+);
+
+router.post(
+  '/cleanup',
+  authMiddleware,
+  authorizeRoles('admin'),
+  async (_req, res) => {
+    await cleanupPastBlockedSlots();
+    res.json({ message: 'Cleanup complete' });
   },
 );
 

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -30,6 +30,10 @@ import {
   startPasswordTokenCleanupJob,
   stopPasswordTokenCleanupJob,
 } from './utils/passwordTokenCleanupJob';
+import {
+  startBlockedSlotCleanupJob,
+  stopBlockedSlotCleanupJob,
+} from './utils/blockedSlotCleanupJob';
 
 const PORT = config.port;
 
@@ -57,6 +61,7 @@ async function init() {
     await seedTimesheets();
     startTimesheetSeedJob();
     startPasswordTokenCleanupJob();
+    startBlockedSlotCleanupJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);
@@ -73,6 +78,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   stopTimesheetSeedJob();
   stopPayPeriodCronJob();
   stopPasswordTokenCleanupJob();
+  stopBlockedSlotCleanupJob();
   shutdownQueue();
   if (server) {
     server.close();

--- a/MJ_FB_Backend/src/utils/blockedSlotCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/blockedSlotCleanupJob.ts
@@ -1,0 +1,28 @@
+import pool from '../db';
+import logger from './logger';
+import scheduleDailyJob from './scheduleDailyJob';
+
+/**
+ * Remove non-recurring blocked slots from past dates.
+ */
+export async function cleanupPastBlockedSlots(): Promise<void> {
+  try {
+    await pool.query('DELETE FROM blocked_slots WHERE date < CURRENT_DATE');
+  } catch (err) {
+    logger.error('Failed to clean up blocked slots', err);
+  }
+}
+
+/**
+ * Schedule the cleanup job to run nightly at 2:00 AM Regina time.
+ */
+const blockedSlotCleanupJob = scheduleDailyJob(
+  cleanupPastBlockedSlots,
+  '0 2 * * *',
+  true,
+  true,
+);
+
+export const startBlockedSlotCleanupJob = blockedSlotCleanupJob.start;
+export const stopBlockedSlotCleanupJob = blockedSlotCleanupJob.stop;
+

--- a/MJ_FB_Backend/tests/blockedSlotCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/blockedSlotCleanupJob.test.ts
@@ -1,0 +1,57 @@
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+jest.mock('../src/utils/scheduleDailyJob', () => {
+  const actual = jest.requireActual('../src/utils/scheduleDailyJob');
+  return {
+    __esModule: true,
+    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
+  };
+});
+const job = require('../src/utils/blockedSlotCleanupJob');
+const {
+  cleanupPastBlockedSlots,
+  startBlockedSlotCleanupJob,
+  stopBlockedSlotCleanupJob,
+} = job;
+import pool from '../src/db';
+
+describe('cleanupPastBlockedSlots', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes past blocked slots', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1 });
+    await cleanupPastBlockedSlots();
+    expect(pool.query).toHaveBeenCalledWith(
+      'DELETE FROM blocked_slots WHERE date < CURRENT_DATE',
+    );
+  });
+});
+
+describe('startBlockedSlotCleanupJob/stopBlockedSlotCleanupJob', () => {
+  let scheduleMock: jest.Mock;
+  let stopMock: jest.Mock;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    scheduleMock = require('node-cron').schedule as jest.Mock;
+    stopMock = jest.fn();
+    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+  });
+
+  afterEach(() => {
+    stopBlockedSlotCleanupJob();
+    jest.useRealTimers();
+    scheduleMock.mockReset();
+  });
+
+  it('schedules and stops the cron job', () => {
+    startBlockedSlotCleanupJob();
+    expect(scheduleMock).toHaveBeenCalledWith(
+      '0 2 * * *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+    stopBlockedSlotCleanupJob();
+    expect(stopMock).toHaveBeenCalled();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Booking confirmation emails include links to public pages for cancelling or rescheduling
   bookings at `/cancel/:token` and `/reschedule/:token`.
 - Email templates display times in 12-hour AM/PM format.
+- Past blocked slots are cleared nightly, with `/api/blocked-slots/cleanup` available for admins to trigger a manual cleanup.
 - Client login page reminds users to sign in with their client ID, provides contact and password reset guidance, and directs staff, volunteers, and agencies to use the internal login button from the menu.
 
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at


### PR DESCRIPTION
## Summary
- purge non-recurring blocked slots nightly
- allow admins to manually trigger blocked slot cleanup
- document blocked slot cleanup job and endpoint

## Testing
- `npm test` *(fails: Test Suites: 22 failed, 93 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be094f0360832db5f81799e0db0ff4