### PR TITLE
Respect new client email reminder preferences

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -170,8 +170,13 @@ export async function fetchBookingsForReminder(
        FROM bookings b
        LEFT JOIN clients u ON b.user_id = u.client_id
        LEFT JOIN new_clients nc ON b.new_client_id = nc.id
+       LEFT JOIN user_preferences up ON (
+         (up.user_type = 'client' AND up.user_id = b.user_id) OR
+         (up.user_type = 'new_client' AND up.user_id = b.new_client_id)
+       )
        INNER JOIN slots s ON b.slot_id = s.id
-       WHERE b.status = 'approved' AND b.date = $1 AND b.reminder_sent = false`,
+       WHERE b.status = 'approved' AND b.date = $1 AND b.reminder_sent = false
+         AND COALESCE(up.email_reminders, true)`,
     [formatReginaDate(date)],
   );
   return res.rows;

--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -120,6 +120,16 @@ describe('sendNextDayBookingReminders', () => {
       [1],
     );
   });
+
+  it('does not queue reminders for new clients who disabled email reminders', async () => {
+    (fetchBookingsForReminder as jest.Mock).mockResolvedValue([]);
+    await sendNextDayBookingReminders();
+    expect(fetchBookingsForReminder).toHaveBeenCalledWith('2024-01-02');
+    expect(enqueueEmail).not.toHaveBeenCalled();
+    expect(notifyOps).toHaveBeenCalledWith(
+      'sendNextDayBookingReminders queued reminders for 0 emails',
+    );
+  });
 });
 
 describe('startBookingReminderJob/stopBookingReminderJob', () => {

--- a/MJ_FB_Backend/tests/bookingRepository.test.ts
+++ b/MJ_FB_Backend/tests/bookingRepository.test.ts
@@ -138,6 +138,19 @@ describe('bookingRepository', () => {
     expect(call[1]).toHaveLength(1);
   });
 
+  it('fetchBookingsForReminder joins user_preferences and filters by email_reminders', async () => {
+    setQueryResults({ rows: [] });
+    await fetchBookingsForReminder('2024-01-01');
+    const [sql] = (mockPool.query as jest.Mock).mock.calls[0];
+    expect(sql).toMatch(/LEFT JOIN user_preferences up ON/);
+    expect(sql).toMatch(
+      new RegExp(
+        "\\(up.user_type = 'client' AND up.user_id = b.user_id\\)\\s+OR\\s+\\(up.user_type = 'new_client' AND up.user_id = b.new_client_id\\)",
+      ),
+    );
+    expect(sql).toMatch(/COALESCE\(up.email_reminders, true\)/);
+  });
+
   it('fetchBookingHistory supports arrays and pagination', async () => {
     setQueryResults({ rows: [] });
     await fetchBookingHistory([1, 2], false, undefined, false, 5, 10);


### PR DESCRIPTION
## Summary
- Join user_preferences when fetching bookings for reminders and honor disabled email reminders
- Add tests for user_preferences join and skipping reminders for new clients who opted out

## Testing
- `npm test tests/bookingRepository.test.ts tests/bookingReminderJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c062097f90832da56d686108249398