### PR TITLE
Enforce case-insensitive uniqueness for new client emails

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000031_add_new_clients_email_lower_idx.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000031_add_new_clients_email_lower_idx.ts
@@ -1,0 +1,10 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`CREATE UNIQUE INDEX new_clients_email_lower_idx ON new_clients (LOWER(email));`);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('DROP INDEX IF EXISTS new_clients_email_lower_idx;');
+}
+

--- a/MJ_FB_Backend/src/models/newClient.ts
+++ b/MJ_FB_Backend/src/models/newClient.ts
@@ -7,11 +7,22 @@ export async function insertNewClient(
   phone: string | null,
   client: Queryable = pool,
 ) {
-  const res = await client.query(
-    `INSERT INTO new_clients (name, email, phone) VALUES ($1, $2, $3) RETURNING id`,
-    [name, email, phone],
-  );
-  return res.rows[0].id;
+  try {
+    const res = await client.query(
+      `INSERT INTO new_clients (name, email, phone) VALUES ($1, $2, $3) RETURNING id`,
+      [name, email, phone],
+    );
+    return res.rows[0].id;
+  } catch (err: any) {
+    if (email && err.code === '23505') {
+      const existing = await client.query(
+        `SELECT id FROM new_clients WHERE LOWER(email) = LOWER($1)`,
+        [email],
+      );
+      if (existing.rowCount > 0) return existing.rows[0].id;
+    }
+    throw err;
+  }
 }
 
 export async function fetchNewClients(client: Queryable = pool) {

--- a/MJ_FB_Backend/tests/newClientModel.test.ts
+++ b/MJ_FB_Backend/tests/newClientModel.test.ts
@@ -1,0 +1,38 @@
+import { insertNewClient } from '../src/models/newClient';
+
+describe('insertNewClient', () => {
+  it('inserts and returns new id', async () => {
+    const client = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ id: 1 }] }),
+    } as any;
+
+    const id = await insertNewClient('Test', 'test@example.com', '123', client);
+
+    expect(id).toBe(1);
+    expect(client.query).toHaveBeenCalledWith(
+      `INSERT INTO new_clients (name, email, phone) VALUES ($1, $2, $3) RETURNING id`,
+      ['Test', 'test@example.com', '123'],
+    );
+  });
+
+  it('returns existing id when email already exists', async () => {
+    const client = {
+      query: jest
+        .fn()
+        .mockRejectedValueOnce({ code: '23505' })
+        .mockResolvedValueOnce({ rows: [{ id: 2 }], rowCount: 1 }),
+    } as any;
+
+    const id = await insertNewClient('Dup', 'dup@example.com', '123', client);
+
+    expect(id).toBe(2);
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      `SELECT id FROM new_clients WHERE LOWER(email) = LOWER($1)`,
+      ['dup@example.com'],
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a migration enforcing case-insensitive uniqueness on `new_clients.email`
- gracefully handle duplicate `new_clients` email inserts by reusing existing records
- cover duplicate email handling with unit tests

## Testing
- `npm test` *(fails: Test Suites: 24 failed, 97 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68be5e17a3d0832d845c94924d103030