### PR TITLE
fix: align mobile timesheet inputs

### DIFF
--- a/MJ_FB_Frontend/src/components/ResponsiveTable.tsx
+++ b/MJ_FB_Frontend/src/components/ResponsiveTable.tsx
@@ -46,8 +46,13 @@ export default function ResponsiveTable<T>({ columns, rows, getRowKey, tableRef 
           <Card key={rowKey(row, rowIndex)} sx={{ mb: 2 }} data-testid="responsive-table-card">
             <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               {columns.map((col) => (
-                <Stack key={col.field} direction="row" spacing={1}>
-                  <Typography variant="subtitle2">{col.header}</Typography>
+                <Stack key={col.field} direction="row" spacing={1} alignItems="center">
+                  <Typography
+                    variant="subtitle2"
+                    sx={{ width: 100, flexShrink: 0 }}
+                  >
+                    {col.header}
+                  </Typography>
                   <Box sx={{ flex: 1 }}>
                     {col.render ? col.render(row) : String(row[col.field])}
                   </Box>

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -218,6 +218,8 @@ export default function Timesheets() {
             disabled={inputsDisabled || row.lockedLeave}
             error={row.paid > 8}
             onChange={e => handleChange(row.index, 'reg', e.target.value)}
+            fullWidth
+            sx={{ width: { xs: '100%', sm: 80 } }}
           />
         ),
       },
@@ -232,6 +234,8 @@ export default function Timesheets() {
             disabled={inputsDisabled || row.lockedLeave}
             error={row.paid > 8}
             onChange={e => handleChange(row.index, 'ot', e.target.value)}
+            fullWidth
+            sx={{ width: { xs: '100%', sm: 80 } }}
           />
         ),
       },
@@ -246,6 +250,8 @@ export default function Timesheets() {
             disabled={inputsDisabled || row.lockedLeave}
             error={row.paid > 8}
             onChange={e => handleChange(row.index, 'stat', e.target.value)}
+            fullWidth
+            sx={{ width: { xs: '100%', sm: 80 } }}
           />
         ),
       },
@@ -260,6 +266,8 @@ export default function Timesheets() {
             disabled={inputsDisabled || row.lockedLeave}
             error={row.paid > 8}
             onChange={e => handleChange(row.index, 'sick', e.target.value)}
+            fullWidth
+            sx={{ width: { xs: '100%', sm: 80 } }}
           />
         ),
       },
@@ -274,6 +282,8 @@ export default function Timesheets() {
             disabled={inputsDisabled || row.lockedLeave}
             error={row.paid > 8}
             onChange={e => handleChange(row.index, 'vac', e.target.value)}
+            fullWidth
+            sx={{ width: { xs: '100%', sm: 80 } }}
           />
         ),
       },
@@ -286,6 +296,8 @@ export default function Timesheets() {
             size="small"
             disabled={inputsDisabled || row.lockedLeave}
             onChange={e => handleChange(row.index, 'note', e.target.value)}
+            fullWidth
+            sx={{ width: { xs: '100%', sm: 200 } }}
           />
         ),
       },

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -11,7 +11,8 @@ Staff see up to seven pay period tabs: the current period, the next period (if
 generated), and up to five previous periods.
 
 On small screens, daily entries render as stacked cards instead of a table,
-making the timesheet easier to read on mobile devices.
+making the timesheet easier to read on mobile devices. Input fields now use
+uniform widths so entries align cleanly.
 
 Hours entered on the page are stored locally until you submit the period. No
 API requests are made while editing, preventing the page from refreshing after


### PR DESCRIPTION
## Summary
- align small-screen table cards with fixed label widths
- make timesheet fields responsive and full-width on mobile
- document aligned mobile inputs in timesheets guide

## Testing
- `npm test` *(fails: Unable to find role="table" and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68be56f17044832d9ab74fff0cb7947f