### PR TITLE
refactor: consolidate login under auth router

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -80,6 +80,60 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       });
     }
 
+    const volunteerQuery = await pool.query(
+      `SELECT v.id, v.first_name, v.last_name, v.password, v.user_id, u.role AS user_role
+         FROM volunteers v
+         LEFT JOIN clients u ON v.user_id = u.client_id
+         WHERE v.email = $1`,
+      [email],
+    );
+    if ((volunteerQuery.rowCount ?? 0) > 0) {
+      const volunteer = volunteerQuery.rows[0];
+      if (!volunteer.password) {
+        return res.status(403).json({ message: 'Password setup link expired' });
+      }
+      const match = await bcrypt.compare(password, volunteer.password);
+      if (!match) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const rolesRes = await pool.query(
+        `SELECT vr.name
+         FROM volunteer_trained_roles vtr
+         JOIN volunteer_roles vr ON vtr.role_id = vr.id
+         WHERE vtr.volunteer_id = $1`,
+        [volunteer.id],
+      );
+      const access: string[] = [];
+      if (rolesRes.rows.some(r => r.name === 'Donation Entry')) {
+        access.push('donation_entry');
+      }
+      const payload: AuthPayload = {
+        id: volunteer.id,
+        role: 'volunteer',
+        type: 'volunteer',
+        ...(access.length && { access }),
+        ...(volunteer.user_id && {
+          userId: volunteer.user_id,
+          userRole: volunteer.user_role || 'shopper',
+        }),
+      };
+      const tokens = await issueAuthTokens(
+        res,
+        payload,
+        `volunteer:${volunteer.id}`,
+      );
+      return res.json({
+        role: 'volunteer',
+        name: `${volunteer.first_name} ${volunteer.last_name}`,
+        ...(volunteer.user_id && {
+          userId: volunteer.user_id,
+          userRole: volunteer.user_role || 'shopper',
+        }),
+        access,
+        ...tokens,
+      });
+    }
+
     const agency = await getAgencyByEmail(email);
     if (!agency) {
       return res.status(401).json({ message: 'Invalid credentials' });

--- a/MJ_FB_Backend/src/routes/auth.ts
+++ b/MJ_FB_Backend/src/routes/auth.ts
@@ -9,10 +9,14 @@ import {
   logout,
   csrfToken,
 } from '../controllers/authController';
+import { loginUser } from '../controllers/userController';
 import { authMiddleware } from '../middleware/authMiddleware';
+import { validate } from '../middleware/validate';
+import { authLoginSchema } from '../schemas/userSchemas';
 
 const router = Router();
 
+router.post('/login', validate(authLoginSchema), loginUser);
 router.post('/request-password-reset', requestPasswordReset);
 router.post('/resend-password-setup', resendPasswordSetup);
 router.get('/password-setup-info', getPasswordSetupInfo);

--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import {
-  loginUser,
   createUser,
   searchUsers,
   getUserProfile,
@@ -13,15 +12,12 @@ import {
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
 import {
-  loginSchema,
   createUserSchema,
   updateUserSchema,
   updateMyProfileSchema,
 } from '../schemas/userSchemas';
 
 const router = express.Router();
-
-router.post('/login', validate(loginSchema), loginUser);
 router.post(
   '/add-client',
   authMiddleware,

--- a/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import {
   updateTrainedArea,
-  loginVolunteer,
   getVolunteerProfile,
   createVolunteer,
   searchVolunteers,
@@ -16,8 +15,6 @@ import { validate } from '../../middleware/validate';
 import { createVolunteerSchema } from '../../schemas/volunteer/volunteerSchemas';
 
 const router = express.Router();
-
-router.post('/login', loginVolunteer);
 
 router.get('/me', authMiddleware, getVolunteerProfile);
 

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 import { passwordSchema } from '../utils/passwordUtils';
 
-// Schema for the login endpoint. Requires a password and either
+// Schema for the /auth/login endpoint. Requires a password and either
 // an email or a clientId (but not both).
-export const loginSchema = z
+export const authLoginSchema = z
   .object({
     email: z.string().email().optional(),
     clientId: z.coerce.number().int().positive().optional(),

--- a/MJ_FB_Backend/tests/agency.test.ts
+++ b/MJ_FB_Backend/tests/agency.test.ts
@@ -77,6 +77,7 @@ jest.mock('bcrypt');
 jest.mock('jsonwebtoken');
 
 const usersRouter = require('../src/routes/users').default;
+const authRouter = require('../src/routes/auth').default;
 const bookingsRouter = require('../src/routes/bookings').default;
 const agenciesRoutes = require('../src/routes/agencies').default;
 const bookingRepository = require('../src/models/bookingRepository');
@@ -100,6 +101,7 @@ test('does not query database on import', () => {
 
 const app = express();
 app.use(express.json());
+app.use('/api/auth', authRouter);
 app.use('/api/users', usersRouter);
 app.use('/api/bookings', bookingsRouter);
 app.use('/agencies', agenciesRoutes);
@@ -137,7 +139,7 @@ describe('Agency login and token issuance', () => {
     (jwt.sign as jest.Mock).mockReturnValue('token');
 
     const res = await request(app)
-      .post('/api/users/login')
+      .post('/api/auth/login')
       .send({ email: 'a@b.com', password: 'secret' });
 
     expect(res.status).toBe(200);

--- a/MJ_FB_Backend/tests/login.test.ts
+++ b/MJ_FB_Backend/tests/login.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import express from 'express';
 import usersRouter from '../src/routes/users';
+import authRouter from '../src/routes/auth';
 import pool from '../src/db';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
@@ -12,6 +13,7 @@ jest.mock('../src/utils/bookingUtils', () => ({
 
 const app = express();
 app.use(express.json());
+app.use('/api/auth', authRouter);
 app.use('/api/users', usersRouter);
 
 beforeAll(() => {
@@ -23,9 +25,9 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('POST /api/users/login', () => {
+describe('POST /api/auth/login', () => {
   it('returns 400 when missing credentials', async () => {
-    const res = await request(app).post('/api/users/login').send({});
+    const res = await request(app).post('/api/auth/login').send({});
     expect(res.status).toBe(400);
   });
 
@@ -45,7 +47,7 @@ describe('POST /api/users/login', () => {
     (jwt.sign as jest.Mock).mockReturnValue('token');
 
     const res = await request(app)
-      .post('/api/users/login')
+      .post('/api/auth/login')
       .send({ email: 'john@example.com', password: 'secret' });
 
     expect(res.status).toBe(200);
@@ -61,7 +63,7 @@ describe('POST /api/users/login', () => {
     (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
     const res = await request(app)
-      .post('/api/users/login')
+      .post('/api/auth/login')
       .send({ email: 'john@example.com', password: 'wrong' });
 
     expect(res.status).toBe(401);

--- a/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
+++ b/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import express from 'express';
-import volunteersRouter from '../src/routes/volunteer/volunteers';
+import authRouter from '../src/routes/auth';
 import pool from '../src/db';
 import bcrypt from 'bcrypt';
 
@@ -13,7 +13,7 @@ jest.mock('../src/utils/authUtils', () => ({
 
 const app = express();
 app.use(express.json());
-app.use('/volunteers', volunteersRouter);
+app.use('/auth', authRouter);
 
 describe('donation entry volunteer login', () => {
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe('donation entry volunteer login', () => {
     (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
     const res = await request(app)
-      .post('/volunteers/login')
+      .post('/auth/login')
       .send({ email: 'jane@example.com', password: 'pw' });
 
     expect(res.status).toBe(200);

--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import express from 'express';
 import volunteersRouter from '../src/routes/volunteer/volunteers';
+import authRouter from '../src/routes/auth';
 import pool from '../src/db';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
@@ -34,6 +35,7 @@ app.use((req, _res, next) => {
   (req as any).user = { id: 1, role: 'volunteer' };
   next();
 });
+app.use('/auth', authRouter);
 app.use('/volunteers', volunteersRouter);
 
 describe('Volunteer routes role ID validation', () => {
@@ -321,7 +323,7 @@ describe('Volunteer login with shopper profile', () => {
     (jwt.sign as jest.Mock).mockReturnValue('token');
 
     const res = await request(app)
-      .post('/volunteers/login')
+      .post('/auth/login')
       .send({ email: 'john@example.com', password: 'Secret1!' });
 
     expect(res.status).toBe(200);

--- a/MJ_FB_Frontend/src/__tests__/volunteersApi.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/volunteersApi.test.tsx
@@ -77,7 +77,7 @@ describe('volunteers api', () => {
 
   it('logs in volunteer with email', async () => {
     await loginVolunteer('user@example.com', 'pass');
-    expect(apiFetch).toHaveBeenCalledWith('/api/volunteers/login', expect.objectContaining({
+    expect(apiFetch).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({
       method: 'POST',
       body: JSON.stringify({ email: 'user@example.com', password: 'pass' }),
     }));

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -15,7 +15,7 @@ export async function loginUser(
   if (!Number.isInteger(id)) {
     return Promise.reject(new Error("Invalid client ID"));
   }
-  const res = await apiFetch(`${API_BASE}/users/login`, {
+  const res = await apiFetch(`${API_BASE}/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ clientId: id, password }),
@@ -27,7 +27,7 @@ export async function loginStaff(
   email: string,
   password: string,
 ): Promise<LoginResponse> {
-  const res = await apiFetch(`${API_BASE}/users/login`, {
+  const res = await apiFetch(`${API_BASE}/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email, password }),
@@ -39,7 +39,7 @@ export async function loginAgency(
   email: string,
   password: string,
 ): Promise<LoginResponse> {
-  const res = await apiFetch(`${API_BASE}/users/login`, {
+  const res = await apiFetch(`${API_BASE}/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email, password }),

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -28,7 +28,7 @@ export async function loginVolunteer(
   email: string,
   password: string
 ): Promise<LoginResponse> {
-  const res = await apiFetch(`${API_BASE}/volunteers/login`, {
+  const res = await apiFetch(`${API_BASE}/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email, password }),


### PR DESCRIPTION
## Summary
- move user login to `/auth/login`
- remove volunteer login route
- rename login schema and update client API calls

## Testing
- `npm test` (failed)
- `npm test` in `MJ_FB_Frontend` (failed)


------
https://chatgpt.com/codex/tasks/task_e_68bf73baabf4832da216a301c3e09348