### PR TITLE
feat: clarify client password reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 - Use `write-excel-file` for spreadsheet exports instead of `sheetjs` or `exceljs`.
 - Use the shared `PasswordField` component for any password input so users can toggle visibility.
 - Passwords must be at least 8 characters and include uppercase, lowercase, and special characters; numbers are optional.
+- Clients reset passwords by entering their client ID and receive an email with a link to finish the reset.
 - Staff can delete client and volunteer accounts from their respective management pages; update help content when these features change.
 
 See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/AGENTS.md` for frontend-specific guidance.

--- a/MJ_FB_Frontend/public/locales/am/translation.json
+++ b/MJ_FB_Frontend/public/locales/am/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/ar/translation.json
+++ b/MJ_FB_Frontend/public/locales/ar/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/en/translation.json
+++ b/MJ_FB_Frontend/public/locales/en/translation.json
@@ -153,6 +153,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/es/translation.json
+++ b/MJ_FB_Frontend/public/locales/es/translation.json
@@ -153,6 +153,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/fa/translation.json
+++ b/MJ_FB_Frontend/public/locales/fa/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/fr/translation.json
+++ b/MJ_FB_Frontend/public/locales/fr/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/hi/translation.json
+++ b/MJ_FB_Frontend/public/locales/hi/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/ml/translation.json
+++ b/MJ_FB_Frontend/public/locales/ml/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/pa/translation.json
+++ b/MJ_FB_Frontend/public/locales/pa/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/ps/translation.json
+++ b/MJ_FB_Frontend/public/locales/ps/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/so/translation.json
+++ b/MJ_FB_Frontend/public/locales/so/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/sw/translation.json
+++ b/MJ_FB_Frontend/public/locales/sw/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/ta/translation.json
+++ b/MJ_FB_Frontend/public/locales/ta/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/ti/translation.json
+++ b/MJ_FB_Frontend/public/locales/ti/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/tl/translation.json
+++ b/MJ_FB_Frontend/public/locales/tl/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/uk/translation.json
+++ b/MJ_FB_Frontend/public/locales/uk/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/public/locales/zh/translation.json
+++ b/MJ_FB_Frontend/public/locales/zh/translation.json
@@ -151,6 +151,7 @@
   "email_or_client_id": "Email or Client ID",
   "setup_link_sent": "If the account exists, a setup link has been sent.",
   "reset_link_sent": "If the account exists, a reset link has been sent.",
+  "client_reset_password_instructions": "Enter your client ID and select submit. You'll get an email with a link to reset your password.",
   "profile_page": {
     "title": "MJ Foodbank - User Profile",
     "user_profile": "User Profile",

--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Dialog, DialogContent, DialogTitle, Button, TextField } from '@mui/material';
+import { Dialog, DialogContent, DialogTitle, Button, TextField, Typography } from '@mui/material';
 import { requestPasswordReset } from '../api/users';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormCard from './FormCard';
@@ -56,6 +56,11 @@ export default function PasswordResetDialog({
             actions={<Button type="submit" variant="contained">{t('submit')}</Button>}
             boxProps={{ minHeight: 'auto', p: 0 }}
           >
+            {type === 'user' && (
+              <Typography variant="body2">
+                {t('client_reset_password_instructions')}
+              </Typography>
+            )}
             <TextField
               autoFocus
               margin="dense"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Email templates display times in 12-hour AM/PM format.
 - Past blocked slots are cleared nightly, with `/api/blocked-slots/cleanup` available for admins to trigger a manual cleanup.
 - Client login page reminds users to sign in with their client ID, provides contact and password reset guidance, and directs staff, volunteers, and agencies to use the internal login button from the menu.
+- Password reset dialog prompts clients to enter their client ID and explains that a reset link will be emailed.
 - Staff dashboards include a Volunteer Coverage card; click a role to see which volunteers are on duty.
 
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -8,3 +8,4 @@ Add the following translation strings to locale files:
 
 - `show_password`
 - `hide_password`
+- `client_reset_password_instructions` – instructs clients to enter their client ID and submit to receive a reset link via email


### PR DESCRIPTION
## Summary
- explain to clients that entering their client ID will send a password reset email
- translate and document the new reset instructions
- note reset flow in repository guidance

## Testing
- `npm test` *(fails: Unable to find an accessible element with the role "table")*

------
https://chatgpt.com/codex/tasks/task_e_68bf04dfa254832d86a0ce57a4702d9b