### PR TITLE
fix: correct user type check in preferences endpoints

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -741,7 +741,7 @@ export async function deleteUserByClientId(
 export async function getMyPreferences(req: Request, res: Response, next: NextFunction) {
   const user = req.user;
   if (!user) return res.status(401).json({ message: 'Unauthorized' });
-  if (user.type !== 'client' && user.type !== 'volunteer') {
+  if (user.type !== 'user' && user.type !== 'volunteer') {
     return res.status(403).json({ message: 'Unsupported user type' });
   }
   try {
@@ -766,7 +766,7 @@ export async function getMyPreferences(req: Request, res: Response, next: NextFu
 export async function updateMyPreferences(req: Request, res: Response, next: NextFunction) {
   const user = req.user;
   if (!user) return res.status(401).json({ message: 'Unauthorized' });
-  if (user.type !== 'client' && user.type !== 'volunteer') {
+  if (user.type !== 'user' && user.type !== 'volunteer') {
     return res.status(403).json({ message: 'Unsupported user type' });
   }
   const { emailReminders, pushNotifications } = req.body as UserPreferences;


### PR DESCRIPTION
## Summary
- ensure user preference endpoints accept clients by checking `user` type

## Testing
- `npm test` *(fails: Test Suites: 26 failed, 102 passed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfae96ce30832d9e44745459578541