### PR TITLE
Validate reschedule tokens and surface no-show errors

### DIFF
--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -15,6 +15,7 @@ import {
   cancelBooking,
   cancelBookingByToken,
   rescheduleBooking,
+  getRescheduleBooking,
   markBookingNoShow,
   markBookingVisited
 } from '../controllers/bookingController';
@@ -87,6 +88,7 @@ router.post(
 );
 
 // Reschedule booking by token
+router.get('/reschedule/:token', optionalAuthMiddleware, getRescheduleBooking);
 router.post('/reschedule/:token', optionalAuthMiddleware, rescheduleBooking);
 
 // Cancel booking by token

--- a/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
+++ b/MJ_FB_Backend/tests/bookingRescheduleEmail.test.ts
@@ -104,4 +104,22 @@ describe('rescheduleBooking', () => {
     expect(enqueueEmailMock).toHaveBeenCalledTimes(1);
     expect(enqueueEmailMock.mock.calls[0][0].to).toBe('client@example.com');
   });
+
+  it('returns no-show message when booking is marked no_show', async () => {
+    fetchBookingByTokenMock.mockResolvedValueOnce({ status: 'no_show' });
+    const req = {
+      params: { token: 'tok' },
+      body: { slotId: 6, date: '2025-01-05' },
+    } as unknown as Request;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await rescheduleBooking(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message:
+        'This booking has already expired and was marked as a no-show. Please book a new appointment.',
+    });
+  });
 });

--- a/MJ_FB_Backend/tests/getRescheduleBooking.test.ts
+++ b/MJ_FB_Backend/tests/getRescheduleBooking.test.ts
@@ -1,0 +1,51 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRescheduleBooking } from '../src/controllers/bookingController';
+import { fetchBookingByToken } from '../src/models/bookingRepository';
+
+jest.mock('../src/models/bookingRepository');
+
+const fetchBookingByTokenMock = fetchBookingByToken as jest.Mock;
+
+describe('getRescheduleBooking', () => {
+  beforeEach(() => {
+    fetchBookingByTokenMock.mockReset();
+  });
+
+  it('returns no-show error for no_show bookings', async () => {
+    fetchBookingByTokenMock.mockResolvedValue({ status: 'no_show' });
+    const req = { params: { token: 'tok' } } as unknown as Request;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await getRescheduleBooking(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message:
+        'This booking has already expired and was marked as a no-show. Please book a new appointment.',
+    });
+  });
+
+  it("returns can't reschedule for non-approved bookings", async () => {
+    fetchBookingByTokenMock.mockResolvedValue({ status: 'cancelled' });
+    const req = { params: { token: 'tok' } } as unknown as Request;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await getRescheduleBooking(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: "This booking can't be rescheduled" });
+  });
+
+  it('allows approved bookings', async () => {
+    fetchBookingByTokenMock.mockResolvedValue({ status: 'approved' });
+    const req = { params: { token: 'tok' } } as unknown as Request;
+    const res = { json: jest.fn() } as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    await getRescheduleBooking(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith({ message: 'Booking can be rescheduled' });
+  });
+});

--- a/MJ_FB_Frontend/public/locales/am/translation.json
+++ b/MJ_FB_Frontend/public/locales/am/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/ar/translation.json
+++ b/MJ_FB_Frontend/public/locales/ar/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/en/translation.json
+++ b/MJ_FB_Frontend/public/locales/en/translation.json
@@ -267,5 +267,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/es/translation.json
+++ b/MJ_FB_Frontend/public/locales/es/translation.json
@@ -260,5 +260,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/fa/translation.json
+++ b/MJ_FB_Frontend/public/locales/fa/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/fr/translation.json
+++ b/MJ_FB_Frontend/public/locales/fr/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/hi/translation.json
+++ b/MJ_FB_Frontend/public/locales/hi/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/ml/translation.json
+++ b/MJ_FB_Frontend/public/locales/ml/translation.json
@@ -264,5 +264,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/pa/translation.json
+++ b/MJ_FB_Frontend/public/locales/pa/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/ps/translation.json
+++ b/MJ_FB_Frontend/public/locales/ps/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/so/translation.json
+++ b/MJ_FB_Frontend/public/locales/so/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/sw/translation.json
+++ b/MJ_FB_Frontend/public/locales/sw/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/ta/translation.json
+++ b/MJ_FB_Frontend/public/locales/ta/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/ti/translation.json
+++ b/MJ_FB_Frontend/public/locales/ti/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/tl/translation.json
+++ b/MJ_FB_Frontend/public/locales/tl/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/uk/translation.json
+++ b/MJ_FB_Frontend/public/locales/uk/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/public/locales/zh/translation.json
+++ b/MJ_FB_Frontend/public/locales/zh/translation.json
@@ -259,5 +259,6 @@
     },
     "close": "Got it"
   },
-  "use_biometrics": "Use biometrics"
+  "use_biometrics": "Use biometrics",
+  "reschedule_no_show_error": "This booking has already expired and was marked as a no-show. Please book a new appointment."
 }

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -342,6 +342,13 @@ export async function createBookingForNewClient(
   await handleResponse<void>(res);
 }
 
