### PR TITLE
refactor: send mail list emails with body params

### DIFF
--- a/MJ_FB_Frontend/src/api/__tests__/monetaryDonorsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/monetaryDonorsApi.test.ts
@@ -107,7 +107,7 @@ describe('monetary donor mail lists api', () => {
   });
 
   it('sends mail list emails', async () => {
-    await sendMailListEmails(2024, 5);
+    await sendMailListEmails({ year: 2024, month: 5 });
     expect(apiFetch).toHaveBeenCalledWith(
       '/api/monetary-donors/mail-lists/send',
       expect.objectContaining({

--- a/MJ_FB_Frontend/src/api/monetaryDonors.ts
+++ b/MJ_FB_Frontend/src/api/monetaryDonors.ts
@@ -140,10 +140,15 @@ export async function getMailLists(
   return handleResponse(res);
 }
 
-export async function sendMailListEmails(
-  year: number,
-  month: number,
-): Promise<void> {
+export interface SendMailListParams {
+  year: number;
+  month: number;
+}
+
+export async function sendMailListEmails({
+  year,
+  month,
+}: SendMailListParams): Promise<void> {
   const res = await apiFetch(`${API_BASE}/monetary-donors/mail-lists/send`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/MJ_FB_Frontend/src/pages/donor-management/MailLists.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/MailLists.tsx
@@ -49,7 +49,7 @@ export default function MailLists() {
 
   async function handleSend() {
     try {
-      await sendMailListEmails(year, month);
+      await sendMailListEmails({ year, month });
       setSnackbar({ open: true, message: 'Emails sent', severity: 'success' });
     } catch (error: any) {
       setSnackbar({


### PR DESCRIPTION
## Summary
- pass year/month as object to send mail list emails
- update tests and donor mail list page for new API

## Testing
- `npm test` (fails: Unable to find an element with the text: Clients: 1 in PantryVisits.test.tsx, and other failing tests)


------
https://chatgpt.com/codex/tasks/task_e_68c078ca8e10832da4d9e5a6e27d7f7f