### PR TITLE
Make volunteer schedule table responsive

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -30,9 +30,10 @@ interface Props {
 
 export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   const safeMaxSlots = Math.max(1, maxSlots);
-  const slotWidth = `calc((100% - 160px) / ${safeMaxSlots})`;
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const timeColumnWidth = isSmall ? 100 : 160;
+  const slotWidth = `calc((100% - ${timeColumnWidth}px) / ${safeMaxSlots})`;
   return (
     <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
         <Table
@@ -54,7 +55,7 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
           }}
         >
         <colgroup>
-          <col style={{ width: 160 }} />
+          <col style={{ width: timeColumnWidth }} />
           {Array.from({ length: safeMaxSlots }).map((_, i) => (
             <col key={i} style={{ width: slotWidth }} />
           ))}


### PR DESCRIPTION
## Summary
- make volunteer schedule table column widths responsive based on screen size

## Testing
- `npm test --runTestsByPath src/__tests__/UserHistory.test.tsx` *(fails: allows staff to delete visits)*

------
https://chatgpt.com/codex/tasks/task_e_68be4a9d6688832d8233b9ce93227fb6