### PR TITLE
Use date range for monthly visit count

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -18,7 +18,8 @@ export async function refreshClientVisitCount(
      SET bookings_this_month = (
        SELECT COUNT(*) FROM client_visits v
        WHERE v.client_id = c.client_id
-         AND DATE_TRUNC('month', v.date) = DATE_TRUNC('month', CURRENT_DATE)
+         AND v.date >= DATE_TRUNC('month', CURRENT_DATE)
+         AND v.date < DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month'
      ),
      booking_count_last_updated = NOW()
      WHERE c.client_id = $1`,

--- a/MJ_FB_Backend/tests/refreshClientVisitCount.test.ts
+++ b/MJ_FB_Backend/tests/refreshClientVisitCount.test.ts
@@ -1,0 +1,17 @@
+import { refreshClientVisitCount } from '../src/controllers/clientVisitController';
+import mockDb from './utils/mockDb';
+
+describe('refreshClientVisitCount', () => {
+  afterEach(() => {
+    (mockDb.query as jest.Mock).mockClear();
+  });
+
+  it('uses date range for current month', async () => {
+    await refreshClientVisitCount(1, mockDb);
+    expect(mockDb.query).toHaveBeenCalledTimes(1);
+    const sql = (mockDb.query as jest.Mock).mock.calls[0][0] as string;
+    expect(sql).toContain("v.date >= DATE_TRUNC('month', CURRENT_DATE)");
+    expect(sql).toContain("v.date < DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month'");
+    expect((mockDb.query as jest.Mock).mock.calls[0][1]).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## Summary
- replace DATE_TRUNC comparison with explicit current-month range in refreshClientVisitCount
- add unit test covering date range logic

## Testing
- `npm test tests/refreshClientVisitCount.test.ts`
- `npm test` *(fails: 24 failed, 97 passed)*
- `EXPLAIN SELECT COUNT(*) FROM client_visits ...`

------
https://chatgpt.com/codex/tasks/task_e_68be5e1a72a8832d8ed54aeebaee9600