### PR TITLE
chore: remove pantry quick links from volunteer management

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/VolunteerManagement.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import StyledTabs from '../../components/StyledTabs';
 import Page from '../../components/Page';
-import PantryQuickLinks from '../../components/PantryQuickLinks';
 import SearchVolunteer from './volunteer-management/SearchVolunteer';
 import AddVolunteer from './volunteer-management/AddVolunteer';
 import EditVolunteer from './volunteer-management/EditVolunteer';
@@ -40,7 +39,7 @@ export default function VolunteerManagement() {
   ];
 
   return (
-    <Page title="Volunteer Management" header={<PantryQuickLinks />}>
+    <Page title="Volunteer Management">
       <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} />
     </Page>
   );


### PR DESCRIPTION
## Summary
- remove pantry quick links from the staff volunteer management page

## Testing
- `npm test` *(fails: expect(element).toBeChecked, SyntaxError: Cannot use 'import.meta' outside a module, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb82cd788832db7c8d6b52ac08c68