### PR TITLE
feat: enhance volunteer role editing

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteer.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import EditVolunteer from '../volunteer-management/EditVolunteer';
 import {
@@ -8,13 +8,17 @@ import {
   getVolunteerById,
 } from '../../../api/volunteers';
 
-jest.mock('../../../api/volunteers', () => ({
-  getVolunteerRoles: jest.fn(),
-  updateVolunteerTrainedAreas: jest.fn(),
-  createVolunteerShopperProfile: jest.fn(),
-  removeVolunteerShopperProfile: jest.fn(),
-  getVolunteerById: jest.fn(),
-}));
+jest.mock('../../../api/volunteers', () => {
+  const actual = jest.requireActual('../../../api/volunteers');
+  return {
+    ...actual,
+    getVolunteerRoles: jest.fn(),
+    updateVolunteerTrainedAreas: jest.fn(),
+    createVolunteerShopperProfile: jest.fn(),
+    removeVolunteerShopperProfile: jest.fn(),
+    getVolunteerById: jest.fn(),
+  };
+});
 
 const mockVolunteer: any = {
   id: 1,
@@ -105,5 +109,76 @@ describe('EditVolunteer shopper profile', () => {
       expect(removeVolunteerShopperProfile).toHaveBeenCalledWith(2),
     );
     expect(getVolunteerById).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('EditVolunteer role selection', () => {
+  beforeEach(() => {
+    (getVolunteerRoles as jest.Mock).mockReset();
+    (createVolunteerShopperProfile as jest.Mock).mockReset();
+    (removeVolunteerShopperProfile as jest.Mock).mockReset();
+    (getVolunteerById as jest.Mock).mockReset();
+  });
+
+  it('adds role via dropdown', async () => {
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        category_id: 1,
+        name: 'Role A',
+        max_volunteers: 1,
+        category_name: 'Master 1',
+        shifts: [],
+      },
+      {
+        id: 2,
+        category_id: 1,
+        name: 'Role B',
+        max_volunteers: 1,
+        category_name: 'Master 1',
+        shifts: [],
+      },
+    ]);
+    mockVolunteer.trainedAreas = [];
+
+    render(
+      <MemoryRouter>
+        <EditVolunteer />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.mouseDown(screen.getByLabelText(/roles/i));
+    const listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText('Role A'));
+    fireEvent.keyDown(listbox, { key: 'Escape' });
+
+    expect(await screen.findByText('Role A')).toBeInTheDocument();
+  });
+
+  it('removes role via chip delete', async () => {
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        category_id: 1,
+        name: 'Role A',
+        max_volunteers: 1,
+        category_name: 'Master 1',
+        shifts: [],
+      },
+    ]);
+    mockVolunteer.trainedAreas = [1];
+
+    render(
+      <MemoryRouter>
+        <EditVolunteer />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText('Select Volunteer'));
+    const chip = await screen.findByText('Role A');
+    const deleteBtn = within(chip.parentElement as HTMLElement).getByRole('button');
+    fireEvent.click(deleteBtn);
+    expect(screen.queryByText('Role A')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- store volunteer role selections by name and map to IDs on save
- show current roles as removable chips and provide grouped multi-select for adding roles
- test role chip removal and selection via dropdown

## Testing
- `npm test` *(fails: TestingLibraryElementError: Unable to find an element with the text: Clients: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb9a7959c832d829421c5743f8b0a