### PR TITLE
Handle FK constraint on client deletion

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -688,6 +688,13 @@ export async function deleteUserByClientId(
     }
     res.json({ message: 'User deleted' });
   } catch (error) {
+    const err = error as { code?: string };
+    if (err.code === '23503') {
+      logger.warn('Cannot delete user with existing references:', error);
+      return res
+        .status(409)
+        .json({ message: 'Cannot delete user with existing records' });
+    }
     logger.error('Error deleting user:', error);
     next(error);
   }

--- a/MJ_FB_Backend/tests/deleteUser.test.ts
+++ b/MJ_FB_Backend/tests/deleteUser.test.ts
@@ -36,4 +36,11 @@ describe('DELETE /users/id/:clientId', () => {
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ message: 'User not found' });
   });
+
+  it('returns 409 when user has related records', async () => {
+    (pool.query as jest.Mock).mockRejectedValue({ code: '23503' });
+    const res = await request(app).delete('/users/id/5');
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ message: 'Cannot delete user with existing records' });
+  });
 });


### PR DESCRIPTION
## Summary
- return 409 when deleting a client with related records
- add test for foreign key constraint violation on delete

## Testing
- `npm test tests/deleteUser.test.ts`
- `npm test` *(fails: 20 failed, 107 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa8720d68832da01946effb9d71d8