### PR TITLE
Add shopper navigation to volunteer bottom nav

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - A unified `/login` page serves clients, staff, volunteers, and agencies; everyone signs in with their client ID or email and password.
 - The login page offers a **Use biometrics** button for WebAuthn-based sign in.
 - Volunteers see an Install App button on their first visit to volunteer pages with an onboarding modal about offline use; installations are tracked.
+- Volunteers with shopper accounts see Bookings and Profile options in the volunteer bottom navigation for quick access to their shopper features.
 - Client and volunteer dashboards show an onboarding modal with tips on first visit; a localStorage flag prevents repeat displays.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/public/locales` when client-visible text is added.

--- a/MJ_FB_Frontend/src/__tests__/VolunteerBottomNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBottomNav.test.tsx
@@ -1,0 +1,30 @@
+import VolunteerBottomNav from '../components/VolunteerBottomNav';
+import { renderWithProviders, screen } from '../../testUtils/renderWithProviders';
+
+describe('VolunteerBottomNav', () => {
+  const originalPath = window.location.pathname;
+
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.pushState({}, '', '/volunteer');
+  });
+
+  afterEach(() => {
+    window.history.pushState({}, '', originalPath);
+  });
+
+  it('shows shopper actions when userRole is shopper', () => {
+    localStorage.setItem('role', 'volunteer');
+    localStorage.setItem('userRole', 'shopper');
+    renderWithProviders(<VolunteerBottomNav />);
+    expect(screen.getByText('Bookings')).toBeInTheDocument();
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+  });
+
+  it('hides shopper actions when userRole is not shopper', () => {
+    localStorage.setItem('role', 'volunteer');
+    renderWithProviders(<VolunteerBottomNav />);
+    expect(screen.queryByText('Bookings')).toBeNull();
+    expect(screen.queryByText('Profile')).toBeNull();
+  });
+});

--- a/MJ_FB_Frontend/src/components/VolunteerBottomNav.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerBottomNav.tsx
@@ -1,10 +1,21 @@
 import { BottomNavigation, BottomNavigationAction, Paper } from '@mui/material';
 import Dashboard from '@mui/icons-material/Dashboard';
 import CalendarToday from '@mui/icons-material/CalendarToday';
+import AccountCircle from '@mui/icons-material/AccountCircle';
+import { useAuth } from '../hooks/useAuth';
 
 export default function VolunteerBottomNav() {
+  let userRole = '';
+  try {
+    userRole = useAuth().userRole;
+  } catch {}
   const path = typeof window !== 'undefined' ? window.location.pathname : '/volunteer';
-  const value = path.startsWith('/volunteer/schedule') ? 'schedule' : 'dashboard';
+  let value: 'dashboard' | 'schedule' | 'bookings' | 'profile' = 'dashboard';
+  if (path.startsWith('/volunteer/schedule')) value = 'schedule';
+  else if (userRole === 'shopper') {
+    if (path.startsWith('/book-appointment') || path.startsWith('/booking-history')) value = 'bookings';
+    else if (path.startsWith('/profile')) value = 'profile';
+  }
 
   return (
     <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
@@ -14,6 +25,8 @@ export default function VolunteerBottomNav() {
         onChange={(_, newValue) => {
           if (newValue === 'dashboard') window.location.assign('/volunteer');
           if (newValue === 'schedule') window.location.assign('/volunteer/schedule');
+          if (newValue === 'bookings') window.location.assign('/book-appointment');
+          if (newValue === 'profile') window.location.assign('/profile');
         }}
       >
         <BottomNavigationAction
@@ -26,6 +39,20 @@ export default function VolunteerBottomNav() {
           value="schedule"
           icon={<CalendarToday aria-label="schedule" />}
         />
+        {userRole === 'shopper' && (
+          <>
+            <BottomNavigationAction
+              label="Bookings"
+              value="bookings"
+              icon={<CalendarToday aria-label="bookings" />}
+            />
+            <BottomNavigationAction
+              label="Profile"
+              value="profile"
+              icon={<AccountCircle aria-label="profile" />}
+            />
+          </>
+        )}
       </BottomNavigation>
     </Paper>
   );

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Staff dashboard includes a pantry visit trend line chart showing monthly totals for clients, adults, and children.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
 - Volunteers see an Install App button on their first visit to volunteer pages. An onboarding modal explains offline benefits, and installs are tracked. iOS users should use Safari's **Add to Home Screen**.
+- Volunteers with shopper accounts see Bookings and Profile options in the volunteer bottom navigation for quick access to their shopper features.
 - Client and volunteer dashboards display onboarding tips on first visit and store a local flag to avoid repeat prompts.
 - An Install App button appears when the app is installable; iOS users should use Safari's **Add to Home Screen**.
 - A Workbox service worker caches built assets plus schedule, booking history, and profile API responses, provides an offline fallback page, and queues offline booking actions for background sync.


### PR DESCRIPTION
## Summary
- extend VolunteerBottomNav to show Bookings and Profile links for shoppers
- document new volunteer shopper navigation in README and AGENTS
- add VolunteerBottomNav tests

## Testing
- `npm test` *(fails: unable to find text in PantryVisits.test.tsx; SyntaxError: Cannot use 'import.meta' outside a module in PantrySchedule.test.tsx)*
- `npm test -- src/__tests__/VolunteerBottomNav.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bfbc1f2274832dbb019b22f81ec9e2