### PR TITLE
chore: add index for booking history

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000031_add_bookings_user_created_at_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000031_add_bookings_user_created_at_index.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction();
+  pgm.sql('CREATE INDEX CONCURRENTLY bookings_user_created_at_idx ON bookings (user_id, created_at DESC);');
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction();
+  pgm.sql('DROP INDEX CONCURRENTLY IF EXISTS bookings_user_created_at_idx;');
+}


### PR DESCRIPTION
## Summary
- add concurrent index on bookings(user_id, created_at DESC) for booking history query
- drop the index on rollback

## Testing
- `npm test` *(fails: Test Suites: 20 failed, 100 passed, 120 total)*
- `npm test tests/bookingRepository.test.ts`
- `EXPLAIN SELECT ... ORDER BY b.created_at DESC LIMIT 10`

------
https://chatgpt.com/codex/tasks/task_e_68be5e1426c4832da45b18f17663b31c