### PR TITLE
feat: refine monetary donor API

### DIFF
--- a/MJ_FB_Frontend/src/api/__tests__/monetaryDonorsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/monetaryDonorsApi.test.ts
@@ -1,11 +1,99 @@
 import { apiFetch } from '../client';
-import { getMailLists, sendMailListEmails } from '../monetaryDonors';
+import {
+  createMonetaryDonor,
+  updateMonetaryDonor,
+  getMonetaryDonor,
+  updateMonetaryDonation,
+  deleteMonetaryDonation,
+  getMailLists,
+  sendMailListEmails,
+} from '../monetaryDonors';
 
 jest.mock('../client', () => ({
   API_BASE: '/api',
   apiFetch: jest.fn(),
   handleResponse: jest.fn().mockResolvedValue(undefined),
 }));
+
+describe('monetary donor api', () => {
+  beforeEach(() => {
+    (apiFetch as jest.Mock).mockResolvedValue(new Response(null));
+    jest.clearAllMocks();
+  });
+
+  it('creates a donor', async () => {
+    await createMonetaryDonor({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+    });
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/monetary-donors',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane@example.com',
+        }),
+      }),
+    );
+  });
+
+  it('updates a donor', async () => {
+    await updateMonetaryDonor(1, {
+      firstName: 'John',
+      lastName: 'Smith',
+      email: 'john@example.com',
+    });
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/monetary-donors/1',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: 'John',
+          lastName: 'Smith',
+          email: 'john@example.com',
+        }),
+      }),
+    );
+  });
+
+  it('fetches a donor', async () => {
+    await getMonetaryDonor(2);
+    expect(apiFetch).toHaveBeenCalledWith('/api/monetary-donors/2');
+  });
+
+  it('updates a donation', async () => {
+    await updateMonetaryDonation(5, {
+      donorId: 3,
+      amount: 50,
+      date: '2024-01-01',
+    });
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/monetary-donors/donations/5',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          donorId: 3,
+          amount: 50,
+          date: '2024-01-01',
+        }),
+      }),
+    );
+  });
+
+  it('deletes a donation', async () => {
+    await deleteMonetaryDonation(7);
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/monetary-donors/donations/7',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});
 
 describe('monetary donor mail lists api', () => {
   beforeEach(() => {

--- a/MJ_FB_Frontend/src/api/monetaryDonors.ts
+++ b/MJ_FB_Frontend/src/api/monetaryDonors.ts
@@ -2,8 +2,9 @@ import { API_BASE, apiFetch, handleResponse } from './client';
 
 export interface MonetaryDonor {
   id: number;
-  name: string;
-  email?: string;
+  firstName: string;
+  lastName: string;
+  email: string;
 }
 
 export interface MonetaryDonation {
@@ -33,7 +34,7 @@ export async function getMonetaryDonors(): Promise<MonetaryDonor[]> {
 }
 
 export async function createMonetaryDonor(
-  data: Pick<MonetaryDonor, 'name' | 'email'>,
+  data: Pick<MonetaryDonor, 'firstName' | 'lastName' | 'email'>,
 ): Promise<MonetaryDonor> {
   const res = await apiFetch(`${API_BASE}/monetary-donors`, {
     method: 'POST',
@@ -45,7 +46,7 @@ export async function createMonetaryDonor(
 
 export async function updateMonetaryDonor(
   id: number,
-  data: Pick<MonetaryDonor, 'name' | 'email'>,
+  data: Pick<MonetaryDonor, 'firstName' | 'lastName' | 'email'>,
 ): Promise<MonetaryDonor> {
   const res = await apiFetch(`${API_BASE}/monetary-donors/${id}`, {
     method: 'PUT',
@@ -86,13 +87,17 @@ export async function createMonetaryDonation(
   return handleResponse(res);
 }
 
+export async function getMonetaryDonor(id: number): Promise<MonetaryDonor> {
+  const res = await apiFetch(`${API_BASE}/monetary-donors/${id}`);
+  return handleResponse(res);
+}
+
 export async function updateMonetaryDonation(
-  donorId: number,
   donationId: number,
-  data: Pick<MonetaryDonation, 'amount' | 'date'>,
+  data: Pick<MonetaryDonation, 'donorId' | 'amount' | 'date'>,
 ): Promise<MonetaryDonation> {
   const res = await apiFetch(
-    `${API_BASE}/monetary-donors/${donorId}/donations/${donationId}`,
+    `${API_BASE}/monetary-donors/donations/${donationId}`,
     {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -103,11 +108,10 @@ export async function updateMonetaryDonation(
 }
 
 export async function deleteMonetaryDonation(
-  donorId: number,
   donationId: number,
 ): Promise<void> {
   const res = await apiFetch(
-    `${API_BASE}/monetary-donors/${donorId}/donations/${donationId}`,
+    `${API_BASE}/monetary-donors/donations/${donationId}`,
     {
       method: 'DELETE',
     },


### PR DESCRIPTION
## Summary
- expose donor first/last names and email via MonetaryDonor type
- add getMonetaryDonor endpoint and send donor name fields on create/update
- update donation update/delete endpoints to `/monetary-donors/donations/:id`
- expand API tests for new donor and donation endpoints

## Testing
- `npm test`
- `npm test src/api/__tests__/monetaryDonorsApi.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c06bd6b358832d85b6a4266bc9c57b