### PR TITLE
Include rescheduled action in booking events

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingEvents.ts
+++ b/MJ_FB_Backend/src/utils/bookingEvents.ts
@@ -1,7 +1,7 @@
 import type { Response } from 'express';
 
 export interface BookingEvent {
-  action: 'created' | 'cancelled';
+  action: 'created' | 'cancelled' | 'rescheduled';
   name: string;
   role: 'client' | 'volunteer';
   date: string;


### PR DESCRIPTION
## Summary
- allow booking event stream to include `rescheduled` actions

## Testing
- `npm test` *(fails: scheduleMock not called, 19 failing suites)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bfab207cb0832dba03365392e399a1