### PR TITLE
Add user notification preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@
 - Passwords must be at least 8 characters and include uppercase, lowercase, and special characters; numbers are optional.
 - Clients reset passwords by entering their client ID and receive an email with a link to finish the reset.
 - Password setup emails mention the user's role and include a direct link to the appropriate login page. The password setup page displays a role-specific login reminder and button.
+- Profile pages let clients and volunteers toggle email reminders and push notifications from `/users/me/preferences`.
 - Staff can delete client and volunteer accounts from their respective management pages; update help content when these features change.
 
 See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/AGENTS.md` for frontend-specific guidance.

--- a/MJ_FB_Backend/src/migrations/1700000000033_add_user_preferences.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000033_add_user_preferences.ts
@@ -1,0 +1,15 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('user_preferences', {
+    user_id: { type: 'integer', notNull: true },
+    user_type: { type: 'text', notNull: true },
+    email_reminders: { type: 'boolean', notNull: true, default: true },
+    push_notifications: { type: 'boolean', notNull: true, default: true },
+  });
+  pgm.createPrimaryKey('user_preferences', ['user_id', 'user_type']);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('user_preferences');
+}

--- a/MJ_FB_Backend/src/models/userPreferences.ts
+++ b/MJ_FB_Backend/src/models/userPreferences.ts
@@ -1,0 +1,4 @@
+export interface UserPreferences {
+  emailReminders: boolean;
+  pushNotifications: boolean;
+}

--- a/MJ_FB_Backend/src/routes/users.ts
+++ b/MJ_FB_Backend/src/routes/users.ts
@@ -8,6 +8,8 @@ import {
   updateUserByClientId,
   updateMyProfile,
   deleteUserByClientId,
+  getMyPreferences,
+  updateMyPreferences,
 } from '../controllers/userController';
 import { authMiddleware, authorizeRoles } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
@@ -15,6 +17,7 @@ import {
   createUserSchema,
   updateUserSchema,
   updateMyProfileSchema,
+  updatePreferencesSchema,
 } from '../schemas/userSchemas';
 
 const router = express.Router();
@@ -53,6 +56,8 @@ router.get(
 );
 router.get('/me', authMiddleware, getUserProfile);
 router.patch('/me', authMiddleware, validate(updateMyProfileSchema), updateMyProfile);
+router.get('/me/preferences', authMiddleware, getMyPreferences);
+router.put('/me/preferences', authMiddleware, validate(updatePreferencesSchema), updateMyPreferences);
 
 
 export default router;

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -66,3 +66,9 @@ export const updateMyProfileSchema = z
   });
 
 
+
+export const updatePreferencesSchema = z.object({
+  emailReminders: z.boolean(),
+  pushNotifications: z.boolean(),
+});
+

--- a/MJ_FB_Backend/tests/userPreferences.test.ts
+++ b/MJ_FB_Backend/tests/userPreferences.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../src/routes/users';
+import pool from '../src/db';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.user = { id: 1, type: 'client', role: 'shopper' };
+    next();
+  },
+  authorizeRoles: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../src/middleware/validate', () => ({
+  validate: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/users', usersRouter);
+
+afterEach(() => {
+  (pool.query as jest.Mock).mockReset();
+});
+
+describe('User preference routes', () => {
+  it('returns defaults when no preferences set', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const res = await request(app).get('/api/users/me/preferences');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ emailReminders: true, pushNotifications: true });
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM user_preferences'),
+      [1, 'client'],
+    );
+  });
+
+  it('updates preferences', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ email_reminders: false, push_notifications: false }],
+    });
+    const res = await request(app)
+      .put('/api/users/me/preferences')
+      .send({ emailReminders: false, pushNotifications: false });
+    expect(res.status).toBe(200);
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_preferences'),
+      [1, 'client', false, false],
+    );
+    expect(res.body).toEqual({ emailReminders: false, pushNotifications: false });
+  });
+});

--- a/MJ_FB_Frontend/public/locales/am/translation.json
+++ b/MJ_FB_Frontend/public/locales/am/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ar/translation.json
+++ b/MJ_FB_Frontend/public/locales/ar/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/en/translation.json
+++ b/MJ_FB_Frontend/public/locales/en/translation.json
@@ -87,7 +87,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -189,7 +189,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/es/translation.json
+++ b/MJ_FB_Frontend/public/locales/es/translation.json
@@ -87,7 +87,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -189,7 +189,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/fa/translation.json
+++ b/MJ_FB_Frontend/public/locales/fa/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/fr/translation.json
+++ b/MJ_FB_Frontend/public/locales/fr/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/hi/translation.json
+++ b/MJ_FB_Frontend/public/locales/hi/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ml/translation.json
+++ b/MJ_FB_Frontend/public/locales/ml/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "എന്റെ വരാനിരിക്കുന്ന അപ്പോയിന്റ്മെന്റ്",
   "my_upcoming_appointments": "എന്റെ വരാനിരിക്കുന്ന അപ്പോയിന്റ്മെന്റുകൾ",

--- a/MJ_FB_Frontend/public/locales/pa/translation.json
+++ b/MJ_FB_Frontend/public/locales/pa/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ps/translation.json
+++ b/MJ_FB_Frontend/public/locales/ps/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/so/translation.json
+++ b/MJ_FB_Frontend/public/locales/so/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/sw/translation.json
+++ b/MJ_FB_Frontend/public/locales/sw/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ta/translation.json
+++ b/MJ_FB_Frontend/public/locales/ta/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ti/translation.json
+++ b/MJ_FB_Frontend/public/locales/ti/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/tl/translation.json
+++ b/MJ_FB_Frontend/public/locales/tl/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/uk/translation.json
+++ b/MJ_FB_Frontend/public/locales/uk/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/zh/translation.json
+++ b/MJ_FB_Frontend/public/locales/zh/translation.json
@@ -85,7 +85,7 @@
         "description": "Update contact information or change your password.",
         "steps": [
           "Navigate to the Profile page.",
-          "Edit your information.",
+          "Edit your information or notification preferences.",
           "Save changes."
         ]
       },
@@ -187,7 +187,11 @@
     "password_updated": "Password updated.",
     "password_min_length": "Password must be at least 8 characters.",
     "password_number": "Password must include uppercase and lowercase letters.",
-    "password_symbol": "Password must include a symbol."
+    "password_symbol": "Password must include a symbol.",
+    "notifications": "Notifications",
+    "email_reminders": "Email reminders",
+    "push_notifications": "Push notifications",
+    "preferences_saved": "Preferences saved."
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -3,6 +3,7 @@ import type {
   UserProfile,
   StaffAccess,
   LoginResponse,
+  UserPreferences,
 } from "../types";
 import { API_BASE, apiFetch, handleResponse } from "./client";
 export type { LoginResponse } from "../types";
@@ -282,3 +283,20 @@ export async function deleteUser(clientId: number): Promise<void> {
   const res = await apiFetch(`${API_BASE}/users/id/${clientId}`, { method: 'DELETE' });
   await handleResponse(res);
 }
+
+export async function getUserPreferences(): Promise<UserPreferences> {
+  const res = await apiFetch(`${API_BASE}/users/me/preferences`);
+  return handleResponse(res);
+}
+
+export async function updateUserPreferences(
+  data: UserPreferences,
+): Promise<UserPreferences> {
+  const res = await apiFetch(`${API_BASE}/users/me/preferences`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import {
   Stack,
   Typography,
+  FormControlLabel,
+  Switch,
   Avatar,
   Divider,
   TextField,
@@ -28,6 +30,8 @@ export default function Profile({ role }: { role: Role }) {
   const [phone, setPhone] = useState('');
   const [phoneError, setPhoneError] = useState('');
   const [saving, setSaving] = useState(false);
+  const [prefs, setPrefs] = useState<UserPreferences>({ emailReminders: true, pushNotifications: true });
+  const [prefsSaving, setPrefsSaving] = useState(false);
   const [toast, setToast] = useState<{
     open: boolean;
     message: string;
@@ -49,6 +53,14 @@ export default function Profile({ role }: { role: Role }) {
       })
       .catch(e => setError(e instanceof Error ? e.message : String(e)));
   }, [role]);
+  useEffect(() => {
+    if (role === 'volunteer' || role === 'shopper' || role === 'delivery') {
+      getUserPreferences()
+        .then(p => setPrefs(p))
+        .catch(e => setError(e instanceof Error ? e.message : String(e)));
+    }
+  }, [role]);
+
   const initials = profile
     ? profile.role === 'agency'
       ? (profile.firstName ?? '').slice(0, 2).toUpperCase()
@@ -99,6 +111,21 @@ export default function Profile({ role }: { role: Role }) {
       setEditing(true);
     }
   }
+  async function handleSavePreferences() {
+    setPrefsSaving(true);
+    try {
+      const updated = await updateUserPreferences(prefs);
+      setPrefs(updated);
+      setToast({ open: true, message: t('profile_page.preferences_saved'), severity: 'success' });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setToast({ open: true, message: msg, severity: 'error' });
+    } finally {
+      setPrefsSaving(false);
+    }
+  }
+
+
 
   return (
     <ErrorBoundary>
@@ -201,6 +228,38 @@ export default function Profile({ role }: { role: Role }) {
             {editing ? t('profile_page.save') : t('profile_page.edit_profile')}
           </Button>
 
+          {(role === 'volunteer' || profile?.role === 'shopper' || profile?.role === 'delivery') && (
+            <>
+              <Divider sx={{ my: 1 }} />
+              <Typography variant="h6">{t('profile_page.notifications')}</Typography>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={prefs.emailReminders}
+                    onChange={e => setPrefs(p => ({ ...p, emailReminders: e.target.checked }))}
+                  />
+                }
+                label={t('profile_page.email_reminders')}
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={prefs.pushNotifications}
+                    onChange={e => setPrefs(p => ({ ...p, pushNotifications: e.target.checked }))}
+                  />
+                }
+                label={t('profile_page.push_notifications')}
+              />
+              <Button
+                variant="outlined"
+                startIcon={prefsSaving ? <CircularProgress size={20} /> : <AccountCircle />}
+                disabled={prefsSaving}
+                onClick={handleSavePreferences}
+              >
+                {t('profile_page.save')}
+              </Button>
+            </>
+          )}
           <Divider sx={{ my: 1 }} />
 
           {/* Password reset */}

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -181,6 +181,11 @@ export interface UserProfile {
   trainedAreas?: string[];
 }
 
+export interface UserPreferences {
+  emailReminders: boolean;
+  pushNotifications: boolean;
+}
+
 export interface RoleOption {
   categoryId: number;
   categoryName: string;

--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Pages are organized into feature-based directories (e.g., booking, staff, volunteer-management, warehouse-management).
 - A language selector lets users switch languages on the login, forgot password, set password, client dashboard, book appointment, booking history, profile, and help pages.
 - Profile pages provide a button to email a password reset link instead of changing passwords directly.
+- Profile pages let clients and volunteers opt in or out of email reminders and push notifications.
 - A shared dashboard component lives in `src/components/dashboard`.
 - Staff dashboard dates display weekday, month, day, and year (e.g., 'Tue, Jan 2, 2024').
 - Staff dashboard includes a pantry visit trend line chart showing monthly totals for clients, adults, and children.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,17 @@
+# Notification preferences
+
+Clients and volunteers can manage notification settings from the Profile page.
+
+## API
+- `GET /users/me/preferences` returns `{ emailReminders, pushNotifications }`.
+- `PUT /users/me/preferences` updates `{ emailReminders, pushNotifications }`.
+
+Both options default to `true`.
+
+## Localization
+Add these translation keys to locale files:
+- `profile_page.notifications`
+- `profile_page.email_reminders`
+- `profile_page.push_notifications`
+- `profile_page.preferences_saved`
+- `help.client.manage_profile_and_password.steps.1`


### PR DESCRIPTION
## Summary
- add email reminder and push notification toggles on profile page
- store user preferences with new API endpoints and migration
- document notification options and update translations

## Testing
- `npm test` (backend) *(fails: booking limit, slots, email queue cleanup, etc.)*
- `npm test` (frontend) *(fails: multiple failing suites, jsdom errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaad37354832db09c82593de50d76