### PR TITLE
feat: show volunteers in coverage card dialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerCoverageCard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerCoverageCard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import VolunteerCoverageCard from '../components/dashboard/VolunteerCoverageCard';
 import { getVolunteerRoles, getVolunteerBookingsByRole } from '../api/volunteers';
 
@@ -27,6 +28,27 @@ describe('VolunteerCoverageCard', () => {
 
     await waitFor(() => expect(getVolunteerBookingsByRole).toHaveBeenCalled());
     expect(await screen.findByText('1/2')).toBeInTheDocument();
+  });
+
+  it('shows volunteers when a coverage entry is clicked', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-15T12:00:00Z'));
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'Greeter', category_name: 'Front', max_volunteers: 2 },
+    ]);
+    (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([
+      { status: 'approved', date: '2024-01-15', volunteer_name: 'Alice' },
+      { status: 'approved', date: '2024-01-15', volunteer_name: 'Bob' },
+    ]);
+
+    render(<VolunteerCoverageCard />);
+
+    await waitFor(() => expect(getVolunteerBookingsByRole).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByText('Greeter (Front)'));
+
+    expect(await screen.findByText('Volunteers – Greeter')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
   });
 });
 

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -373,6 +373,18 @@ export function getHelpContent(
       },
     },
     {
+      title: 'View volunteers on duty',
+      body: {
+        description:
+          'Volunteer Coverage lists scheduled volunteers for each role.',
+        steps: [
+          'Open the staff dashboard.',
+          'Check the Volunteer Coverage card.',
+          'Click a role to view volunteers on duty.',
+        ],
+      },
+    },
+    {
       title: t('help.pantry.timesheets.title'),
       body: {
         description: t('help.pantry.timesheets.description'),
@@ -397,6 +409,17 @@ export function getHelpContent(
     },
   ],
   warehouse: [
+    {
+      title: 'View volunteers on duty',
+      body: {
+        description: 'Volunteer Coverage lists scheduled warehouse volunteers.',
+        steps: [
+          'Open the Warehouse Dashboard.',
+          'Review the Volunteer Coverage card.',
+          'Click a role to view volunteers on duty.',
+        ],
+      },
+    },
     {
       title: 'Log donations and outgoing shipments',
       body: {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Email templates display times in 12-hour AM/PM format.
 - Past blocked slots are cleared nightly, with `/api/blocked-slots/cleanup` available for admins to trigger a manual cleanup.
 - Client login page reminds users to sign in with their client ID, provides contact and password reset guidance, and directs staff, volunteers, and agencies to use the internal login button from the menu.
+- Staff dashboards include a Volunteer Coverage card; click a role to see which volunteers are on duty.
 
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 `/leave-requests` from the profile menu once logged in. Admin users also see


### PR DESCRIPTION
## Summary
- track volunteer names for each role and show them in a dialog when a coverage entry is clicked
- document that staff dashboards allow clicking volunteer coverage to see volunteers on duty
- note coverage card behavior in README

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68be3af713e4832da73e2d090166a40e