### PR TITLE
feat: enhance PWA manifest and icons

### DIFF
--- a/MJ_FB_Frontend/index.html
+++ b/MJ_FB_Frontend/index.html
@@ -5,7 +5,8 @@
     <link rel="icon" type="image/png" href="/images/mjfoodbank_logo.png" />
     <link
       rel="apple-touch-icon"
-      href="https://raw.githubusercontent.com/github/explore/main/topics/pwa/pwa.png"
+      sizes="180x180"
+      href="/images/mjfoodbank_logo.png"
     />
     <link rel="preload" as="image" href="/images/mjfoodbank_logo.png" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/MJ_FB_Frontend/public/manifest.webmanifest
+++ b/MJ_FB_Frontend/public/manifest.webmanifest
@@ -3,6 +3,9 @@
   "short_name": "MJ Foodbank",
   "start_url": "/",
   "display": "standalone",
+  "theme_color": "#941818",
+  "background_color": "#ffffff",
+  "orientation": "portrait",
   "icons": [
     {
       "src": "/images/icon.svg",
@@ -13,6 +16,16 @@
       "src": "/images/icon.svg",
       "sizes": "512x512",
       "type": "image/svg+xml"
+    },
+    {
+      "src": "/images/mjfoodbank_logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/mjfoodbank_logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add theme and background colors and portrait orientation to PWA manifest
- reuse existing logo for PNG PWA icons and Apple touch icon

## Testing
- `npm test` *(fails: Unable to find element "Clients: 1" in PantryVisits.test.tsx and SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9ce26dc4832db9cba37a82a5fc77