### PR TITLE
Fix volunteer badge query typing

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -415,7 +415,10 @@ export async function getVolunteerStats(
     );
     const badges = new Set(manualRes.rows.map(r => r.badge_code));
 
-    const earlyRes = await pool.query<{ has_early_bird: boolean }>(
+    // Determine whether this volunteer qualifies for the early-bird badge.
+    // The query returns a single boolean column aliased as `early`,
+    // so type the result accordingly.
+    const earlyRes = await pool.query<{ early: boolean }>(
       `SELECT has_early_bird OR EXISTS (
          SELECT 1 FROM volunteer_bookings vb
          JOIN volunteer_slots vs ON vb.slot_id = vs.slot_id


### PR DESCRIPTION
## Summary
- type early-bird query result correctly for volunteer stats

## Testing
- `npm test` (fails: 24 failed, 93 passed)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be11d82a78832d81c3e7e8e9b2200e