### PR TITLE
Filter reminder bookings by email preference

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -168,9 +168,11 @@ export async function fetchBookingsForReminder(
         b.reschedule_token
        FROM bookings b
        LEFT JOIN clients u ON b.user_id = u.client_id
+       LEFT JOIN user_preferences up ON up.user_id = b.user_id AND up.user_type = 'client'
        LEFT JOIN new_clients nc ON b.new_client_id = nc.id
        INNER JOIN slots s ON b.slot_id = s.id
-       WHERE b.status = 'approved' AND b.date = $1`,
+       WHERE b.status = 'approved' AND b.date = $1
+         AND COALESCE(up.email_reminders, true)`,
     [formatReginaDate(date)],
   );
   return res.rows;

--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -74,6 +74,17 @@ describe('sendNextDayBookingReminders', () => {
     );
   });
 
+  it('excludes users with email reminders disabled', async () => {
+    (fetchBookingsForReminder as jest.Mock).mockResolvedValue([]);
+
+    await sendNextDayBookingReminders();
+
+    expect(enqueueEmail).not.toHaveBeenCalled();
+    expect(notifyOps).toHaveBeenCalledWith(
+      'sendNextDayBookingReminders queued reminders for 0 emails',
+    );
+  });
+
   it('alerts ops and surfaces failures from enqueueEmail', async () => {
     (fetchBookingsForReminder as jest.Mock).mockResolvedValue([
       {

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -133,6 +133,10 @@ describe('bookingRepository', () => {
     expect(call[0]).toMatch(/WHERE/);
     expect(call[0]).toMatch(/b.status = 'approved'/);
     expect(call[0]).toMatch(/b.date = \$1/);
+    expect(call[0]).toMatch(
+      /LEFT JOIN user_preferences up ON up.user_id = b.user_id AND up.user_type = 'client'/,
+    );
+    expect(call[0]).toMatch(/COALESCE\(up.email_reminders, true\)/);
     expect(call[1]).toEqual(expect.arrayContaining(['2024-01-01']));
     expect(call[1]).toHaveLength(1);
   });


### PR DESCRIPTION
## Summary
- Check user email reminder preferences when selecting bookings for reminder emails
- Add tests to confirm bookings with email reminders disabled are skipped

## Testing
- `npm test` *(fails: 25 failed, 107 passed)*
- `npm test tests/bookingRepository.test.ts tests/bookingReminderJob.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c06005f004832d9d78223cc3f1645e