### PR TITLE
Stack booking history action buttons on small screens

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -207,7 +207,11 @@ export default function ClientHistory() {
                         </TableCell>
                         <TableCell sx={cellSx}>
                           {['approved'].includes(b.status.toLowerCase()) && (
-                            <Stack direction="row" spacing={1}>
+                            <Stack
+                              direction={isSmall ? 'column' : 'row'}
+                              spacing={1}
+                              alignItems={isSmall ? 'stretch' : 'center'}
+                            >
                               <Button
                                 onClick={() => setRescheduleBooking(b)}
                                 variant="outlined"

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -328,7 +328,11 @@ export default function UserHistory({
                         )}
                         <TableCell sx={cellSx}>
                           {['approved'].includes(b.status.toLowerCase()) && (
-                            <Stack direction="row" spacing={1}>
+                            <Stack
+                              direction={isSmall ? 'column' : 'row'}
+                              spacing={1}
+                              alignItems={isSmall ? 'stretch' : 'center'}
+                            >
                               <Button
                                 onClick={() => setCancelId(b.id)}
                                 variant="outlined"


### PR DESCRIPTION
## Summary
- Stack cancel/reschedule buttons vertically on small screens for booking history tables
- Stack cancel/reschedule buttons vertically for staff client history view

## Testing
- `npm test` *(fails: Unable to find role="button" and name "Cancel" etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be11a9b6a4832d84358f29eca03690