### PR TITLE
Add date picker & today navigation to volunteer schedules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Use Node.js 22+; run `nvm use` to switch to the pinned version in `.nvmrc`.
 - Keep recurring-booking tests current in both the backend and frontend whenever this feature changes.
 - The pantry schedule receives live updates through an SSE endpoint at `/bookings/stream`.
-- Pantry and volunteer schedules include a date picker for jumping directly to specific days.
+- Pantry and volunteer schedules include a Today button and a date picker for jumping directly to specific days.
 - `/slots/range` returns 90 days of availability by default so the pantry schedule can load slots three months ahead.
 - Staff can add existing clients to the app from the pantry schedule's Assign User modal by entering a client ID. The client is created as a shopper with online access disabled and immediately assigned to the selected slot.
 - A unified `/login` page serves clients, staff, volunteers, and agencies; everyone signs in with their client ID or email and password.

--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -438,3 +438,62 @@ describe('VolunteerManagement schedule statuses', () => {
   });
 });
 
+describe('VolunteerManagement schedule navigation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-29T19:00:00Z'));
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        category_id: 1,
+        name: 'Greeter',
+        max_volunteers: 1,
+        category_name: 'Front',
+        shifts: [
+          {
+            id: 10,
+            start_time: '09:00:00',
+            end_time: '10:00:00',
+            is_wednesday_slot: false,
+            is_active: true,
+          },
+        ],
+      },
+    ]);
+    (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resets to today when Today is clicked', async () => {
+    render(
+      <MemoryRouter initialEntries={['/volunteers/schedule']}>
+        <Routes>
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.mouseDown(screen.getByLabelText('Role'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Greeter' }));
+
+    const nextBtn = await screen.findByRole('button', { name: 'Next' });
+    fireEvent.click(nextBtn);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+        '2024-01-30',
+      ),
+    );
+
+    const todayBtn = screen.getByRole('button', { name: 'Today' });
+    fireEvent.click(todayBtn);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+        '2024-01-29',
+      ),
+    );
+  });
+});
+

--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -243,4 +243,49 @@ describe("VolunteerSchedule", () => {
 
     await waitFor(() => expect(requestVolunteerBooking).toHaveBeenCalled());
   });
+
+  it('jumps to today when Today is clicked', async () => {
+    (getHolidays as jest.Mock).mockResolvedValue([]);
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        name: 'Greeter',
+        start_time: '9:00:00',
+        end_time: '12:00:00',
+        max_volunteers: 1,
+        booked: 0,
+        available: 1,
+        status: 'available',
+        date: '2024-01-29',
+        category_id: 1,
+        category_name: 'Front',
+        is_wednesday_slot: false,
+      },
+    ]);
+
+    renderWithProviders(<VolunteerSchedule />);
+
+    fireEvent.mouseDown(screen.getByLabelText(i18n.t('role')));
+    fireEvent.click(await screen.findByText('Greeter'));
+
+    const nextBtn = await screen.findByRole('button', { name: 'Next' });
+    fireEvent.click(nextBtn);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { level: 3 }),
+      ).toHaveTextContent('2024-01-30'),
+    );
+
+    const todayBtn = screen.getByRole('button', { name: 'Today' });
+    fireEvent.click(todayBtn);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { level: 3 }),
+      ).toHaveTextContent('2024-01-29'),
+    );
+  });
 });

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -46,6 +46,8 @@ import {
   Chip,
   CircularProgress,
 } from '@mui/material';
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { lighten } from '@mui/material/styles';
 const Dashboard = React.lazy(
   () => import('../../components/dashboard/Dashboard')
@@ -53,6 +55,7 @@ const Dashboard = React.lazy(
 import EntitySearch from '../../components/EntitySearch';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { formatDate, addDays } from '../../utils/date';
+import dayjs from '../../utils/date';
 import Page from '../../components/Page';
 import { useTranslation } from 'react-i18next';
 import EditVolunteerDialog from './EditVolunteerDialog';
@@ -237,6 +240,10 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
     const todayStr = formatDate();
     return fromZonedTime(`${todayStr}T00:00:00`, reginaTimeZone);
   });
