### PR TITLE
Use React Router navigation hooks for bottom nav bars

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientBottomNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientBottomNav.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ClientBottomNav from '../components/ClientBottomNav';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+describe('ClientBottomNav', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('highlights bookings tab on booking routes', () => {
+    render(
+      <MemoryRouter initialEntries={['/booking-history']}>
+        <ClientBottomNav />
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText('bookings')).toHaveClass('Mui-selected');
+  });
+
+  it('navigates to profile when profile tab clicked', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ClientBottomNav />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByLabelText('profile'));
+    expect(mockNavigate).toHaveBeenCalledWith('/profile');
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/VolunteerBottomNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBottomNav.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerBottomNav from '../components/VolunteerBottomNav';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+describe('VolunteerBottomNav', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('selects schedule tab when on schedule route', () => {
+    render(
+      <MemoryRouter initialEntries={['/volunteer/schedule']}>
+        <VolunteerBottomNav />
+      </MemoryRouter>,
+    );
+    const scheduleBtn = screen.getByRole('button', { name: /schedule/i });
+    expect(scheduleBtn).toHaveClass('Mui-selected');
+  });
+
+  it('navigates to dashboard when dashboard tab clicked', () => {
+    render(
+      <MemoryRouter initialEntries={['/volunteer/schedule']}>
+        <VolunteerBottomNav />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /dashboard/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/volunteer');
+  });
+});

--- a/MJ_FB_Frontend/src/components/ClientBottomNav.tsx
+++ b/MJ_FB_Frontend/src/components/ClientBottomNav.tsx
@@ -3,13 +3,15 @@ import Dashboard from '@mui/icons-material/Dashboard';
 import CalendarToday from '@mui/icons-material/CalendarToday';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import { useTheme } from '@mui/material/styles';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function ClientBottomNav() {
   const theme = useTheme();
-  const path = typeof window !== 'undefined' ? window.location.pathname : '/';
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
   let value: 'dashboard' | 'bookings' | 'profile' = 'dashboard';
-  if (path.startsWith('/book-appointment') || path.startsWith('/booking-history')) value = 'bookings';
-  else if (path.startsWith('/profile')) value = 'profile';
+  if (pathname.startsWith('/book-appointment') || pathname.startsWith('/booking-history')) value = 'bookings';
+  else if (pathname.startsWith('/profile')) value = 'profile';
 
   return (
     <Paper
@@ -20,9 +22,9 @@ export default function ClientBottomNav() {
         showLabels
         value={value}
         onChange={(_, newValue) => {
-          if (newValue === 'dashboard') window.location.assign('/');
-          if (newValue === 'bookings') window.location.assign('/book-appointment');
-          if (newValue === 'profile') window.location.assign('/profile');
+          if (newValue === 'dashboard') navigate('/');
+          if (newValue === 'bookings') navigate('/book-appointment');
+          if (newValue === 'profile') navigate('/profile');
         }}
       >
         <BottomNavigationAction label="Dashboard" value="dashboard" icon={<Dashboard />} aria-label="dashboard" />

--- a/MJ_FB_Frontend/src/components/VolunteerBottomNav.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerBottomNav.tsx
@@ -1,10 +1,12 @@
 import { BottomNavigation, BottomNavigationAction, Paper } from '@mui/material';
 import Dashboard from '@mui/icons-material/Dashboard';
 import CalendarToday from '@mui/icons-material/CalendarToday';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function VolunteerBottomNav() {
-  const path = typeof window !== 'undefined' ? window.location.pathname : '/volunteer';
-  const value = path.startsWith('/volunteer/schedule') ? 'schedule' : 'dashboard';
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const value = pathname.startsWith('/volunteer/schedule') ? 'schedule' : 'dashboard';
 
   return (
     <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
@@ -12,8 +14,8 @@ export default function VolunteerBottomNav() {
         showLabels
         value={value}
         onChange={(_, newValue) => {
-          if (newValue === 'dashboard') window.location.assign('/volunteer');
-          if (newValue === 'schedule') window.location.assign('/volunteer/schedule');
+          if (newValue === 'dashboard') navigate('/volunteer');
+          if (newValue === 'schedule') navigate('/volunteer/schedule');
         }}
       >
         <BottomNavigationAction


### PR DESCRIPTION
## Summary
- use `useNavigate` and `useLocation` for client and volunteer bottom navs
- add tests covering active tab state and navigation

## Testing
- `npm test` *(fails: Unable to find element; additional failures in other suites)*
- `npm test src/__tests__/ClientBottomNav.test.tsx src/__tests__/VolunteerBottomNav.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfbc23efd4832d95559486ff30f1c1