### PR TITLE
Ensure bottom nav sits above sticky booking panel

### DIFF
--- a/MJ_FB_Frontend/src/components/ClientBottomNav.tsx
+++ b/MJ_FB_Frontend/src/components/ClientBottomNav.tsx
@@ -10,7 +10,10 @@ export default function ClientBottomNav() {
   else if (path.startsWith('/profile')) value = 'profile';
 
   return (
-    <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
+    <Paper
+      sx={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: (theme) => theme.zIndex.appBar + 1 }}
+      elevation={3}
+    >
       <BottomNavigation
         showLabels
         value={value}


### PR DESCRIPTION
## Summary
- keep client bottom navigation above sticky booking panel by bumping its z-index

## Testing
- `npm test` *(fails: unable to find "Clients: 1" in PantryVisits.test.tsx, various other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb81124e8832dabf9e8b7b0e940c9