### PR TITLE
feat(volunteer): prompt PWA install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - `/slots/range` returns 90 days of availability by default so the pantry schedule can load slots three months ahead.
 - Staff can add existing clients to the app from the pantry schedule's Assign User modal by entering a client ID. The client is created as a shopper with online access disabled and immediately assigned to the selected slot.
 - A login selection page at `/login` links to client, volunteer, staff, and agency login screens.
+- Volunteers see an Install App button on their first visit to volunteer pages with an onboarding modal about offline use; installations are tracked.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/public/locales` when client-visible text is added.
 - Pantry visits track daily sunshine bag weights and client counts via the `sunshine_bag_log` table.

--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -3,6 +3,8 @@
 This project is the React + Vite front end for the MJ Food Bank booking system. Volunteers can manage recurring bookings from `/volunteer/recurring`.
 Authenticated users can access a role-based help page at `/help`. Admins can view all help topics, including client and volunteer guidance.
 
+Volunteers are prompted to install the app on their first visit to volunteer pages. A modal explains offline benefits and installation events are tracked.
+
 Client bookings include a confirmation step that lists the selected date, time, and current-month visit count on separate lines, with an optional client note field for staff.
 
 ## Node Version

--- a/MJ_FB_Frontend/public/locales/en/translation.json
+++ b/MJ_FB_Frontend/public/locales/en/translation.json
@@ -124,7 +124,7 @@
     },
     "install_app": {
       "title": "Install the app",
-      "description": "Add the web app to your device.",
+      "description": "Add the web app to your device to use volunteer tools offline.",
       "steps": [
         "Click Install App when the button appears.",
         "On iOS, open in Safari and use Add to Home Screen."

--- a/MJ_FB_Frontend/src/__tests__/InstallAppButton.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/InstallAppButton.test.tsx
@@ -1,0 +1,42 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import InstallAppButton from '../components/InstallAppButton';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('InstallAppButton', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows button and onboarding on first volunteer visit', () => {
+    render(
+      <MemoryRouter initialEntries={['/volunteer/dashboard']}>
+        <InstallAppButton />
+      </MemoryRouter>,
+    );
+    const prompt = jest.fn().mockResolvedValue(undefined);
+    const event = new Event('beforeinstallprompt') as any;
+    event.prompt = prompt;
+    fireEvent(window, event);
+
+    expect(screen.getByText('Install App')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Install this app to access volunteer tools offline./i),
+    ).toBeInTheDocument();
+  });
+
+  it('tracks app installs', () => {
+    render(
+      <MemoryRouter initialEntries={['/volunteer']}>
+        <InstallAppButton />
+      </MemoryRouter>,
+    );
+    const sendBeacon = jest.fn();
+    Object.defineProperty(navigator, 'sendBeacon', {
+      writable: true,
+      value: sendBeacon,
+    });
+
+    fireEvent(window, new Event('appinstalled'));
+    expect(sendBeacon).toHaveBeenCalledWith('/api/pwa-install');
+  });
+});

--- a/MJ_FB_Frontend/src/components/InstallAppButton.tsx
+++ b/MJ_FB_Frontend/src/components/InstallAppButton.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from 'react';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -9,7 +15,10 @@ interface BeforeInstallPromptEvent extends Event {
 
 export default function InstallAppButton() {
   const { t } = useTranslation();
+  const location = useLocation();
   const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -20,25 +29,78 @@ export default function InstallAppButton() {
     return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
   }, []);
 
-  if (!promptEvent) {
+  useEffect(() => {
+    if (promptEvent && location.pathname.startsWith('/volunteer')) {
+      setShowPrompt(true);
+      if (!localStorage.getItem('pwaPromptShown')) {
+        setShowOnboarding(true);
+        localStorage.setItem('pwaPromptShown', 'true');
+      }
+    } else {
+      setShowPrompt(false);
+    }
+  }, [location, promptEvent]);
+
+  useEffect(() => {
+    const handler = () => {
+      navigator.sendBeacon('/api/pwa-install');
+    };
+    window.addEventListener('appinstalled', handler);
+    return () => window.removeEventListener('appinstalled', handler);
+  }, []);
+
+  if (!showPrompt || !promptEvent) {
     return null;
   }
 
   const handleClick = async () => {
     await promptEvent.prompt();
     setPromptEvent(null);
+    setShowPrompt(false);
   };
 
   return (
-    <Box sx={{ position: 'fixed', bottom: 16, right: 16 }}>
-      <Button
-        variant="contained"
-        size="small"
-        onClick={handleClick}
-        sx={{ textTransform: 'none' }}
-      >
-        {t('install_app')}
-      </Button>
-    </Box>
+    <>
+      {showOnboarding && (
+        <Dialog open onClose={() => setShowOnboarding(false)}>
+          <DialogTitle sx={{ textTransform: 'none' }}>{t('install_app')}</DialogTitle>
+          <DialogContent>
+            <Typography>
+              Install this app to access volunteer tools offline.
+            </Typography>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              size="small"
+              onClick={() => setShowOnboarding(false)}
+              sx={{ textTransform: 'none' }}
+            >
+              Not now
+            </Button>
+            <Button
+              variant="contained"
+              size="small"
+              onClick={() => {
+                setShowOnboarding(false);
+                handleClick();
+              }}
+              sx={{ textTransform: 'none' }}
+            >
+              {t('install_app')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
+      <Box sx={{ position: 'fixed', bottom: 16, right: 16 }}>
+        <Button
+          variant="contained"
+          size="small"
+          onClick={handleClick}
+          sx={{ textTransform: 'none' }}
+        >
+          {t('install_app')}
+        </Button>
+      </Box>
+    </>
   );
 }

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Staff dashboard dates display weekday, month, day, and year (e.g., 'Tue, Jan 2, 2024').
 - Staff dashboard includes a pantry visit trend line chart showing monthly totals for clients, adults, and children.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
-- An Install App button appears when the app is installable; iOS users should use Safari's **Add to Home Screen**.
+- Volunteers see an Install App button on their first visit to volunteer pages. An onboarding modal explains offline benefits, and installs are tracked. iOS users should use Safari's **Add to Home Screen**.
 - Booking confirmations include links to add appointments to Google Calendar or download an ICS file.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.
 - Sunshine bag, surplus, pig pound, and outgoing donation logs roll up into monthly summary tables, and raw log entries older than one year are deleted each Jan 31.

--- a/docs/installApp.md
+++ b/docs/installApp.md
@@ -6,6 +6,6 @@ Add the following translation strings to locale files:
 
 - `install_app` – label for the Install App button.
 - `help.install_app.title` – help topic title.
-- `help.install_app.description` – description for installing the web app.
+- `help.install_app.description` – description for installing the web app and its offline benefits.
 - `help.install_app.steps.0` – instructs users to click Install App when the button appears.
 - `help.install_app.steps.1` – tells iOS users to open in Safari and use Add to Home Screen.


### PR DESCRIPTION
## Summary
- show Install App button on first volunteer visit with onboarding modal
- track PWA installs for analytics
- document install flow and offline benefits

## Testing
- `npm test` *(fails: jsdom location errors, worker exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68bf75cf88d8832d9fc36efcb05a4c43