### PR TITLE
Wrap key routes in error boundaries

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -267,6 +267,9 @@ export default function App() {
   const AppContent = () => {
     const location = useLocation();
     const path = location.pathname;
+    useEffect(() => {
+      console.log('Navigated to', path);
+    }, [path]);
     const showLanguageSelector =
       path.startsWith('/login') ||
       path.startsWith('/forgot-password') ||

--- a/MJ_FB_Frontend/src/components/ErrorBoundary.tsx
+++ b/MJ_FB_Frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
+  }
+}

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffForm.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffForm.tsx
@@ -6,6 +6,7 @@ import StaffForm from '../../components/StaffForm';
 import { getStaff, createStaff, updateStaff } from '../../api/adminStaff';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import type { Staff } from '../../types';
+import ErrorBoundary from '../../components/ErrorBoundary';
 
 export default function AdminStaffForm() {
   const { id } = useParams();
@@ -21,35 +22,37 @@ export default function AdminStaffForm() {
   }, [id]);
 
   return (
-    <Page title={id ? 'Edit Staff' : 'Create Staff'}>
-      <Box p={2}>
-        <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-        <Button variant="outlined" component={RouterLink} to="/admin/staff" sx={{ mb: 2 }}>
-          Back to Staff List
-        </Button>
-        <StaffForm
-          initial={initial}
-          submitLabel={id ? 'Save' : 'Add Staff'}
-          onSubmit={async data => {
-            if (id) {
-              await updateStaff(
-                Number(id),
-                data.firstName,
-                data.lastName,
-                data.email,
-                data.access,
-              );
-            } else {
-              await createStaff(
-                data.firstName,
-                data.lastName,
-                data.email,
-                data.access,
-              );
-            }
-          }}
-        />
-      </Box>
-    </Page>
+    <ErrorBoundary>
+      <Page title={id ? 'Edit Staff' : 'Create Staff'}>
+        <Box p={2}>
+          <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+          <Button variant="outlined" component={RouterLink} to="/admin/staff" sx={{ mb: 2 }}>
+            Back to Staff List
+          </Button>
+          <StaffForm
+            initial={initial}
+            submitLabel={id ? 'Save' : 'Add Staff'}
+            onSubmit={async data => {
+              if (id) {
+                await updateStaff(
+                  Number(id),
+                  data.firstName,
+                  data.lastName,
+                  data.email,
+                  data.access,
+                );
+              } else {
+                await createStaff(
+                  data.firstName,
+                  data.lastName,
+                  data.email,
+                  data.access,
+                );
+              }
+            }}
+          />
+        </Box>
+      </Page>
+    </ErrorBoundary>
   );
 }

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
@@ -13,6 +13,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import ResponsiveTable from '../../components/ResponsiveTable';
 import { listStaff, deleteStaff, searchStaff } from '../../api/adminStaff';
 import type { Staff, StaffAccess } from '../../types';
+import ErrorBoundary from '../../components/ErrorBoundary';
 
 export default function AdminStaffList() {
   const [staff, setStaff] = useState<Staff[]>([]);
@@ -54,53 +55,55 @@ export default function AdminStaffList() {
   }
 
   return (
-    <Page title="Staff List">
-      <Box p={2}>
-        <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
-        <FeedbackSnackbar open={!!success} onClose={() => setSuccess('')} message={success} />
-        <Box mb={2} display="flex" justifyContent="space-between" alignItems="center">
-          <TextField
-            label="Search"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            size="small"
+    <ErrorBoundary>
+      <Page title="Staff List">
+        <Box p={2}>
+          <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+          <FeedbackSnackbar open={!!success} onClose={() => setSuccess('')} message={success} />
+          <Box mb={2} display="flex" justifyContent="space-between" alignItems="center">
+            <TextField
+              label="Search"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              size="small"
+            />
+            <Button variant="contained" component={RouterLink} to="/admin/staff/create">
+              Add Staff
+            </Button>
+          </Box>
+          <ResponsiveTable
+            columns={[
+              {
+                field: 'firstName',
+                header: 'Name',
+                render: (row: Staff) => `${row.firstName} ${row.lastName}`,
+              },
+              { field: 'email', header: 'Email' },
+              {
+                field: 'access',
+                header: 'Access',
+                render: (row: Staff) => row.access.map(a => accessLabels[a]).join(', '),
+              },
+              {
+                field: 'id',
+                header: 'Actions',
+                render: (row: Staff) => (
+                  <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <IconButton component={RouterLink} to={`/admin/staff/${row.id}`} size="small" aria-label="edit">
+                      <EditIcon />
+                    </IconButton>
+                    <IconButton onClick={() => handleDelete(row.id)} size="small" aria-label="delete">
+                      <DeleteIcon />
+                    </IconButton>
+                  </Box>
+                ),
+              },
+            ]}
+            rows={staff}
+            getRowKey={row => row.id}
           />
-          <Button variant="contained" component={RouterLink} to="/admin/staff/create">
-            Add Staff
-          </Button>
         </Box>
-        <ResponsiveTable
-          columns={[
-            {
-              field: 'firstName',
-              header: 'Name',
-              render: (row: Staff) => `${row.firstName} ${row.lastName}`,
-            },
-            { field: 'email', header: 'Email' },
-            {
-              field: 'access',
-              header: 'Access',
-              render: (row: Staff) => row.access.map(a => accessLabels[a]).join(', '),
-            },
-            {
-              field: 'id',
-              header: 'Actions',
-              render: (row: Staff) => (
-                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                  <IconButton component={RouterLink} to={`/admin/staff/${row.id}`} size="small" aria-label="edit">
-                    <EditIcon />
-                  </IconButton>
-                  <IconButton onClick={() => handleDelete(row.id)} size="small" aria-label="delete">
-                    <DeleteIcon />
-                  </IconButton>
-                </Box>
-              ),
-            },
-          ]}
-          rows={staff}
-          getRowKey={row => row.id}
-        />
-      </Box>
-    </Page>
+      </Page>
+    </ErrorBoundary>
   );
 }

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -17,6 +17,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import PageContainer from '../../components/layout/PageContainer';
 import PageCard from '../../components/layout/PageCard';
 import { useTranslation } from 'react-i18next';
