### PR TITLE
Fix duplicate monetary donor retrieval export

### DIFF
--- a/MJ_FB_Frontend/src/api/monetaryDonors.ts
+++ b/MJ_FB_Frontend/src/api/monetaryDonors.ts
@@ -103,11 +103,6 @@ export async function createMonetaryDonation(
   return handleResponse(res);
 }
 
-export async function getMonetaryDonor(id: number): Promise<MonetaryDonor> {
-  const res = await apiFetch(`${API_BASE}/monetary-donors/${id}`);
-  return handleResponse(res);
-}
-
 export async function updateMonetaryDonation(
   donationId: number,
   data: Pick<MonetaryDonation, 'donorId' | 'amount' | 'date'>,


### PR DESCRIPTION
## Summary
- remove duplicate `getMonetaryDonor` function from monetary donor API module

## Testing
- `npm test` *(fails: multiple suites such as PantryVisits, VolunteerManagement, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c0700fcfbc832d9b7c7c5b400558f6