### PR TITLE
Make assign volunteer dialog responsive

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -1094,7 +1094,14 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
             justifyContent: 'center',
           }}
         >
-          <div style={{ background: 'white', padding: 16, borderRadius: 10, width: 300 }}>
+          <Box
+            sx={{
+              background: 'white',
+              p: 2,
+              borderRadius: 2,
+              width: { xs: '90vw', sm: 300 },
+            }}
+          >
             <h4>Assign Volunteer</h4>
               <TextField
                 type="text"
@@ -1135,7 +1142,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
             >
               Close
             </Button>
-          </div>
+          </Box>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- make Assign Volunteer dialog adapt width from 90vw on small screens to 300px on larger ones

## Testing
- `npm test` *(fails: UserHistory.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68be4a8f1db8832d811d9d996dd109af