### PR TITLE
fix(db-bloat-monitor): align notifyOps usage

### DIFF
--- a/MJ_FB_Backend/src/utils/dbBloatMonitorJob.ts
+++ b/MJ_FB_Backend/src/utils/dbBloatMonitorJob.ts
@@ -16,7 +16,7 @@ export async function checkDbBloat(): Promise<void> {
         .join(', ');
       const subject = 'Database tables require vacuum';
       const body = `Tables exceeding dead row threshold ${config.vacuumAlertDeadRowsThreshold}: ${details}`;
-      await notifyOps(subject, body);
+      await notifyOps(`${subject}\n${body}`);
     }
   } catch (err) {
     logger.error('Failed to check database bloat', err);

--- a/MJ_FB_Backend/tests/dbBloatMonitorJob.test.ts
+++ b/MJ_FB_Backend/tests/dbBloatMonitorJob.test.ts
@@ -31,9 +31,10 @@ describe('checkDbBloat', () => {
       [config.vacuumAlertDeadRowsThreshold],
     );
     expect(notifyOps).toHaveBeenCalledWith(
-      'Database tables require vacuum',
-      expect.stringContaining('foo (6000 dead rows)'),
+      expect.stringContaining('Database tables require vacuum'),
     );
+    const message = (notifyOps as jest.Mock).mock.calls[0][0] as string;
+    expect(message).toContain('foo (6000 dead rows)');
   });
 
   it('skips notification when no tables exceed threshold', async () => {


### PR DESCRIPTION
## Summary
- send a single formatted message to `notifyOps` in db bloat monitor
- update db bloat monitor test to match new signature

## Testing
- `npm test tests/dbBloatMonitorJob.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be57926f80832d8ac930998d5af273