### PR TITLE
feat: add offline fallback and background sync

### DIFF
--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -31,8 +31,7 @@ Run tests with `npm test` so `.env.test` and `jest.setup.ts` execute, providing 
 
 ## Service Worker
 
-The frontend registers a Workbox-powered service worker that precaches built assets and caches schedule-related API responses. Offline use is not supported; a network connection is still required.
-
+The frontend registers a Workbox-powered service worker that precaches built assets, caches schedule, booking history, and profile API responses, and serves an offline fallback page when navigation fails. Booking actions made while offline are queued and retried in the background once connectivity returns. A network connection is still recommended for full functionality.
 
 ## Environment Variables
 

--- a/MJ_FB_Frontend/public/offline.html
+++ b/MJ_FB_Frontend/public/offline.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline</title>
+    <style>
+      body { font-family: sans-serif; padding: 2rem; text-align: center; }
+    </style>
+  </head>
+  <body>
+    <h1>You are offline</h1>
+    <p>Please check your internet connection.</p>
+  </body>
+</html>

--- a/MJ_FB_Frontend/src/service-worker.ts
+++ b/MJ_FB_Frontend/src/service-worker.ts
@@ -1,7 +1,12 @@
 import { precacheAndRoute } from 'workbox-precaching'
 import { registerRoute } from 'workbox-routing'
-import { CacheFirst, StaleWhileRevalidate } from 'workbox-strategies'
+import {
+  CacheFirst,
+  StaleWhileRevalidate,
+  NetworkOnly,
+} from 'workbox-strategies'
 import { ExpirationPlugin } from 'workbox-expiration'
+import { BackgroundSyncPlugin } from 'workbox-background-sync'
 
 // self.__WB_MANIFEST is injected at build time
 precacheAndRoute(self.__WB_MANIFEST)
@@ -32,5 +37,66 @@ registerRoute(
     fetchOptions: { credentials: 'include' },
   }),
   'GET',
+)
+
+// Cache booking history
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/api/bookings/history'),
+  new StaleWhileRevalidate({
+    cacheName: 'booking-history-api',
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 60 * 60 }),
+    ],
+    fetchOptions: { credentials: 'include' },
+  }),
+  'GET',
+)
+
+// Cache profile data
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/api/users/me'),
+  new StaleWhileRevalidate({
+    cacheName: 'profile-api',
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 1, maxAgeSeconds: 60 * 60 }),
+    ],
+    fetchOptions: { credentials: 'include' },
+  }),
+  'GET',
+)
+
+// Offline fallback for navigation requests
+registerRoute(
+  ({ request }) => request.mode === 'navigate',
+  async ({ event }) => {
+    try {
+      return await fetch(event.request)
+    } catch {
+      return await caches.match('/offline.html')
+    }
+  },
+)
+
+// Queue booking actions when offline
+const bookingQueue = new BackgroundSyncPlugin('booking-queue', {
+  maxRetentionTime: 24 * 60, // Retry for up to 24 hours
+})
+
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/api/bookings'),
+  new NetworkOnly({
+    fetchOptions: { credentials: 'include' },
+    plugins: [bookingQueue],
+  }),
+  'POST',
+)
+
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/api/bookings'),
+  new NetworkOnly({
+    fetchOptions: { credentials: 'include' },
+    plugins: [bookingQueue],
+  }),
+  'PATCH',
 )
 

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Volunteers see an Install App button on their first visit to volunteer pages. An onboarding modal explains offline benefits, and installs are tracked. iOS users should use Safari's **Add to Home Screen**.
 - An Install App button appears when the app is installable; iOS users should use Safari's **Add to Home Screen**.
-- A Workbox service worker caches built assets and schedule-related API responses to speed up repeat visits; offline use remains unsupported.
+- A Workbox service worker caches built assets plus schedule, booking history, and profile API responses, provides an offline fallback page, and queues offline booking actions for background sync.
 - Booking confirmations include links to add appointments to Google Calendar or download an ICS file.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.
 - Sunshine bag, surplus, pig pound, and outgoing donation logs roll up into monthly summary tables, and raw log entries older than one year are deleted each Jan 31.


### PR DESCRIPTION
## Summary
- cache booking history and profile APIs in service worker
- show offline fallback page when navigation fails
- queue offline booking requests for background sync

## Testing
- `npm test` *(fails: Unable to find an element with the text: Clients: 1; SyntaxError: Cannot use 'import.meta' outside a module; Unable to find a label with the text of: /select .* time slot/i; Unable to find role="button" and name "Cancel"; Not implemented: navigation (except hash changes))*

------
https://chatgpt.com/codex/tasks/task_e_68bf9ce9df04832db9f0f25c240188f9