### PR TITLE
feat: add iOS web app metadata and icons

### DIFF
--- a/MJ_FB_Frontend/index.html
+++ b/MJ_FB_Frontend/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/images/mjfoodbank_logo.png" />
+    <link
+      rel="apple-touch-icon"
+      href="https://raw.githubusercontent.com/github/explore/main/topics/pwa/pwa.png"
+    />
     <link rel="preload" as="image" href="/images/mjfoodbank_logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
@@ -10,6 +14,8 @@
       content="Reserve appointments and manage MJ Foodbank services."
     />
     <meta name="theme-color" content="#941818" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <link rel="stylesheet" href="/src/reset.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Golos+Text:wght@400;500;700&display=swap"


### PR DESCRIPTION
## Summary
- include iOS web app tags in HTML
- load iOS touch icon from CDN instead of bundling images

## Testing
- `npm test` *(fails: Unable to find an accessible element with the role "table" in UserHistory.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bf71266ce0832d9f91506d585822f7