+export async function validateRescheduleToken(
+  rescheduleToken: string,
+): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/bookings/reschedule/${rescheduleToken}`);
+  await handleResponse<void>(res);
+}
+
 export async function rescheduleBookingByToken(
   rescheduleToken: string,
   slotId: string,

--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -74,9 +74,9 @@ export default function RescheduleDialog({
       onClose();
       setDate('');
       setSlotId('');
-    } catch {
+    } catch (err: any) {
       setSnackbarSeverity('error');
-      setMessage('Failed to reschedule booking');
+      setMessage(err.message);
     }
   }
 

--- a/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
@@ -11,7 +11,7 @@ import FormCard from '../components/FormCard';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
 import ClientBottomNav from '../components/ClientBottomNav';
 import VolunteerBottomNav from '../components/VolunteerBottomNav';
-import { getSlots, rescheduleBookingByToken } from '../api/bookings';
+import { getSlots, rescheduleBookingByToken, validateRescheduleToken } from '../api/bookings';
 import { formatTime } from '../utils/time';
 import { formatReginaDate, toDayjs } from '../utils/date';
 import type { Slot } from '../types';
@@ -26,8 +26,21 @@ export default function RescheduleBooking() {
   const [slotId, setSlotId] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [tokenValid, setTokenValid] = useState(true);
   const todayStr = formatReginaDate(new Date());
   const { role } = useAuth();
+
+  useEffect(() => {
+    if (!token) {
+      setError(t('invalid_or_expired_token'));
+      setTokenValid(false);
+      return;
+    }
+    validateRescheduleToken(token).catch(err => {
+      setError(err.message);
+      setTokenValid(false);
+    });
+  }, [token, t]);
 
   useEffect(() => {
     if (date) {
@@ -67,8 +80,8 @@ export default function RescheduleBooking() {
     try {
       await rescheduleBookingByToken(token, slotId, date);
       setMessage(t('booking_rescheduled'));
-    } catch {
-      setError(t('reschedule_failed'));
+    } catch (err: any) {
+      setError(err.message || t('reschedule_failed'));
     }
   }
 
@@ -76,41 +89,43 @@ export default function RescheduleBooking() {
     <Page title={t('reschedule')}>
       <Grid container spacing={2} justifyContent="center">
         <Grid size={{ xs: 12, sm: 8, md: 6 }}>
-          <FormCard
-            title={t('reschedule')}
-            onSubmit={handleSubmit}
-            actions={
-              <Button type="submit" variant="contained">
-                {t('reschedule')}
-              </Button>
-            }
-          >
-            <TextField
-              type="date"
-              label={t('date')}
-              value={date}
-              onChange={e => setDate(e.target.value)}
-              fullWidth
-              margin="normal"
-              InputLabelProps={{ shrink: true }}
-              inputProps={{ min: todayStr }}
-            />
-            <TextField
-              select
-              label={t('time')}
-              value={slotId}
-              onChange={e => setSlotId(e.target.value)}
-              fullWidth
-              margin="normal"
-              disabled={!date || slots.length === 0}
+          {tokenValid && (
+            <FormCard
+              title={t('reschedule')}
+              onSubmit={handleSubmit}
+              actions={
+                <Button type="submit" variant="contained">
+                  {t('reschedule')}
+                </Button>
+              }
             >
-              {slots.map(s => (
-                <MenuItem key={s.id} value={s.id}>
-                  {formatTime(s.startTime)} - {formatTime(s.endTime)}
-                </MenuItem>
-              ))}
-            </TextField>
-          </FormCard>
+              <TextField
+                type="date"
+                label={t('date')}
+                value={date}
+                onChange={e => setDate(e.target.value)}
+                fullWidth
+                margin="normal"
+                InputLabelProps={{ shrink: true }}
+                inputProps={{ min: todayStr }}
+              />
+              <TextField
+                select
+                label={t('time')}
+                value={slotId}
+                onChange={e => setSlotId(e.target.value)}
+                fullWidth
+                margin="normal"
+                disabled={!date || slots.length === 0}
+              >
+                {slots.map(s => (
+                  <MenuItem key={s.id} value={s.id}>
+                    {formatTime(s.startTime)} - {formatTime(s.endTime)}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </FormCard>
+          )}
         </Grid>
       </Grid>
       <FeedbackSnackbar

--- a/docs/bookings.md
+++ b/docs/bookings.md
@@ -11,5 +11,6 @@ Translations apply only to client-visible booking messages (e.g., `no_reschedule
 - `add_to_apple_calendar`
 - `booking_rescheduled`
 - `reschedule_failed`
+- `reschedule_no_show_error`
 - `select_date_time`
 - `visits_this_month`


### PR DESCRIPTION
## Summary
- prevent rescheduling bookings marked as `no_show`
- expose `GET /bookings/reschedule/:token` to validate reschedule tokens
- verify tokens on the reschedule page and display API error messages; surface reschedule errors in dialog
- add localized `reschedule_no_show_error` string and document it

## Testing
- `npm test` *(backend – fails: Test Suites: 28 failed, 104 passed)*
- `npm test tests/bookingRescheduleEmail.test.ts tests/getRescheduleBooking.test.ts`
- `npm test` *(frontend – fails: e.g., PantryVisits.test.tsx)*


------
https://chatgpt.com/codex/tasks/task_e_68c055fa7c30832db12e98cfecc8480d