+import ErrorBoundary from '../../components/ErrorBoundary';
 
 export default function Profile({ role }: { role: Role }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
@@ -100,14 +101,15 @@ export default function Profile({ role }: { role: Role }) {
   }
 
   return (
-    <PageContainer maxWidth="sm">
-      <PageCard
-        variant="elevation"
-        elevation={0}
-        sx={{ p: 3, borderRadius: 3, boxShadow: 3 }}
-        contentProps={{ sx: { p: 0 } }}
-      >
-        <Stack spacing={3}>
+    <ErrorBoundary>
+      <PageContainer maxWidth="sm">
+        <PageCard
+          variant="elevation"
+          elevation={0}
+          sx={{ p: 3, borderRadius: 3, boxShadow: 3 }}
+          contentProps={{ sx: { p: 0 } }}
+        >
+          <Stack spacing={3}>
           {/* Header */}
           <Stack direction="row" alignItems="center" spacing={2}>
             <Avatar sx={{ bgcolor: 'primary.main', width: 56, height: 56 }}>
@@ -230,5 +232,6 @@ export default function Profile({ role }: { role: Role }) {
         severity={toast.severity}
       />
     </PageContainer>
+    </ErrorBoundary>
   );
 }

--- a/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
+++ b/MJ_FB_Frontend/src/pages/help/HelpPage.tsx
@@ -14,6 +14,7 @@ import { getHelpContent, type HelpSection } from './content';
 import resetCss from '../../reset.css?url';
 import RoleTabs, { type RoleTabOption } from '../../components/RoleTabs';
 import { useTranslation } from 'react-i18next';
+import ErrorBoundary from '../../components/ErrorBoundary';
 
 function roleLabel(role: string) {
   return role.charAt(0).toUpperCase() + role.slice(1);
@@ -95,31 +96,33 @@ export default function HelpPage() {
   }, [roles, search, helpContent, t]);
 
   return (
-    <Page
-      title={t('help.title')}
-      header={
-        <Stack spacing={2} sx={{ mb: 2, '@media print': { display: 'none' } }}>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <TextField
-              label={t('help.search')}
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-              size="small"
-              sx={{ '@media print': { display: 'none' } }}
-            />
-            <Button
-              variant="outlined"
-              onClick={() => window.print()}
-              sx={{ '@media print': { display: 'none' } }}
-            >
-              {t('help.print')}
-            </Button>
+    <ErrorBoundary>
+      <Page
+        title={t('help.title')}
+        header={
+          <Stack spacing={2} sx={{ mb: 2, '@media print': { display: 'none' } }}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <TextField
+                label={t('help.search')}
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                size="small"
+                sx={{ '@media print': { display: 'none' } }}
+              />
+              <Button
+                variant="outlined"
+                onClick={() => window.print()}
+                sx={{ '@media print': { display: 'none' } }}
+              >
+                {t('help.print')}
+              </Button>
+            </Stack>
           </Stack>
-        </Stack>
-      }
-    >
-      {roles.length > 1 ? tabs.length && <RoleTabs tabs={tabs} /> : tabs[0]?.content}
-    </Page>
+        }
+      >
+        {roles.length > 1 ? tabs.length && <RoleTabs tabs={tabs} /> : tabs[0]?.content}
+      </Page>
+    </ErrorBoundary>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../api/staff';
 import { searchStaff as searchAdminStaff } from '../../api/adminStaff';
 import type { Staff } from '../../types';
+import ErrorBoundary from '../../components/ErrorBoundary';
 
 interface Day {
   date: string;
@@ -371,7 +372,8 @@ export default function Timesheets() {
     : [];
 
   return (
-    <Page title={t('timesheets.title')}>
+    <ErrorBoundary>
+      <Page title={t('timesheets.title')}>
       {inAdmin && (
         <>
           <Autocomplete
@@ -485,7 +487,8 @@ export default function Timesheets() {
         message={message}
         severity="error"
       />
-    </Page>
+      </Page>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
## Summary
- create reusable ErrorBoundary component
- guard Profile, Help, Timesheets, and admin staff pages with ErrorBoundary
- log route changes in App for debugging navigation

## Testing
- `npm test` *(fails: Unable to find table role in UserHistory.test.tsx and other test failures)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be5dc5d6c4832d97fd21ab5487397c