### PR TITLE
Fix profile preferences and grid sizing

### DIFF
--- a/MJ_FB_Frontend/src/pages/CancelBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/CancelBooking.tsx
@@ -36,7 +36,7 @@ export default function CancelBooking() {
   return (
     <Page title={t('cancel_booking')}>
       <Grid container spacing={2} justifyContent="center">
-        <Grid xs={12} sm={8} md={6}>
+        <Grid size={{ xs: 12, sm: 8, md: 6 }}>
           <FormCard title={t('cancel_booking')} onSubmit={handleSubmit} actions={
             <Button component={RouterLink} to="/" variant="contained">
               {t('back_to_login')}

--- a/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
@@ -71,7 +71,7 @@ export default function RescheduleBooking() {
   return (
     <Page title={t('reschedule')}>
       <Grid container spacing={2} justifyContent="center">
-        <Grid xs={12} sm={8} md={6}>
+        <Grid size={{ xs: 12, sm: 8, md: 6 }}>
           <FormCard
             title={t('reschedule')}
             onSubmit={handleSubmit}

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -12,8 +12,14 @@ import {
 } from '@mui/material';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import Lock from '@mui/icons-material/Lock';
-import type { Role, UserProfile } from '../../types';
-import { getUserProfile, requestPasswordReset, updateMyProfile } from '../../api/users';
+import type { Role, UserProfile, UserPreferences } from '../../types';
+import {
+  getUserProfile,
+  requestPasswordReset,
+  updateMyProfile,
+  getUserPreferences,
+  updateUserPreferences,
+} from '../../api/users';
 import { getVolunteerProfile } from '../../api/volunteers';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import PageContainer from '../../components/layout/PageContainer';

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -355,6 +355,7 @@ export default function VolunteerSchedule() {
         });
       } else {
         cells.push({
+          content: "",
           onClick: () => {
             if (!isClosed) {
               quickBook(role);


### PR DESCRIPTION
## Summary
- import missing user preference helpers and types in profile page
- use `size` prop on grids in cancel/reschedule booking pages
- ensure volunteer schedule cells include content when clickable

## Testing
- `npm test` *(fails: Unable to find an element with the text "Clients: 1", Jest encountered an unexpected token, TypeError: Cannot read properties of null (reading '_location'), and other test failures)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfaea48c1c832d9d46c7047fdafe4f