+  const todayStart = fromZonedTime(
+    `${formatDate()}T00:00:00`,
+    reginaTimeZone,
+  );
 
   function changeDay(delta: number) {
     setCurrentDate(d => addDays(d, delta));
@@ -763,13 +770,11 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
           </FormControl>
           {selectedRole && roleInfos.length > 0 ? (
             <>
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  mt: 2,
-                }}
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+                mt={2}
               >
                 <Button onClick={() => changeDay(-1)} variant="outlined" color="primary">
                   Previous
@@ -781,10 +786,39 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                 >
                   {formatDate(currentDate)}
                 </Typography>
-                <Button onClick={() => changeDay(1)} variant="outlined" color="primary">
-                  Next
-                </Button>
-              </Box>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Button
+                    onClick={() => setCurrentDate(todayStart)}
+                    variant="outlined"
+                    color="primary"
+                  >
+                    Today
+                  </Button>
+                  <LocalizationProvider
+                    dateAdapter={AdapterDayjs}
+                    dateLibInstance={dayjs}
+                  >
+                    <DatePicker
+                      value={dayjs(currentDate)}
+                      format="YYYY-MM-DD"
+                      onChange={(d) => {
+                        if (d) {
+                          setCurrentDate(
+                            fromZonedTime(
+                              `${formatDate(d)}T00:00:00`,
+                              reginaTimeZone,
+                            ),
+                          );
+                        }
+                      }}
+                      slotProps={{ textField: { size: 'medium' } }}
+                    />
+                  </LocalizationProvider>
+                  <Button onClick={() => changeDay(1)} variant="outlined" color="primary">
+                    Next
+                  </Button>
+                </Stack>
+              </Stack>
               <VolunteerScheduleTable
                 maxSlots={maxSlots}
                 rows={rows}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -419,13 +419,11 @@ export default function VolunteerSchedule() {
         </FormControl>
         {selectedRoleKey ? (
           <>
-            <Box
-              sx={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                mb: 2,
-              }}
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              mb={2}
             >
               <Button
                 size="large"
@@ -436,19 +434,31 @@ export default function VolunteerSchedule() {
               >
                 Previous
               </Button>
+              <Typography
+                variant="h5"
+                component="h3"
+                sx={{ fontWeight: theme.typography.fontWeightBold }}
+              >
+                {dateStr} - {dayName}
+                {isHoliday
+                  ? ` (Holiday${holidayObj?.reason ? ": " + holidayObj.reason : ""})`
+                  : isWeekend
+                    ? " (Weekend)"
+                    : ""}
+              </Typography>
               <Stack direction="row" spacing={1} alignItems="center">
-                <Typography
-                  variant="h5"
-                  component="h3"
-                  sx={{ fontWeight: theme.typography.fontWeightBold }}
+                <Button
+                  size="large"
+                  onClick={() =>
+                    setCurrentDate(
+                      fromZonedTime(`${formatDate()}T00:00:00`, reginaTimeZone),
+                    )
+                  }
+                  variant="outlined"
+                  color="primary"
                 >
-                  {dateStr} - {dayName}
-                  {isHoliday
-                    ? ` (Holiday${holidayObj?.reason ? ": " + holidayObj.reason : ""})`
-                    : isWeekend
-                      ? " (Weekend)"
-                      : ""}
-                </Typography>
+                  Today
+                </Button>
                 <LocalizationProvider
                   dateAdapter={AdapterDayjs}
                   dateLibInstance={dayjs}
@@ -469,16 +479,16 @@ export default function VolunteerSchedule() {
                     slotProps={{ textField: { size: "medium" } }}
                   />
                 </LocalizationProvider>
+                <Button
+                  size="large"
+                  onClick={() => changeDay(1)}
+                  variant="outlined"
+                  color="primary"
+                >
+                  Next
+                </Button>
               </Stack>
-              <Button
-                size="large"
-                onClick={() => changeDay(1)}
-                variant="outlined"
-                color="primary"
-              >
-                Next
-              </Button>
-            </Box>
+            </Stack>
             <FeedbackSnackbar
               open={!!message}
               onClose={() => setMessage("")}

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Filled pantry schedule slots display the client's ID in parentheses, or show `[NEW CLIENT] Name` when booked for an unregistered individual.
 - Staff can add existing clients to the app from the pantry schedule's **Assign User** modal by entering a client ID and choosing **Add existing client to the app**, which creates a shopper without online access and assigns the slot.
 - Pantry and volunteer schedule pages present a mobile-friendly card layout on extra-small screens.
-- Pantry and volunteer schedules include a date picker for jumping directly to specific days.
+- Pantry and volunteer schedules include a Today button and a date picker for jumping directly to specific days.
 - Font sizes on mobile screens have been slightly increased for better readability.
 - Wednesdays include an additional 6:30–7:00 PM pantry slot.
 - Agencies can book appointments for their associated clients via the Agency → Book Appointment page. Clients are searched server-side and appear as you type, avoiding long lists. The page hides the client list after a selection and uses a single “Book Appointment” heading for clarity.


### PR DESCRIPTION
## Summary
- add Today button and date picker to volunteer schedule pages
- document schedule navigation options

## Testing
- `npm test` *(fails: PantryVisits › shows summary for visits)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb8f12e04832daf7937151eebb07b