### PR TITLE
Anchor pantry schedule navigation to Regina start of day

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -10,7 +10,7 @@ import { searchUsers, addClientById, type UserSearchResult } from "../../api/use
 import type { Slot, Holiday, Booking } from "../../types";
 import { fromZonedTime, toZonedTime } from "date-fns-tz";
 import { formatTime } from "../../utils/time";
-import { formatDate, addDays } from "../../utils/date";
+import { formatDate, addDays, reginaStartOfDay } from "../../utils/date";
 import VolunteerScheduleTable from "../../components/VolunteerScheduleTable";
 import ScheduleCards from "../../components/ScheduleCards";
 import FeedbackSnackbar from "../../components/FeedbackSnackbar";
@@ -203,7 +203,9 @@ export default function PantrySchedule({
   }, [searchTerm, assignSlot]);
 
   function changeDay(delta: number) {
-    setCurrentDate((d) => addDays(d, delta));
+    setCurrentDate((d) =>
+      reginaStartOfDay(addDays(d, delta)).toDate()
+    );
   }
 
   function retryStream() {

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
@@ -208,6 +208,41 @@ describe('PantrySchedule status display', () => {
   });
 });
 
+describe('PantrySchedule navigation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-02T00:00:00-06:00'));
+    (bookingApi.getSlots as jest.Mock).mockResolvedValue([
+      { id: '1', startTime: '09:00:00', endTime: '09:30:00', available: 1, maxCapacity: 1 },
+    ]);
+    (bookingApi.getBookings as jest.Mock).mockResolvedValue([]);
+    (bookingApi.getHolidays as jest.Mock).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders slots after navigating past the current week', async () => {
+    render(
+      <MemoryRouter>
+        <PantrySchedule />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('9:00 AM - 9:30 AM');
+    const nextBtn = screen.getByRole('button', { name: 'Next' });
+    for (let i = 0; i < 7; i++) {
+      fireEvent.click(nextBtn);
+    }
+
+    await waitFor(() => {
+      expect(bookingApi.getSlots).toHaveBeenLastCalledWith('2024-01-09', true);
+    });
+    expect(await screen.findByText('9:00 AM - 9:30 AM')).toBeInTheDocument();
+  });
+});
+
 describe('PantrySchedule Wednesday evening slot', () => {
   beforeEach(() => {
     jest.useFakeTimers();


### PR DESCRIPTION
## Summary
- Anchor pantry schedule date changes to Regina start of day
- Add regression test ensuring navigation beyond current week still shows future slots

## Testing
- `nvm use`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bf95dc343c832d9c353484b6f57d5b