### PR TITLE
Fix WarehouseDashboard Chip syntax error

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -466,7 +466,7 @@ export default function WarehouseDashboard() {
           <CardHeader
             title="Top Donors"
             subheader="This year by total lbs"
-            action={<Chip label={filteredDonors.length} /}
+            action={<Chip label={filteredDonors.length} />}
           />
           <CardContent>
             {filteredDonors.length ? (
@@ -494,7 +494,7 @@ export default function WarehouseDashboard() {
           <CardHeader
             title="Top Receivers"
             subheader="This year by total lbs"
-            action={<Chip label={filteredReceivers.length} /}
+            action={<Chip label={filteredReceivers.length} />}
           />
           <CardContent>
             {filteredReceivers.length ? (


### PR DESCRIPTION
## Summary
- Fix Chip components in WarehouseDashboard CardHeader action props

## Testing
- `npm test` *(fails: Unable to find an element with the text: Clients: 1; SyntaxError: Cannot use 'import.meta' outside a module)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfa15ae4d8832dbd2d796020690304