### PR TITLE
fix: handle null rowCount for existing new clients

### DIFF
--- a/MJ_FB_Backend/src/models/newClient.ts
+++ b/MJ_FB_Backend/src/models/newClient.ts
@@ -19,7 +19,7 @@ export async function insertNewClient(
         `SELECT id FROM new_clients WHERE LOWER(email) = LOWER($1)`,
         [email],
       );
-      if (existing.rowCount > 0) return existing.rows[0].id;
+      if ((existing.rowCount ?? 0) > 0) return existing.rows[0].id;
     }
     throw err;
   }


### PR DESCRIPTION
## Summary
- handle null rowCount in new client insert to avoid build error

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bef1b2aaa0832d806e84eb7b33ad01