### PR TITLE
feat: add client bottom navigation

### DIFF
--- a/MJ_FB_Frontend/src/components/ClientBottomNav.tsx
+++ b/MJ_FB_Frontend/src/components/ClientBottomNav.tsx
@@ -1,0 +1,33 @@
+import { BottomNavigation, BottomNavigationAction, Paper } from '@mui/material';
+import Dashboard from '@mui/icons-material/Dashboard';
+import CalendarToday from '@mui/icons-material/CalendarToday';
+import AccountCircle from '@mui/icons-material/AccountCircle';
+import HelpOutline from '@mui/icons-material/HelpOutline';
+
+export default function ClientBottomNav() {
+  const path = typeof window !== 'undefined' ? window.location.pathname : '/';
+  let value: 'dashboard' | 'bookings' | 'profile' | 'help' = 'dashboard';
+  if (path.startsWith('/book-appointment') || path.startsWith('/booking-history')) value = 'bookings';
+  else if (path.startsWith('/profile')) value = 'profile';
+  else if (path.startsWith('/help')) value = 'help';
+
+  return (
+    <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
+      <BottomNavigation
+        showLabels
+        value={value}
+        onChange={(_, newValue) => {
+          if (newValue === 'dashboard') window.location.assign('/');
+          if (newValue === 'bookings') window.location.assign('/book-appointment');
+          if (newValue === 'profile') window.location.assign('/profile');
+          if (newValue === 'help') window.location.assign('/help');
+        }}
+      >
+        <BottomNavigationAction label="Dashboard" value="dashboard" icon={<Dashboard />} aria-label="dashboard" />
+        <BottomNavigationAction label="Bookings" value="bookings" icon={<CalendarToday />} aria-label="bookings" />
+        <BottomNavigationAction label="Profile" value="profile" icon={<AccountCircle />} aria-label="profile" />
+        <BottomNavigationAction label="Help" value="help" icon={<HelpOutline />} aria-label="help" />
+      </BottomNavigation>
+    </Paper>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -38,6 +38,7 @@ import FeedbackModal from '../components/FeedbackModal';
 import DialogCloseButton from '../components/DialogCloseButton';
 import { Link as RouterLink } from 'react-router-dom';
 import Page from '../components/Page';
+import ClientBottomNav from '../components/ClientBottomNav';
 import type { ApiError } from '../api/client';
 import { useTranslation } from 'react-i18next';
 
@@ -199,22 +200,24 @@ export default function BookingUI({
             <Stack direction="row" spacing={1}>
               {res?.googleCalendarUrl && (
                 <Button
-                  
                   variant="contained"
                   component="a"
                   href={res.googleCalendarUrl}
                   target="_blank"
                   rel="noopener"
+                  size="medium"
+                  sx={{ minHeight: 48 }}
                 >
                   {t('add_to_google_calendar')}
                 </Button>
               )}
               {res?.icsUrl && (
                 <Button
-                  
                   variant="outlined"
                   component="a"
                   href={res.icsUrl}
+                  size="medium"
+                  sx={{ minHeight: 48 }}
                 >
                   {t('add_to_apple_calendar')}
                 </Button>
@@ -487,11 +490,11 @@ export default function BookingUI({
           </Typography>
           <Button
             variant="contained"
-            
             disabled={!selectedSlotId || booking || loadingConfirm}
             onClick={handleOpenConfirm}
             fullWidth
-            sx={{ width: { sm: 'auto' } }}
+            size="medium"
+            sx={{ width: { sm: 'auto' }, minHeight: 48 }}
           >
             {t('book_selected_slot')}
           </Button>
@@ -517,11 +520,14 @@ export default function BookingUI({
             label={t('client_note_label')}
             value={note}
             onChange={e => setNote(e.target.value)}
+            size="medium"
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setConfirmOpen(false)}>{t('cancel')}</Button>
-          <Button onClick={handleBook} variant="contained" disabled={booking}>
+          <Button onClick={() => setConfirmOpen(false)} size="medium" sx={{ minHeight: 48 }}>
+            {t('cancel')}
+          </Button>
+          <Button onClick={handleBook} variant="contained" disabled={booking} size="medium" sx={{ minHeight: 48 }}>
             {t('confirm')}
           </Button>
         </DialogActions>
@@ -544,6 +550,11 @@ export default function BookingUI({
   );
 
   if (embedded) return content;
-  return <Page title={t('book_appointment')}>{content}</Page>;
+  return (
+    <Page title={t('book_appointment')}>
+      {content}
+      <ClientBottomNav />
+    </Page>
+  );
 }
 

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -76,6 +76,8 @@ export default function Login({
               variant="contained"
               color="primary"
               fullWidth
+              size="medium"
+              sx={{ minHeight: 48 }}
             >
               {t('login')}
             </Button>
@@ -90,6 +92,7 @@ export default function Login({
             name="identifier"
             autoComplete="username"
             fullWidth
+            size="medium"
             required
             error={identifierError}
             helperText={identifierError ? t('client_id_required') : ''}
@@ -101,6 +104,7 @@ export default function Login({
             name="password"
             autoComplete="current-password"
             fullWidth
+            size="medium"
             required
             error={passwordError}
             helperText={passwordError ? t('password_required') : ''}

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -18,6 +18,7 @@ import PageContainer from '../../components/layout/PageContainer';
 import PageCard from '../../components/layout/PageCard';
 import { useTranslation } from 'react-i18next';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import ClientBottomNav from '../../components/ClientBottomNav';
 
 export default function Profile({ role }: { role: Role }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
@@ -232,6 +233,7 @@ export default function Profile({ role }: { role: Role }) {
         severity={toast.severity}
       />
     </PageContainer>
+    <ClientBottomNav />
     </ErrorBoundary>
   );
 }

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -19,6 +19,7 @@ import Announcement from '@mui/icons-material/Announcement';
 import History from '@mui/icons-material/History';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import ClientBottomNav from '../../components/ClientBottomNav';
 import { getBookingHistory, getSlots, getHolidays, cancelBooking } from '../../api/bookings';
 import { getEvents, type EventGroups } from '../../api/events';
 import type { Slot, Holiday, Booking } from '../../types';
@@ -373,6 +374,7 @@ export default function ClientDashboard() {
         message={message}
         severity={snackbarSeverity}
       />
+      <ClientBottomNav />
     </Page>
   );
 }


### PR DESCRIPTION
## Summary
- add ClientBottomNav component with dashboard, booking, profile, and help links
- show ClientBottomNav on client dashboard, booking, and profile pages
- ensure login and booking forms use medium-sized controls for accessible tap targets

## Testing
- `npm test` *(fails: Unable to find an element with the text: Clients: 1)*


------
https://chatgpt.com/codex/tasks/task_e_68bfaabdeb78832dbc1e86bea9fafde7