### PR TITLE
Show Install App instructions on iOS

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/InstallAppButton.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/InstallAppButton.test.tsx
@@ -18,10 +18,35 @@ describe('InstallAppButton', () => {
     event.prompt = prompt;
     fireEvent(window, event);
 
-    expect(screen.getByText('Install App')).toBeInTheDocument();
+    const buttons = screen.getAllByText('Install App');
+    expect(buttons[0]).toBeInTheDocument();
     expect(
       screen.getByText(/Install this app to access volunteer tools offline./i),
     ).toBeInTheDocument();
+  });
+
+  it('shows instructions on iOS devices', () => {
+    const originalUA = navigator.userAgent;
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'iPhone',
+      configurable: true,
+    });
+    render(
+      <MemoryRouter initialEntries={['/volunteer/dashboard']}>
+        <InstallAppButton />
+      </MemoryRouter>,
+    );
+
+    const buttons = screen.getAllByText('Install App');
+    expect(buttons[0]).toBeInTheDocument();
+    fireEvent.click(buttons[0]);
+    expect(
+      screen.getByText(/Add to Home Screen/i),
+    ).toBeInTheDocument();
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: originalUA,
+      configurable: true,
+    });
   });
 
   it('tracks app installs', () => {

--- a/MJ_FB_Frontend/src/components/InstallAppButton.tsx
+++ b/MJ_FB_Frontend/src/components/InstallAppButton.tsx
@@ -19,6 +19,8 @@ export default function InstallAppButton() {
   const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
   const [showPrompt, setShowPrompt] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const [showIosInstructions, setShowIosInstructions] = useState(false);
+  const isIOS = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -30,7 +32,7 @@ export default function InstallAppButton() {
   }, []);
 
   useEffect(() => {
-    if (promptEvent && location.pathname.startsWith('/volunteer')) {
+    if (location.pathname.startsWith('/volunteer') && (promptEvent || isIOS)) {
       setShowPrompt(true);
       if (!localStorage.getItem('pwaPromptShown')) {
         setShowOnboarding(true);
@@ -39,7 +41,7 @@ export default function InstallAppButton() {
     } else {
       setShowPrompt(false);
     }
-  }, [location, promptEvent]);
+  }, [location, promptEvent, isIOS]);
 
   useEffect(() => {
     const handler = () => {
@@ -49,14 +51,18 @@ export default function InstallAppButton() {
     return () => window.removeEventListener('appinstalled', handler);
   }, []);
 
-  if (!showPrompt || !promptEvent) {
+  if (!showPrompt) {
     return null;
   }
 
   const handleClick = async () => {
-    await promptEvent.prompt();
-    setPromptEvent(null);
-    setShowPrompt(false);
+    if (promptEvent) {
+      await promptEvent.prompt();
+      setPromptEvent(null);
+      setShowPrompt(false);
+    } else if (isIOS) {
+      setShowIosInstructions(true);
+    }
   };
 
   return (
@@ -87,6 +93,21 @@ export default function InstallAppButton() {
               sx={{ textTransform: 'none' }}
             >
               {t('install_app')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
+      {showIosInstructions && (
+        <Dialog open onClose={() => setShowIosInstructions(false)}>
+          <DialogTitle sx={{ textTransform: 'none' }}>{t('install_app')}</DialogTitle>
+          <DialogContent>
+            <Typography>
+              Open Safari&rsquo;s share menu and tap “Add to Home Screen”.
+            </Typography>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setShowIosInstructions(false)} sx={{ textTransform: 'none' }}>
+              Close
             </Button>
           </DialogActions>
         </Dialog>

--- a/docs/installApp.md
+++ b/docs/installApp.md
@@ -1,5 +1,9 @@
 # Install App
 
+The Install App button appears on volunteer pages when the `beforeinstallprompt`
+event fires or on iOS devices. On iOS, selecting the button shows instructions
+for using Safari's **Add to Home Screen** option.
+
 ## Localization
 
 Add the following translation strings to locale files:


### PR DESCRIPTION
## Summary
- ensure volunteers see Install App button on iOS by detecting Apple devices
- open a dialog with Add to Home Screen instructions when the PWA prompt isn't available
- document iOS support for the Install App button

## Testing
- `npm test` *(fails: missing environment/test errors)*
- `npx jest --runTestsByPath src/__tests__/InstallAppButton.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfab7eb25c832d82231635e31a04c2