### PR TITLE
Allow searching names with middle parts

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -292,6 +292,8 @@ export async function searchUsers(req: Request, res: Response, next: NextFunctio
       return res.json([]); // short input: skip query
     }
 
+    const searchPattern = `%${search.replace(/\s+/g, '%')}%`;
+
     const usersResult = await pool.query(
       `SELECT client_id, first_name, last_name, email, phone, password
        FROM clients
@@ -301,7 +303,7 @@ export async function searchUsers(req: Request, res: Response, next: NextFunctio
           OR CAST(client_id AS TEXT) ILIKE $1
        ORDER BY first_name, last_name ASC
        LIMIT 5`,
-      [`%${search}%`]
+      [searchPattern]
     );
 
     const formatted = usersResult.rows.map(u => ({

--- a/MJ_FB_Backend/tests/searchUsers.test.ts
+++ b/MJ_FB_Backend/tests/searchUsers.test.ts
@@ -1,0 +1,56 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  authorizeRoles: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/users', usersRouter);
+
+describe('GET /users/search', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('matches users with middle names in first name', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          client_id: 1,
+          first_name: 'John Paul',
+          last_name: 'Smith',
+          email: 'john@example.com',
+          phone: '123',
+          password: null,
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/users/search')
+      .query({ search: 'John Smith' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        name: 'John Paul Smith',
+        email: 'john@example.com',
+        phone: '123',
+        client_id: 1,
+        hasPassword: false,
+      },
+    ]);
+
+    expect(pool.query).toHaveBeenCalledWith(
+      `SELECT client_id, first_name, last_name, email, phone, password\n       FROM clients\n       WHERE (first_name || ' ' || last_name) ILIKE $1\n          OR email ILIKE $1\n          OR phone ILIKE $1\n          OR CAST(client_id AS TEXT) ILIKE $1\n       ORDER BY first_name, last_name ASC\n       LIMIT 5`,
+      ['%John%Smith%'],
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- improve search by allowing wildcard between name parts to support middle names
- cover middle-name search behavior with new backend test

## Testing
- `npm test tests/searchUsers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bf977945e4832da8431c456dec7b78