### PR TITLE
fix: keep booking bar above navigation

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -496,14 +496,14 @@ export default function BookingUI({
       </Grid>
       <Box
         component={Paper}
-        sx={{
+        sx={theme => ({
           position: 'sticky',
-          bottom: 0,
+          bottom: embedded ? 0 : theme.spacing(7),
           mt: 2,
           p: 2,
           borderRadius: { xs: 0, md: 2 },
-          zIndex: theme => theme.zIndex.appBar,
-        }}
+          zIndex: theme.zIndex.appBar,
+        })}
       >
         <Stack
           direction={{ xs: 'column', sm: 'row' }}


### PR DESCRIPTION
## Summary
- offset booking action bar so it sits above the client bottom navigation

## Testing
- `npm test` *(fails: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68bfb44acf14832da81b40e15876a446