### PR TITLE
Fix small-screen booking button layout

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -471,8 +471,13 @@ export default function BookingUI({
           zIndex: theme => theme.zIndex.appBar,
         }}
       >
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Typography>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          justifyContent={{ xs: 'center', sm: 'space-between' }}
+          spacing={1}
+        >
+          <Typography sx={{ mb: { xs: 1, sm: 0 } }}>
             {selectedSlotId
               ? t('selected_on', {
                   slot: selectedLabel,
@@ -485,6 +490,8 @@ export default function BookingUI({
             size="small"
             disabled={!selectedSlotId || booking || loadingConfirm}
             onClick={handleOpenConfirm}
+            fullWidth
+            sx={{ width: { sm: 'auto' } }}
           >
             {t('book_selected_slot')}
           </Button>


### PR DESCRIPTION
## Summary
- Make the booking confirmation action bar responsive on small screens by stacking text and expanding button

## Testing
- `npm test` *(fails: multiple suites such as UserHistory and RecurringBookings)*

------
https://chatgpt.com/codex/tasks/task_e_68be3af23738832d851aa08ed134593e