### PR TITLE
Expose upcoming timesheets for staff

### DIFF
--- a/MJ_FB_Backend/src/utils/timesheetSeeder.ts
+++ b/MJ_FB_Backend/src/utils/timesheetSeeder.ts
@@ -2,11 +2,11 @@ import pool from '../db';
 import logger from './logger';
 
 /**
- * Seed timesheets for staff in the current pay period. When the `staff` table
- * includes an `active` column, only active staff are processed; otherwise all
- * staff are seeded. For each staff member, ensure a timesheet exists for the
- * current pay period and insert weekday rows with zeroed hours. Stat holiday
- * rows are handled via database triggers.
+ * Seed timesheets for staff in the current and next four pay periods. When the
+ * `staff` table includes an `active` column, only active staff are processed;
+ * otherwise all staff are seeded. For each staff member, ensure a timesheet
+ * exists for each period and insert weekday rows with zeroed hours. Stat
+ * holiday rows are handled via database triggers.
  *
  * @param staffId Optional staff ID to seed for a specific staff member. If
  * omitted, seeds for all staff (or only active staff when supported).
@@ -31,7 +31,14 @@ export async function seedTimesheets(staffId?: number): Promise<void> {
       return; // No current pay period
     }
 
-    const period = payPeriodRes.rows[0];
+    const currentPeriod = payPeriodRes.rows[0];
+
+    // Fetch current and next four pay periods
+    const periodsRes = await pool.query(
+      `SELECT id, start_date, end_date FROM pay_periods WHERE start_date >= $1 ORDER BY start_date ASC LIMIT 5`,
+      [currentPeriod.start_date],
+    );
+    const periods = periodsRes.rows;
 
     // Check if the staff table has starts_on and active columns to avoid errors on older schemas
     const colCheck = await pool.query(
@@ -54,47 +61,49 @@ export async function seedTimesheets(staffId?: number): Promise<void> {
     const staffRes = await pool.query(staffSql, staffParams);
 
     for (const staff of staffRes.rows) {
-      // Check for existing timesheet
-      const tsRes = await pool.query(
-        'SELECT id FROM timesheets WHERE staff_id = $1 AND start_date = $2 AND end_date = $3',
-        [staff.id, period.start_date, period.end_date],
-      );
-
-      let timesheetId: number;
-      if (tsRes.rowCount && tsRes.rowCount > 0) {
-        timesheetId = tsRes.rows[0].id;
-      } else {
-        const insertRes = await pool.query(
-          'INSERT INTO timesheets (staff_id, start_date, end_date) VALUES ($1, $2, $3) RETURNING id',
+      for (const period of periods) {
+        // Check for existing timesheet
+        const tsRes = await pool.query(
+          'SELECT id FROM timesheets WHERE staff_id = $1 AND start_date = $2 AND end_date = $3',
           [staff.id, period.start_date, period.end_date],
         );
-        timesheetId = insertRes.rows[0].id;
+
+        let timesheetId: number;
+        if (tsRes.rowCount && tsRes.rowCount > 0) {
+          timesheetId = tsRes.rows[0].id;
+        } else {
+          const insertRes = await pool.query(
+            'INSERT INTO timesheets (staff_id, start_date, end_date) VALUES ($1, $2, $3) RETURNING id',
+            [staff.id, period.start_date, period.end_date],
+          );
+          timesheetId = insertRes.rows[0].id;
+        }
+
+        // Insert weekday rows with zeroed hours
+        const seriesStart = hasStartsOn ? 'GREATEST($2::date, $3::date)' : '$2::date';
+        const params = hasStartsOn
+          ? [timesheetId, period.start_date, staff.starts_on, period.end_date]
+          : [timesheetId, period.start_date, period.end_date];
+
+        await pool.query(
+          `INSERT INTO timesheet_days (
+              timesheet_id,
+              work_date,
+              expected_hours,
+              reg_hours,
+              ot_hours,
+              stat_hours,
+              sick_hours,
+              vac_hours,
+              note
+           )
+           SELECT $1, gs.day, 0, 0, 0, 0, 0, 0, NULL
+             FROM generate_series(${seriesStart}, $${hasStartsOn ? 4 : 3}::date, '1 day') AS gs(day)
+            WHERE EXTRACT(ISODOW FROM gs.day) < 6
+            ON CONFLICT (timesheet_id, work_date) DO NOTHING`,
+          params,
+        );
       }
-
-      // Insert weekday rows with zeroed hours
-      const seriesStart = hasStartsOn ? 'GREATEST($2::date, $3::date)' : '$2::date';
-      const params = hasStartsOn
-        ? [timesheetId, period.start_date, staff.starts_on, period.end_date]
-        : [timesheetId, period.start_date, period.end_date];
-
-      await pool.query(
-        `INSERT INTO timesheet_days (
-            timesheet_id,
-            work_date,
-            expected_hours,
-            reg_hours,
-            ot_hours,
-            stat_hours,
-            sick_hours,
-            vac_hours,
-            note
-         )
-         SELECT $1, gs.day, 0, 0, 0, 0, 0, 0, NULL
-           FROM generate_series(${seriesStart}, $${hasStartsOn ? 4 : 3}::date, '1 day') AS gs(day)
-          WHERE EXTRACT(ISODOW FROM gs.day) < 6
-          ON CONFLICT (timesheet_id, work_date) DO NOTHING`,
-        params,
-      );
     }
   } catch (err) {
     logger.error('Error seeding timesheets:', err);

--- a/MJ_FB_Backend/tests/timesheetSeeder.test.ts
+++ b/MJ_FB_Backend/tests/timesheetSeeder.test.ts
@@ -9,6 +9,7 @@ describe('seedTimesheets', () => {
 
   it('creates timesheet rows when staff start and active columns are not tracked', async () => {
     const calls: any[] = [];
+    let tsId = 100;
     (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
       calls.push({ sql, params });
       if (sql.includes("to_regclass('public.pay_periods')")) {
@@ -17,8 +18,20 @@ describe('seedTimesheets', () => {
       if (sql.includes("FROM information_schema.columns")) {
         return { rows: [], rowCount: 0 }; // no starts_on or active columns
       }
-      if (sql.includes('FROM pay_periods')) {
+      if (sql.includes('CURRENT_DATE BETWEEN')) {
         return { rows: [{ id: 1, start_date: '2024-06-01', end_date: '2024-06-15' }], rowCount: 1 };
+      }
+      if (sql.includes('start_date >= $1')) {
+        return {
+          rows: [
+            { id: 1, start_date: '2024-06-01', end_date: '2024-06-15' },
+            { id: 2, start_date: '2024-06-16', end_date: '2024-06-30' },
+            { id: 3, start_date: '2024-07-01', end_date: '2024-07-15' },
+            { id: 4, start_date: '2024-07-16', end_date: '2024-07-30' },
+            { id: 5, start_date: '2024-07-31', end_date: '2024-08-14' },
+          ],
+          rowCount: 5,
+        };
       }
       if (sql.includes('FROM staff')) {
         return { rows: [{ id: 7 }], rowCount: 1 };
@@ -27,7 +40,7 @@ describe('seedTimesheets', () => {
         return { rows: [], rowCount: 0 };
       }
       if (sql.startsWith('INSERT INTO timesheets')) {
-        return { rows: [{ id: 99 }], rowCount: 1 };
+        return { rows: [{ id: tsId++ }], rowCount: 1 };
       }
       return { rows: [], rowCount: 0 };
     });
@@ -36,12 +49,12 @@ describe('seedTimesheets', () => {
 
     const staffCall = calls.find((c) => c.sql.includes('FROM staff'));
     expect(staffCall.sql).not.toMatch(/active/);
-    const insertTs = calls.find((c) => c.sql.startsWith('INSERT INTO timesheets'));
-    expect(insertTs).toBeDefined();
-    const insertDays = calls.find((c) => c.sql.startsWith('INSERT INTO timesheet_days'));
-    expect(insertDays).toBeDefined();
-    expect(insertDays.sql).not.toContain('GREATEST');
-    expect(insertDays.params).toEqual([99, '2024-06-01', '2024-06-15']);
+    const insertTs = calls.filter((c) => c.sql.startsWith('INSERT INTO timesheets'));
+    expect(insertTs).toHaveLength(5);
+    const insertDays = calls.filter((c) => c.sql.startsWith('INSERT INTO timesheet_days'));
+    expect(insertDays).toHaveLength(5);
+    expect(insertDays[0].sql).not.toContain('GREATEST');
+    expect(insertDays[0].params?.slice(1)).toEqual(['2024-06-01', '2024-06-15']);
   });
 
   it('uses staff start date and filters active staff when columns are present', async () => {
@@ -54,8 +67,20 @@ describe('seedTimesheets', () => {
       if (sql.includes("FROM information_schema.columns")) {
         return { rows: [{ column_name: 'starts_on' }, { column_name: 'active' }], rowCount: 2 };
       }
-      if (sql.includes('FROM pay_periods')) {
+      if (sql.includes('CURRENT_DATE BETWEEN')) {
         return { rows: [{ id: 2, start_date: '2024-06-01', end_date: '2024-06-15' }], rowCount: 1 };
+      }
+      if (sql.includes('start_date >= $1')) {
+        return {
+          rows: [
+            { id: 2, start_date: '2024-06-01', end_date: '2024-06-15' },
+            { id: 3, start_date: '2024-06-16', end_date: '2024-06-30' },
+            { id: 4, start_date: '2024-07-01', end_date: '2024-07-15' },
+            { id: 5, start_date: '2024-07-16', end_date: '2024-07-30' },
+            { id: 6, start_date: '2024-07-31', end_date: '2024-08-14' },
+          ],
+          rowCount: 5,
+        };
       }
       if (sql.includes('FROM staff')) {
         return { rows: [{ id: 5, starts_on: '2024-06-05' }], rowCount: 1 };
@@ -70,12 +95,12 @@ describe('seedTimesheets', () => {
 
     const staffCall = calls.find((c) => c.sql.includes('FROM staff'));
     expect(staffCall.sql).toMatch(/WHERE active = true/);
-    const insertTs = calls.find((c) => c.sql.startsWith('INSERT INTO timesheets'));
-    expect(insertTs).toBeUndefined();
-    const insertDays = calls.find((c) => c.sql.startsWith('INSERT INTO timesheet_days'));
-    expect(insertDays).toBeDefined();
-    expect(insertDays.sql).toContain('GREATEST($2::date, $3::date)');
-    expect(insertDays.params).toEqual([50, '2024-06-01', '2024-06-05', '2024-06-15']);
+    const insertTs = calls.filter((c) => c.sql.startsWith('INSERT INTO timesheets'));
+    expect(insertTs).toHaveLength(0);
+    const insertDays = calls.filter((c) => c.sql.startsWith('INSERT INTO timesheet_days'));
+    expect(insertDays).toHaveLength(5);
+    expect(insertDays[0].sql).toContain('GREATEST($2::date, $3::date)');
+    expect(insertDays[0].params).toEqual([50, '2024-06-01', '2024-06-05', '2024-06-15']);
   });
 
   it('skips seeding when pay_periods table is missing', async () => {

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -171,12 +171,12 @@ describe('Timesheets', () => {
     expect(mockSubmit).toHaveBeenCalledWith(1);
   });
 
-  it('shows at most seven timesheet tabs with next period last', () => {
-    const timesheets = Array.from({ length: 9 }).map((_, i) => ({
+  it('shows current and next four timesheet tabs with up to five previous', () => {
+    const timesheets = Array.from({ length: 12 }).map((_, i) => ({
       id: i + 1,
       staff_id: 1,
-      start_date: `2024-0${i + 1}-01`,
-      end_date: `2024-0${i + 1}-07`,
+      start_date: `2024-${(i + 1).toString().padStart(2, '0')}-01`,
+      end_date: `2024-${(i + 1).toString().padStart(2, '0')}-07`,
       submitted_at: null,
       approved_at: i < 7 ? '2024-01-01' : null,
       total_hours: 0,
@@ -191,9 +191,9 @@ describe('Timesheets', () => {
     });
     render();
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(7);
+    expect(tabs).toHaveLength(10);
     expect(tabs[0]).toHaveTextContent('2024-03-01 - 2024-03-07');
-    expect(tabs[6]).toHaveTextContent('2024-09-01 - 2024-09-07');
+    expect(tabs[9]).toHaveTextContent('2024-12-01 - 2024-12-07');
   });
 
   it('locks day when leave approved', () => {

--- a/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/timesheets.tsx
@@ -104,7 +104,7 @@ export default function Timesheets() {
     const idx = timesheets.findIndex(p => !p.approved_at);
     const currentIdx = idx === -1 ? timesheets.length - 1 : idx;
     const start = Math.max(0, currentIdx - 5);
-    const end = Math.min(timesheets.length, currentIdx + 2);
+    const end = Math.min(timesheets.length, currentIdx + 5);
     return timesheets.slice(start, end);
   }, [timesheets, inAdmin]);
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 **Timesheets** at `/admin/timesheet` and **Leave Requests** at
 `/admin/leave-requests` under the Admin menu for reviewing submissions. Admins can
 retrieve any staff timesheet's day entries through the API at
-`GET /timesheets/:id/days` and list periods via `GET /timesheets`.
+`GET /timesheets/:id/days` and list periods via `GET /timesheets`. The interface
+shows the current and next four pay periods so staff can enter hours in advance.
 
 ## Staff Access Roles
 

--- a/docs/timesheets.md
+++ b/docs/timesheets.md
@@ -7,8 +7,8 @@ from the **Hello** menu in the top-right corner. Admins can review periods at
 `/admin/timesheet` and vacation requests at `/admin/leave-requests` from the
 Admin menu. Admins select a staff member before viewing their periods.
 
-Staff see up to seven pay period tabs: the current period, the next period (if
-generated), and up to five previous periods.
+Staff see up to ten pay period tabs: the current period, the next four periods
+(if generated), and up to five previous periods.
 
 On small screens, daily entries render as stacked cards instead of a table,
 making the timesheet easier to read on mobile devices. Input fields now use
@@ -37,8 +37,9 @@ node src/utils/payPeriodSeeder.ts START_DATE END_DATE
 ```
 
 3. Timesheets for staff are created on startup and refreshed daily by a cron
-   job. If the `staff` table includes an `active` column, only active staff are
-   processed. You can seed them manually for the current pay period if
+   job. The seeder ensures each active staff member has timesheets for the
+   current and next four pay periods. If the `staff` table includes an `active`
+   column, only active staff are processed. You can seed them manually if
    necessary:
 
 ```bash


### PR DESCRIPTION
## Summary
- seed timesheets for the current and next four pay periods
- surface upcoming four periods in the staff timesheet tabs
- document extended pay period availability

## Testing
- `npm test` *(fails: 24 failed, 98 passed)*
- `npm test src/pages/staff/__tests__/timesheets.test.tsx` *(fails: Maximum update depth exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68beea673664832db1fe8690583b4fc5