### PR TITLE
Fix SSE hook using API base constant

### DIFF
--- a/MJ_FB_Frontend/src/hooks/useSlotStream.ts
+++ b/MJ_FB_Frontend/src/hooks/useSlotStream.ts
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
+import { API_BASE } from '../api/client';
 
 export type SlotStreamMessage = any;
 
 export default function useSlotStream(onMessage: (data: SlotStreamMessage) => void) {
   useEffect(() => {
     if (typeof EventSource === 'undefined') return;
-    const base = process.env.VITE_API_BASE || '';
-    const es = new EventSource(`${base}/bookings/stream`, {
+    const es = new EventSource(`${API_BASE}/bookings/stream`, {
       withCredentials: true,
     });
     es.onmessage = ev => {


### PR DESCRIPTION
## Summary
- use shared API_BASE constant in useSlotStream hook to avoid referencing Node-specific `process`

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb29870f4832dad0ef63f35b3246b