### PR TITLE
Improve Volunteer schedule table mobile usability

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -35,16 +35,15 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   const timeColumnWidth = isSmall ? 100 : 160;
   const slotWidth = `calc((100% - ${timeColumnWidth}px) / ${safeMaxSlots})`;
   return (
-    <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
+    <TableContainer component={Paper} sx={{ overflowX: 'auto', width: '100%' }}>
         <Table
-          size="small"
           stickyHeader={false}
           sx={{
             tableLayout: 'fixed',
             width: '100%',
             '& .MuiTableCell-root': {
-              p: isSmall ? 0.5 : 1,
-              fontSize: isSmall ? '0.75rem' : 'inherit',
+              p: isSmall ? 1 : 1.5,
+              fontSize: isSmall ? '0.875rem' : 'inherit',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',


### PR DESCRIPTION
## Summary
- increase Volunteer schedule table font size and padding on small screens
- remove small sizing and maintain horizontal scroll

## Testing
- `npm test src/pages/staff/__tests__/PantrySchedule.test.tsx` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9ce4ec18832db42875e0a019c155