### PR TITLE
Track booking reminders to avoid duplicate emails

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000036_add_reminder_sent_to_bookings.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000036_add_reminder_sent_to_bookings.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('bookings', {
+    reminder_sent: { type: 'boolean', notNull: true, default: false },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('bookings', 'reminder_sent');
+}

--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -161,6 +161,7 @@ export async function fetchBookingsForReminder(
 ) {
   const res = await client.query(
     `SELECT
+        b.id,
         b.user_id,
         COALESCE(u.email, nc.email) as user_email,
         s.start_time,
@@ -170,7 +171,7 @@ export async function fetchBookingsForReminder(
        LEFT JOIN clients u ON b.user_id = u.client_id
        LEFT JOIN new_clients nc ON b.new_client_id = nc.id
        INNER JOIN slots s ON b.slot_id = s.id
-       WHERE b.status = 'approved' AND b.date = $1`,
+       WHERE b.status = 'approved' AND b.date = $1 AND b.reminder_sent = false`,
     [formatReginaDate(date)],
   );
   return res.rows;

--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -1,3 +1,4 @@
+import pool from '../db';
 import { fetchBookingsForReminder } from '../models/bookingRepository';
 import { enqueueEmail } from './emailQueue';
 import { formatReginaDate, formatReginaDateWithDay, formatTimeToAmPm } from './dateUtils';
@@ -33,6 +34,9 @@ export async function sendNextDayBookingReminders(): Promise<void> {
         templateId: config.bookingReminderTemplateId,
         params: { body, cancelLink, rescheduleLink, type: 'Shopping Appointment' },
       });
+      await pool.query('UPDATE bookings SET reminder_sent = true WHERE id = $1', [
+        b.id,
+      ]);
       recipients.push(b.user_email);
     }
     await notifyOps(

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -128,11 +128,12 @@ describe('bookingRepository', () => {
     const call = (mockPool.query as jest.Mock).mock.calls[0];
     expect(call[0]).toMatch(/SELECT/);
     expect(call[0]).toMatch(
-      /b.user_id,\s+COALESCE\(u.email, nc.email\) as user_email,\s+s.start_time,\s+s.end_time,\s+b.reschedule_token/,
+      /b.id,\s+b.user_id,\s+COALESCE\(u.email, nc.email\) as user_email,\s+s.start_time,\s+s.end_time,\s+b.reschedule_token/,
     );
     expect(call[0]).toMatch(/WHERE/);
     expect(call[0]).toMatch(/b.status = 'approved'/);
     expect(call[0]).toMatch(/b.date = \$1/);
+    expect(call[0]).toMatch(/b.reminder_sent = false/);
     expect(call[1]).toEqual(expect.arrayContaining(['2024-01-01']));
     expect(call[1]).toHaveLength(1);
   });


### PR DESCRIPTION
## Summary
- add `reminder_sent` column to `bookings` via migration
- skip previously reminded bookings and mark reminders sent
- ensure reminder job only queues unsent bookings once

## Testing
- `npm test tests/bookingReminderJob.test.ts tests/bookingRepository.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c06001aad8832d8e24a21723bbad2b