### PR TITLE
fix volunteer management type errors

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/AddVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/AddVolunteer.tsx
@@ -1,9 +1,6 @@
 import { useState, useEffect } from 'react';
-import {
-  createVolunteer,
-  getVolunteerRoles,
-  type VolunteerRoleWithShifts,
-} from '../../../api/volunteers';
+import { createVolunteer, getVolunteerRoles } from '../../../api/volunteers';
+import type { VolunteerRoleWithShifts } from '../../../types';
 import {
   Box,
   Button,

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
@@ -6,9 +6,9 @@ import {
   getVolunteerById,
   createVolunteerShopperProfile,
   removeVolunteerShopperProfile,
-  type VolunteerRoleWithShifts,
   type VolunteerSearchResult,
 } from '../../../api/volunteers';
+import type { VolunteerRoleWithShifts } from '../../../types';
 import {
   Box,
   Button,

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -77,18 +77,9 @@ interface RoleOption {
   has_shifts: boolean;
 }
 
-interface VolunteerResult {
-  id: number;
-  name: string;
-  firstName: string;
-  lastName: string;
-  email?: string;
-  phone?: string;
-  trainedAreas: number[];
-  hasShopper: boolean;
-  hasPassword: boolean;
+type VolunteerResult = Omit<VolunteerSearchResult, 'clientId'> & {
   clientId?: number;
-}
+};
 
 interface VolunteerManagementProps {
   initialTab?: 'dashboard' | 'schedule' | 'search' | 'create';
@@ -118,8 +109,10 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'error' | 'info' | 'warning'>('success');
 
-  const [selectedVolunteer, setSelectedVolunteer] = useState<VolunteerResult | null>(null);
-  const [editVolunteer, setEditVolunteer] = useState<VolunteerResult | null>(null);
+  const [selectedVolunteer, setSelectedVolunteer] =
+    useState<VolunteerResult | null>(null);
+  const [editVolunteer, setEditVolunteer] =
+    useState<VolunteerResult | null>(null);
   const [trainedEdit, setTrainedEdit] = useState<string[]>([]);
   const [newTrainedRole, setNewTrainedRole] = useState('');
   const [editMsg, setEditMsg] = useState('');
@@ -176,7 +169,8 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
   const [assignSearch, setAssignSearch] = useState('');
   const [assignResults, setAssignResults] = useState<VolunteerResult[]>([]);
   const [assignMsg, setAssignMsg] = useState('');
-  const [confirmAssign, setConfirmAssign] = useState<VolunteerResult | null>(null);
+  const [confirmAssign, setConfirmAssign] =
+    useState<VolunteerResult | null>(null);
   const [manageShift, setManageShift] =
     useState<VolunteerBookingDetail | null>(null);
   const [cancelRecurringBooking, setCancelRecurringBooking] =
@@ -373,7 +367,16 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
     const id = searchParams.get('id');
     const name = searchParams.get('name');
     if (id && name) {
-      selectVolunteer({ id: Number(id), name, trainedAreas: [], hasShopper: false, hasPassword: false });
+      selectVolunteer({
+        id: Number(id),
+        name,
+        firstName: name.split(' ')[0] || '',
+        lastName: name.split(' ').slice(1).join(' ') || '',
+        trainedAreas: [],
+        hasShopper: false,
+        hasPassword: false,
+        clientId: undefined,
+      });
     }
   }, [tab, searchParams, selectedVolunteer]);
 
@@ -1256,7 +1259,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
         onUpdated={handleManageUpdated}
       />
       <EditVolunteerDialog
-        volunteer={editVolunteer}
+        volunteer={editVolunteer ? { ...editVolunteer, clientId: editVolunteer.clientId ?? null } : null}
         onClose={() => setEditVolunteer(null)}
         onSaved={() => {
           setEditVolunteer(null);


### PR DESCRIPTION
## Summary
- import volunteer role types directly from shared types
- streamline volunteer search and selection types
- ensure `EditVolunteerDialog` receives nullable `clientId`

## Testing
- `npm run build`
- `npm test` *(fails: useNavigate may only be used within a Router, exceeded timeout, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc037dc48832dac6e80aa555092ca