### PR TITLE
refactor client management tabs

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -15,7 +15,6 @@ import {
   ToggleButtonGroup,
   ToggleButton,
 } from '@mui/material';
-import Page from '../../../components/Page';
 import PasswordField from '../../../components/PasswordField';
 
 export default function AddClient() {
@@ -74,7 +73,10 @@ export default function AddClient() {
   }
 
   return (
-    <Page title="Create Client">
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Create Client
+      </Typography>
       <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
         <Box maxWidth={400} width="100%" mt={4}>
           <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
@@ -145,7 +147,7 @@ export default function AddClient() {
         </Stack>
         </Box>
       </Box>
-    </Page>
+    </Box>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/DeleteClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/DeleteClient.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@mui/material';
-import Page from '../../../components/Page';
+import { Box, Button, Typography } from '@mui/material';
 import EntitySearch from '../../../components/EntitySearch';
 import ConfirmDialog from '../../../components/ConfirmDialog';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
@@ -29,7 +28,10 @@ export default function DeleteClient() {
   }
 
   return (
-    <Page title="Delete Client">
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Delete Client
+      </Typography>
       <EntitySearch type="user" placeholder="Search client" onSelect={c => setClient(c as Client)} />
       {client && (
         <Button
@@ -55,6 +57,6 @@ export default function DeleteClient() {
         message={message}
         severity={severity}
       />
-    </Page>
+    </Box>
   );
 }

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NewClients.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NewClients.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
 import {
+  Box,
   Table,
   TableHead,
   TableRow,
   TableCell,
   TableBody,
   IconButton,
+  Typography,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import Page from '../../../components/Page';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import {
   getNewClients,
@@ -50,7 +51,10 @@ export default function NewClients() {
   }
 
   return (
-    <Page title="New Clients">
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        New Clients
+      </Typography>
       <Table size="small">
         <TableHead>
           <TableRow>
@@ -83,7 +87,7 @@ export default function NewClients() {
         message={snackbar?.message ?? ''}
         severity={snackbar?.severity}
       />
-    </Page>
+    </Box>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import {
+  Box,
   Table,
   TableHead,
   TableRow,
@@ -16,8 +17,8 @@ import {
   FormControlLabel,
   Checkbox,
   Tooltip,
+  Typography,
 } from "@mui/material";
-import Page from "../../../components/Page";
 import FeedbackSnackbar from "../../../components/FeedbackSnackbar";
 import DialogCloseButton from "../../../components/DialogCloseButton";
 import {
@@ -145,7 +146,10 @@ export default function UpdateClientData() {
   }
 
   return (
-    <Page title="Update Client Data">
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Update Client Data
+      </Typography>
       <Table size="small">
         <TableHead>
           <TableRow>
@@ -275,6 +279,6 @@ export default function UpdateClientData() {
         message={snackbar?.message || ""}
         severity={snackbar?.severity}
       />
-    </Page>
+    </Box>
   );
 }

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -46,7 +46,6 @@ import DialogCloseButton from '../../../components/DialogCloseButton';
 import PasswordField from '../../../components/PasswordField';
 import { useTranslation } from 'react-i18next';
 import { toDate, formatDate } from '../../../utils/date';
-import Page from '../../../components/Page';
 import type { Booking } from '../../../types';
 
 interface User {
@@ -237,7 +236,10 @@ export default function UserHistory({
   }
 
   return (
-    <Page title={initialUser ? t('booking_history') : t('client_history')}>
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        {initialUser ? t('booking_history') : t('client_history')}
+      </Typography>
       <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
         <Box width="100%" maxWidth={800} mt={4}>
         {!initialUser && (
@@ -609,13 +611,13 @@ export default function UserHistory({
             </DialogActions>
           </Dialog>
           <FeedbackSnackbar
-          open={!!message}
-          onClose={() => setMessage('')}
-          message={message}
-          severity={severity}
-        />
+            open={!!message}
+            onClose={() => setMessage('')}
+            message={message}
+            severity={severity}
+          />
         </Box>
       </Box>
-    </Page>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- simplify staff client-management tab content by replacing Page wrappers with local Box containers and h5 titles
- keep ClientManagement page as single Page wrapper

## Testing
- `npm test` *(fails: RecurringBookings.test.tsx, BookingUI.test.tsx, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68be50ff8174832da780b0fe2a8887ac