### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -28,7 +28,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Box,
   Chip,
   List,
   ListItem,

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -248,7 +248,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
   useEffect(() => {
     getVolunteerRoles()
       .then(data => {
-        const flattened: RoleOption[] = data.flatMap(r => {
+        const flattened: RoleOption[] = data.flatMap<RoleOption>(r => {
           if (r.shifts.length === 0) {
             return [
               {


### PR DESCRIPTION
## Summary
- fix build by typing `flatMap` callback to return `RoleOption` for volunteer roles
- remove unused `Box` import in pantry schedule

## Testing
- `npm test` *(fails: Unable to find an accessible element with the role "table"; SyntaxError: Cannot use 'import.meta' outside a module)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bef201138c832d82343824ea5bf4b3