### PR TITLE
feat: use responsive tables for warehouse pages

### DIFF
--- a/MJ_FB_Frontend/src/components/ResponsiveTable.tsx
+++ b/MJ_FB_Frontend/src/components/ResponsiveTable.tsx
@@ -1,7 +1,19 @@
-import { Card, CardContent, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography, useMediaQuery, useTheme } from '@mui/material';
-import type { ReactNode } from 'react';
+import {
+  Card,
+  CardContent,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import type { ReactNode, Ref } from 'react';
 
-interface Column<T> {
+export interface Column<T> {
   /** Unique field identifier */
   field: keyof T & string;
   /** Header label */
@@ -15,9 +27,11 @@ interface Props<T> {
   rows: T[];
   /** Returns a unique key for each row */
   getRowKey?: (row: T, index: number) => React.Key;
+  /** Optional ref to the underlying table element */
+  tableRef?: Ref<HTMLTableElement>;
 }
 
-export default function ResponsiveTable<T>({ columns, rows, getRowKey }: Props<T>) {
+export default function ResponsiveTable<T>({ columns, rows, getRowKey, tableRef }: Props<T>) {
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -46,7 +60,7 @@ export default function ResponsiveTable<T>({ columns, rows, getRowKey }: Props<T
   }
 
   return (
-    <Table size="small" data-testid="responsive-table-table">
+    <Table size="small" data-testid="responsive-table-table" ref={tableRef}>
       <TableHead>
         <TableRow>
           {columns.map((col) => (

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -7,11 +7,6 @@ import {
   DialogActions,
   DialogContentText,
   TextField,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
   TableContainer,
   Stack,
   Autocomplete,
@@ -27,6 +22,7 @@ import { getDonors, createDonor } from '../../api/donors';
 import { getDonations, createDonation, updateDonation, deleteDonation } from '../../api/donations';
 import type { Donor } from '../../api/donors';
 import type { Donation } from '../../api/donations';
+import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 import { formatLocaleDate, toDate, formatDate, addDays } from '../../utils/date';
 
 function startOfWeek(date: Date) {
@@ -68,6 +64,53 @@ export default function DonationLog() {
     weight: '',
   });
   const [donorName, setDonorName] = useState('');
+
+  type DonationRow = Donation & { actions?: string };
+
+  const columns: Column<DonationRow>[] = [
+    {
+      field: 'date',
+      header: 'Date',
+      render: d => formatLocaleDate(d.date),
+    },
+    { field: 'donor', header: 'Donor' },
+    {
+      field: 'weight',
+      header: 'Weight (lbs)',
+      render: d => `${d.weight} lbs`,
+    },
+    {
+      field: 'actions' as keyof DonationRow & string,
+      header: 'Actions',
+      render: d => (
+        <>
+          <IconButton
+            size="small"
+            onClick={e => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              setEditing(d);
+              setForm({ date: d.date, donorId: d.donorId, weight: String(d.weight) });
+              setRecordOpen(true);
+            }}
+            aria-label="Edit donation"
+          >
+            <Edit fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            onClick={e => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              setToDelete(d);
+              setDeleteOpen(true);
+            }}
+            aria-label="Delete donation"
+          >
+            <Delete fontSize="small" />
+          </IconButton>
+        </>
+      ),
+    },
+  ];
 
   useEffect(() => {
     getDonors()
@@ -120,48 +163,11 @@ export default function DonationLog() {
 
   const table = (
     <TableContainer sx={{ overflowX: 'auto' }}>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Donor</TableCell>
-            <TableCell>Weight (lbs)</TableCell>
-            <TableCell align="right"></TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {donations.map(d => (
-            <TableRow key={d.id}>
-              <TableCell>{d.donor}</TableCell>
-              <TableCell>{d.weight} lbs</TableCell>
-              <TableCell align="right">
-                <IconButton
-                  size="small"
-                  onClick={e => {
-                    (e.currentTarget as HTMLButtonElement).blur();
-                    setEditing(d);
-                    setForm({ date: d.date, donorId: d.donorId, weight: String(d.weight) });
-                    setRecordOpen(true);
-                  }}
-                  aria-label="Edit donation"
-                >
-                  <Edit fontSize="small" />
-                </IconButton>
-                <IconButton
-                  size="small"
-                  onClick={e => {
-                    (e.currentTarget as HTMLButtonElement).blur();
-                    setToDelete(d);
-                    setDeleteOpen(true);
-                  }}
-                  aria-label="Delete donation"
-                >
-                  <Delete fontSize="small" />
-                </IconButton>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <ResponsiveTable
+        columns={columns}
+        rows={donations}
+        getRowKey={r => r.id}
+      />
     </TableContainer>
   );
 

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
@@ -5,11 +5,6 @@ import {
   Card,
   CardContent,
   Typography,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
 } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import {
@@ -20,6 +15,7 @@ import {
 } from '../../api/donors';
 import { formatLocaleDate } from '../../utils/date';
 import Page from '../../components/Page';
+import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 
 export default function DonorProfile() {
   const { id } = useParams<{ id: string }>();
@@ -37,6 +33,15 @@ export default function DonorProfile() {
       .then(setDonations)
       .catch(err => setError(err.message || 'Failed to load donations'));
   }, [id]);
+
+  const columns: Column<DonorDonation>[] = [
+    {
+      field: 'date',
+      header: 'Date',
+      render: d => formatLocaleDate(d.date),
+    },
+    { field: 'weight', header: 'Weight (lbs)' },
+  ];
 
   return (
     <Page title="Donor Profile">
@@ -59,31 +64,13 @@ export default function DonorProfile() {
           <Typography variant="subtitle1" gutterBottom>
             Donations
           </Typography>
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Date</TableCell>
-                <TableCell>Weight (lbs)</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {donations.map(d => (
-                <TableRow key={d.id}>
-                  <TableCell>{formatLocaleDate(d.date)}</TableCell>
-                  <TableCell>{d.weight}</TableCell>
-                </TableRow>
-              ))}
-              {donations.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={2}>
-                    <Typography variant="body2" color="text.secondary">
-                      No donations found.
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+          {donations.length ? (
+            <ResponsiveTable columns={columns} rows={donations} getRowKey={d => d.id} />
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No donations found.
+            </Typography>
+          )}
         </CardContent>
       </Card>
       <FeedbackSnackbar

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
@@ -6,11 +6,6 @@ import {
   DialogContent,
   DialogActions,
   DialogContentText,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
   TableContainer,
   Stack,
   TextField,
@@ -30,6 +25,7 @@ import {
   type PigPound,
 } from '../../api/pigPounds';
 import { formatLocaleDate, toDate, formatDate, addDays } from '../../utils/date';
+import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 
 function startOfWeek(date: Date) {
   const d = toDate(date);
@@ -105,58 +101,55 @@ export default function TrackPigpound() {
       );
   }
 
+  type PigPoundRow = PigPound & { actions?: string };
+
+  const columns: Column<PigPoundRow>[] = [
+    { field: 'date', header: 'Date', render: e => formatLocaleDate(e.date) },
+    {
+      field: 'weight',
+      header: 'Weight (lbs)',
+      render: e => `${e.weight} lbs`,
+    },
+    {
+      field: 'actions' as keyof PigPoundRow & string,
+      header: 'Actions',
+      render: e => (
+        <>
+          <IconButton
+            size="small"
+            onClick={() => {
+              setEditing(e);
+              setForm({ date: formatDate(e.date), weight: String(e.weight) });
+              setRecordOpen(true);
+            }}
+            aria-label="Edit entry"
+          >
+            <Edit fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            onClick={() => {
+              setToDelete(e);
+              setDeleteOpen(true);
+            }}
+            aria-label="Delete entry"
+          >
+            <Delete fontSize="small" />
+          </IconButton>
+        </>
+      ),
+    },
+  ];
+
   const table = (
     <TableContainer sx={{ overflowX: 'auto' }}>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell>Weight (lbs)</TableCell>
-            <TableCell align="right"></TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {entries.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={3} align="center">
-                No records
-              </TableCell>
-            </TableRow>
-          ) : (
-            entries.map(e => (
-              <TableRow key={e.id}>
-                <TableCell>
-                  {formatLocaleDate(e.date)}
-                </TableCell>
-                <TableCell>{e.weight} lbs</TableCell>
-                <TableCell align="right">
-                  <IconButton
-                    size="small"
-                    onClick={() => {
-                      setEditing(e);
-                      setForm({ date: formatDate(e.date), weight: String(e.weight) });
-                      setRecordOpen(true);
-                    }}
-                    aria-label="Edit entry"
-                  >
-                    <Edit fontSize="small" />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    onClick={() => {
-                      setToDelete(e);
-                      setDeleteOpen(true);
-                    }}
-                    aria-label="Delete entry"
-                  >
-                    <Delete fontSize="small" />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
+      {entries.length === 0 ? (
+        <Stack alignItems="center" py={2}>
+          No records
+        </Stack>
+      ) : (
+        <ResponsiveTable columns={columns} rows={entries} getRowKey={r => r.id} />
+      )}
     </TableContainer>
   );
 

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
@@ -6,11 +6,6 @@ import {
   DialogContent,
   DialogTitle,
   Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
   TableContainer,
   TextField,
   MenuItem,
@@ -34,6 +29,7 @@ import {
   getWarehouseSettings,
   type WarehouseSettings,
 } from '../../api/warehouseSettings';
+import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 
 function startOfWeek(date: Date) {
   const d = toDate(date);
@@ -121,59 +117,67 @@ export default function TrackSurplus() {
       .catch(err => setSnackbar({ open: true, message: err.message || 'Failed to save surplus' }));
   }
 
+  type SurplusRow = Surplus & { actions?: string };
+
+  const columns: Column<SurplusRow>[] = [
+    {
+      field: 'date',
+      header: 'Date',
+      render: r =>
+        formatLocaleDate(r.date, {
+          weekday: 'short',
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        }),
+    },
+    { field: 'type', header: 'Type' },
+    { field: 'count', header: 'Count' },
+    {
+      field: 'weight',
+      header: 'Weight (lbs)',
+      render: r => `${r.weight} lbs`,
+    },
+    {
+      field: 'actions' as keyof SurplusRow & string,
+      header: 'Actions',
+      render: r => (
+        <>
+          <IconButton
+            size="small"
+            onClick={() => {
+              setEditing(r);
+              setForm({ date: normalize(r.date), type: r.type, count: String(r.count) });
+              setRecordOpen(true);
+            }}
+            aria-label="Edit surplus"
+          >
+            <Edit fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            onClick={() => {
+              setToDelete(r);
+              setDeleteOpen(true);
+            }}
+            aria-label="Delete surplus"
+          >
+            <Delete fontSize="small" />
+          </IconButton>
+        </>
+      ),
+    },
+  ];
+
   const table = (
     <TableContainer sx={{ overflowX: 'auto' }}>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell>Type</TableCell>
-            <TableCell>Count</TableCell>
-            <TableCell>Weight (lbs)</TableCell>
-            <TableCell align="right"></TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {filteredRecords.map(r => (
-            <TableRow key={r.id}>
-              <TableCell>
-                {formatLocaleDate(r.date, {
-                  weekday: 'short',
-                  year: 'numeric',
-                  month: 'short',
-                  day: 'numeric',
-                })}
-              </TableCell>
-              <TableCell>{r.type}</TableCell>
-              <TableCell>{r.count}</TableCell>
-              <TableCell>{r.weight} lbs</TableCell>
-              <TableCell align="right">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setEditing(r);
-                    setForm({ date: normalize(r.date), type: r.type, count: String(r.count) });
-                    setRecordOpen(true);
-                  }}
-                  aria-label="Edit surplus"
-                >
-                  <Edit fontSize="small" />
-                </IconButton>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setToDelete(r);
-                    setDeleteOpen(true);
-                  }}
-                  aria-label="Delete surplus"
-                >
-                  <Delete fontSize="small" />
-                </IconButton>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      {filteredRecords.length ? (
+        <ResponsiveTable columns={columns} rows={filteredRecords} getRowKey={r => r.id} />
+      ) : (
+        <Stack alignItems="center" py={2}>
+          No records
+        </Stack>
+      )}
     </TableContainer>
   );
 


### PR DESCRIPTION
## Summary
- replace warehouse management tables with responsive card/table component
- add mobile-friendly row summaries for donations and surplus tracking

## Testing
- `npm test` *(fails: Multiple tests in frontend suite)*

------
https://chatgpt.com/codex/tasks/task_e_68be517a29dc832d93e8ed2b63a9cc0d