### PR TITLE
Display detailed leave requests for admins

### DIFF
--- a/MJ_FB_Backend/src/models/leaveRequest.ts
+++ b/MJ_FB_Backend/src/models/leaveRequest.ts
@@ -45,6 +45,7 @@ export async function selectLeaveRequests(): Promise<LeaveRequest[]> {
     `SELECT lr.*, s.first_name || ' ' || s.last_name AS requester_name
      FROM leave_requests lr
      JOIN staff s ON s.id = lr.staff_id
+     WHERE lr.status = 'pending'
      ORDER BY lr.start_date`,
   );
   return res.rows;

--- a/MJ_FB_Backend/tests/leaveRequests.test.ts
+++ b/MJ_FB_Backend/tests/leaveRequests.test.ts
@@ -2,6 +2,7 @@ import "./setupTests";
 import {
   createLeaveRequest,
   approveLeaveRequest,
+  listLeaveRequests,
   listLeaveRequestsByStaff,
 } from "../src/controllers/leaveRequestController";
 import mockPool from "./utils/mockDb";
@@ -214,5 +215,45 @@ describe("leave requests controller", () => {
       },
     ]);
     expect(mockPool.query).toHaveBeenCalledWith(expect.any(String), [1]);
+  });
+
+  it("lists only pending leave requests", async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 4,
+          staff_id: 1,
+          start_date: "2024-04-01",
+          end_date: "2024-04-02",
+          type: "vacation",
+          status: "pending",
+          reason: null,
+          requester_name: "Test User",
+          created_at: "now",
+          updated_at: "now",
+        },
+      ],
+      rowCount: 1,
+    });
+    const req: any = {};
+    const res = makeRes();
+    await listLeaveRequests(req, res as any, () => {});
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE lr.status = 'pending'"),
+    );
+    expect(res.json).toHaveBeenCalledWith([
+      {
+        id: 4,
+        staff_id: 1,
+        start_date: "2024-04-01",
+        end_date: "2024-04-02",
+        type: "vacation",
+        status: "pending",
+        reason: null,
+        requester_name: "Test User",
+        created_at: "now",
+        updated_at: "now",
+      },
+    ]);
   });
 });

