### PR TITLE
Add volunteer management tabs for staff

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -65,8 +65,8 @@ const StaffRecurringBookings = React.lazy(() =>
 const VolunteerRankings = React.lazy(() =>
   import('./pages/volunteer-management/VolunteerRankings')
 );
-const VolunteerTabs = React.lazy(() =>
-  import('./pages/volunteer-management/VolunteerTabs')
+const VolunteerAdmin = React.lazy(() =>
+  import('./pages/staff/VolunteerManagement')
 );
 const WarehouseDashboard = React.lazy(() =>
   import('./pages/warehouse-management/WarehouseDashboard')
@@ -453,7 +453,7 @@ export default function App() {
                       />
                       <Route
                         path="/volunteer-management/volunteers"
-                        element={<VolunteerTabs />}
+                        element={<VolunteerAdmin />}
                       />
                       <Route
                         path="/volunteer-management/rankings"

--- a/MJ_FB_Frontend/src/pages/help/content.ts
+++ b/MJ_FB_Frontend/src/pages/help/content.ts
@@ -328,12 +328,13 @@ export function getHelpContent(
       title: 'Manage volunteers',
       body: {
         description:
-          'Search, add, delete, and review volunteers. Choose Set Password or Send Setup Link for online access.',
+          'Search, add, edit, and delete volunteers. Choose Set Password or Send Setup Link for online access.',
         steps: [
           'Go to the Volunteers page.',
-          'Search by name.',
-          'View, edit, or delete volunteer information.',
-          'Choose Set Password or Send Setup Link when creating a volunteer.',
+          'Search by name in the Search tab.',
+          'Use Add to create a volunteer.',
+          'Use Edit to adjust trained areas.',
+          'Use Delete to remove a volunteer.',
         ],
       },
     },

--- a/MJ_FB_Frontend/src/pages/staff/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/VolunteerManagement.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import StyledTabs from '../../components/StyledTabs';
+import Page from '../../components/Page';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
+import SearchVolunteer from './volunteer-management/SearchVolunteer';
+import AddVolunteer from './volunteer-management/AddVolunteer';
+import EditVolunteer from './volunteer-management/EditVolunteer';
+import DeleteVolunteer from './volunteer-management/DeleteVolunteer';
+
+export default function VolunteerManagement() {
+  const [searchParams] = useSearchParams();
+  const initial = searchParams.get('tab');
+  const [tab, setTab] = useState(() => {
+    switch (initial) {
+      case 'add':
+        return 1;
+      case 'edit':
+        return 2;
+      case 'delete':
+        return 3;
+      default:
+        return 0;
+    }
+  });
+
+  useEffect(() => {
+    const t = searchParams.get('tab');
+    if (t === 'add') setTab(1);
+    else if (t === 'edit') setTab(2);
+    else if (t === 'delete') setTab(3);
+    else setTab(0);
+  }, [searchParams]);
+
+  const tabs = [
+    { label: 'Search Volunteer', content: <SearchVolunteer /> },
+    { label: 'Add', content: <AddVolunteer /> },
+    { label: 'Edit', content: <EditVolunteer /> },
+    { label: 'Delete', content: <DeleteVolunteer /> },
+  ];
+
+  return (
+    <Page title="Volunteer Management" header={<PantryQuickLinks />}>
+      <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />
+    </Page>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerManagement.test.tsx
@@ -1,0 +1,20 @@
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerManagement from '../VolunteerManagement';
+import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
+
+describe('VolunteerManagement tabs', () => {
+  it('renders volunteer management tabs', () => {
+    renderWithProviders(
+      <MemoryRouter>
+        <VolunteerManagement />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole('tab', { name: /search volunteer/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /add/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /delete/i })).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/AddVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/AddVolunteer.tsx
@@ -1,0 +1,171 @@
+import { useState, useEffect } from 'react';
+import {
+  createVolunteer,
+  getVolunteerRoles,
+  type VolunteerRoleWithShifts,
+} from '../../../api/volunteers';
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import PasswordField from '../../../components/PasswordField';
+
+export default function AddVolunteer() {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [onlineAccess, setOnlineAccess] = useState(false);
+  const [sendPasswordLink, setSendPasswordLink] = useState(true);
+  const [password, setPassword] = useState('');
+  const [roles, setRoles] = useState<VolunteerRoleWithShifts[]>([]);
+  const [selectedRoles, setSelectedRoles] = useState<number[]>([]);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<'success' | 'error'>('success');
+
+  useEffect(() => {
+    getVolunteerRoles()
+      .then(r => setRoles(r))
+      .catch(() => setRoles([]));
+  }, []);
+
+  function toggleRole(id: number, checked: boolean) {
+    setSelectedRoles(prev =>
+      checked ? [...prev, id] : prev.filter(r => r !== id),
+    );
+  }
+
+  async function handleSubmit() {
+    if (!firstName || !lastName) {
+      setMessage('First and last name required');
+      setSeverity('error');
+      return;
+    }
+    try {
+      await createVolunteer(
+        firstName,
+        lastName,
+        selectedRoles,
+        onlineAccess,
+        email || undefined,
+        phone || undefined,
+        sendPasswordLink ? undefined : password || undefined,
+        sendPasswordLink,
+      );
+      setMessage('Volunteer created');
+      setSeverity('success');
+      setFirstName('');
+      setLastName('');
+      setEmail('');
+      setPhone('');
+      setOnlineAccess(false);
+      setSendPasswordLink(true);
+      setPassword('');
+      setSelectedRoles([]);
+    } catch (err: unknown) {
+      setMessage(err instanceof Error ? err.message : 'Create failed');
+      setSeverity('error');
+    }
+  }
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Add Volunteer
+      </Typography>
+      <Stack spacing={2} maxWidth={400}>
+        <TextField
+          label="First Name"
+          value={firstName}
+          onChange={e => setFirstName(e.target.value)}
+        />
+        <TextField
+          label="Last Name"
+          value={lastName}
+          onChange={e => setLastName(e.target.value)}
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={onlineAccess}
+              onChange={e => {
+                setOnlineAccess(e.target.checked);
+                if (!e.target.checked) {
+                  setSendPasswordLink(true);
+                  setPassword('');
+                }
+              }}
+            />
+          }
+          label="Online Access"
+        />
+        {onlineAccess && (
+          <>
+            <ToggleButtonGroup
+              value={sendPasswordLink ? 'link' : 'password'}
+              exclusive
+              onChange={(_, v) => v && setSendPasswordLink(v === 'link')}
+            >
+              <ToggleButton value="link">Send link</ToggleButton>
+              <ToggleButton value="password">Set password</ToggleButton>
+            </ToggleButtonGroup>
+            {sendPasswordLink ? (
+              <Typography variant="body2" color="text.secondary">
+                An email invitation will be sent.
+              </Typography>
+            ) : (
+              <PasswordField
+                label="Password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+              />
+            )}
+          </>
+        )}
+        <TextField
+          label={onlineAccess ? 'Email' : 'Email (optional)'}
+          type="email"
+          required={onlineAccess}
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <TextField
+          label="Phone (optional)"
+          type="tel"
+          value={phone}
+          onChange={e => setPhone(e.target.value)}
+        />
+        <Typography variant="subtitle1">Trained Areas</Typography>
+        {roles.map(r => (
+          <FormControlLabel
+            key={r.id}
+            control={
+              <Checkbox
+                checked={selectedRoles.includes(r.id)}
+                onChange={e => toggleRole(r.id, e.target.checked)}
+              />
+            }
+            label={r.name}
+          />
+        ))}
+        <Button variant="contained" onClick={handleSubmit}>
+          Add Volunteer
+        </Button>
+      </Stack>
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity={severity}
+      />
+    </Box>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/DeleteVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/DeleteVolunteer.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import EntitySearch from '../../../components/EntitySearch';
+import ConfirmDialog from '../../../components/ConfirmDialog';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import { deleteVolunteer, type VolunteerSearchResult } from '../../../api/volunteers';
+
+export default function DeleteVolunteer() {
+  const [volunteer, setVolunteer] =
+    useState<VolunteerSearchResult | null>(null);
+  const [confirm, setConfirm] = useState(false);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<'success' | 'error'>('success');
+
+  async function handleDelete() {
+    if (!volunteer) return;
+    try {
+      await deleteVolunteer(volunteer.id);
+      setMessage('Volunteer deleted');
+      setSeverity('success');
+      setVolunteer(null);
+    } catch {
+      setMessage('Delete failed');
+      setSeverity('error');
+    }
+    setConfirm(false);
+  }
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Delete Volunteer
+      </Typography>
+      <EntitySearch
+        type="volunteer"
+        placeholder="Search volunteer"
+        onSelect={v => setVolunteer(v as VolunteerSearchResult)}
+      />
+      {volunteer && (
+        <Button
+          variant="contained"
+          color="error"
+          sx={{ mt: 2 }}
+          onClick={() => setConfirm(true)}
+        >
+          Delete
+        </Button>
+      )}
+      {confirm && (
+        <ConfirmDialog
+          message={`Delete ${volunteer?.name}?`}
+          onConfirm={handleDelete}
+          onCancel={() => setConfirm(false)}
+        />
+      )}
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity={severity}
+      />
+    </Box>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import EntitySearch from '../../../components/EntitySearch';
+import {
+  getVolunteerRoles,
+  updateVolunteerTrainedAreas,
+  type VolunteerRoleWithShifts,
+  type VolunteerSearchResult,
+} from '../../../api/volunteers';
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Stack,
+  Typography,
+} from '@mui/material';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+
+export default function EditVolunteer() {
+  const [volunteer, setVolunteer] =
+    useState<VolunteerSearchResult | null>(null);
+  const [roles, setRoles] = useState<VolunteerRoleWithShifts[]>([]);
+  const [selected, setSelected] = useState<number[]>([]);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<'success' | 'error'>('success');
+
+  useEffect(() => {
+    getVolunteerRoles()
+      .then(r => setRoles(r))
+      .catch(() => setRoles([]));
+  }, []);
+
+  function handleSelect(v: VolunteerSearchResult) {
+    setVolunteer(v);
+    setSelected(v.trainedAreas);
+  }
+
+  function toggleRole(id: number, checked: boolean) {
+    setSelected(prev => (checked ? [...prev, id] : prev.filter(r => r !== id)));
+  }
+
+  async function handleSave() {
+    if (!volunteer) return;
+    try {
+      await updateVolunteerTrainedAreas(volunteer.id, selected);
+      setMessage('Volunteer updated');
+      setSeverity('success');
+    } catch (err: unknown) {
+      setMessage(err instanceof Error ? err.message : 'Update failed');
+      setSeverity('error');
+    }
+  }
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Edit Volunteer
+      </Typography>
+      <EntitySearch
+        type="volunteer"
+        placeholder="Search volunteer"
+        onSelect={v => handleSelect(v as VolunteerSearchResult)}
+      />
+      {volunteer && (
+        <Stack spacing={2} mt={2} maxWidth={400}>
+          <Typography>{volunteer.name}</Typography>
+          {roles.map(r => (
+            <FormControlLabel
+              key={r.id}
+              control={
+                <Checkbox
+                  checked={selected.includes(r.id)}
+                  onChange={e => toggleRole(r.id, e.target.checked)}
+                />
+              }
+              label={r.name}
+            />
+          ))}
+          <Button variant="contained" onClick={handleSave}>
+            Save
+          </Button>
+        </Stack>
+      )}
+      <FeedbackSnackbar
+        open={!!message}
+        onClose={() => setMessage('')}
+        message={message}
+        severity={severity}
+      />
+    </Box>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/SearchVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/SearchVolunteer.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import EntitySearch from '../../../components/EntitySearch';
+import ResponsiveTable, { type Column } from '../../../components/ResponsiveTable';
+import type { VolunteerSearchResult } from '../../../api/volunteers';
+
+export default function SearchVolunteer() {
+  const [selected, setSelected] = useState<VolunteerSearchResult | null>(null);
+  const columns: Column<VolunteerSearchResult>[] = [
+    { field: 'name', header: 'Name' },
+    { field: 'clientId', header: 'Client ID' },
+  ];
+  return (
+    <div>
+      <EntitySearch
+        type="volunteer"
+        placeholder="Search volunteer"
+        onSelect={v => setSelected(v as VolunteerSearchResult)}
+      />
+      {selected && <ResponsiveTable columns={columns} rows={[selected]} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add dedicated Volunteer Management page with Search, Add, Edit, and Delete tabs for staff
- Implement volunteer CRUD components reusing existing search and table patterns
- Document volunteer management workflow in Help content

## Testing
- `npm test` *(fails: PantryVisits.test.tsx, PantrySchedule.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb134d3a0832d83f9789921efb9b4