### PR TITLE
Aggregate warehouse logs and purge old data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/public/locales` when client-visible text is added.
 - Pantry visits track daily sunshine bag weights and client counts via the `sunshine_bag_log` table.
+- Sunshine bag, surplus, pig pound, and outgoing donation logs roll up into monthly aggregates and raw log entries older than one year are purged every Jan 31.
 - Anonymous pantry visits display "(ANONYMOUS)" after the client ID and their family size is excluded from the summary counts.
 - Bulk pantry visit imports use the `POST /client-visits/import` endpoint (also available at `/visits/import`) and overwrite existing visits when client/date duplicates are found; see `docs/pantryVisits.md` for sheet naming and dry-run options.
 - Client visits enforce a unique client/date combination; attempts to record a second visit for the same client and day return a 409 error.

--- a/MJ_FB_Backend/AGENTS.md
+++ b/MJ_FB_Backend/AGENTS.md
@@ -33,6 +33,7 @@
 - A nightly volunteer no-show cleanup job (`src/utils/volunteerNoShowCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 20 * * *` Regina time to mark past approved volunteer bookings as `no_show`. It logs results, emails coordinators, and waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`) after each shift before auto-marking.
 - An expired token cleanup job (`src/utils/expiredTokenCleanupJob.ts`) runs nightly at 3:00 AM Regina time to delete `password_setup_tokens` and `client_email_verifications` rows with `expires_at` more than 10 days ago. It exposes `startExpiredTokenCleanupJob`/`stopExpiredTokenCleanupJob`.
 - A daily password token cleanup job (`src/utils/passwordTokenCleanupJob.ts`) runs at server startup and uses `node-cron` with `0 1 * * *` Regina time to delete used or expired password setup tokens. It exposes `startPasswordTokenCleanupJob`/`stopPasswordTokenCleanupJob`.
+- A yearly log cleanup job (`src/utils/logCleanupJob.ts`) runs every Jan 31 to aggregate the previous year's warehouse and sunshine bag logs then purge those old records from the live tables.
 
 ## Project Layout
 

--- a/MJ_FB_Backend/src/migrations/1700000000030_add_sunshine_bag_overall.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000030_add_sunshine_bag_overall.ts
@@ -1,0 +1,18 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable(
+    'sunshine_bag_overall',
+    {
+      year: { type: 'integer', notNull: true },
+      month: { type: 'integer', notNull: true, check: 'month BETWEEN 1 AND 12' },
+      weight: { type: 'integer', notNull: true, default: 0 },
+      client_count: { type: 'integer', notNull: true, default: 0 },
+    },
+    { constraints: { primaryKey: ['year', 'month'] } },
+  );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('sunshine_bag_overall');
+}

--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -30,6 +30,7 @@ import {
   startPasswordTokenCleanupJob,
   stopPasswordTokenCleanupJob,
 } from './utils/passwordTokenCleanupJob';
+import { startLogCleanupJob, stopLogCleanupJob } from './utils/logCleanupJob';
 
 const PORT = config.port;
 
