### PR TITLE
feat: add bottom navs to booking pages

### DIFF
--- a/MJ_FB_Frontend/AGENTS.md
+++ b/MJ_FB_Frontend/AGENTS.md
@@ -13,6 +13,7 @@
 - React app built with Vite.
 - Build requires `VITE_API_BASE` to be set in `MJ_FB_Frontend/.env`.
 - `pages/` define top-level views and are organized into feature-based directories (booking, staff, volunteer-management, warehouse-management, etc.).
+- Client pages include `<ClientBottomNav />`, and volunteer pages include `<VolunteerBottomNav />` for consistent navigation.
 - `components/` provide reusable UI elements; use `FeedbackSnackbar` for notifications. The dashboard UI lives in `components/dashboard`.
 - `api/` wraps server requests.
 - `utils/`, `types.ts`, and theming files manage helpers, typings, and Material UI themes.

--- a/MJ_FB_Frontend/src/pages/CancelBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/CancelBooking.tsx
@@ -4,6 +4,7 @@ import { Typography, Button, Grid } from '@mui/material';
 import Page from '../components/Page';
 import FormCard from '../components/FormCard';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
+import ClientBottomNav from '../components/ClientBottomNav';
 import { cancelBookingByToken } from '../api/bookings';
 import { useTranslation } from 'react-i18next';
 
@@ -55,6 +56,7 @@ export default function CancelBooking() {
         message={error || message}
         severity={error ? 'error' : 'success'}
       />
+      <ClientBottomNav />
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
@@ -9,6 +9,7 @@ import {
 import Page from '../components/Page';
 import FormCard from '../components/FormCard';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
+import ClientBottomNav from '../components/ClientBottomNav';
 import { getSlots, rescheduleBookingByToken } from '../api/bookings';
 import { formatTime } from '../utils/time';
 import { formatReginaDate, toDayjs } from '../utils/date';
@@ -118,6 +119,7 @@ export default function RescheduleBooking() {
         message={error || message}
         severity={error ? 'error' : 'success'}
       />
+      <ClientBottomNav />
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBooking.tsx
@@ -29,6 +29,7 @@ import { formatTime } from '../../utils/time';
 import Page from '../../components/Page';
 import OverlapBookingDialog from '../../components/OverlapBookingDialog';
 import useHolidays from '../../hooks/useHolidays';
+import VolunteerBottomNav from '../../components/VolunteerBottomNav';
 import type { VolunteerBookingConflict } from '../../types';
 
 function useVolunteerSlots(
@@ -272,6 +273,7 @@ export default function VolunteerBooking() {
           duration={4000}
         />
       </Container>
+      <VolunteerBottomNav />
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
@@ -12,6 +12,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import VolunteerRescheduleDialog from '../../components/VolunteerRescheduleDialog';
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
+import VolunteerBottomNav from '../../components/VolunteerBottomNav';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -212,6 +213,7 @@ export default function VolunteerBookingHistory() {
         message={message}
         severity={severity}
       />
+      <VolunteerBottomNav />
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerRecurringBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerRecurringBookings.tsx
@@ -14,6 +14,7 @@ import type {
 } from '../../types';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import VolunteerBottomNav from '../../components/VolunteerBottomNav';
 import {
   Box,
   FormControl,
@@ -257,6 +258,7 @@ export default function VolunteerRecurringBookings() {
         message={message}
         severity={severity}
       />
+      <VolunteerBottomNav />
     </Page>
   );
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Password fields include a visibility toggle so users can verify what they type.
 - Booking confirmation emails include links to public pages for cancelling or rescheduling
   bookings at `/cancel/:token` and `/reschedule/:token`.
+- Public cancel and reschedule pages include the client bottom navigation for quick access
+  to other sections.
 - Email templates display times in 12-hour AM/PM format.
 - Past blocked slots are cleared nightly, with `/api/blocked-slots/cleanup` available for admins to trigger a manual cleanup.
 - All users sign in at a consolidated `/login` page using their client ID or email and password. The page offers contact and password reset guidance and notes that staff, volunteers, and agencies also sign in here.


### PR DESCRIPTION
## Summary
- show ClientBottomNav on cancel and reschedule pages
- show VolunteerBottomNav on volunteer booking history, booking, and recurring booking pages
- document bottom navigation requirement in frontend guide and README

## Testing
- `npm test` *(fails: TestingLibraryElementError: Unable to find an element with the text: Clients: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbc1b12a8832db76e507dc83205f2