### PR TITLE
feat: add shopper nav to volunteer bottom nav

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerBottomNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBottomNav.test.tsx
@@ -3,15 +3,21 @@ import { MemoryRouter } from 'react-router-dom';
 import VolunteerBottomNav from '../components/VolunteerBottomNav';
 
 const mockNavigate = jest.fn();
+const mockUseAuth = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
 }));
 
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
 describe('VolunteerBottomNav', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
+    mockUseAuth.mockReturnValue({ userRole: '' });
   });
 
   it('selects schedule tab when on schedule route', () => {
@@ -32,5 +38,29 @@ describe('VolunteerBottomNav', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /dashboard/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/volunteer');
+  });
+
+  it('shows shopper navigation when userRole is shopper', () => {
+    mockUseAuth.mockReturnValue({ userRole: 'shopper' });
+    render(
+      <MemoryRouter initialEntries={['/volunteer']}>
+        <VolunteerBottomNav />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('button', { name: /bookings/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /profile/i })).toBeInTheDocument();
+  });
+
+  it('navigates to shopper pages', () => {
+    mockUseAuth.mockReturnValue({ userRole: 'shopper' });
+    render(
+      <MemoryRouter initialEntries={['/volunteer']}>
+        <VolunteerBottomNav />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /bookings/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/book-appointment');
+    fireEvent.click(screen.getByRole('button', { name: /profile/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/profile');
   });
 });

--- a/MJ_FB_Frontend/src/components/VolunteerBottomNav.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerBottomNav.tsx
@@ -1,12 +1,22 @@
 import { BottomNavigation, BottomNavigationAction, Paper } from '@mui/material';
 import Dashboard from '@mui/icons-material/Dashboard';
 import CalendarToday from '@mui/icons-material/CalendarToday';
+import AccountCircle from '@mui/icons-material/AccountCircle';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
 
 export default function VolunteerBottomNav() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const value = pathname.startsWith('/volunteer/schedule') ? 'schedule' : 'dashboard';
+  let userRole = '';
+  try {
+    ({ userRole } = useAuth());
+  } catch {}
+  let value: 'dashboard' | 'schedule' | 'bookings' | 'profile' = 'dashboard';
+  if (pathname.startsWith('/volunteer/schedule')) value = 'schedule';
+  else if (pathname.startsWith('/book-appointment') || pathname.startsWith('/booking-history'))
+    value = 'bookings';
+  else if (pathname.startsWith('/profile')) value = 'profile';
 
   return (
     <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
@@ -16,6 +26,8 @@ export default function VolunteerBottomNav() {
         onChange={(_, newValue) => {
           if (newValue === 'dashboard') navigate('/volunteer');
           if (newValue === 'schedule') navigate('/volunteer/schedule');
+          if (newValue === 'bookings') navigate('/book-appointment');
+          if (newValue === 'profile') navigate('/profile');
         }}
       >
         <BottomNavigationAction
@@ -28,6 +40,20 @@ export default function VolunteerBottomNav() {
           value="schedule"
           icon={<CalendarToday aria-label="schedule" />}
         />
+        {userRole === 'shopper' && [
+          <BottomNavigationAction
+            key="bookings"
+            label="Bookings"
+            value="bookings"
+            icon={<CalendarToday aria-label="bookings" />}
+          />,
+          <BottomNavigationAction
+            key="profile"
+            label="Profile"
+            value="profile"
+            icon={<AccountCircle aria-label="profile" />}
+          />,
+        ]}
       </BottomNavigation>
     </Paper>
   );


### PR DESCRIPTION
## Summary
- show bookings and profile tabs in volunteer bottom nav when shopper role detected
- cover shopper navigation in bottom nav tests

## Testing
- `npm test` *(fails: useNavigate() may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbe28e2c0832d8f1759c45ad6d773