### PR TITLE
feat: onboarding modal and volunteer signup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Staff can add existing clients to the app from the pantry schedule's Assign User modal by entering a client ID. The client is created as a shopper with online access disabled and immediately assigned to the selected slot.
 - A unified `/login` page serves clients, staff, volunteers, and agencies; everyone signs in with their client ID or email and password.
 - Volunteers see an Install App button on their first visit to volunteer pages with an onboarding modal about offline use; installations are tracked.
+- Client and volunteer dashboards show an onboarding modal with tips on first visit; a localStorage flag prevents repeat displays.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/public/locales` when client-visible text is added.
 - Pantry visits track daily sunshine bag weights and client counts via the `sunshine_bag_log` table.

--- a/MJ_FB_Frontend/public/locales/am/translation.json
+++ b/MJ_FB_Frontend/public/locales/am/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "ውጣ",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/ar/translation.json
+++ b/MJ_FB_Frontend/public/locales/ar/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "تسجيل الخروج",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/en/translation.json
+++ b/MJ_FB_Frontend/public/locales/en/translation.json
@@ -99,6 +99,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -138,6 +142,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "Logout",
@@ -343,5 +353,17 @@
   "staff_login": "Staff Login",
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
-  "client_id_or_email": "Client ID or Email"
+  "client_id_or_email": "Client ID or Email",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/es/translation.json
+++ b/MJ_FB_Frontend/public/locales/es/translation.json
@@ -99,6 +99,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -138,6 +142,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "Cerrar sesión",
@@ -336,5 +346,17 @@
   "staff_login": "Staff Login",
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
-  "client_id_or_email": "Client ID or Email"
+  "client_id_or_email": "Client ID or Email",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/fa/translation.json
+++ b/MJ_FB_Frontend/public/locales/fa/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "خروج",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/fr/translation.json
+++ b/MJ_FB_Frontend/public/locales/fr/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "Déconnexion",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/hi/translation.json
+++ b/MJ_FB_Frontend/public/locales/hi/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "लॉगआउट",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/ml/translation.json
+++ b/MJ_FB_Frontend/public/locales/ml/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "ലോഗ് ഔട്ട്",
@@ -340,5 +350,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/pa/translation.json
+++ b/MJ_FB_Frontend/public/locales/pa/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "ਲੌਗ ਆਊਟ",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/ps/translation.json
+++ b/MJ_FB_Frontend/public/locales/ps/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "وتل",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/so/translation.json
+++ b/MJ_FB_Frontend/public/locales/so/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "Ka bax",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/sw/translation.json
+++ b/MJ_FB_Frontend/public/locales/sw/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "Toka",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/ta/translation.json
+++ b/MJ_FB_Frontend/public/locales/ta/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "வெளியேறு",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/ti/translation.json
+++ b/MJ_FB_Frontend/public/locales/ti/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "መውጽእ",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/tl/translation.json
+++ b/MJ_FB_Frontend/public/locales/tl/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "Mag-logout",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/uk/translation.json
+++ b/MJ_FB_Frontend/public/locales/uk/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "Вийти",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/public/locales/zh/translation.json
+++ b/MJ_FB_Frontend/public/locales/zh/translation.json
@@ -97,6 +97,10 @@
           "Review your visit counter.",
           "Check reminders for upcoming bookings."
         ]
+      },
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
       }
     },
     "pantry": {
@@ -136,6 +140,12 @@
         "Enter your client ID or email and password.",
         "Press Sign In."
       ]
+    },
+    "volunteer": {
+      "dashboard_tips": {
+        "title": "Dashboard tips",
+        "description": "Review the tips shown on your first visit."
+      }
     }
   },
   "logout": "退出登录",
@@ -335,5 +345,17 @@
   "volunteer_login": "Volunteer Login",
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
-  "incorrect_id_password": "Incorrect ID or email or password"
+  "incorrect_id_password": "Incorrect ID or email or password",
+  "sign_up": "Sign Up",
+  "onboarding": {
+    "client": {
+      "title": "Welcome",
+      "body": "Use Book Appointment to schedule visits. Your dashboard shows upcoming bookings."
+    },
+    "volunteer": {
+      "title": "Welcome",
+      "body": "Tap Schedule to sign up for shifts. Install the app for faster access."
+    },
+    "close": "Got it"
+  }
 }

--- a/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientDashboard.test.tsx
@@ -14,6 +14,9 @@ jest.mock('../api/bookings', () => ({
 jest.mock('../api/events', () => ({ getEvents: jest.fn() }));
 
 describe('ClientDashboard', () => {
+  beforeEach(() => {
+    localStorage.setItem('clientOnboarding', 'true');
+  });
   it('shows events in News & Events section', async () => {
     (getBookingHistory as jest.Mock).mockResolvedValue([]);
     (getSlots as jest.Mock).mockResolvedValue([]);

--- a/MJ_FB_Frontend/src/__tests__/OnboardingModal.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/OnboardingModal.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import OnboardingModal from '../components/OnboardingModal';
+import i18n from '../i18n';
+
+describe('OnboardingModal', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('shows and stores flag on close', () => {
+    render(<OnboardingModal storageKey="test" title="T" body="B" />);
+    expect(screen.getByText('T')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('onboarding.close') }));
+    expect(localStorage.getItem('test')).toBe('true');
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -69,6 +69,7 @@ describe('VolunteerDashboard', () => {
       monthFamilies: 0,
     });
     localStorage.clear();
+    localStorage.setItem('volunteerOnboarding', 'true');
   });
 
   afterEach(() => jest.useRealTimers());

--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import * as mui from "@mui/material";
 import VolunteerSchedule from "../pages/volunteer-management/VolunteerSchedule";
 import i18n from "../i18n";
@@ -196,5 +196,37 @@ describe("VolunteerSchedule", () => {
     expect(await screen.findByText(i18n.t("no_bookings"))).toBeInTheDocument();
     expect(screen.queryByRole("table")).toBeNull();
     mq.mockRestore();
+  });
+
+  it('books a slot via Sign Up button', async () => {
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        name: 'Greeter',
+        start_time: '09:00:00',
+        end_time: '12:00:00',
+        max_volunteers: 1,
+        booked: 0,
+        available: 1,
+        status: 'open',
+        date: '2024-01-29',
+        category_id: 1,
+        category_name: 'Front',
+        is_wednesday_slot: false,
+      },
+    ]);
+    (requestVolunteerBooking as jest.Mock).mockResolvedValue({});
+
+    renderWithProviders(<VolunteerSchedule />);
+
+    fireEvent.mouseDown(screen.getByLabelText(i18n.t('role')));
+    fireEvent.click(await screen.findByText('Greeter'));
+
+    fireEvent.click(await screen.findByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => expect(requestVolunteerBooking).toHaveBeenCalled());
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/VolunteerScheduleTable.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerScheduleTable.test.tsx
@@ -10,6 +10,12 @@ describe("Schedule views", () => {
     expect(screen.getByText(i18n.t("no_bookings"))).toBeInTheDocument();
   });
 
+  it('shows Sign Up button for open slots', () => {
+    const handle = jest.fn();
+    render(<VolunteerScheduleTable maxSlots={1} rows={[{ time: '9', cells: [{ onClick: handle }] }]} />);
+    expect(screen.getByRole('button', { name: /sign up/i })).toBeInTheDocument();
+  });
+
   it("handles maxSlots=0 gracefully in card view", () => {
     render(<ScheduleCards maxSlots={0} rows={[]} />);
     expect(screen.getByText(i18n.t("no_bookings"))).toBeInTheDocument();

--- a/MJ_FB_Frontend/src/components/OnboardingModal.tsx
+++ b/MJ_FB_Frontend/src/components/OnboardingModal.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+import i18n from '../i18n';
+
+interface OnboardingModalProps {
+  storageKey: string;
+  title: string;
+  body: string;
+}
+
+export default function OnboardingModal({ storageKey, title, body }: OnboardingModalProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const seen = localStorage.getItem(storageKey);
+    if (!seen) {
+      setOpen(true);
+    }
+  }, [storageKey]);
+
+  const handleClose = () => {
+    localStorage.setItem(storageKey, 'true');
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Typography>{body}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>{i18n.t('onboarding.close')}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -8,8 +8,10 @@ import {
   Paper,
   useMediaQuery,
   useTheme,
+  Button,
 } from '@mui/material';
 import type { ReactNode } from 'react';
+import i18n from '../i18n';
 
 interface Cell {
   content: ReactNode;
@@ -85,17 +87,18 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
                   <TableCell
                     key={i}
                     colSpan={cell.colSpan}
-                    onClick={cell.onClick}
                     sx={{
                       textAlign: 'center',
-                      cursor: cell.onClick ? 'pointer' : 'default',
                       backgroundColor: cell.backgroundColor,
-                      ...(cell.backgroundColor && {
-                        '&:hover': { backgroundColor: cell.backgroundColor },
-                      }),
                     }}
                   >
-                    {cell.content}
+                    {cell.onClick ? (
+                      <Button size="small" onClick={cell.onClick} variant="outlined">
+                        {cell.content ?? i18n.t('sign_up')}
+                      </Button>
+                    ) : (
+                      cell.content
+                    )}
                   </TableCell>
                 ))}
                 {Array.from({ length: safeMaxSlots - used }).map((_, i) => (

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -174,6 +174,7 @@ export default function BookingUI({
     try {
       const profile = await getUserProfile();
       setUsage(profile.bookingsThisMonth ?? 0);
+      setNote(profile.defaultBookingNote ?? '');
       setConfirmOpen(true);
     } finally {
       setLoadingConfirm(false);

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -29,6 +29,7 @@ import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 import Page from '../../components/Page';
 import { useTranslation } from 'react-i18next';
+import OnboardingModal from '../../components/OnboardingModal';
 
 interface NextSlot {
   date: string;
@@ -138,6 +139,11 @@ export default function ClientDashboard() {
 
   return (
     <Page title={t('client_dashboard')}>
+      <OnboardingModal
+        storageKey="clientOnboarding"
+        title={t('onboarding.client.title')}
+        body={t('onboarding.client.body')}
+      />
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <Stack spacing={2}>

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -37,6 +37,12 @@ export function getHelpContent(
       loginSection,
       installAppSection,
       {
+        title: t('help.client.dashboard_tips.title'),
+        body: {
+          description: t('help.client.dashboard_tips.description'),
+        },
+      },
+      {
         title: t('help.client.booking_appointments.title'),
         body: {
           description: t('help.client.booking_appointments.description'),
@@ -95,6 +101,12 @@ export function getHelpContent(
     volunteer: [
       loginSection,
       installAppSection,
+    {
+      title: t('help.volunteer.dashboard_tips.title'),
+      body: {
+        description: t('help.volunteer.dashboard_tips.description'),
+      },
+    },
     {
       title: 'View schedule',
       body: {

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -56,6 +56,7 @@ import OverlapBookingDialog from '../../components/OverlapBookingDialog';
 import type { ApiError } from '../../api/client';
 import type { VolunteerBookingConflict } from '../../types';
 import VolunteerBottomNav from '../../components/VolunteerBottomNav';
+import OnboardingModal from '../../components/OnboardingModal';
 
 function formatDateLabel(dateStr: string) {
   const d = toDate(dateStr);
@@ -324,6 +325,11 @@ export default function VolunteerDashboard() {
 
   return (
     <Page title="Volunteer Dashboard" sx={{ pb: 7 }}>
+      <OnboardingModal
+        storageKey="volunteerOnboarding"
+        title={t('onboarding.volunteer.title')}
+        body={t('onboarding.volunteer.body')}
+      />
       {loading && (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
           <CircularProgress />

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -59,6 +59,7 @@ import {
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "../../utils/date";
 import VolunteerBottomNav from "../../components/VolunteerBottomNav";
+import i18n from "../../i18n";
 
 const reginaTimeZone = "America/Regina";
 
@@ -157,6 +158,22 @@ export default function VolunteerSchedule() {
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  async function quickBook(role: VolunteerRole) {
+    try {
+      await requestVolunteerBooking(role.id, formatDate(currentDate));
+      setSnackbarSeverity('success');
+      setMessage(i18n.t('slot_booked_success'));
+      await loadData();
+    } catch (err: any) {
+      if (err?.conflict) {
+        setConflict(err.conflict);
+      } else {
+        setSnackbarSeverity('error');
+        setMessage(i18n.t('booking_failed'));
+      }
+    }
+  }
 
   function changeDay(delta: number) {
     setCurrentDate((d) => {
@@ -333,20 +350,9 @@ export default function VolunteerSchedule() {
         });
       } else {
         cells.push({
-          content: (
-            <>
-              Volunteer Needed
-              <br />
-              Click Here to Book
-            </>
-          ),
           onClick: () => {
             if (!isClosed) {
-              setFrequency("one-time");
-              setWeekdays([reginaDate.getDay()]);
-              setEndDate("");
-              setRequestRole(role);
-              setMessage("");
+              quickBook(role);
             } else {
               setSnackbarSeverity("error");
               setMessage("Booking not allowed on weekends or holidays");

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -179,6 +179,7 @@ export interface UserProfile {
   bookingsThisMonth?: number;
   roles?: StaffAccess[];
   trainedAreas?: string[];
+  defaultBookingNote?: string;
 }
 
 export interface RoleOption {

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Before merging a pull request, confirm the following:
 - Volunteer dashboard hides shifts already booked by the volunteer and shows detailed error messages from the server when requests fail.
 - Conflicting volunteer shift requests return a 409 with both the attempted and existing shift details; resolve conflicts via `POST /volunteer-bookings/resolve-conflict` (body: `{ existingBookingId, keep, roleId?, date? }`; `roleId` and `date` are required only when keeping the new booking).
 - Volunteer schedule prevents navigating to past dates and hides shifts that have already started.
+- Volunteer schedule open slots include a **Sign Up** button for one‑tap booking.
 - Staff assigning volunteers can override a full role via a confirmation prompt, which increases that slot's `max_volunteers`.
 - Volunteer badges are calculated from activity and manually awardable. Manual awards are issued via `POST /volunteers/me/badges`. `GET /volunteers/me/stats` returns earned badges along with lifetime hours, this month's hours, total completed shifts, and current streak. Only shifts marked as `completed` contribute to hours and shift totals; `approved` or `no_show` shifts are ignored. The endpoint also flags milestones at 5, 10, and 25 shifts so the dashboard can show a celebration banner.
 - The stats endpoint now provides a milestone message and contribution totals (`familiesServed`, `poundsHandled`) along with current-month figures (`monthFamiliesServed`, `monthPoundsHandled`) so the dashboard can display appreciation.
@@ -242,6 +243,7 @@ Before merging a pull request, confirm the following:
 - Staff can delete visit records from booking history if they were recorded in error; clients cannot remove visits.
 - Booking requests are automatically approved; the submitted state has been removed.
 - Booking confirmations display "Shift booked"; the volunteer dashboard shows only approved bookings.
+- Booking confirmation dialogs prefill notes from the user's profile when available.
 - Booking history endpoint `/bookings/history` accepts `includeVisits=true` to include walk-in visits in results.
 - When `includeStaffNotes=true` or the requester is staff, `/bookings/history` returns both `client_note` and `staff_note` for each entry.
 - Agencies can supply `clientIds`, `limit`, and `offset` to `/bookings/history` for multi-client, paginated booking history.
@@ -472,6 +474,7 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Staff dashboard includes a pantry visit trend line chart showing monthly totals for clients, adults, and children.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Volunteers see an Install App button on their first visit to volunteer pages. An onboarding modal explains offline benefits, and installs are tracked. iOS users should use Safari's **Add to Home Screen**.
+- Client and volunteer dashboards display onboarding tips on first visit and store a local flag to avoid repeat prompts.
 - An Install App button appears when the app is installable; iOS users should use Safari's **Add to Home Screen**.
 - A Workbox service worker caches built assets plus schedule, booking history, and profile API responses, provides an offline fallback page, and queues offline booking actions for background sync.
 - Booking confirmations include links to add appointments to Google Calendar or download an ICS file.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,14 @@
+# Onboarding
+
+Add the following translation strings to locale files:
+
+- `sign_up`
+- `onboarding.client.title`
+- `onboarding.client.body`
+- `onboarding.volunteer.title`
+- `onboarding.volunteer.body`
+- `onboarding.close`
+- `help.client.dashboard_tips.title`
+- `help.client.dashboard_tips.description`
+- `help.volunteer.dashboard_tips.title`
+- `help.volunteer.dashboard_tips.description`


### PR DESCRIPTION
## Summary
- show tips on first visit with new OnboardingModal stored in localStorage
- add Sign Up button for open volunteer schedule slots and quick booking
- preload booking notes from profile data

## Testing
- `npm test` *(failed: Unable to find an element with the text: Clients: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaac160e0832d94aaa492f6511d03