@@ -57,6 +58,7 @@ async function init() {
     await seedTimesheets();
     startTimesheetSeedJob();
     startPasswordTokenCleanupJob();
+    startLogCleanupJob();
   } catch (err) {
     logger.error('❌ Failed to connect to the database:', err);
     process.exit(1);
@@ -73,6 +75,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   stopTimesheetSeedJob();
   stopPayPeriodCronJob();
   stopPasswordTokenCleanupJob();
+  stopLogCleanupJob();
   shutdownQueue();
   if (server) {
     server.close();

--- a/MJ_FB_Backend/src/utils/logCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/logCleanupJob.ts
@@ -1,0 +1,33 @@
+import pool from '../db';
+import logger from './logger';
+import scheduleDailyJob from './scheduleDailyJob';
+import { refreshWarehouseOverall } from '../controllers/warehouse/warehouseOverallController';
+import { refreshSunshineBagOverall } from '../controllers/sunshineBagController';
+
+export async function cleanupOldLogs(now: Date = new Date()): Promise<void> {
+  const currentYear = now.getUTCFullYear();
+  const previousYear = currentYear - 1;
+  try {
+    for (let month = 1; month <= 12; month++) {
+      await refreshWarehouseOverall(previousYear, month);
+      await refreshSunshineBagOverall(previousYear, month);
+    }
+    const cutoff = `${currentYear}-01-01`;
+    const tables = [
+      'sunshine_bag_log',
+      'surplus_log',
+      'pig_pound_log',
+      'outgoing_donation_log',
+    ];
+    for (const table of tables) {
+      await pool.query(`DELETE FROM ${table} WHERE date < $1`, [cutoff]);
+    }
+  } catch (err) {
+    logger.error('Failed to clean up old logs', err);
+  }
+}
+
+const logCleanupJob = scheduleDailyJob(cleanupOldLogs, '0 2 31 1 *', false);
+
+export const startLogCleanupJob = logCleanupJob.start;
+export const stopLogCleanupJob = logCleanupJob.stop;

--- a/MJ_FB_Backend/tests/logCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/logCleanupJob.test.ts
@@ -1,0 +1,42 @@
+import mockPool from './utils/mockDb';
+import { cleanupOldLogs } from '../src/utils/logCleanupJob';
+import { refreshWarehouseOverall } from '../src/controllers/warehouse/warehouseOverallController';
+import { refreshSunshineBagOverall } from '../src/controllers/sunshineBagController';
+
+jest.mock('../src/controllers/warehouse/warehouseOverallController');
+jest.mock('../src/controllers/sunshineBagController');
+
+describe('cleanupOldLogs', () => {
+  beforeEach(() => {
+    (mockPool.query as jest.Mock).mockReset().mockResolvedValue({});
+    (refreshWarehouseOverall as jest.Mock).mockReset().mockResolvedValue(undefined);
+    (refreshSunshineBagOverall as jest.Mock).mockReset().mockResolvedValue(undefined);
+  });
+
+  it('aggregates previous year and deletes old rows', async () => {
+    await cleanupOldLogs(new Date('2025-01-31T00:00:00Z'));
+
+    for (let month = 1; month <= 12; month++) {
+      expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, month);
+      expect(refreshSunshineBagOverall).toHaveBeenCalledWith(2024, month);
+    }
+
+    const cutoff = '2025-01-01';
+    expect(mockPool.query).toHaveBeenCalledWith(
+      'DELETE FROM sunshine_bag_log WHERE date < $1',
+      [cutoff],
+    );
+    expect(mockPool.query).toHaveBeenCalledWith(
+      'DELETE FROM surplus_log WHERE date < $1',
+      [cutoff],
+    );
+    expect(mockPool.query).toHaveBeenCalledWith(
+      'DELETE FROM pig_pound_log WHERE date < $1',
+      [cutoff],
+    );
+    expect(mockPool.query).toHaveBeenCalledWith(
+      'DELETE FROM outgoing_donation_log WHERE date < $1',
+      [cutoff],
+    );
+  });
+});

--- a/MJ_FB_Backend/tests/sunshineBagController.test.ts
+++ b/MJ_FB_Backend/tests/sunshineBagController.test.ts
@@ -23,10 +23,12 @@ describe('sunshine bag log', () => {
   });
 
   it('upserts sunshine bag weight and client count', async () => {
-    (pool.query as jest.Mock).mockResolvedValueOnce({
-      rows: [{ date: '2024-01-01', weight: 5, clientCount: 3 }],
-      rowCount: 1,
-    });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rows: [{ date: '2024-01-01', weight: 5, clientCount: 3 }],
+        rowCount: 1,
+      })
+      .mockResolvedValue({ rows: [{ weight: 5, client_count: 3 }], rowCount: 1 });
     const res = await request(app)
       .post('/sunshine-bags')
       .send({ date: '2024-01-01', weight: 5, clientCount: 3 });

--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ The volunteer no-show cleanup job waits `VOLUNTEER_NO_SHOW_HOURS` (default `24`)
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Booking confirmations include links to add appointments to Google Calendar or download an ICS file.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.
+- Sunshine bag, surplus, pig pound, and outgoing donation logs roll up into monthly summary tables, and raw log entries older than one year are deleted each Jan 31.
 - Warehouse Aggregations page provides yearly totals and supports exporting them via `/warehouse-overall/export`.
 - Page and form titles render in uppercase with a lighter font weight for clarity.
 - Admin staff creation page provides a link back to the staff list for easier navigation.


### PR DESCRIPTION
## Summary
- add monthly sunshine bag aggregation and yearly cleanup job for log tables
- schedule annual log cleanup and update docs

## Testing
- `npm test tests/logCleanupJob.test.ts tests/sunshineBagController.test.ts`
- `npm test` *(fails: 18 failed, 97 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be09e285f0832d83e73320b02070ce