### PR TITLE
feat: add warehouse quick links

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/WarehouseQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/WarehouseQuickLinks.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import WarehouseQuickLinks from '../components/WarehouseQuickLinks';
+
+describe('WarehouseQuickLinks', () => {
+  it('renders links to warehouse routes', () => {
+    render(
+      <MemoryRouter>
+        <WarehouseQuickLinks />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute(
+      'href',
+      '/warehouse-management',
+    );
+    expect(screen.getByRole('link', { name: /Donation Log/i })).toHaveAttribute(
+      'href',
+      '/warehouse-management/donation-log',
+    );
+    expect(screen.getByRole('link', { name: /Track Surplus/i })).toHaveAttribute(
+      'href',
+      '/warehouse-management/track-surplus',
+    );
+    expect(screen.getByRole('link', { name: /Track Pigpound/i })).toHaveAttribute(
+      'href',
+      '/warehouse-management/track-pigpound',
+    );
+    expect(
+      screen.getByRole('link', { name: /Track Outgoing Donations/i }),
+    ).toHaveAttribute('href', '/warehouse-management/track-outgoing-donations');
+    expect(screen.getByRole('link', { name: /Aggregations/i })).toHaveAttribute(
+      'href',
+      '/warehouse-management/aggregations',
+    );
+    expect(screen.getByRole('link', { name: /Exports/i })).toHaveAttribute(
+      'href',
+      '/warehouse-management/exports',
+    );
+  });
+});
+

--- a/MJ_FB_Frontend/src/components/WarehouseQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/WarehouseQuickLinks.tsx
@@ -1,0 +1,89 @@
+import { Stack, Button } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+
+export default function WarehouseQuickLinks() {
+  const buttonSx = {
+    textTransform: 'none',
+    '&:hover': { color: 'primary.main' },
+  } as const;
+
+  return (
+    <Stack
+      direction={{ xs: 'column', md: 'row' }}
+      spacing={{ xs: 1, md: 2 }}
+      sx={{ width: '100%', flexWrap: 'wrap' }}
+    >
+      <Button
+        size="small"
+        variant="outlined"
+        sx={buttonSx}
+        component={RouterLink}
+        to="/warehouse-management"
+        fullWidth
+      >
+        Dashboard
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        sx={buttonSx}
+        component={RouterLink}
+        to="/warehouse-management/donation-log"
+        fullWidth
+      >
+        Donation Log
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        sx={buttonSx}
+        component={RouterLink}
+        to="/warehouse-management/track-surplus"
+        fullWidth
+      >
+        Track Surplus
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        sx={buttonSx}
+        component={RouterLink}
+        to="/warehouse-management/track-pigpound"
+        fullWidth
+      >
+        Track Pigpound
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        sx={buttonSx}
+        component={RouterLink}
+        to="/warehouse-management/track-outgoing-donations"
+        fullWidth
+      >
+        Track Outgoing Donations
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        sx={buttonSx}
+        component={RouterLink}
+        to="/warehouse-management/aggregations"
+        fullWidth
+      >
+        Aggregations
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        sx={buttonSx}
+        component={RouterLink}
+        to="/warehouse-management/exports"
+        fullWidth
+      >
+        Exports
+      </Button>
+    </Stack>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -425,6 +425,13 @@ export function getHelpContent(
   warehouse: [
     installAppSection,
     {
+      title: 'Warehouse quick links',
+      body: {
+        description:
+          'Warehouse pages include a quick-access bar with links to Dashboard, Donation Log, Track Surplus, Track Pigpound, Track Outgoing Donations, Aggregations, and Exports.',
+      },
+    },
+    {
       title: 'View volunteers on duty',
       body: {
         description: 'Volunteer Coverage lists scheduled warehouse volunteers.',

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../api/warehouseOverall';
 import { getDonorAggregations, type DonorAggregation } from '../../api/donations';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import { toDate } from '../../utils/date';
 import { exportTableToExcel } from '../../utils/exportTableToExcel';
@@ -307,7 +308,7 @@ export default function Aggregations() {
   ];
 
   return (
-    <Page title="Aggregations">
+    <Page title="Aggregations" header={<WarehouseQuickLinks />}>
       <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
       <FeedbackSnackbar
         open={snackbar.open}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -16,6 +16,7 @@ import Edit from '@mui/icons-material/Edit';
 import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import { getDonors, createDonor } from '../../api/donors';
@@ -180,29 +181,32 @@ export default function DonationLog() {
     <Page
       title="Donation Log"
       header={
-        <Stack direction="row" spacing={1} mb={2}>
-          <Button
-            size="small"
-            variant="contained"
-            onClick={e => {
-              (e.currentTarget as HTMLButtonElement).blur();
-              setForm({ date: format(selectedDate), donorId: null, weight: '' });
-              setEditing(null);
-              setRecordOpen(true);
-            }}
-          >
-            Record Donation
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={e => {
-              (e.currentTarget as HTMLButtonElement).blur();
-              setNewDonorOpen(true);
-            }}
-          >
-            Add Donor
-          </Button>
+        <Stack spacing={2}>
+          <WarehouseQuickLinks />
+          <Stack direction="row" spacing={1}>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={e => {
+                (e.currentTarget as HTMLButtonElement).blur();
+                setForm({ date: format(selectedDate), donorId: null, weight: '' });
+                setEditing(null);
+                setRecordOpen(true);
+              }}
+            >
+              Record Donation
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={e => {
+                (e.currentTarget as HTMLButtonElement).blur();
+                setNewDonorOpen(true);
+              }}
+            >
+              Add Donor
+            </Button>
+          </Stack>
         </Stack>
       }
     >

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Exports.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Exports.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import {
   getWarehouseOverallYears,
   rebuildWarehouseOverall,
@@ -88,7 +89,7 @@ export default function Exports() {
   };
 
   return (
-    <Page title="Exports">
+    <Page title="Exports" header={<WarehouseQuickLinks />}>
       <Stack spacing={2} sx={{ mb: 2 }} direction="row">
         <FormControl size="small" sx={{ minWidth: 120 }}>
           <InputLabel id="year-label">Year</InputLabel>

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
@@ -16,6 +16,7 @@ import Edit from '@mui/icons-material/Edit';
 import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import { getOutgoingReceivers, createOutgoingReceiver } from '../../api/outgoingReceivers';
@@ -195,28 +196,31 @@ export default function TrackOutgoingDonations() {
     <Page
       title="Track Outgoing Donations"
       header={
-        <Stack direction="row" spacing={1} mb={2}>
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => {
-              setForm({ date: format(selectedDate), receiverId: null, weight: '', note: '' });
-              setEditing(null);
-              setRecordOpen(true);
-            }}
-          >
-            Record Outgoing Donation
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setReceiverName('');
-              setNewReceiverOpen(true);
-            }}
-          >
-            Add Receiver
-          </Button>
+        <Stack spacing={2}>
+          <WarehouseQuickLinks />
+          <Stack direction="row" spacing={1}>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={() => {
+                setForm({ date: format(selectedDate), receiverId: null, weight: '', note: '' });
+                setEditing(null);
+                setRecordOpen(true);
+              }}
+            >
+              Record Outgoing Donation
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => {
+                setReceiverName('');
+                setNewReceiverOpen(true);
+              }}
+            >
+              Add Receiver
+            </Button>
+          </Stack>
         </Stack>
       }
     >

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
@@ -15,6 +15,7 @@ import Edit from '@mui/icons-material/Edit';
 import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import {
@@ -162,17 +163,20 @@ export default function TrackPigpound() {
     <Page
       title="Track Pigpound"
       header={
-        <Button
-          size="small"
-          variant="contained"
-          onClick={() => {
-            setForm({ date: format(selectedDate), weight: '' });
-            setEditing(null);
-            setRecordOpen(true);
-          }}
-        >
-          Record Pig Pound Donation
-        </Button>
+        <Stack spacing={2}>
+          <WarehouseQuickLinks />
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => {
+              setForm({ date: format(selectedDate), weight: '' });
+              setEditing(null);
+              setRecordOpen(true);
+            }}
+          >
+            Record Pig Pound Donation
+          </Button>
+        </Stack>
       }
     >
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
@@ -15,6 +15,7 @@ import Edit from '@mui/icons-material/Edit';
 import Delete from '@mui/icons-material/Delete';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import {
@@ -190,17 +191,20 @@ export default function TrackSurplus() {
     <Page
       title="Track Surplus"
       header={
-        <Button
-          size="small"
-          variant="contained"
-          onClick={() => {
-            setForm({ date: format(selectedDate), type: 'BREAD', count: '' });
-            setEditing(null);
-            setRecordOpen(true);
-          }}
-        >
-          Record Surplus
-        </Button>
+        <Stack spacing={2}>
+          <WarehouseQuickLinks />
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => {
+              setForm({ date: format(selectedDate), type: 'BREAD', count: '' });
+              setEditing(null);
+              setRecordOpen(true);
+            }}
+          >
+            Record Surplus
+          </Button>
+        </Stack>
       }
     >
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -47,6 +47,7 @@ import { getTopReceivers, type TopReceiver } from '../../api/outgoingReceivers';
 import { getEvents, type EventGroups } from '../../api/events';
 import type { AlertColor } from '@mui/material';
 import Page from '../../components/Page';
+import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 
 interface MonthlyTotal {
   year: number;
@@ -248,7 +249,7 @@ export default function WarehouseDashboard() {
   ];
 
   return (
-    <Page title="Warehouse Manager Dashboard">
+    <Page title="Warehouse Manager Dashboard" header={<WarehouseQuickLinks />}>
       <Box>
       <Stack
         direction={{ xs: 'column', md: 'row' }}

--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Staff can enter pay period timesheets with daily hour categories, request vacation leave, and submit periods for approval with admin review and processing.
 - Staff can delete client and volunteer accounts from the Client Management and Volunteer Management pages.
 - Pantry pages include quick links for Pantry Schedule, Record a Visit, and Search Client.
+- Warehouse pages include quick links for Dashboard, Donation Log, Track Surplus, Track Pigpound, Track Outgoing Donations, Aggregations, and Exports.
 - Pantry Visits page includes a search field to filter visits by client name or ID.
 - Pantry Visits can log daily sunshine bag weights, shown in the summary above the visit table.
 - Anonymous Pantry Visits show "(ANONYMOUS)" after the client ID and their family size is excluded from summary counts.


### PR DESCRIPTION
## Summary
- add warehouse quick links component with navigation to key tracking pages
- show quick links across warehouse dashboard and log/track/aggregation/export screens
- document warehouse quick links in help and README

## Testing
- `npm test` *(fails: Unable to find an accessible element with the role "table", etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be5c8804cc832da621c730b97508a2