### PR TITLE
feat: use responsive table components

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ResponsiveTable.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ResponsiveTable.test.tsx
@@ -39,4 +39,19 @@ describe('ResponsiveTable', () => {
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Age')).toBeInTheDocument();
   });
+
+  it('handles row clicks', () => {
+    useMediaQueryMock.mockReturnValue(false);
+    const handleClick = jest.fn();
+    render(
+      <ResponsiveTable
+        columns={columns}
+        rows={rows}
+        getRowKey={(r) => r.id}
+        onRowClick={handleClick}
+      />,
+    );
+    screen.getByText('Alice').closest('tr')?.click();
+    expect(handleClick).toHaveBeenCalledWith(rows[0]);
+  });
 });

--- a/MJ_FB_Frontend/src/components/ResponsiveTable.tsx
+++ b/MJ_FB_Frontend/src/components/ResponsiveTable.tsx
@@ -15,9 +15,11 @@ interface Props<T> {
   rows: T[];
   /** Returns a unique key for each row */
   getRowKey?: (row: T, index: number) => React.Key;
+  /** Called when a row/card is clicked */
+  onRowClick?: (row: T) => void;
 }
 
-export default function ResponsiveTable<T>({ columns, rows, getRowKey }: Props<T>) {
+export default function ResponsiveTable<T>({ columns, rows, getRowKey, onRowClick }: Props<T>) {
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -28,7 +30,12 @@ export default function ResponsiveTable<T>({ columns, rows, getRowKey }: Props<T
     return (
       <>
         {rows.map((row, rowIndex) => (
-          <Card key={rowKey(row, rowIndex)} sx={{ mb: 2 }} data-testid="responsive-table-card">
+          <Card
+            key={rowKey(row, rowIndex)}
+            sx={{ mb: 2, cursor: onRowClick ? 'pointer' : undefined }}
+            onClick={onRowClick ? () => onRowClick(row) : undefined}
+            data-testid="responsive-table-card"
+          >
             <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               {columns.map((col) => (
                 <Stack key={col.field} direction="row" spacing={1}>
@@ -56,7 +63,12 @@ export default function ResponsiveTable<T>({ columns, rows, getRowKey }: Props<T
       </TableHead>
       <TableBody>
         {rows.map((row, rowIndex) => (
-          <TableRow key={rowKey(row, rowIndex)}>
+          <TableRow
+            key={rowKey(row, rowIndex)}
+            hover={!!onRowClick}
+            onClick={onRowClick ? () => onRowClick(row) : undefined}
+            sx={onRowClick ? { cursor: 'pointer' } : undefined}
+          >
             {columns.map((col) => (
               <TableCell key={col.field}>
                 {col.render ? col.render(row) : (row as any)[col.field]}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NewClients.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NewClients.tsx
@@ -1,15 +1,9 @@
 import { useEffect, useState } from 'react';
-import {
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
-  IconButton,
-} from '@mui/material';
+import { IconButton, Stack } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import Page from '../../../components/Page';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import ResponsiveTable from '../../../components/ResponsiveTable';
 import {
   getNewClients,
   deleteNewClient,
@@ -51,32 +45,31 @@ export default function NewClients() {
 
   return (
     <Page title="New Clients">
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell>Email</TableCell>
-            <TableCell>Phone</TableCell>
-            <TableCell>Created</TableCell>
-            <TableCell align="right">Actions</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {clients.map(c => (
-            <TableRow key={c.id}>
-              <TableCell>{c.name}</TableCell>
-              <TableCell>{c.email}</TableCell>
-              <TableCell>{c.phone}</TableCell>
-              <TableCell>{c.created_at}</TableCell>
-              <TableCell align="right">
-                <IconButton aria-label="delete" onClick={() => handleDelete(c.id)} size="small">
+      <ResponsiveTable
+        columns={[
+          { field: 'name', header: 'Name' },
+          { field: 'email', header: 'Email' },
+          { field: 'phone', header: 'Phone' },
+          { field: 'created_at', header: 'Created' },
+          {
+            field: 'actions' as keyof NewClient & string,
+            header: 'Actions',
+            render: c => (
+              <Stack direction="row" justifyContent="flex-end">
+                <IconButton
+                  aria-label="delete"
+                  onClick={() => handleDelete(c.id)}
+                  size="small"
+                >
                   <DeleteIcon />
                 </IconButton>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+              </Stack>
+            ),
+          },
+        ]}
+        rows={clients}
+        getRowKey={c => c.id}
+      />
       <FeedbackSnackbar
         open={!!snackbar}
         onClose={() => setSnackbar(null)}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NoShowWeek.tsx
@@ -2,26 +2,13 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { getBookings } from '../../../api/bookings';
 import { formatDate, toDayjs, REGINA_TIMEZONE } from '../../../utils/date';
 import { formatTime } from '../../../utils/time';
-import {
-  Box,
-  Typography,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Stack,
-} from '@mui/material';
+import { Box, Typography, FormControl, InputLabel, Select, MenuItem, Stack, TableContainer } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 import ManageBookingDialog from '../../../components/ManageBookingDialog';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import StyledTabs from '../../../components/StyledTabs';
 import type { Booking } from '../../../types';
+import ResponsiveTable from '../../../components/ResponsiveTable';
 
 export default function NoShowWeek() {
   const [start] = useState(() => toDayjs().tz(REGINA_TIMEZONE).startOf('week'));
@@ -74,6 +61,20 @@ export default function NoShowWeek() {
     loadWeek();
   }
 
+  const columns = [
+    {
+      field: 'start_time',
+      header: 'Time',
+      render: (b: Booking) => (b.start_time ? formatTime(b.start_time) : ''),
+    },
+    { field: 'user_name', header: 'Client' },
+    {
+      field: 'status',
+      header: 'Status',
+      render: (b: Booking) => b.status.replace('_', ' '),
+    },
+  ] as const;
+
   const tabs = days.map(d => {
     const dateStr = formatDate(d);
     const list = filtered(dateStr);
@@ -105,39 +106,13 @@ export default function NoShowWeek() {
           {list.length === 0 ? (
             <Typography>No bookings</Typography>
           ) : (
-            <TableContainer>
-              <Table
-                size="small"
-                data-testid={
-                  dateStr === todayStr ? 'today-bookings' : undefined
-                }
-              >
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Time</TableCell>
-                    <TableCell>Client</TableCell>
-                    <TableCell>Status</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {list.map(b => (
-                    <TableRow
-                      key={b.id}
-                      hover
-                      sx={{ cursor: 'pointer' }}
-                      onClick={() => setManageBooking(b)}
-                    >
-                      <TableCell>
-                        {b.start_time ? formatTime(b.start_time) : ''}
-                      </TableCell>
-                      <TableCell>{b.user_name}</TableCell>
-                      <TableCell sx={{ textTransform: 'capitalize' }}>
-                        {b.status.replace('_', ' ')}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+            <TableContainer data-testid={dateStr === todayStr ? 'today-bookings' : undefined}>
+              <ResponsiveTable
+                columns={columns}
+                rows={list}
+                getRowKey={b => b.id}
+                onRowClick={b => setManageBooking(b)}
+              />
             </TableContainer>
           )}
         </Box>

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useState } from "react";
 import {
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
   Button,
   Dialog,
   DialogTitle,
@@ -30,6 +25,7 @@ import {
 import type { AlertColor } from "@mui/material";
 import type { ApiError } from "../../../api/client";
 import PasswordField from "../../../components/PasswordField";
+import ResponsiveTable from "../../../components/ResponsiveTable";
 
 export default function UpdateClientData() {
   const [clients, setClients] = useState<IncompleteUser[]>([]);
@@ -146,28 +142,27 @@ export default function UpdateClientData() {
 
   return (
     <Page title="Update Client Data">
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Client ID</TableCell>
-            <TableCell>Profile Link</TableCell>
-            <TableCell align="right">Actions</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {clients.map((client) => (
-            <TableRow key={client.clientId}>
-              <TableCell>{client.clientId}</TableCell>
-              <TableCell>
-                <Link
-                  href={client.profileLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {client.profileLink}
-                </Link>
-              </TableCell>
-              <TableCell align="right">
+      <ResponsiveTable
+        columns={[
+          { field: 'clientId', header: 'Client ID' },
+          {
+            field: 'profileLink',
+            header: 'Profile Link',
+            render: client => (
+              <Link
+                href={client.profileLink}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {client.profileLink}
+              </Link>
+            ),
+          },
+          {
+            field: 'actions' as keyof IncompleteUser & string,
+            header: 'Actions',
+            render: client => (
+              <Stack direction="row" justifyContent="flex-end">
                 <Button
                   size="small"
                   variant="outlined"
@@ -175,11 +170,13 @@ export default function UpdateClientData() {
                 >
                   Edit
                 </Button>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+              </Stack>
+            ),
+          },
+        ]}
+        rows={clients}
+        getRowKey={c => c.clientId}
+      />
 
       <Dialog open={!!selected} onClose={() => setSelected(null)}>
         <DialogCloseButton onClose={() => setSelected(null)} />


### PR DESCRIPTION
## Summary
- replace staff client management tables with ResponsiveTable
- add card rendering and row click support to ResponsiveTable
- cover row click behavior with tests

## Testing
- `npm test` *(fails: UserHistory test unable to find table, other failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68be515cdd18832d9b5fdddddbb5ec53