--- a/MJ_FB_Frontend/src/api/leaveRequests.ts
+++ b/MJ_FB_Frontend/src/api/leaveRequests.ts
@@ -91,24 +91,28 @@ export function useCreateLeaveRequest(timesheetId?: number) {
 
 export function useApproveLeaveRequest() {
   const qc = useQueryClient();
-  return useMutation<void, ApiError, { requestId: number; timesheetId: number }>({
+  return useMutation<void, ApiError, { requestId: number; timesheetId?: number }>({
     mutationFn: ({ requestId }) => approveLeaveRequest(requestId),
     onSuccess: (_, { timesheetId }) => {
       qc.invalidateQueries({ queryKey: ['leaveRequests'] });
-      qc.invalidateQueries({ queryKey: ['leaveRequests', timesheetId] });
-      qc.invalidateQueries({ queryKey: ['timesheets', timesheetId, 'days'] });
+      if (timesheetId) {
+        qc.invalidateQueries({ queryKey: ['leaveRequests', timesheetId] });
+        qc.invalidateQueries({ queryKey: ['timesheets', timesheetId, 'days'] });
+      }
     },
   });
 }
 
 export function useRejectLeaveRequest() {
   const qc = useQueryClient();
-  return useMutation<void, ApiError, { requestId: number; timesheetId: number }>({
+  return useMutation<void, ApiError, { requestId: number; timesheetId?: number }>({
     mutationFn: ({ requestId }) => rejectLeaveRequest(requestId),
     onSuccess: (_, { timesheetId }) => {
       qc.invalidateQueries({ queryKey: ['leaveRequests'] });
-      qc.invalidateQueries({ queryKey: ['leaveRequests', timesheetId] });
-      qc.invalidateQueries({ queryKey: ['timesheets', timesheetId, 'days'] });
+      if (timesheetId) {
+        qc.invalidateQueries({ queryKey: ['leaveRequests', timesheetId] });
+        qc.invalidateQueries({ queryKey: ['timesheets', timesheetId, 'days'] });
+      }
     },
   });
 }

--- a/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
@@ -1,4 +1,10 @@
-import { Box, Button, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Typography,
+} from '@mui/material';
 import Page from '../../components/Page';
 import {
   useAllLeaveRequests,
@@ -7,46 +13,74 @@ import {
 } from '../../api/leaveRequests';
 import { formatLocaleDate } from '../../utils/date';
 import { useTranslation } from 'react-i18next';
+import { useEffect, useState } from 'react';
 
 export default function AdminLeaveRequests() {
   const { t } = useTranslation();
-  const { requests } = useAllLeaveRequests();
+  const { requests: fetched } = useAllLeaveRequests();
+  const [requests, setRequests] = useState(fetched);
   const approve = useApproveLeaveRequest();
   const reject = useRejectLeaveRequest();
 
+  useEffect(() => setRequests(fetched), [fetched]);
+
+  const removeRequest = (id: number) =>
+    setRequests(prev => prev.filter(r => r.id !== id));
+
   return (
     <Page title={t('leave.title')}>
-      {requests.map(r => (
-        <Box
-          key={r.id}
-          sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 1 }}
-        >
-          <Typography component="span" sx={{ flexGrow: 1 }}>
-            {r.requester_name}: {formatLocaleDate(r.work_date)} - {r.hours}h
-          </Typography>
-          <Button
-            variant="contained"
-            size="small"
-            onClick={() => {
-              if (!r.timesheet_id) return;
-              approve.mutate({ requestId: r.id, timesheetId: r.timesheet_id });
-            }}
-          >
-            {t('timesheets.approve_leave')}
-          </Button>
-          <Button
-            variant="contained"
-            color="error"
-            size="small"
-            onClick={() => {
-              if (!r.timesheet_id) return;
-              reject.mutate({ requestId: r.id, timesheetId: r.timesheet_id });
-            }}
-          >
-            {t('timesheets.reject_leave')}
-          </Button>
-        </Box>
-      ))}
+      {requests.map(r => {
+        const days =
+          Math.round(
+            (new Date(r.end_date!).getTime() -
+              new Date(r.start_date!).getTime()) /
+              86400000,
+          ) + 1;
+        return (
+          <Card key={r.id} sx={{ mb: 2 }}>
+            <CardContent
+              sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+            >
+              <Box sx={{ flexGrow: 1 }}>
+                <Typography fontWeight="bold">{r.requester_name}</Typography>
+                <Typography variant="body2">
+                  {formatLocaleDate(r.start_date!)} – {formatLocaleDate(r.end_date!)} ({
+                    days
+                  }{' '}
+                  days) • {r.type ? t(`leave.type.${r.type}`) : ''}
+                </Typography>
+              </Box>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Button
+                  variant="contained"
+                  size="small"
+                  onClick={() =>
+                    approve.mutate(
+                      { requestId: r.id },
+                      { onSuccess: () => removeRequest(r.id) },
+                    )
+                  }
+                >
+                  {t('timesheets.approve_leave')}
+                </Button>
+                <Button
+                  variant="contained"
+                  color="error"
+                  size="small"
+                  onClick={() =>
+                    reject.mutate(
+                      { requestId: r.id },
+                      { onSuccess: () => removeRequest(r.id) },
+                    )
+                  }
+                >
+                  {t('timesheets.reject_leave')}
+                </Button>
+              </Box>
+            </CardContent>
+          </Card>
+        );
+      })}
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/LeaveRequests.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/LeaveRequests.test.tsx
@@ -1,19 +1,19 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
 import LeaveRequests from '../LeaveRequests';
 
-const mockApprove = jest.fn();
-const mockReject = jest.fn();
+const mockApprove = jest.fn((_, opts) => act(() => opts?.onSuccess?.()));
+const mockReject = jest.fn((_, opts) => act(() => opts?.onSuccess?.()));
 
 jest.mock('../../../api/leaveRequests', () => ({
   useAllLeaveRequests: () => ({
     requests: [
       {
         id: 1,
-        work_date: '2024-01-02',
-        hours: 8,
-        timesheet_id: 1,
+        start_date: '2024-01-02',
+        end_date: '2024-01-03',
+        type: 'paid',
         requester_name: 'Jane Doe',
       },
     ],
@@ -25,14 +25,17 @@ jest.mock('../../../api/leaveRequests', () => ({
 }));
 
 describe('AdminLeaveRequests', () => {
-  it('renders requester name and action buttons', async () => {
+  it('renders leave details and removes card after rejection', async () => {
     const user = userEvent.setup();
     renderWithProviders(<LeaveRequests />);
     expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument();
+    expect(screen.getByText(/Paid/)).toBeInTheDocument();
     const rejectBtn = screen.getByRole('button', { name: 'Reject' });
     await user.click(rejectBtn);
-    expect(mockReject).toHaveBeenCalledWith({ requestId: 1, timesheetId: 1 });
+    expect(mockReject).toHaveBeenCalledWith({ requestId: 1 }, expect.any(Object));
+    await waitFor(() =>
+      expect(screen.queryByText(/Jane Doe/)).not.toBeInTheDocument(),
+    );
   });
 });
 

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -536,8 +536,8 @@ export function getHelpContent(
         description: 'Review staff vacation requests.',
         steps: [
           'Navigate to Admin > Leave Requests.',
-          'Review pending requests.',
-          'Approve or reject requests as needed.',
+          'Each card lists the start and end dates, leave type, and day count.',
+          'Approve or reject requests to clear them from the list.',
         ],
       },
     },

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -63,8 +63,10 @@ Staff can request vacation, sick, or personal leave via `/api/leave/requests`.
 Personal days are limited to one per calendar quarter and approved requests do
 **not** prefill timesheets. Admins can view requests for a specific staff member
 at `/api/timesheets/leave-requests/:staffId` or list all requests at
-`/api/leave/requests`. Approving a vacation or sick request adds default hours
-for each day in the request but leaves the entries editable. An approved request
+`/api/leave/requests`. The Admin → Leave Requests page shows the start and end
+dates, request type, and an automatically calculated day count for each pending
+request. Approving a vacation or sick request adds default hours for each day in
+the request but leaves the entries editable. An approved request
 also creates a `staff_leave` event visible to clients and volunteers. Rejection
 simply removes the request.
 


### PR DESCRIPTION
## Summary
- Show pending leave requests to admins with start/end dates, day count, and leave type in card layout
- Allow approving or rejecting requests to remove them from the list
- Document admin leave request review steps and pending-only backend query

## Testing
- `npm test tests/leaveRequests.test.ts`
- `npm test src/pages/admin/__tests__/LeaveRequests.test.tsx` *(fails: see logs for act-related warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68be509c9b40832db68baebc4f16f565