### PR TITLE
feat: add agency client search

### DIFF
--- a/MJ_FB_Backend/src/controllers/agencyController.ts
+++ b/MJ_FB_Backend/src/controllers/agencyController.ts
@@ -158,7 +158,26 @@ export async function getAgencyClients(
     ) {
       return res.status(403).json({ message: 'Forbidden' });
     }
-    const clients = await fetchAgencyClients(agencyId);
+    const search = req.query.search as string | undefined;
+    const limitParam = req.query.limit as string | undefined;
+    const offsetParam = req.query.offset as string | undefined;
+    let limit = 25;
+    if (limitParam !== undefined) {
+      const parsed = Number(limitParam);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        return res.status(400).json({ message: 'Invalid limit' });
+      }
+      limit = Math.min(parsed, 100);
+    }
+    let offset = 0;
+    if (offsetParam !== undefined) {
+      const parsed = Number(offsetParam);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        return res.status(400).json({ message: 'Invalid offset' });
+      }
+      offset = parsed;
+    }
+    const clients = await fetchAgencyClients(agencyId, search, limit, offset);
     res.json(clients);
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/tests/agencyClientsMe.test.ts
+++ b/MJ_FB_Backend/tests/agencyClientsMe.test.ts
@@ -48,6 +48,17 @@ describe('GET /agencies/me/clients', () => {
     expect(res.body).toEqual([
       { client_id: 5, first_name: 'John', last_name: 'Doe', email: null },
     ]);
-    expect(getAgencyClients).toHaveBeenCalledWith(1);
+    expect(getAgencyClients).toHaveBeenCalledWith(1, undefined, 25, 0);
+  });
+
+  it('forwards search and pagination parameters', async () => {
+    (getAgencyClients as jest.Mock).mockResolvedValue([]);
+
+    const res = await request(app)
+      .get('/agencies/me/clients')
+      .query({ search: 'Jo', limit: '5', offset: '10' });
+
+    expect(res.status).toBe(200);
+    expect(getAgencyClients).toHaveBeenCalledWith(1, 'Jo', 5, 10);
   });
 });

--- a/MJ_FB_Frontend/AGENTS.md
+++ b/MJ_FB_Frontend/AGENTS.md
@@ -33,7 +33,7 @@
 - After setting a password, users are redirected to the login page for their role.
 - Volunteer role start and end times use a native time picker; `saveRole` expects `HH:MM:SS` strings.
 - Staff can assign clients to agencies from the Harvest Pantry → Agency Management page via the **Add Client to Agency** tab, which includes agency search, client listing, and removal confirmations. Initially, the page shows only agency search; selecting an agency reveals a two-column layout with client search on the left and the agency's client list on the right.
-- Agencies can book appointments for their associated clients from the Agency → Book Appointment page. Clients load once and display only after entering a search term, with filtering performed client-side to avoid long lists.
+- Agencies can book appointments for their associated clients from the Agency → Book Appointment page. Client results are fetched from the server as you type to avoid long lists.
 - Agency navigation provides Dashboard, Book Appointment, and Booking History pages, all protected by `AgencyGuard`.
 - Agencies can view pantry slot availability and manage bookings—including creating, cancelling, and rescheduling—for their linked clients.
 - Volunteer navigation includes a **Recurring Bookings** submenu for managing repeating shifts; keep related documentation up to date.

--- a/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import AgencyBookAppointment from '../pages/agency/AgencyBookAppointment';
 
 jest.mock('../api/agencies', () => ({
-  getMyAgencyClients: jest.fn(),
+  searchAgencyClients: jest.fn(),
 }));
 
 const mockBookingUI = jest.fn();
@@ -15,8 +15,8 @@ describe('AgencyBookAppointment', () => {
   });
 
   it('shows loading indicator while BookingUI loads', async () => {
-    const { getMyAgencyClients } = require('../api/agencies');
-    (getMyAgencyClients as jest.Mock).mockResolvedValue([
+    const { searchAgencyClients } = require('../api/agencies');
+    (searchAgencyClients as jest.Mock).mockResolvedValue([
       { id: 1, name: 'Alice', email: 'a@example.com' },
     ]);
     mockBookingUI.mockImplementation(({ shopperName, userId }: any) => (
@@ -35,8 +35,8 @@ describe('AgencyBookAppointment', () => {
   });
 
   it('renders BookingUI when a client is selected', async () => {
-    const { getMyAgencyClients } = require('../api/agencies');
-    (getMyAgencyClients as jest.Mock).mockResolvedValue([
+    const { searchAgencyClients } = require('../api/agencies');
+    (searchAgencyClients as jest.Mock).mockResolvedValue([
       { id: 1, name: 'Alice', email: 'a@example.com' },
     ]);
     mockBookingUI.mockImplementation(({ shopperName, userId, onLoadingChange }: any) => {

--- a/MJ_FB_Frontend/src/api/agencies.ts
+++ b/MJ_FB_Frontend/src/api/agencies.ts
@@ -7,6 +7,30 @@ export async function searchAgencies(query: string) {
   return handleResponse(res);
 }
 
+let searchTimer: ReturnType<typeof setTimeout> | undefined;
+let lastReject: ((reason?: any) => void) | undefined;
+
+export function searchAgencyClients(term: string) {
+  if (searchTimer) {
+    clearTimeout(searchTimer);
+    lastReject?.(new Error('canceled'));
+  }
+
+  return new Promise<any[]>((resolve, reject) => {
+    lastReject = reject;
+    searchTimer = setTimeout(async () => {
+      try {
+        const res = await apiFetch(
+          `${API_BASE}/agencies/me/clients?search=${encodeURIComponent(term)}`,
+        );
+        resolve(await handleResponse(res));
+      } catch (err) {
+        reject(err);
+      }
+    }, 300);
+  });
+}
+
 export async function getAgencyClients(agencyId: number | 'me') {
   const res = await apiFetch(`${API_BASE}/agencies/${agencyId}/clients`, {
     method: 'GET',

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Staff can book new clients directly from the pantry schedule's **Assign User** modal by checking **New client** and entering a name (email and phone optional).
 - Pantry and volunteer schedule pages present a mobile-friendly card layout on extra-small screens.
 - Wednesdays include an additional 6:30–7:00 PM pantry slot.
-- Agencies can book appointments for their associated clients via the Agency → Book Appointment page. Clients load once and appear only after entering a search term, avoiding long lists. The page hides the client list after a selection and uses a single “Book Appointment” heading for clarity.
+- Agencies can book appointments for their associated clients via the Agency → Book Appointment page. Clients are searched server-side and appear as you type, avoiding long lists. The page hides the client list after a selection and uses a single “Book Appointment” heading for clarity.
 - Agencies can view slot availability and cancel or reschedule bookings for their clients using the standard booking APIs.
 - Agency navigation offers Dashboard, Book Appointment, Booking History, Clients, and Schedule pages, all behind an `AgencyGuard`.
 - Agency profile page shows the agency's name, email, and contact info with editable fields and sends password reset links via email.


### PR DESCRIPTION
## Summary
- allow agencies to search clients via `/agencies/:id/clients?search=` with pagination
- add debounced `searchAgencyClients` API hook
- fetch client results on the fly in Agency Book Appointment page

## Testing
- `npm test` *(backend, fails: Test Suites: 24 failed, 96 passed)*
- `npm test` *(frontend, fails with jsdom TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68be5e014670832dac90bb03a22a82d2