### PR TITLE
Fix build errors in frontend service worker and password reset dialog

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PasswordResetDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PasswordResetDialog.test.tsx
@@ -14,7 +14,7 @@ describe('PasswordResetDialog', () => {
   });
 
   it('submits email identifier', async () => {
-    render(<PasswordResetDialog open onClose={() => {}} type="user" />);
+    render(<PasswordResetDialog open onClose={() => {}} />);
     fireEvent.change(screen.getByLabelText(/email or client id/i), {
       target: { value: 'user@example.com' },
     });
@@ -27,7 +27,7 @@ describe('PasswordResetDialog', () => {
   });
 
   it('submits numeric client identifier', async () => {
-    render(<PasswordResetDialog open onClose={() => {}} type="user" />);
+    render(<PasswordResetDialog open onClose={() => {}} />);
     fireEvent.change(screen.getByLabelText(/email or client id/i), {
       target: { value: '12345' },
     });

--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -10,11 +10,9 @@ import { useTranslation } from 'react-i18next';
 export default function PasswordResetDialog({
   open,
   onClose,
-  type,
 }: {
   open: boolean;
   onClose: () => void;
-  type: 'user' | 'staff' | 'volunteer';
 }) {
   const [identifier, setIdentifier] = useState('');
   const [message, setMessage] = useState('');

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -110,7 +110,7 @@ export default function Login({
           </Link>
         </FormCard>
       </Box>
-      <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} type="user" />
+      <PasswordResetDialog open={resetOpen} onClose={() => setResetOpen(false)} />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <Dialog open={noticeOpen} onClose={handleNoticeClose}>
         <DialogContent sx={{ position: 'relative', pt: 4 }}>

--- a/MJ_FB_Frontend/src/service-worker.ts
+++ b/MJ_FB_Frontend/src/service-worker.ts
@@ -1,3 +1,4 @@
+/// <reference lib="webworker" />
 import { precacheAndRoute } from 'workbox-precaching'
 import { registerRoute } from 'workbox-routing'
 import {
@@ -7,6 +8,8 @@ import {
 } from 'workbox-strategies'
 import { ExpirationPlugin } from 'workbox-expiration'
 import { BackgroundSyncPlugin } from 'workbox-background-sync'
+
+declare let self: ServiceWorkerGlobalScope & { __WB_MANIFEST: any }
 
 // self.__WB_MANIFEST is injected at build time
 precacheAndRoute(self.__WB_MANIFEST)
@@ -68,11 +71,11 @@ registerRoute(
 // Offline fallback for navigation requests
 registerRoute(
   ({ request }) => request.mode === 'navigate',
-  async ({ event }) => {
+  async ({ request }) => {
     try {
-      return await fetch(event.request)
+      return await fetch(request)
     } catch {
-      return await caches.match('/offline.html')
+      return (await caches.match('/offline.html')) || Response.error()
     }
   },
 )

--- a/MJ_FB_Frontend/src/vite-env.d.ts
+++ b/MJ_FB_Frontend/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />


### PR DESCRIPTION
## Summary
- Remove unused `type` prop from `PasswordResetDialog` and update calls/tests
- Add PWA type references and service worker typings
- Ensure offline fallback in service worker always returns a `Response`

## Testing
- `npm run build`
- `npm test` *(fails: Unable to find an element with the text: Clients: 1; Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9f9a8904832da9884a654336d7bd