### PR TITLE
Ensure Assign User modal fits small screens

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -423,7 +423,15 @@ export default function PantrySchedule({
             justifyContent: 'center',
           }}
         >
-          <div style={{ background: 'white', padding: 16, borderRadius: 10, width: '300px' }}>
+          <div
+            style={{
+              background: 'white',
+              padding: 16,
+              borderRadius: 10,
+              width: 300,
+              maxWidth: '90vw',
+            }}
+          >
             <h4>Assign User</h4>
             <FormControlLabel
               control={<Checkbox checked={isNewClient} onChange={e => setIsNewClient(e.target.checked)} />}


### PR DESCRIPTION
## Summary
- prevent Assign User modal from exceeding viewport width by adding a 90vw max width

## Testing
- `npm test` *(fails: UserHistory, RecurringBookings, BookingUI, ClientDashboard, VolunteerSchedule and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68be4a89fba0832d9a5e0af7ee972ec1