### PR TITLE
chore: add telegram alerts for booking updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - Expired password setup and email verification tokens are purged nightly once they are more than 10 days past `expires_at`.
 - Nightly no-show cleanup jobs mark past bookings and volunteer shifts as `no_show` and alert a Telegram channel (`TELEGRAM_BOT_TOKEN`/`TELEGRAM_ALERT_CHAT_ID`) on failure.
 - API requests that return a 5xx error send a Telegram alert with the HTTP method and path when `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALERT_CHAT_ID` are configured.
+- Telegram alerts are sent when clients or volunteers create, cancel, or reschedule bookings.
 - Stale email queue entries older than `EMAIL_QUEUE_MAX_AGE_DAYS` are purged nightly and the job logs the queue size, warning when it exceeds `EMAIL_QUEUE_WARNING_SIZE`.
 - Maintain database health: set database-level autovacuum thresholds, schedule manual `VACUUM ANALYZE` during low-traffic windows, plan quarterly `REINDEX` or `pg_repack` runs for heavily updated tables, and monitor table bloat metrics. Record these tasks in ops docs.
 - Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to Azure".

--- a/MJ_FB_Backend/tests/bookingCancelTelegramAlert.test.ts
+++ b/MJ_FB_Backend/tests/bookingCancelTelegramAlert.test.ts
@@ -1,0 +1,48 @@
+import { Request, Response, NextFunction } from 'express';
+
+describe('booking cancel telegram alert', () => {
+  let cancelBooking: any;
+  let fetchBookingById: jest.Mock;
+  let updateBooking: jest.Mock;
+  let pool: any;
+  let notifyOps: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/utils/emailQueue', () => ({ __esModule: true, enqueueEmail: jest.fn() }));
+      jest.doMock('../src/models/bookingRepository', () => ({
+        __esModule: true,
+        fetchBookingById: jest.fn(),
+        updateBooking: jest.fn().mockResolvedValue(undefined),
+      }));
+      jest.doMock('../src/db', () => ({ __esModule: true, default: { query: jest.fn() } }));
+      cancelBooking = require('../src/controllers/bookingController').cancelBooking;
+      fetchBookingById = require('../src/models/bookingRepository').fetchBookingById;
+      updateBooking = require('../src/models/bookingRepository').updateBooking;
+      pool = require('../src/db').default;
+      notifyOps = require('../src/utils/opsAlert').notifyOps;
+    });
+  });
+
+  it('notifies via telegram when booking is cancelled', async () => {
+    const futureDate = '2030-01-01';
+    fetchBookingById.mockResolvedValue({ id: 1, user_id: '2', slot_id: 5, status: 'approved', date: futureDate });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ email: 'client@example.com', first_name: 'A', last_name: 'B' }] })
+      .mockResolvedValueOnce({ rows: [{ start_time: '09:00:00' }] });
+    const req = {
+      params: { id: '1' },
+      user: { role: 'staff', id: '99' },
+      body: { reason: 'scheduling conflict', type: 'Shopping Appointment' },
+    } as unknown as Request;
+    const res = { json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await cancelBooking(req, res, next);
+
+    expect(notifyOps).toHaveBeenCalledWith(
+      expect.stringContaining('cancelled booking for Tue, Jan 1, 2030 at 9:00 AM'),
+    );
+  });
+});

--- a/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
+++ b/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
@@ -11,6 +11,7 @@ import {
   isDateWithinCurrentOrNextMonth,
   countVisitsAndBookingsForMonth,
 } from '../src/utils/bookingUtils';
+import { notifyOps } from '../src/utils/opsAlert';
 
 jest.mock('../src/utils/emailQueue', () => ({
   enqueueEmail: jest.fn(),
@@ -80,6 +81,7 @@ describe('rescheduleBooking', () => {
     expect(params.oldTime).toBe('9:00 AM to 10:00 AM');
     expect(params.newDate).toBe('Sun, Jan 5, 2025');
     expect(params.newTime).toBe('11:00 AM to 12:00 PM');
+    expect(notifyOps).toHaveBeenCalled();
   });
 
   it('fetches email without joining new_clients when table is missing', async () => {

--- a/MJ_FB_Backend/tests/bookingTelegramAlerts.test.ts
+++ b/MJ_FB_Backend/tests/bookingTelegramAlerts.test.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from 'express';
+
+describe('booking telegram alerts', () => {
+  let createBookingForUser: any;
+  let notifyOps: jest.Mock;
+  let pool: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      jest.doMock('../src/utils/emailQueue', () => ({
+        __esModule: true,
+        enqueueEmail: jest.fn(),
+      }));
+      jest.doMock('../src/utils/bookingUtils', () => ({
+        __esModule: true,
+        isDateWithinCurrentOrNextMonth: jest.fn().mockReturnValue(true),
+        countVisitsAndBookingsForMonth: jest.fn().mockResolvedValue(0),
+        findUpcomingBooking: jest.fn().mockResolvedValue(null),
+        LIMIT_MESSAGE: 'limit',
+      }));
+      jest.doMock('../src/models/bookingRepository', () => ({
+        __esModule: true,
+        insertBooking: jest.fn().mockResolvedValue(undefined),
+        checkSlotCapacity: jest.fn().mockResolvedValue(undefined),
+      }));
+      jest.doMock('../src/db', () => ({
+        __esModule: true,
+        default: { query: jest.fn(), connect: jest.fn() },
+      }));
+      createBookingForUser = require('../src/controllers/bookingController').createBookingForUser;
+      notifyOps = require('../src/utils/opsAlert').notifyOps;
+      pool = require('../src/db').default;
+    });
+  });
+
+  it('notifies via telegram when booking is created', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ email: 'client@example.com', first_name: 'A', last_name: 'B' }] })
+      .mockResolvedValueOnce({ rows: [{ start_time: '09:00:00', end_time: '09:30:00' }] });
+    const req = {
+      user: { role: 'staff', id: 99 },
+      body: { userId: 1, slotId: 2, date: '2024-01-15' },
+    } as unknown as Request;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await createBookingForUser(req, res, next);
+
+    expect(notifyOps).toHaveBeenCalledWith(
+      expect.stringContaining('booked Mon, Jan 15, 2024 at 9:00 AM'),
+    );
+  });
+});

