### PR TITLE
test: fix timer cleanup in BookingUI tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -48,8 +48,6 @@ describe('BookingUI visible slots', () => {
   });
 
   afterAll(() => {
-    jest.useRealTimers();
-    jest.useFakeTimers();
     jest.setSystemTime(new Date());
     jest.useRealTimers();
   });
@@ -135,6 +133,7 @@ describe('Booking confirmation', () => {
   });
 
   afterAll(() => {
+    jest.setSystemTime(new Date());
     jest.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary
- Simplify timer cleanup in BookingUI visible slots tests
- Restore system time and real timers in Booking confirmation tests

## Testing
- `npm test` *(fails: multiple test failures, e.g., LeaveManagement.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbe41da80832db5f682922c338d6f