### PR TITLE
Fix reschedule booking email query

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -536,7 +536,7 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
       ? await pool.query(
           `SELECT COALESCE(u.email, nc.email) AS email
            FROM bookings b
-           LEFT JOIN users u ON b.user_id = u.user_id
+           LEFT JOIN clients u ON b.user_id = u.client_id
            LEFT JOIN new_clients nc ON b.new_client_id = nc.id
            WHERE b.id=$1`,
           [booking.id],
@@ -544,7 +544,7 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
       : await pool.query(
           `SELECT u.email AS email
            FROM bookings b
-           LEFT JOIN users u ON b.user_id = u.user_id
+           LEFT JOIN clients u ON b.user_id = u.client_id
            WHERE b.id=$1`,
           [booking.id],
         );

--- a/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
+++ b/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
@@ -95,7 +95,10 @@ describe('rescheduleBooking', () => {
 
     await rescheduleBooking(req, res, next);
 
-    expect(poolQueryMock.mock.calls[3][0]).not.toContain('new_clients');
+    const query = poolQueryMock.mock.calls[3][0];
+    expect(query).not.toContain('new_clients');
+    expect(query).toContain('LEFT JOIN clients');
+    expect(query).not.toContain('users');
     expect(enqueueEmailMock).toHaveBeenCalledTimes(1);
     expect(enqueueEmailMock.mock.calls[0][0].to).toBe('client@example.com');
   });


### PR DESCRIPTION
## Summary
- Fix booking reschedule email lookup to use clients table
- Add test assertion ensuring reschedule query joins clients and not users

## Testing
- `npm test` *(fails: Test Suites: 27 failed, 90 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be1073a080832d99d00cd4f8484fd2