### PR TITLE
feat: explain disabled donor email button

### DIFF
--- a/MJ_FB_Frontend/src/pages/donor-management/MailLists.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/MailLists.tsx
@@ -7,6 +7,7 @@ import {
   List,
   ListItem,
   ListItemText,
+  Tooltip,
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 import Page from '../../components/Page';
@@ -60,19 +61,33 @@ export default function MailLists() {
     }
   }
 
+  const noDonors = Boolean(lists && !RANGES.some(range => lists[range].length > 0));
+
   return (
     <Page title="Mail Lists">
       <Stack spacing={2}>
         <Stack direction="row" spacing={2} alignItems="center">
           <Typography>{`Month: ${month}`}</Typography>
           <Typography>{`Year: ${year}`}</Typography>
-          <Button
-            variant="contained"
-            onClick={handleSend}
-            disabled={!lists || !RANGES.some(range => lists[range].length > 0)}
+          <Tooltip
+            title="No donors to email for last month"
+            disableHoverListener={!noDonors}
+            disableFocusListener={!noDonors}
+            disableTouchListener={!noDonors}
           >
-            Send Emails
-          </Button>
+            <span>
+              <Button
+                variant="contained"
+                onClick={handleSend}
+                disabled={!lists || noDonors}
+              >
+                Send Emails
+              </Button>
+            </span>
+          </Tooltip>
+          {noDonors && (
+            <Typography color="text.secondary">No donors to email for last month</Typography>
+          )}
         </Stack>
         {lists &&
           RANGES.map(range => (


### PR DESCRIPTION
## Summary
- clarify disabled state for donor email button by adding tooltip and inline message when no donors are available
- add regression tests for donor mail list logic

## Testing
- `npm test src/__tests__/MailLists.test.tsx`
- `npm test` *(fails: Unable to find text in PantryVisits, plus multiple other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c083b68bb4832d942ef74120688c64