### PR TITLE
Allow pantry staff to read app config

### DIFF
--- a/MJ_FB_Backend/src/routes/admin/appConfig.ts
+++ b/MJ_FB_Backend/src/routes/admin/appConfig.ts
@@ -8,9 +8,7 @@ const router = Router();
 
 router.use(authMiddleware);
 router.use(authorizeRoles('staff'));
-router.use(authorizeAccess('admin'));
-
-router.get('/', getAppConfig);
-router.put('/', validate(appConfigSchema), updateAppConfig);
+router.get('/', authorizeAccess('admin', 'pantry'), getAppConfig);
+router.put('/', authorizeAccess('admin'), validate(appConfigSchema), updateAppConfig);
 
 export default router;

--- a/MJ_FB_Backend/tests/appConfig.test.ts
+++ b/MJ_FB_Backend/tests/appConfig.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import appConfigRouter from '../src/routes/admin/appConfig';
+import pool from '../src/db';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (req as any).user = { role: 'staff', access: ['pantry'] };
+    next();
+  },
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeAccess: (...allowed: string[]) => (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    const access = ((req.user as any)?.access || []) as string[];
+    if (allowed.some(a => access.includes(a))) return next();
+    return res.status(403).json({ message: 'Forbidden' });
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/app-config', appConfigRouter);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('app-config routes', () => {
+  it('allows pantry staff to fetch config', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ key: 'cart_tare', value: '7' }] });
+    const res = await request(app).get('/app-config');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ cartTare: 7 });
+  });
+
+  it('rejects updates from pantry staff', async () => {
+    const res = await request(app).put('/app-config').send({ cartTare: 8 });
+    expect(res.status).toBe(403);
+  });
+});

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -80,7 +80,7 @@ describe('PantryVisits', () => {
     jest.useRealTimers();
   });
 
-  it('uses cart tare from config when calculating weight', async () => {
+  it('fetches cart tare for pantry staff and auto-deducts weight', async () => {
     (getClientVisits as jest.Mock).mockResolvedValue([]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 10 });
     (getSunshineBag as jest.Mock).mockResolvedValue(null);
@@ -94,8 +94,9 @@ describe('PantryVisits', () => {
     const withCart = screen.getByLabelText('Weight With Cart');
     fireEvent.change(withCart, { target: { value: '50' } });
 
-    const withoutCart = screen.getByLabelText('Weight Without Cart');
-    expect(withoutCart).toHaveValue(40);
+    await waitFor(() =>
+      expect(screen.getByLabelText('Weight Without Cart')).toHaveValue(40),
+    );
   });
 
   it('selects only one visit type and can return to regular', async () => {


### PR DESCRIPTION
## Summary
- Relax admin app-config route to permit pantry staff to fetch settings while keeping updates admin-only
- Add backend test to confirm pantry staff can retrieve cart tare but cannot update it
- Cover cart tare auto-deduction in pantry visits frontend tests

## Testing
- `npm test` *(fails: 22 failed, 101 passed)*
- `npm test tests/appConfig.test.ts`
- `npm test` *(frontend, fails with multiple suite errors)*


------
https://chatgpt.com/codex/tasks/task_e_68bf0abcca30832d8e1c264bcb366cdc