### PR TITLE
Fix missing Box closing tag in WarehouseDashboard

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -524,14 +524,15 @@ export default function WarehouseDashboard() {
         Tip: Press Ctrl/Cmd+K in the search box to quickly filter donors/receivers.
       </Typography>
 
-        <FeedbackSnackbar
-          open={snackbar.open}
-          onClose={() => setSnackbar({ ...snackbar, open: false })}
-          message={snackbar.message}
-          severity={snackbar.severity}
-        />
-        </Page>
-      </>
-    );
-  }
+      </Box>
+      <FeedbackSnackbar
+        open={snackbar.open}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        message={snackbar.message}
+        severity={snackbar.severity}
+      />
+    </Page>
+  </>
+  );
+}
 


### PR DESCRIPTION
## Summary
- close stray Box wrapper in `WarehouseDashboard` to fix JSX parse error

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module, plus numerous other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bef320a354832d8f459d791a56d705