### PR TITLE
Refactor login flow to use unified endpoint

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyAccess.test.tsx
@@ -1,11 +1,11 @@
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
-import { loginAgency } from '../api/users';
+import { login } from '../api/users';
 import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
 jest.mock('../api/users', () => ({
-  loginAgency: jest.fn(),
+  login: jest.fn(),
 }));
 
 jest.mock('../pages/agency/AgencyBookAppointment', () => () => <div>AgencyBookAppointment</div>);
@@ -32,7 +32,7 @@ describe('Agency UI access', () => {
   });
 
   it('allows agency login and shows agency links', async () => {
-    (loginAgency as jest.Mock).mockResolvedValue({
+    (login as jest.Mock).mockResolvedValue({
       role: 'agency',
       name: 'Agency',
       id: 1,

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -11,10 +11,10 @@ jest.mock('../api/users', () => ({
 describe('Login component', () => {
   it('submits login credentials and calls onLogin', async () => {
     (login as jest.Mock).mockResolvedValue({
-      role: 'user',
+      role: 'shopper',
       name: 'Test',
     });
-    const onLogin = jest.fn().mockResolvedValue(undefined);
+    const onLogin = jest.fn().mockResolvedValue('/');
     render(
       <MemoryRouter>
         <Login onLogin={onLogin} />
@@ -29,7 +29,7 @@ describe('Login component', () => {
   it('shows friendly message on unauthorized error', async () => {
     const apiErr = Object.assign(new Error('backend'), { status: 401 });
     (login as jest.Mock).mockRejectedValue(apiErr);
-    const onLogin = jest.fn();
+    const onLogin = jest.fn().mockResolvedValue('/');
     render(
       <MemoryRouter>
         <Login onLogin={onLogin} />
@@ -52,7 +52,7 @@ describe('Login component', () => {
     const apiErr = Object.assign(new Error('expired'), { status: 403 });
     (login as jest.Mock).mockRejectedValue(apiErr);
     (resendPasswordSetup as jest.Mock).mockResolvedValue(undefined);
-    const onLogin = jest.fn();
+    const onLogin = jest.fn().mockResolvedValue('/');
     render(
       <MemoryRouter>
         <Login onLogin={onLogin} />

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -20,7 +20,7 @@ export async function login(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  return handleResponse(res);
+  return handleResponse<LoginResponse>(res);
 }
 
 export async function logout(): Promise<void> {

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next';
 export default function Login({
   onLogin,
 }: {
-  onLogin: (user: LoginResponse) => Promise<void>;
+  onLogin: (user: LoginResponse) => Promise<string>;
 }) {
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
@@ -49,8 +49,8 @@ export default function Login({
     if (identifier === '' || password === '') return;
     try {
       const user = await login(identifier, password);
-      await onLogin(user);
-      navigate('/');
+      const redirect = await onLogin(user);
+      navigate(redirect);
     } catch (err: unknown) {
       const apiErr = err as ApiError;
       if (apiErr?.status === 401) {


### PR DESCRIPTION
## Summary
- consolidate role-specific login calls into single login() hitting /auth/login
- update auth hook to parse role details and return appropriate dashboard redirects
- adjust login page and tests for new login flow

## Testing
- `npm test` *(fails: Unable to find an accessible element with the role "table"; SyntaxError: Cannot use 'import.meta' outside a module; and numerous other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7b671d18832da82be64f58f75fd4