--- a/MJ_FB_Backend/tests/setupTests.ts
+++ b/MJ_FB_Backend/tests/setupTests.ts
@@ -2,9 +2,16 @@
 import './setupFetch';
 import mockPool, { setQueryResults } from './utils/mockDb';
 
+jest.mock('../src/utils/opsAlert', () => ({
+  alertOps: jest.fn(),
+  notifyOps: jest.fn(),
+}));
+import { notifyOps } from '../src/utils/opsAlert';
+
 beforeEach(() => {
   (mockPool.query as jest.Mock).mockReset();
   setQueryResults({ rows: [], rowCount: 0 });
+  (notifyOps as jest.Mock).mockReset();
 });
 
 export {};

--- a/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingStatusEmail.test.ts
@@ -4,6 +4,7 @@ import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
 import logger from '../src/utils/logger';
+import { notifyOps } from '../src/utils/opsAlert';
 
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn().mockResolvedValue(undefined),
@@ -137,6 +138,7 @@ describe('cancelVolunteerBookingOccurrence', () => {
       expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1);
       expect(sendTemplatedEmailMock.mock.calls[0][0].to).toBe('vol@example.com');
       expect(sendTemplatedEmailMock.mock.calls[0][0].params.body).toContain('sick');
+      expect(notifyOps).toHaveBeenCalled();
     });
 
   it('does not send email when volunteer cancels', async () => {
@@ -146,6 +148,7 @@ describe('cancelVolunteerBookingOccurrence', () => {
       .send({ reason: 'sick' });
     expect(res.status).toBe(200);
     expect(sendTemplatedEmailMock).not.toHaveBeenCalled();
+    expect(notifyOps).toHaveBeenCalled();
   });
 });
 

--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';
 import pool from '../src/db';
 import { enqueueEmail } from '../src/utils/emailQueue';
+import { notifyOps } from '../src/utils/opsAlert';
 
 jest.mock('../src/utils/emailQueue', () => ({
   enqueueEmail: jest.fn(),
@@ -71,5 +72,6 @@ describe('rescheduleVolunteerBooking', () => {
     expect(params.googleCalendarLink).toBe('#g');
     expect(params.appleCalendarLink).toBe('#a');
     expect(params.appleCalendarCancelLink).toBe('#');
+    expect(notifyOps).toHaveBeenCalled();
   });
 });

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ TIMESHEET_APPROVER_EMAILS=admin1@example.com,admin2@example.com # optional
 Booking confirmation, reminder, and reschedule templates can surface "Add to Calendar" buttons by referencing
 `{{ params.googleCalendarLink }}` and `{{ params.appleCalendarLink }}` in the Brevo templates.
 The backend supplies these URLs automatically; no extra environment variables are required.
-Ops alerts include the failing job or API route and are forwarded to a Telegram chat when `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALERT_CHAT_ID` are configured.
+Ops alerts include the failing job or API route and are forwarded to a Telegram chat when `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALERT_CHAT_ID` are configured. When set, Telegram also receives a note whenever a client or volunteer creates, cancels, or reschedules a booking.
 Calendar emails attach an `.ics` file. If `ICS_BASE_URL` is configured, `appleCalendarLink`
 points to the hosted file; otherwise it falls back to a base64 `data:` URI.
 


### PR DESCRIPTION
## Summary
- notify ops via Telegram when clients or volunteers book, cancel, or reschedule
- document booking Telegram alerts
- test booking and volunteer Telegram notifications

## Testing
- `npm test tests/bookingTelegramAlerts.test.ts tests/bookingCancelTelegramAlert.test.ts tests/bookingRescheduleEmail.test.ts tests/volunteerReschedule.test.ts tests/volunteerBookingStatusEmail.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bfa58d399c832db281430f3f82cfa6