### PR TITLE
Hide biometrics login button on desktop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - `/slots/range` returns 90 days of availability by default so the pantry schedule can load slots three months ahead.
 - Staff can add existing clients to the app from the pantry schedule's Assign User modal by entering a client ID. The client is created as a shopper with online access disabled and immediately assigned to the selected slot.
 - A unified `/login` page serves clients, staff, volunteers, and agencies; everyone signs in with their client ID or email and password.
-- The login page offers a **Use biometrics** button for WebAuthn-based sign in.
+- The login page on mobile offers a **Use biometrics** button for WebAuthn-based sign in.
 - Volunteers see an Install App button on their first visit to volunteer pages with an onboarding modal about offline use; installations are tracked.
 - Client and volunteer dashboards show an onboarding modal with tips on first visit; a localStorage flag prevents repeat displays.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Login from '../pages/auth/Login';
 import { login, resendPasswordSetup } from '../api/users';
+import * as mui from '@mui/material';
 
 jest.mock('../api/users', () => ({
   login: jest.fn(),
@@ -71,6 +72,32 @@ describe('Login component', () => {
     await waitFor(() =>
       expect(screen.getByLabelText(/email or client id/i)).toBeInTheDocument(),
     );
+  });
+
+  it('hides biometrics button on desktop', () => {
+    const onLogin = jest.fn().mockResolvedValue('/');
+    render(
+      <MemoryRouter>
+        <Login onLogin={onLogin} />
+      </MemoryRouter>
+    );
+    expect(
+      screen.queryByRole('button', { name: /use biometrics/i })
+    ).toBeNull();
+  });
+
+  it('shows biometrics button on small screens', () => {
+    const mq = jest.spyOn(mui, 'useMediaQuery').mockReturnValue(true);
+    const onLogin = jest.fn().mockResolvedValue('/');
+    render(
+      <MemoryRouter>
+        <Login onLogin={onLogin} />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole('button', { name: /use biometrics/i })
+    ).toBeInTheDocument();
+    mq.mockRestore();
   });
 
 });

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -6,6 +6,8 @@ import type { LoginResponse } from '../../api/users';
 import type { ApiError } from '../../api/client';
 import { Link, TextField, Button, Box, Dialog, DialogContent, IconButton, Typography, Stack } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import PasswordField from '../../components/PasswordField';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -28,6 +30,8 @@ export default function Login({
   const [noticeOpen, setNoticeOpen] = useState(false);
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   useEffect(() => {
     const count = Number(localStorage.getItem('clientLoginNoticeCount') ?? '0');
@@ -157,15 +161,17 @@ export default function Login({
               >
                 {t('login')}
               </Button>
-              <Button
-                type="button"
-                variant="outlined"
-                fullWidth
-                size="medium"
-                onClick={handleWebAuthn}
-              >
-                {t('use_biometrics')}
-              </Button>
+              {isMobile && (
+                <Button
+                  type="button"
+                  variant="outlined"
+                  fullWidth
+                  size="medium"
+                  onClick={handleWebAuthn}
+                >
+                  {t('use_biometrics')}
+                </Button>
+              )}
             </Stack>
           }
           centered={false}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Email templates display times in 12-hour AM/PM format.
 - Past blocked slots are cleared nightly, with `/api/blocked-slots/cleanup` available for admins to trigger a manual cleanup.
 - All users sign in at a consolidated `/login` page using their client ID or email and password. The page offers contact and password reset guidance and notes that staff, volunteers, and agencies also sign in here.
-- A **Use biometrics** option on the login page lets users sign in with platform authenticators via WebAuthn.
+- A **Use biometrics** option on the mobile login page lets users sign in with platform authenticators via WebAuthn.
 - Password reset dialog prompts clients to enter their client ID and explains that a reset link will be emailed.
 - Input fields feature larger touch targets on mobile devices for easier tapping.
 - Staff dashboards include a Volunteer Coverage card; click a role to see which volunteers are on duty.


### PR DESCRIPTION
## Summary
- Show WebAuthn biometric login only on small screens
- Cover login biometrics visibility with new tests
- Document mobile-only biometrics option in README and AGENTS

## Testing
- `npm test` *(fails: PantryVisits.test.tsx, PantrySchedule.test.tsx, Login.test.tsx, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb8db394832da7ce64a1752a4532