### PR TITLE
fix: prevent reset link from submitting login form

### DIFF
--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -105,7 +105,7 @@ export default function Login({
             error={passwordError}
             helperText={passwordError ? t('password_required') : ''}
           />
-          <Link component="button" onClick={() => setResetOpen(true)} underline="hover">
+          <Link component="button" type="button" onClick={() => setResetOpen(true)} underline="hover">
             {t('forgot_password')}
           </Link>
         </FormCard>


### PR DESCRIPTION
## Summary
- Add `type="button"` to the Login page's forgot password link so it doesn't submit the form

## Testing
- `npm test` *(fails: Unable to find role="button" and name "Cancel")*


------
https://chatgpt.com/codex/tasks/task_e_68bf9c4312d0832db0776a9754b2741f