### PR TITLE
Fix push token migration import

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000032_add_push_tokens.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000032_add_push_tokens.ts
@@ -1,4 +1,4 @@
-import { MigrationBuilder } from 'node-pg-migrate';
+import type { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createTable('push_tokens', {


### PR DESCRIPTION
## Summary
- use type-only import for MigrationBuilder to avoid runtime export error

## Testing
- `npm test` *(fails: Test Suites: 24 failed, 101 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9e9bd3d0832db2090255c322455c