### PR TITLE
Use sticky booking action bars

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -399,6 +399,7 @@ export default function BookingUI({
             ref={slotsRef}
             sx={{
               p: 2,
+              pb: 8,
               borderRadius: 2,
               maxHeight: { xs: 420, md: 560 },
               overflow: 'auto',
@@ -459,12 +460,11 @@ export default function BookingUI({
           </Paper>
         </Grid>
       </Grid>
-      <Paper
+      <Box
+        component={Paper}
         sx={{
-          position: 'fixed',
+          position: 'sticky',
           bottom: 0,
-          left: 0,
-          right: 0,
           mt: 2,
           p: 2,
           borderRadius: { xs: 0, md: 2 },
@@ -496,7 +496,7 @@ export default function BookingUI({
             {t('book_selected_slot')}
           </Button>
         </Stack>
-      </Paper>
+      </Box>
       <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
         <DialogCloseButton onClose={() => setConfirmOpen(false)} />
         <DialogTitle>{t('confirm_booking')}</DialogTitle>

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -183,7 +183,7 @@ export default function VolunteerBooking() {
         <Grid size={{ xs: 12, md: 'grow' }} sx={{ flexGrow: 1 }}>
           <Paper
             ref={slotsRef}
-            sx={{ p: 2, borderRadius: 2, maxHeight: { xs: 420, md: 560 }, overflow: 'auto' }}
+            sx={{ p: 2, pb: 8, borderRadius: 2, maxHeight: { xs: 420, md: 560 }, overflow: 'auto' }}
           >
             {isLoading ? (
               <Box>
@@ -215,12 +215,11 @@ export default function VolunteerBooking() {
           </Paper>
         </Grid>
       </Grid>
-      <Paper
+      <Box
+        component={Paper}
         sx={{
-          position: 'fixed',
+          position: 'sticky',
           bottom: 0,
-          left: 0,
-          right: 0,
           mt: 2,
           p: 2,
           borderRadius: { xs: 0, md: 2 },
@@ -244,7 +243,7 @@ export default function VolunteerBooking() {
             Request shift
           </Button>
         </Stack>
-      </Paper>
+      </Box>
         {conflict && (
           <OverlapBookingDialog
             open


### PR DESCRIPTION
## Summary
- Keep booking action bars visible by switching from `fixed` to `sticky` positioning
- Add bottom padding to slot lists so final items remain reachable

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68be5e0f5ef8832d84974b83d364fb16