### PR TITLE
Fix volunteer bottom nav schedule disappearing

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ProfileNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ProfileNav.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Profile from '../pages/booking/Profile';
+
+jest.mock('../api/users', () => ({
+  getUserProfile: jest.fn().mockResolvedValue({
+    firstName: 'Test',
+    lastName: 'User',
+    email: 't@e.st',
+    phone: '',
+    role: 'shopper',
+    clientId: 1,
+  }),
+  requestPasswordReset: jest.fn(),
+  updateMyProfile: jest.fn().mockResolvedValue({
+    firstName: 'Test',
+    lastName: 'User',
+    email: 't@e.st',
+    phone: '',
+    role: 'shopper',
+    clientId: 1,
+  }),
+  getUserPreferences: jest.fn().mockResolvedValue({ emailReminders: true }),
+  updateUserPreferences: jest.fn(),
+}));
+
+jest.mock('../api/volunteers', () => ({
+  getVolunteerProfile: jest.fn().mockResolvedValue({
+    firstName: 'Vol',
+    lastName: 'User',
+    email: 'v@e.st',
+    phone: '',
+    role: 'volunteer',
+    clientId: 1,
+  }),
+}));
+
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ userRole: 'shopper' }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+
+describe('Profile bottom nav', () => {
+  it('shows schedule option for volunteers', async () => {
+    render(
+      <MemoryRouter initialEntries={['/profile']}>
+        <Profile role="volunteer" />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole('button', { name: /schedule/i })).toBeInTheDocument();
+  });
+
+  it('does not show schedule option for shoppers', () => {
+    render(
+      <MemoryRouter initialEntries={['/profile']}>
+        <Profile role="shopper" />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('button', { name: /schedule/i })).not.toBeInTheDocument();
+  });
+});
+

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -40,8 +40,10 @@ import DialogCloseButton from '../components/DialogCloseButton';
 import { Link as RouterLink } from 'react-router-dom';
 import Page from '../components/Page';
 import ClientBottomNav from '../components/ClientBottomNav';
+import VolunteerBottomNav from '../components/VolunteerBottomNav';
 import type { ApiError } from '../api/client';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '../hooks/useAuth';
 
 // Wrappers to match required signatures
 function useSlots(
@@ -137,6 +139,7 @@ export default function BookingUI({
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const slotsRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
+  const { role } = useAuth();
 
   const handleStream = useCallback(
     (data: any) => {
@@ -585,7 +588,7 @@ export default function BookingUI({
   return (
     <Page title={t('book_appointment')}>
       {content}
-      <ClientBottomNav />
+      {role === 'volunteer' ? <VolunteerBottomNav /> : <ClientBottomNav />}
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/CancelBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/CancelBooking.tsx
@@ -5,14 +5,17 @@ import Page from '../components/Page';
 import FormCard from '../components/FormCard';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
 import ClientBottomNav from '../components/ClientBottomNav';
+import VolunteerBottomNav from '../components/VolunteerBottomNav';
 import { cancelBookingByToken } from '../api/bookings';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '../hooks/useAuth';
 
 export default function CancelBooking() {
   const { token } = useParams();
   const { t } = useTranslation();
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const { role } = useAuth();
 
   useEffect(() => {
     async function run() {
@@ -56,7 +59,7 @@ export default function CancelBooking() {
         message={error || message}
         severity={error ? 'error' : 'success'}
       />
-      <ClientBottomNav />
+      {role === 'volunteer' ? <VolunteerBottomNav /> : <ClientBottomNav />}
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
@@ -10,11 +10,13 @@ import Page from '../components/Page';
 import FormCard from '../components/FormCard';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
 import ClientBottomNav from '../components/ClientBottomNav';
+import VolunteerBottomNav from '../components/VolunteerBottomNav';
 import { getSlots, rescheduleBookingByToken } from '../api/bookings';
 import { formatTime } from '../utils/time';
 import { formatReginaDate, toDayjs } from '../utils/date';
 import type { Slot } from '../types';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '../hooks/useAuth';
 
 export default function RescheduleBooking() {
   const { token } = useParams();
@@ -25,6 +27,7 @@ export default function RescheduleBooking() {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const todayStr = formatReginaDate(new Date());
+  const { role } = useAuth();
 
   useEffect(() => {
     if (date) {
@@ -119,7 +122,7 @@ export default function RescheduleBooking() {
         message={error || message}
         severity={error ? 'error' : 'success'}
       />
-      <ClientBottomNav />
+      {role === 'volunteer' ? <VolunteerBottomNav /> : <ClientBottomNav />}
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -27,6 +27,7 @@ import PageCard from '../../components/layout/PageCard';
 import { useTranslation } from 'react-i18next';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import ClientBottomNav from '../../components/ClientBottomNav';
+import VolunteerBottomNav from '../../components/VolunteerBottomNav';
 
 export default function Profile({ role }: { role: Role }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
@@ -289,7 +290,7 @@ export default function Profile({ role }: { role: Role }) {
         severity={toast.severity}
       />
     </PageContainer>
-    <ClientBottomNav />
+      {role === 'volunteer' ? <VolunteerBottomNav /> : <ClientBottomNav />}
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## Summary
- show volunteer schedule tab on booking and profile pages
- cover bottom nav behavior for volunteers vs shoppers

## Testing
- `npm test src/__tests__/ProfileNav.test.tsx`
- `npm test` *(fails: unable to find button/act warnings in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc09d632c832d8b09145279904dbf