### PR TITLE
feat: add responsive table component

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ResponsiveTable.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ResponsiveTable.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import ResponsiveTable from '../components/ResponsiveTable';
+import { useMediaQuery } from '@mui/material';
+
+jest.mock('@mui/material', () => {
+  const actual = jest.requireActual('@mui/material');
+  return { ...actual, useMediaQuery: jest.fn() };
+});
+
+const useMediaQueryMock = useMediaQuery as jest.Mock;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ResponsiveTable', () => {
+  const columns = [
+    { field: 'name', header: 'Name' },
+    { field: 'age', header: 'Age' },
+  ];
+  const rows = [{ id: 1, name: 'Alice', age: 30 }];
+
+  it('renders a table on large screens', () => {
+    useMediaQueryMock.mockReturnValue(false);
+    render(
+      <ResponsiveTable columns={columns} rows={rows} getRowKey={(r) => r.id} />,
+    );
+    expect(screen.getByTestId('responsive-table-table')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('renders cards on small screens', () => {
+    useMediaQueryMock.mockReturnValue(true);
+    render(
+      <ResponsiveTable columns={columns} rows={rows} getRowKey={(r) => r.id} />,
+    );
+    expect(screen.queryByTestId('responsive-table-table')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('responsive-table-card')).toHaveLength(1);
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Age')).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/components/ResponsiveTable.tsx
+++ b/MJ_FB_Frontend/src/components/ResponsiveTable.tsx
@@ -1,0 +1,71 @@
+import { Card, CardContent, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography, useMediaQuery, useTheme } from '@mui/material';
+import type { ReactNode } from 'react';
+
+interface Column<T> {
+  /** Unique field identifier */
+  field: keyof T & string;
+  /** Header label */
+  header: string;
+  /** Optional renderer for cell/field content */
+  render?: (row: T) => ReactNode;
+}
+
+interface Props<T> {
+  columns: Column<T>[];
+  rows: T[];
+  /** Returns a unique key for each row */
+  getRowKey?: (row: T, index: number) => React.Key;
+}
+
+export default function ResponsiveTable<T>({ columns, rows, getRowKey }: Props<T>) {
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const rowKey = (row: T, index: number) =>
+    getRowKey ? getRowKey(row, index) : index;
+
+  if (isSmall) {
+    return (
+      <>
+        {rows.map((row, rowIndex) => (
+          <Card key={rowKey(row, rowIndex)} sx={{ mb: 2 }} data-testid="responsive-table-card">
+            <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {columns.map((col) => (
+                <Stack key={col.field} direction="row" spacing={1}>
+                  <Typography variant="subtitle2">{col.header}</Typography>
+                  <Typography sx={{ flex: 1 }}>
+                    {col.render ? col.render(row) : String(row[col.field])}
+                  </Typography>
+                </Stack>
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <Table size="small" data-testid="responsive-table-table">
+      <TableHead>
+        <TableRow>
+          {columns.map((col) => (
+            <TableCell key={col.field}>{col.header}</TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map((row, rowIndex) => (
+          <TableRow key={rowKey(row, rowIndex)}>
+            {columns.map((col) => (
+              <TableCell key={col.field}>
+                {col.render ? col.render(row) : (row as any)[col.field]}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ResponsiveTable component that renders cards on small screens and a table on larger screens
- support column definitions with custom renderers
- cover ResponsiveTable with unit tests

## Testing
- `npm test` *(fails: RecurringBookings.test.tsx, others)*
- `npm test src/__tests__/ResponsiveTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be501a3a4c832d9a8a7b9e0c1f2f35