### PR TITLE
Unify login endpoint for all roles

### DIFF
--- a/MJ_FB_Backend/tests/volunteers.test.ts
+++ b/MJ_FB_Backend/tests/volunteers.test.ts
@@ -330,11 +330,9 @@ describe('Volunteer login with shopper profile', () => {
     expect(res.body).toEqual({
       role: 'volunteer',
       name: 'John Doe',
-      userId: 9,
       userRole: 'shopper',
-      token: 'token',
-      refreshToken: 'token',
       access: [],
+      id: 1,
     });
     expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/WHERE v.email = \$1/);
     expect((jwt.sign as jest.Mock).mock.calls[0][0]).toMatchObject({

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -23,7 +23,7 @@ export interface LoginResponse {
   name: string;
   bookingsThisMonth?: number;
   userRole?: UserRole;
-  access: StaffAccess[];
+  access?: StaffAccess[];
   id?: number;
 }
 


### PR DESCRIPTION
## Summary
- allow `/auth/login` to accept either email or clientId and check volunteers, staff, agencies, then clients
- drop separate volunteer login handler
- update volunteer login test and shared login response type

## Testing
- `npm test` (backend) *(fails: 27 failed, 97 passed, 124 total)*
- `npm test` (frontend) *(errors: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bf75b329f8832d9338076dc1bd1753