### PR TITLE
Fix composite key creation in user preferences migration

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000033_add_user_preferences.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000033_add_user_preferences.ts
@@ -6,7 +6,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     user_type: { type: 'text', notNull: true },
     email_reminders: { type: 'boolean', notNull: true, default: true },
   });
-  pgm.createPrimaryKey('user_preferences', ['user_id', 'user_type']);
+  pgm.addConstraint('user_preferences', 'user_preferences_pkey', {
+    primaryKey: ['user_id', 'user_type'],
+  });
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {


### PR DESCRIPTION
## Summary
- replace unsupported `createPrimaryKey` call with `addConstraint` for the `user_preferences` table

## Testing
- `npm test` *(fails: Test Suites: 24 failed, 106 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc58a8078832db29bfbbf94d9428f