### PR TITLE
Restore new client booking option in staff schedule

### DIFF
--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -364,6 +364,17 @@ export function getHelpContent(
       },
     },
     {
+      title: 'Book new clients from the schedule',
+      body: {
+        description: 'Assign a slot to someone without a client ID.',
+        steps: [
+          'Click Assign User on a slot.',
+          'Check New client and enter their name.',
+          'Select Assign new client.',
+        ],
+      },
+    },
+    {
       title: 'Manage agencies and their clients',
       body: {
         description: 'Link or unlink agency clients and make bookings on their behalf.',

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
@@ -9,6 +9,7 @@ jest.mock('../../../api/bookings', () => ({
   getBookings: jest.fn(),
   getHolidays: jest.fn(),
   createBookingForUser: jest.fn(),
+  createBookingForNewClient: jest.fn(),
 }));
 
 jest.mock('../../../api/users', () => ({
@@ -97,6 +98,41 @@ describe('PantrySchedule add existing client workflow', () => {
         1,
         expect.any(String),
         true,
+      );
+    });
+  });
+
+  it('assigns new client booking', async () => {
+    (bookingApi.getBookings as jest.Mock).mockResolvedValue([]);
+    (bookingApi.createBookingForNewClient as jest.Mock).mockResolvedValue(
+      undefined,
+    );
+    render(
+      <MemoryRouter>
+        <PantrySchedule />
+      </MemoryRouter>,
+    );
+
+    const rows = await screen.findAllByRole('row');
+    const cells = within(rows[1]).getAllByRole('cell');
+    fireEvent.click(cells[1]);
+
+    const newClientBox = await screen.findByRole('checkbox', {
+      name: /new client/i,
+    });
+    fireEvent.click(newClientBox);
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Someone New' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Assign new client' }));
+
+    await waitFor(() => {
+      expect(bookingApi.createBookingForNewClient).toHaveBeenCalledWith(
+        'Someone New',
+        1,
+        expect.any(String),
       );
     });
   });


### PR DESCRIPTION
## Summary
- Allow staff to book appointments for brand new clients from the Assign User modal
- Tidy up empty search results layout with separate action button
- Document new client booking workflow in help content

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bf09453f7c832d8143243844adceaf