### PR TITLE
feat: allow optional service worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 - Maintain database health: set database-level autovacuum thresholds, schedule manual `VACUUM ANALYZE` during low-traffic windows, plan quarterly `REINDEX` or `pg_repack` runs for heavily updated tables, and monitor table bloat metrics. Record these tasks in ops docs.
 - Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to Azure".
 - Always document new environment variables in the repository README and `.env.example` files.
+- Set `VITE_ENABLE_SERVICE_WORKER=true` in `MJ_FB_Frontend/.env` to register the service worker outside production for PWA testing.
 - Implement all database schema changes via migrations in `MJ_FB_Backend/src/migrations`; do not modify `src/setupDatabase.ts` for schema updates.
 - Volunteers sign in with their email address instead of a username, and volunteer emails must be unique (email remains optional).
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.

--- a/MJ_FB_Frontend/.env.example
+++ b/MJ_FB_Frontend/.env.example
@@ -4,4 +4,8 @@ VITE_API_BASE=http://localhost:4000/api
 # Origin used in invitation links; should match the first entry in BACKEND `FRONTEND_ORIGIN`
 VITE_FRONTEND_ORIGIN=http://localhost:5173
 
+# Enable service worker registration outside production for PWA testing
+# Set to "true" to register the service worker in dev
+VITE_ENABLE_SERVICE_WORKER=false
+
 # Agency authentication relies on JWT secrets configured in `MJ_FB_Backend/.env`.

--- a/MJ_FB_Frontend/AGENTS.md
+++ b/MJ_FB_Frontend/AGENTS.md
@@ -16,6 +16,7 @@
 
 ## Environment
 - Requires Node.js 22+; run `nvm use` to match the version in `.nvmrc`.
+- Set `VITE_ENABLE_SERVICE_WORKER=true` in `.env` to register the service worker outside production for PWA testing.
 
 ## Project Layout
 - React app built with Vite.

--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -45,7 +45,7 @@ The build will fail if this variable is missing.
 
 ## Progressive Web App
 
-The app registers a service worker when running in a secure context. Use HTTPS when serving the built site.
+The app registers a service worker when running in a secure context. Use HTTPS when serving the built site. Set `VITE_ENABLE_SERVICE_WORKER=true` to register the worker outside production for local PWA testing.
 
 - `npm run preview` serves the production build over HTTPS.
 - The Docker image uses Nginx configured for HTTPS. Provide `tls.crt` and `tls.key` under `/etc/nginx/certs`.

--- a/MJ_FB_Frontend/src/registerServiceWorker.ts
+++ b/MJ_FB_Frontend/src/registerServiceWorker.ts
@@ -1,8 +1,12 @@
 export function registerServiceWorker() {
-  const mode = (import.meta as any).env?.MODE ?? process.env.NODE_ENV;
-  if (mode !== 'production') {
+  const env = (import.meta as any).env ?? process.env;
+  const mode = env?.MODE ?? env?.NODE_ENV;
+  const enable = env?.VITE_ENABLE_SERVICE_WORKER === 'true';
+
+  if (mode !== 'production' && !enable) {
     return;
   }
+
   if ('serviceWorker' in navigator && window.isSecureContext) {
     window.addEventListener('load', () => {
       navigator.serviceWorker

--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ VITE_API_BASE=http://localhost:4000/api
 
 The build will fail if this variable is missing.
 
+Set `VITE_ENABLE_SERVICE_WORKER=true` in `MJ_FB_Frontend/.env` to register the service worker outside production for local PWA testing. It defaults to disabled.
+
 Refer to the submodule repositories for detailed configuration and environment variables.
 
 The backend surplus tracking feature uses two optional environment variables to


### PR DESCRIPTION
## Summary
- allow service worker registration when `VITE_ENABLE_SERVICE_WORKER` is set
- document `VITE_ENABLE_SERVICE_WORKER` for local PWA testing

## Testing
- `npm test` *(fails: Jest encountered an unexpected token and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68be3e0470cc832da2389316a2cb6400