### PR TITLE
Fix user preferences migration primary key definition

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000033_add_user_preferences.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000033_add_user_preferences.ts
@@ -1,13 +1,20 @@
 import type { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.createTable('user_preferences', {
-    user_id: { type: 'integer', notNull: true },
-    user_type: { type: 'text', notNull: true },
-    email_reminders: { type: 'boolean', notNull: true, default: true },
-    push_notifications: { type: 'boolean', notNull: true, default: true },
-  });
-  pgm.createPrimaryKey('user_preferences', ['user_id', 'user_type']);
+  pgm.createTable(
+    'user_preferences',
+    {
+      user_id: { type: 'integer', notNull: true },
+      user_type: { type: 'text', notNull: true },
+      email_reminders: { type: 'boolean', notNull: true, default: true },
+      push_notifications: { type: 'boolean', notNull: true, default: true },
+    },
+    {
+      constraints: {
+        primaryKey: ['user_id', 'user_type'],
+      },
+    },
+  );
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {


### PR DESCRIPTION
## Summary
- define composite primary key in user_preferences migration using constraints option

## Testing
- `npm test --silent -- --json --outputFile=/tmp/result.json` *(fails: 23 failing test suites)*
- `npm run migrate` *(fails: missing JWT_SECRET and JWT_REFRESH_SECRET env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb0c3f044832d9e6f7b2f175ee596