### PR TITLE
Alert ops for email queue cleanup issues

### DIFF
--- a/MJ_FB_Backend/src/utils/emailQueueCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/emailQueueCleanupJob.ts
@@ -2,6 +2,7 @@ import pool from '../db';
 import config from '../config';
 import logger from './logger';
 import scheduleDailyJob from './scheduleDailyJob';
+import { alertOps, notifyOps } from './opsAlert';
 
 export async function cleanupEmailQueue(): Promise<void> {
   try {
@@ -14,9 +15,14 @@ export async function cleanupEmailQueue(): Promise<void> {
     logger.info('Email queue size', { size });
     if (size > config.emailQueueWarningSize) {
       logger.warn('Email queue size exceeds threshold', { size, threshold: config.emailQueueWarningSize });
+      await notifyOps(
+        'Email queue size exceeds threshold',
+        `Email queue size ${size} exceeds warning threshold ${config.emailQueueWarningSize}`,
+      );
     }
   } catch (err) {
     logger.error('Failed to clean up email queue', err);
+    await alertOps('cleanupEmailQueue', err);
   }
 }
 

--- a/MJ_FB_Backend/src/utils/opsAlert.ts
+++ b/MJ_FB_Backend/src/utils/opsAlert.ts
@@ -30,3 +30,18 @@ export async function alertOps(job: string, err: unknown): Promise<void> {
   tasks.push(sendTelegram(message));
   await Promise.all(tasks);
 }
+
+export async function notifyOps(subject: string, body: string): Promise<void> {
+  const fullSubject = `[MJFB] ${subject}`;
+  const message = `${fullSubject}\n${body}`;
+  const tasks: Promise<unknown>[] = [];
+  if (config.opsAlertEmails.length) {
+    tasks.push(
+      ...config.opsAlertEmails.map(email =>
+        sendEmail(email, fullSubject, body).catch(e => logger.error('Failed to send ops alert', e)),
+      ),
+    );
+  }
+  tasks.push(sendTelegram(message));
+  await Promise.all(tasks);
+}


### PR DESCRIPTION
## Summary
- alert ops if nightly email queue cleanup fails
- notify ops via Telegram when email queue exceeds warning threshold
- test email queue cleanup warning and failure paths

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'sendNextDayVolunteerShiftRemindersMock' before initialization)*


------
https://chatgpt.com/codex/tasks/task_e_68be1b98224c832dad97710c96b483b9