### PR TITLE
Use card layout for booking history on small screens

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerBookingHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBookingHistory.test.tsx
@@ -12,6 +12,23 @@ jest.mock('../api/volunteers', () => ({
   getVolunteerRolesForVolunteer: jest.fn(),
 }));
 
+const originalMatchMedia = window.matchMedia;
+function setScreen(matches: boolean) {
+  window.matchMedia = () => ({
+    matches,
+    media: '',
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  });
+}
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
 describe('VolunteerBookingHistory', () => {
   beforeEach(() => {
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([
@@ -58,6 +75,27 @@ describe('VolunteerBookingHistory', () => {
         is_wednesday_slot: false,
       },
     ]);
+  });
+
+  it('renders table on large screens', async () => {
+    setScreen(false);
+    render(
+      <MemoryRouter>
+        <VolunteerBookingHistory />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole('table')).toBeInTheDocument();
+  });
+
+  it('renders cards on small screens', async () => {
+    setScreen(true);
+    render(
+      <MemoryRouter>
+        <VolunteerBookingHistory />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(await screen.findByText(/cancel/i)).toBeInTheDocument();
   });
 
   it('shows only available slots in reschedule dialog', async () => {

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -19,6 +19,9 @@ import {
   useTheme,
   Stack,
   Typography,
+  Card,
+  CardContent,
+  CardActions,
 } from '@mui/material';
 import RescheduleDialog from '../../components/RescheduleDialog';
 import EntitySearch from '../../components/EntitySearch';
@@ -163,26 +166,11 @@ export default function ClientHistory() {
                 <MenuItem value="past">{t('past')}</MenuItem>
               </Select>
             </FormControl>
-            <TableContainer sx={{ overflowX: 'auto' }}>
-              <Table size="small" sx={{ width: '100%', borderCollapse: 'collapse' }}>
-                <TableHead>
-                  <TableRow>
-                    <TableCell sx={cellSx}>{t('date')}</TableCell>
-                    <TableCell sx={cellSx}>{t('time')}</TableCell>
-                    <TableCell sx={cellSx}>{t('status')}</TableCell>
-                    <TableCell sx={cellSx}>{t('reason')}</TableCell>
-                    <TableCell sx={cellSx}>{t('staff_note_label')}</TableCell>
-                    <TableCell sx={cellSx}>{t('actions')}</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {paginated.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={6} sx={{ textAlign: 'center' }}>
-                        {t('no_bookings')}
-                      </TableCell>
-                    </TableRow>
-                  )}
+            {isSmall ? (
+              paginated.length === 0 ? (
+                <Typography align="center">{t('no_bookings')}</Typography>
+              ) : (
+                <Stack spacing={2}>
                   {paginated.map(b => {
                     const startTime = b.start_time ? formatTime(b.start_time) : 'N/A';
                     const endTime = b.end_time ? formatTime(b.end_time) : 'N/A';
@@ -191,50 +179,133 @@ export default function ClientHistory() {
                         ? formatDate(b.date, 'MMM D, YYYY')
                         : 'N/A';
                     return (
-                      <TableRow key={`${b.id}-${b.date}`}>
-                        <TableCell sx={cellSx}>{formattedDate}</TableCell>
-                        <TableCell sx={cellSx}>
-                          {startTime !== 'N/A' && endTime !== 'N/A'
-                            ? `${startTime} - ${endTime}`
-                            : 'N/A'}
-                        </TableCell>
-                        <TableCell sx={cellSx}>{t(b.status)}</TableCell>
-                        <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
-                        <TableCell sx={cellSx}>
+                      <Card key={`${b.id}-${b.date}`}>
+                        <CardContent>
+                          <Typography variant="subtitle2">
+                            {t('date')}: {formattedDate}
+                          </Typography>
+                          <Typography variant="body2">
+                            {t('time')}: {startTime !== 'N/A' && endTime !== 'N/A'
+                              ? `${startTime} - ${endTime}`
+                              : 'N/A'}
+                          </Typography>
+                          <Typography variant="body2">
+                            {t('status')}: {t(b.status)}
+                          </Typography>
+                          {b.reason && (
+                            <Typography variant="body2">
+                              {t('reason')}: {b.reason}
+                            </Typography>
+                          )}
                           {b.staff_note && (
-                            <Typography variant="body2">{b.staff_note}</Typography>
+                            <Typography variant="body2">
+                              {t('staff_note_label')}: {b.staff_note}
+                            </Typography>
                           )}
-                        </TableCell>
-                        <TableCell sx={cellSx}>
-                          {['approved'].includes(b.status.toLowerCase()) && (
-                            <Stack
-                              direction={isSmall ? 'column' : 'row'}
-                              spacing={1}
-                              alignItems={isSmall ? 'stretch' : 'center'}
-                            >
-                              <Button
-                                onClick={() => setRescheduleBooking(b)}
-                                variant="outlined"
-                                color="primary"
-                              >
-                                {t('reschedule')}
-                              </Button>
-                              <Button
-                                onClick={() => handleCancel(b)}
-                                variant="outlined"
-                                color="error"
-                              >
-                                {t('cancel')}
-                              </Button>
-                            </Stack>
-                          )}
-                        </TableCell>
-                      </TableRow>
+                        </CardContent>
+                        <CardActions>
+                          <Stack direction="column" spacing={1} sx={{ width: '100%' }}>
+                            {['approved'].includes(b.status.toLowerCase()) && (
+                              <>
+                                <Button
+                                  onClick={() => setRescheduleBooking(b)}
+                                  variant="outlined"
+                                  color="primary"
+                                  fullWidth
+                                >
+                                  {t('reschedule')}
+                                </Button>
+                                <Button
+                                  onClick={() => handleCancel(b)}
+                                  variant="outlined"
+                                  color="error"
+                                  fullWidth
+                                >
+                                  {t('cancel')}
+                                </Button>
+                              </>
+                            )}
+                          </Stack>
+                        </CardActions>
+                      </Card>
                     );
                   })}
-                </TableBody>
-              </Table>
-            </TableContainer>
+                </Stack>
+              )
+            ) : (
+              <TableContainer sx={{ overflowX: 'auto' }}>
+                <Table size="small" sx={{ width: '100%', borderCollapse: 'collapse' }}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={cellSx}>{t('date')}</TableCell>
+                      <TableCell sx={cellSx}>{t('time')}</TableCell>
+                      <TableCell sx={cellSx}>{t('status')}</TableCell>
+                      <TableCell sx={cellSx}>{t('reason')}</TableCell>
+                      <TableCell sx={cellSx}>{t('staff_note_label')}</TableCell>
+                      <TableCell sx={cellSx}>{t('actions')}</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {paginated.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={6} sx={{ textAlign: 'center' }}>
+                          {t('no_bookings')}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {paginated.map(b => {
+                      const startTime = b.start_time ? formatTime(b.start_time) : 'N/A';
+                      const endTime = b.end_time ? formatTime(b.end_time) : 'N/A';
+                      const formattedDate =
+                        b.date && !isNaN(toDate(b.date).getTime())
+                          ? formatDate(b.date, 'MMM D, YYYY')
+                          : 'N/A';
+                      return (
+                        <TableRow key={`${b.id}-${b.date}`}>
+                          <TableCell sx={cellSx}>{formattedDate}</TableCell>
+                          <TableCell sx={cellSx}>
+                            {startTime !== 'N/A' && endTime !== 'N/A'
+                              ? `${startTime} - ${endTime}`
+                              : 'N/A'}
+                          </TableCell>
+                          <TableCell sx={cellSx}>{t(b.status)}</TableCell>
+                          <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
+                          <TableCell sx={cellSx}>
+                            {b.staff_note && (
+                              <Typography variant="body2">{b.staff_note}</Typography>
+                            )}
+                          </TableCell>
+                          <TableCell sx={cellSx}>
+                            {['approved'].includes(b.status.toLowerCase()) && (
+                              <Stack
+                                direction={isSmall ? 'column' : 'row'}
+                                spacing={1}
+                                alignItems={isSmall ? 'stretch' : 'center'}
+                              >
+                                <Button
+                                  onClick={() => setRescheduleBooking(b)}
+                                  variant="outlined"
+                                  color="primary"
+                                >
+                                  {t('reschedule')}
+                                </Button>
+                                <Button
+                                  onClick={() => handleCancel(b)}
+                                  variant="outlined"
+                                  color="error"
+                                >
+                                  {t('cancel')}
+                                </Button>
+                              </Stack>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
             {totalPages > 1 && (
               <Box
                 sx={{

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -25,6 +25,9 @@ import {
   Checkbox,
   Stack,
   Tooltip,
+  Card,
+  CardContent,
+  CardActions,
   Table,
   TableBody,
   TableCell,
@@ -280,28 +283,11 @@ export default function UserHistory({
                 label={t('visits_with_notes_only')}
               />
             )}
-            <TableContainer sx={{ overflowX: 'auto' }}>
-              <Table size="small" sx={{ width: '100%', borderCollapse: 'collapse' }}>
-                <TableHead>
-                  <TableRow>
-                    <TableCell sx={cellSx}>{t('date')}</TableCell>
-                    <TableCell sx={cellSx}>{t('time')}</TableCell>
-                    <TableCell sx={cellSx}>{t('status')}</TableCell>
-                    <TableCell sx={cellSx}>{t('reason')}</TableCell>
-                    {showNotes && (
-                      <TableCell sx={cellSx}>{t('staff_note_label')}</TableCell>
-                    )}
-                    <TableCell sx={cellSx}>{t('actions')}</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {paginated.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={showNotes ? 6 : 5} sx={{ textAlign: 'center' }}>
-                        {t('no_bookings')}
-                      </TableCell>
-                    </TableRow>
-                  )}
+            {isSmall ? (
+              paginated.length === 0 ? (
+                <Typography align="center">{t('no_bookings')}</Typography>
+              ) : (
+                <Stack spacing={2}>
                   {paginated.map(b => {
                     const startTime = b.start_time ? formatTime(b.start_time) : 'N/A';
                     const endTime = b.end_time ? formatTime(b.end_time) : 'N/A';
@@ -310,63 +296,158 @@ export default function UserHistory({
                         ? formatDate(b.date, 'MMM D, YYYY')
                         : 'N/A';
                     return (
-                      <TableRow key={`${b.id}-${b.date}`}>
-                        <TableCell sx={cellSx}>{formattedDate}</TableCell>
-                        <TableCell sx={cellSx}>
-                          {startTime !== 'N/A' && endTime !== 'N/A'
-                            ? `${startTime} - ${endTime}`
-                            : 'N/A'}
-                        </TableCell>
-                        <TableCell sx={cellSx}>{t(b.status)}</TableCell>
-                        <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
-                        {showNotes && (
-                          <TableCell sx={cellSx}>
-                            {b.staff_note && (
-                              <Typography variant="body2">{b.staff_note}</Typography>
+                      <Card key={`${b.id}-${b.date}`}>
+                        <CardContent>
+                          <Typography variant="subtitle2">
+                            {t('date')}: {formattedDate}
+                          </Typography>
+                          <Typography variant="body2">
+                            {t('time')}: {startTime !== 'N/A' && endTime !== 'N/A'
+                              ? `${startTime} - ${endTime}`
+                              : 'N/A'}
+                          </Typography>
+                          <Typography variant="body2">
+                            {t('status')}: {t(b.status)}
+                          </Typography>
+                          {b.reason && (
+                            <Typography variant="body2">
+                              {t('reason')}: {b.reason}
+                            </Typography>
+                          )}
+                          {showNotes && b.staff_note && (
+                            <Typography variant="body2">
+                              {t('staff_note_label')}: {b.staff_note}
+                            </Typography>
+                          )}
+                        </CardContent>
+                        <CardActions>
+                          <Stack direction="column" spacing={1} sx={{ width: '100%' }}>
+                            {['approved'].includes(b.status.toLowerCase()) && (
+                              <>
+                                <Button
+                                  onClick={() => setCancelId(b.id)}
+                                  variant="outlined"
+                                  color="primary"
+                                  fullWidth
+                                >
+                                  {t('cancel')}
+                                </Button>
+                                <Button
+                                  onClick={() => setRescheduleBooking(b)}
+                                  variant="outlined"
+                                  color="primary"
+                                  fullWidth
+                                >
+                                  {t('reschedule')}
+                                </Button>
+                              </>
                             )}
-                          </TableCell>
-                        )}
-                        <TableCell sx={cellSx}>
-                          {['approved'].includes(b.status.toLowerCase()) && (
-                            <Stack
-                              direction={isSmall ? 'column' : 'row'}
-                              spacing={1}
-                              alignItems={isSmall ? 'stretch' : 'center'}
-                            >
+                            {role === 'staff' && b.status === 'visited' && !b.slot_id && (
                               <Button
-                                onClick={() => setCancelId(b.id)}
+                                onClick={() => setDeleteVisitId(b.id)}
                                 variant="outlined"
-                                color="primary"
+                                color="error"
+                                fullWidth
                               >
-                                {t('cancel')}
+                                Delete visit
                               </Button>
-                              <Button
-                                onClick={() => setRescheduleBooking(b)}
-                                variant="outlined"
-                                color="primary"
-                              >
-                                {t('reschedule')}
-                              </Button>
-                            </Stack>
-                          )}
-                          {role === 'staff' && b.status === 'visited' && !b.slot_id && (
-                            <Button
-                              onClick={() => setDeleteVisitId(b.id)}
-                              variant="outlined"
-                              color="error"
-                              size="small"
-                              sx={{ mt: ['approved'].includes(b.status.toLowerCase()) ? 1 : 0 }}
-                            >
-                              Delete visit
-                            </Button>
-                          )}
-                        </TableCell>
-                      </TableRow>
+                            )}
+                          </Stack>
+                        </CardActions>
+                      </Card>
                     );
                   })}
-                </TableBody>
-              </Table>
-            </TableContainer>
+                </Stack>
+              )
+            ) : (
+              <TableContainer sx={{ overflowX: 'auto' }}>
+                <Table size="small" sx={{ width: '100%', borderCollapse: 'collapse' }}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={cellSx}>{t('date')}</TableCell>
+                      <TableCell sx={cellSx}>{t('time')}</TableCell>
+                      <TableCell sx={cellSx}>{t('status')}</TableCell>
+                      <TableCell sx={cellSx}>{t('reason')}</TableCell>
+                      {showNotes && (
+                        <TableCell sx={cellSx}>{t('staff_note_label')}</TableCell>
+                      )}
+                      <TableCell sx={cellSx}>{t('actions')}</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {paginated.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={showNotes ? 6 : 5} sx={{ textAlign: 'center' }}>
+                          {t('no_bookings')}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {paginated.map(b => {
+                      const startTime = b.start_time ? formatTime(b.start_time) : 'N/A';
+                      const endTime = b.end_time ? formatTime(b.end_time) : 'N/A';
+                      const formattedDate =
+                        b.date && !isNaN(toDate(b.date).getTime())
+                          ? formatDate(b.date, 'MMM D, YYYY')
+                          : 'N/A';
+                      return (
+                        <TableRow key={`${b.id}-${b.date}`}>
+                          <TableCell sx={cellSx}>{formattedDate}</TableCell>
+                          <TableCell sx={cellSx}>
+                            {startTime !== 'N/A' && endTime !== 'N/A'
+                              ? `${startTime} - ${endTime}`
+                              : 'N/A'}
+                          </TableCell>
+                          <TableCell sx={cellSx}>{t(b.status)}</TableCell>
+                          <TableCell sx={cellSx}>{b.reason || ''}</TableCell>
+                          {showNotes && (
+                            <TableCell sx={cellSx}>
+                              {b.staff_note && (
+                                <Typography variant="body2">{b.staff_note}</Typography>
+                              )}
+                            </TableCell>
+                          )}
+                          <TableCell sx={cellSx}>
+                            {['approved'].includes(b.status.toLowerCase()) && (
+                              <Stack
+                                direction={isSmall ? 'column' : 'row'}
+                                spacing={1}
+                                alignItems={isSmall ? 'stretch' : 'center'}
+                              >
+                                <Button
+                                  onClick={() => setCancelId(b.id)}
+                                  variant="outlined"
+                                  color="primary"
+                                >
+                                  {t('cancel')}
+                                </Button>
+                                <Button
+                                  onClick={() => setRescheduleBooking(b)}
+                                  variant="outlined"
+                                  color="primary"
+                                >
+                                  {t('reschedule')}
+                                </Button>
+                              </Stack>
+                            )}
+                            {role === 'staff' && b.status === 'visited' && !b.slot_id && (
+                              <Button
+                                onClick={() => setDeleteVisitId(b.id)}
+                                variant="outlined"
+                                color="error"
+                                size="small"
+                                sx={{ mt: ['approved'].includes(b.status.toLowerCase()) ? 1 : 0 }}
+                              >
+                                Delete visit
+                              </Button>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
             {totalPages > 1 && (
               <Box
                 sx={{

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
@@ -25,6 +25,13 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Card,
+  CardContent,
+  CardActions,
+  Stack,
+  Typography,
+  useTheme,
+  useMediaQuery,
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 
@@ -38,6 +45,9 @@ export default function VolunteerBookingHistory() {
   const [message, setMessage] = useState('');
   const [severity, setSeverity] = useState<AlertColor>('success');
   const { t } = useTranslation();
+
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
   const loadHistory = useCallback(() => {
     getMyVolunteerBookings()
@@ -109,39 +119,40 @@ export default function VolunteerBookingHistory() {
 
   return (
     <Page title={t('booking_history')}>
-      <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>{t('role')}</TableCell>
-              <TableCell>{t('date')}</TableCell>
-              <TableCell>{t('time')}</TableCell>
-              <TableCell>{t('status')}</TableCell>
-              <TableCell>{t('actions')}</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
+      {isSmall ? (
+        history.length === 0 ? (
+          <Typography align="center">{t('no_bookings')}</Typography>
+        ) : (
+          <Stack spacing={2}>
             {groups.flatMap(group =>
               group.map(h => (
-                <TableRow key={h.id}>
-                  <TableCell>{h.role_name}</TableCell>
-                  <TableCell>{h.date}</TableCell>
-                  <TableCell>
-                    {formatTime(h.start_time)} - {formatTime(h.end_time)}
-                  </TableCell>
-                  <TableCell>{t(h.status)}</TableCell>
-                  <TableCell>
+                <Card key={h.id}>
+                  <CardContent>
+                    <Typography variant="subtitle2">{h.role_name}</Typography>
+                    <Typography variant="body2">
+                      {t('date')}: {h.date}
+                    </Typography>
+                    <Typography variant="body2">
+                      {t('time')}: {formatTime(h.start_time)} - {formatTime(h.end_time)}
+                    </Typography>
+                    <Typography variant="body2">
+                      {t('status')}: {t(h.status)}
+                    </Typography>
+                  </CardContent>
+                  <CardActions>
                     {h.status.toLowerCase() === 'approved' && (
-                      <>
+                      <Stack direction="column" spacing={1} sx={{ width: '100%' }}>
                         <Button
                           size="small"
                           onClick={() => setCancelBooking(h)}
+                          fullWidth
                         >
                           {t('cancel')}
                         </Button>
                         <Button
                           size="small"
                           onClick={() => setRescheduleBooking(h)}
+                          fullWidth
                         >
                           {t('reschedule')}
                         </Button>
@@ -149,26 +160,81 @@ export default function VolunteerBookingHistory() {
                           <Button
                             size="small"
                             onClick={() => setCancelSeriesId(h.recurring_id!)}
+                            fullWidth
                           >
                             {t('cancel_all_upcoming_short')}
                           </Button>
                         )}
-                      </>
+                      </Stack>
                     )}
-                  </TableCell>
-                </TableRow>
+                  </CardActions>
+                </Card>
               )),
             )}
-            {history.length === 0 && (
+          </Stack>
+        )
+      ) : (
+        <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
+          <Table size="small">
+            <TableHead>
               <TableRow>
-                <TableCell colSpan={5} align="center">
-                  {t('no_bookings')}
-                </TableCell>
+                <TableCell>{t('role')}</TableCell>
+                <TableCell>{t('date')}</TableCell>
+                <TableCell>{t('time')}</TableCell>
+                <TableCell>{t('status')}</TableCell>
+                <TableCell>{t('actions')}</TableCell>
               </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </TableContainer>
+            </TableHead>
+            <TableBody>
+              {groups.flatMap(group =>
+                group.map(h => (
+                  <TableRow key={h.id}>
+                    <TableCell>{h.role_name}</TableCell>
+                    <TableCell>{h.date}</TableCell>
+                    <TableCell>
+                      {formatTime(h.start_time)} - {formatTime(h.end_time)}
+                    </TableCell>
+                    <TableCell>{t(h.status)}</TableCell>
+                    <TableCell>
+                      {h.status.toLowerCase() === 'approved' && (
+                        <>
+                          <Button
+                            size="small"
+                            onClick={() => setCancelBooking(h)}
+                          >
+                            {t('cancel')}
+                          </Button>
+                          <Button
+                            size="small"
+                            onClick={() => setRescheduleBooking(h)}
+                          >
+                            {t('reschedule')}
+                          </Button>
+                          {h.recurring_id && (
+                            <Button
+                              size="small"
+                              onClick={() => setCancelSeriesId(h.recurring_id!)}
+                            >
+                              {t('cancel_all_upcoming_short')}
+                            </Button>
+                          )}
+                        </>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )),
+              )}
+              {history.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={5} align="center">
+                    {t('no_bookings')}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
 
       <Dialog open={!!cancelBooking} onClose={() => setCancelBooking(null)}>
         <DialogCloseButton onClose={() => setCancelBooking(null)} />


### PR DESCRIPTION
## Summary
- Replace tables with card stacks in UserHistory, ClientHistory, and VolunteerBookingHistory on small viewports
- Stack action buttons vertically with full-width for touch friendliness
- Add tests ensuring small and large screen layouts render correctly

## Testing
- `npm test src/__tests__/UserHistory.test.tsx src/__tests__/AgencyClientHistory.test.tsx src/__tests__/VolunteerBookingHistory.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be4b5e0bac832d9edfec36707571e5