### PR TITLE
Refactor volunteer editing to select roles by name

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import EntitySearch from '../../../components/EntitySearch';
 import {
   getVolunteerRoles,
@@ -9,10 +9,17 @@ import {
 import {
   Box,
   Button,
+  Chip,
   Checkbox,
-  FormControlLabel,
+  FormControl,
+  InputLabel,
+  ListItemText,
+  ListSubheader,
+  MenuItem,
+  Select,
   Stack,
   Typography,
+  type SelectChangeEvent,
 } from '@mui/material';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 
@@ -20,7 +27,7 @@ export default function EditVolunteer() {
   const [volunteer, setVolunteer] =
     useState<VolunteerSearchResult | null>(null);
   const [roles, setRoles] = useState<VolunteerRoleWithShifts[]>([]);
-  const [selected, setSelected] = useState<number[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
   const [message, setMessage] = useState('');
   const [severity, setSeverity] = useState<'success' | 'error'>('success');
 
@@ -30,19 +37,66 @@ export default function EditVolunteer() {
       .catch(() => setRoles([]));
   }, []);
 
+  const groupedRoles = useMemo(() => {
+    const groups = new Map<string, { name: string }[]>();
+    roles.forEach(r => {
+      const arr = groups.get(r.category_name) || [];
+      if (!arr.some(a => a.name === r.name)) arr.push({ name: r.name });
+      groups.set(r.category_name, arr);
+    });
+    return Array.from(groups.entries()).map(([category, roles]) => ({
+      category,
+      roles,
+    }));
+  }, [roles]);
+
+  const nameToRoleIds = useMemo(() => {
+    const map = new Map<string, number[]>();
+    roles.forEach(r => {
+      const arr = map.get(r.name) || [];
+      arr.push(r.id);
+      map.set(r.name, arr);
+    });
+    return map;
+  }, [roles]);
+
+  const idToName = useMemo(() => {
+    const map = new Map<number, string>();
+    roles.forEach(r => map.set(r.id, r.name));
+    return map;
+  }, [roles]);
+
   function handleSelect(v: VolunteerSearchResult) {
     setVolunteer(v);
-    setSelected(v.trainedAreas);
   }
 
-  function toggleRole(id: number, checked: boolean) {
-    setSelected(prev => (checked ? [...prev, id] : prev.filter(r => r !== id)));
+  useEffect(() => {
+    if (!volunteer) {
+      setSelected([]);
+      return;
+    }
+    const names = volunteer.trainedAreas
+      .map(id => idToName.get(id))
+      .filter((n): n is string => !!n);
+    setSelected(names);
+  }, [volunteer, idToName]);
+
+  function handleChange(event: SelectChangeEvent<string[]>) {
+    const value = event.target.value as string[];
+    setSelected(typeof value === 'string' ? value.split(',') : value);
+  }
+
+  function handleDelete(name: string) {
+    setSelected(prev => prev.filter(r => r !== name));
   }
 
   async function handleSave() {
     if (!volunteer) return;
     try {
-      await updateVolunteerTrainedAreas(volunteer.id, selected);
+      const ids = Array.from(
+        new Set(selected.flatMap(name => nameToRoleIds.get(name) || [])),
+      );
+      await updateVolunteerTrainedAreas(volunteer.id, ids);
       setMessage('Volunteer updated');
       setSeverity('success');
     } catch (err: unknown) {
@@ -64,18 +118,34 @@ export default function EditVolunteer() {
       {volunteer && (
         <Stack spacing={2} mt={2} maxWidth={400}>
           <Typography>{volunteer.name}</Typography>
-          {roles.map(r => (
-            <FormControlLabel
-              key={r.id}
-              control={
-                <Checkbox
-                  checked={selected.includes(r.id)}
-                  onChange={e => toggleRole(r.id, e.target.checked)}
-                />
-              }
-              label={r.name}
-            />
-          ))}
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            {selected.map(name => (
+              <Chip key={name} label={name} onDelete={() => handleDelete(name)} />
+            ))}
+          </Stack>
+          <FormControl fullWidth>
+            <InputLabel id="roles-label">Roles</InputLabel>
+            <Select
+              labelId="roles-label"
+              multiple
+              value={selected}
+              label="Roles"
+              onChange={handleChange}
+              renderValue={selected => (selected as string[]).join(', ')}
+            >
+              {groupedRoles.map(g => (
+                <div key={g.category}>
+                  <ListSubheader>{g.category}</ListSubheader>
+                  {g.roles.map(r => (
+                    <MenuItem key={r.name} value={r.name}>
+                      <Checkbox checked={selected.includes(r.name)} />
+                      <ListItemText primary={r.name} />
+                    </MenuItem>
+                  ))}
+                </div>
+              ))}
+            </Select>
+          </FormControl>
           <Button variant="contained" onClick={handleSave}>
             Save
           </Button>

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/__tests__/EditVolunteer.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/__tests__/EditVolunteer.test.tsx
@@ -1,0 +1,64 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EditVolunteer from '../EditVolunteer';
+import { renderWithProviders } from '../../../../../testUtils/renderWithProviders';
+import { getVolunteerRoles } from '../../../../api/volunteers';
+
+jest.mock('../../../../api/volunteers');
+
+const mockVolunteer = { id: 1, name: 'Jane Doe', trainedAreas: [1] };
+
+jest.mock('../../../../components/EntitySearch', () => (props: any) => (
+  <button onClick={() => props.onSelect(mockVolunteer)}>select volunteer</button>
+));
+
+describe('EditVolunteer role selection', () => {
+  const roles = [
+    {
+      id: 1,
+      category_id: 1,
+      name: 'Pantry',
+      max_volunteers: 1,
+      category_name: 'General',
+      shifts: [],
+    },
+    {
+      id: 2,
+      category_id: 1,
+      name: 'Warehouse',
+      max_volunteers: 1,
+      category_name: 'General',
+      shifts: [],
+    },
+  ];
+
+  beforeEach(() => {
+    (getVolunteerRoles as jest.Mock).mockResolvedValue(roles);
+  });
+
+  it('adds chip when selecting from dropdown', async () => {
+    renderWithProviders(<EditVolunteer />);
+    await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', { name: /select volunteer/i }));
+    expect(await screen.findByText('Pantry')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Roles'));
+    await userEvent.click(await screen.findByText('Warehouse'));
+    await userEvent.click(document.body);
+
+    expect(screen.getByText('Warehouse')).toBeInTheDocument();
+  });
+
+  it('removes chip on delete', async () => {
+    renderWithProviders(<EditVolunteer />);
+    await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', { name: /select volunteer/i }));
+    const chip = await screen.findByText('Pantry');
+    const deleteIcon = chip.parentElement?.querySelector('svg');
+    if (deleteIcon) await userEvent.click(deleteIcon);
+    expect(screen.queryByText('Pantry')).not.toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- refactor EditVolunteer to manage role selections by name and display chips for chosen roles
- use grouped role data with name-to-id mappings and multi-select dropdown
- add tests covering role selection and chip deletion

## Testing
- `npm test` *(fails: TestingLibraryElementError and SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb820cb5c832d858ec763dc40ad0e