### PR TITLE
Restrict donor management access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 - Password setup emails mention the user's role and include a direct link to the appropriate login page. The password setup page includes a login button without any role-specific reminder text.
 - Profile pages let clients and volunteers toggle email reminders from `/users/me/preferences`.
 - Staff can delete client and volunteer accounts from their respective management pages; update help content when these features change.
+- Donation management pages are accessible only to staff with donor_management access.
 
 See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/AGENTS.md` for frontend-specific guidance.
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -8,7 +8,7 @@ const Dashboard = React.lazy(
 import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import MainLayout from './components/layout/MainLayout';
-import { useAuth, AgencyGuard } from './hooks/useAuth';
+import { useAuth, AgencyGuard, DonorManagementGuard } from './hooks/useAuth';
 import type { StaffAccess } from './types';
 import { getVolunteerBookingsForReview } from './api/volunteers';
 import { getStaffRootPath } from './utils/staffRootPath';
@@ -471,19 +471,35 @@ export default function App() {
                     <>
                       <Route
                         path="/donor-management"
-                        element={<DonorDashboard />}
+                        element={
+                          <DonorManagementGuard>
+                            <DonorDashboard />
+                          </DonorManagementGuard>
+                        }
                       />
                       <Route
                         path="/donor-management/donation-log"
-                        element={<DonorDonationLog />}
+                        element={
+                          <DonorManagementGuard>
+                            <DonorDonationLog />
+                          </DonorManagementGuard>
+                        }
                       />
                       <Route
                         path="/donor-management/mail-lists"
-                        element={<MailLists />}
+                        element={
+                          <DonorManagementGuard>
+                            <MailLists />
+                          </DonorManagementGuard>
+                        }
                       />
                       <Route
                         path="/donor-management/donors/:id"
-                        element={<DonorProfilePage />}
+                        element={
+                          <DonorManagementGuard>
+                            <DonorProfilePage />
+                          </DonorManagementGuard>
+                        }
                       />
                     </>
                   )}

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
 import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
 import { renderWithProviders } from '../../testUtils/renderWithProviders';
@@ -132,6 +132,16 @@ describe('App authentication persistence', () => {
     window.history.pushState({}, '', '/donor-management');
     renderWithProviders(<App />);
     expect(await screen.findByText('MailLists')).toBeInTheDocument();
+  });
+
+  it('redirects staff without donor_management access away from donor pages', async () => {
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test Staff');
+    localStorage.setItem('access', JSON.stringify(['pantry']));
+    window.history.pushState({}, '', '/donor-management/donation-log');
+    renderWithProviders(<App />);
+    await waitFor(() => expect(window.location.pathname).toBe('/'));
+    expect(screen.queryByText('DonationLogPage')).not.toBeInTheDocument();
   });
 
   it('computes donor management path for single donor management access', () => {

--- a/MJ_FB_Frontend/src/hooks/useAuth.tsx
+++ b/MJ_FB_Frontend/src/hooks/useAuth.tsx
@@ -221,3 +221,9 @@ export function AgencyGuard({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+export function DonorManagementGuard({ children }: { children: React.ReactNode }) {
+  const { role, access } = useAuth();
+  const allowed = role === 'staff' && (access.includes('admin') || access.includes('donor_management'));
+  if (!allowed) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ npm run test:frontend  # frontend tests
 - Staff can create recurring volunteer booking series for volunteers via `POST /volunteer-bookings/recurring/staff` and list active series with `GET /volunteer-bookings/recurring/volunteer/:volunteer_id`.
 - Recurring volunteer bookings and recurring blocked slots handled by [volunteerBookingController](MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts) and [recurringBlockedSlots routes](MJ_FB_Backend/src/routes/recurringBlockedSlots.ts). Volunteers can create new series and manage existing ones from separate tabs on the **Recurring Bookings** page.
 - Donor and event management modules ([donorController](MJ_FB_Backend/src/controllers/donorController.ts), [eventController](MJ_FB_Backend/src/controllers/eventController.ts)) with multi-day events supported via start and end dates.
+- Donation management pages for recording monetary donations require staff to have donor_management access.
 - Events are visible to all staff by default; the former "Staff Involved" selector has been removed.
 - Self-service client registration with email OTP verification (currently disabled pending further testing).
 - Warehouse management pages for donations, surplus, pig pound, and exports using `write-excel-file`.


### PR DESCRIPTION
## Summary
- add DonorManagementGuard to limit donor management pages to staff with donor_management access
- document donor management access requirement
- test donor page redirects for unauthorized staff

## Testing
- `npm test` *(fails: Unable to find element "Clients: 1" in PantryVisits.test.tsx; useNavigate may be used only in Router)*

------
https://chatgpt.com/codex/tasks/task_e_68c084aa3990832d9bbbf9785459bb5c