### PR TITLE
Fix leave request endpoint path

### DIFF
--- a/MJ_FB_Frontend/src/api/leaveRequests.ts
+++ b/MJ_FB_Frontend/src/api/leaveRequests.ts
@@ -26,10 +26,10 @@ export async function createLeaveRequest(
 }
 
 export async function listLeaveRequests(
-  timesheetId: number,
+  staffId: number,
 ): Promise<LeaveRequest[]> {
   const res = await apiFetch(
-    `${API_BASE}/timesheets/${timesheetId}/leave-requests`,
+    `${API_BASE}/timesheets/leave-requests/${staffId}`,
   );
   return handleResponse(res);
 }
@@ -55,11 +55,11 @@ export async function rejectLeaveRequest(requestId: number): Promise<void> {
   await handleResponse(res);
 }
 
-export function useLeaveRequests(timesheetId?: number) {
+export function useLeaveRequests(staffId?: number) {
   const { data, isFetching, error } = useQuery<LeaveRequest[]>({
-    queryKey: ['leaveRequests', timesheetId],
-    queryFn: () => listLeaveRequests(timesheetId!),
-    enabled: !!timesheetId,
+    queryKey: ['leaveRequests', staffId],
+    queryFn: () => listLeaveRequests(staffId!),
+    enabled: !!staffId,
   });
   return { requests: data ?? [], isLoading: isFetching, error };
 }

--- a/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
@@ -29,7 +29,7 @@ export default function LeaveManagement() {
   const current =
     timesheets.find(p => !p.approved_at) || timesheets[timesheets.length - 1];
   const leaveMutation = useCreateLeaveRequest(current?.id);
-  const { requests } = useLeaveRequests(current?.id);
+  const { requests } = useLeaveRequests(current?.staff_id);
   const [open, setOpen] = useState(false);
 
   const columns = [

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/LeaveManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/LeaveManagement.test.tsx
@@ -11,6 +11,7 @@ jest.mock('../../../api/timesheets', () => ({
     timesheets: [
       {
         id: 1,
+        staff_id: 1,
         start_date: '2024-01-01',
         end_date: '2024-01-07',
         approved_at: null,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Leave request API under `/api/leave/requests` for staff leave, supporting
   vacation, sick, or personal requests (one personal day per quarter) with optional reasons.
   Admins can view requests for a specific staff member via
-  `/api/timesheets/leave-requests/:staffId`.
+  `/api/timesheets/leave-requests/:staffId` (using the staff ID, not the timesheet ID).
 - Password fields include a visibility toggle so users can verify what they type.
 - Booking confirmation emails include links to public pages for cancelling or rescheduling
   bookings at `/cancel/:token` and `/reschedule/:token`.

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -65,8 +65,8 @@ in `summary.ot_bank_remaining`.
 Staff can request vacation, sick, or personal leave via `/api/leave/requests`.
 Personal days are limited to one per calendar quarter and approved requests do
 **not** prefill timesheets. Admins can view requests for a specific staff member
-at `/api/timesheets/leave-requests/:staffId` or list all requests at
-`/api/leave/requests`. Approving a vacation or sick request adds default hours
+at `/api/timesheets/leave-requests/:staffId` (use the staff ID, not the timesheet ID)
+or list all requests at `/api/leave/requests`. Approving a vacation or sick request adds default hours
 for each day in the request but leaves the entries editable. An approved request
 also creates a `staff_leave` event visible to clients and volunteers. Rejection
 simply removes the request.


### PR DESCRIPTION
## Summary
- use `/api/timesheets/leave-requests/:staffId` for leave request lookups
- clarify docs that endpoint expects a staff ID

## Testing
- `npm run test:backend` *(fails: Timesheet not found, slot errors, etc.)*
- `npm run test:frontend` *(fails: React act warnings and jsdom location errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be5413dd20832d9648f959efb830e2