### PR TITLE
test: cover monetary donor mail list logic

### DIFF
--- a/MJ_FB_Backend/tests/monetaryDonors.test.ts
+++ b/MJ_FB_Backend/tests/monetaryDonors.test.ts
@@ -130,7 +130,28 @@ describe('Mailing list generation', () => {
     expect(res.body['501+']).toHaveLength(1);
   });
 
-  it('sends mailing lists', async () => {
+  it('uses previous month by default', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-07-05T00:00:00Z'));
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff', access: ['donor_management'] });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [authRow] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get('/monetary-donors/mail-lists')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('EXTRACT(YEAR'),
+      [2024, 6],
+    );
+    jest.useRealTimers();
+  });
+
+  it('sends mailing lists with default month and template mapping', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-07-05T00:00:00Z'));
     (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff', access: ['donor_management'] });
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 1, rows: [authRow] })
@@ -138,30 +159,41 @@ describe('Mailing list generation', () => {
         rows: [
           { first_name: 'A', email: 'a@example.com', amount: 50 },
           { first_name: 'B', email: 'b@example.com', amount: 150 },
+          { first_name: 'C', email: 'c@example.com', amount: 600 },
         ],
-        rowCount: 2,
+        rowCount: 3,
       })
       .mockResolvedValueOnce({
-        rows: [{ adults: 10, children: 5, pounds: 100 }],
+        rows: [{ families: 4, children: 7, pounds: 120 }],
       });
 
     const res = await request(app)
       .post('/monetary-donors/mail-lists/send')
-      .send({ year: 2024, month: 5 })
       .set('Authorization', 'Bearer token');
 
     expect(res.status).toBe(200);
-    expect(sendTemplatedEmail).toHaveBeenCalledTimes(2);
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('EXTRACT(YEAR'),
+      [2024, 6],
+    );
+    expect(sendTemplatedEmail).toHaveBeenCalledTimes(3);
     expect((sendTemplatedEmail as jest.Mock).mock.calls[0][0]).toEqual({
       to: 'a@example.com',
       templateId: 11,
-      params: { firstName: 'A', adults: 10, children: 5, pounds: 100, amount: 50 },
+      params: { firstName: 'A', amount: 50, families: 4, children: 7, pounds: 120 },
     });
     expect((sendTemplatedEmail as jest.Mock).mock.calls[1][0]).toEqual({
       to: 'b@example.com',
       templateId: 12,
-      params: { firstName: 'B', adults: 10, children: 5, pounds: 100, amount: 150 },
+      params: { firstName: 'B', amount: 150, families: 4, children: 7, pounds: 120 },
     });
-    expect(res.body).toEqual({ sent: 2 });
+    expect((sendTemplatedEmail as jest.Mock).mock.calls[2][0]).toEqual({
+      to: 'c@example.com',
+      templateId: 13,
+      params: { firstName: 'C', amount: 600, families: 4, children: 7, pounds: 120 },
+    });
+    expect(res.body).toEqual({ sent: 3 });
+    jest.useRealTimers();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/MailLists.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/MailLists.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MailLists from '../pages/donor-management/MailLists';
+import { getMailLists, sendMailListEmails } from '../api/monetaryDonors';
+import { renderWithProviders } from '../testUtils/renderWithProviders';
+
+jest.mock('../api/monetaryDonors', () => ({
+  getMailLists: jest.fn(),
+  sendMailListEmails: jest.fn(),
+}));
+
+describe('MailLists', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-07-05T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('calls sendMailListEmails when the send button is clicked', async () => {
+    (getMailLists as jest.Mock).mockResolvedValue({
+      '1-100': [
+        { id: 1, firstName: 'Alice', lastName: 'A', email: 'a@example.com', amount: 50 },
+      ],
+      '101-500': [],
+      '501+': [],
+    });
+
+    renderWithProviders(<MailLists />);
+
+    const btn = await screen.findByRole('button', { name: /send emails/i });
+    expect(btn).toBeEnabled();
+
+    await userEvent.click(btn);
+    expect(sendMailListEmails).toHaveBeenCalledWith(2024, 6);
+  });
+});
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Password fields include a visibility toggle so users can verify what they type.
 - Booking confirmation emails include links to public pages for cancelling or rescheduling
   bookings at `/cancel/:token` and `/reschedule/:token`.
+- Donor Management → Mail Lists groups monetary donors by monthly contribution and
+  lets staff email each group a summary of families, children, and pounds served. Month
+  defaults to the previous month when unspecified.
 - Public cancel and reschedule pages include the client bottom navigation for quick access
   to other sections.
 - Email templates display times in 12-hour AM/PM format.


### PR DESCRIPTION
## Summary
- add backend tests for donor mail list default month and template mapping
- add MailLists send button test
- document donor mail list feature

## Testing
- `npm test` (backend) *(fails: 24 failed, 108 passed)*
- `npm test` (frontend) *(fails to complete: multiple suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0794ed700832d82b5b38804e22ca0