### PR TITLE
feat: add pantry week utilities

### DIFF
--- a/MJ_FB_Frontend/src/utils/__tests__/pantryWeek.test.ts
+++ b/MJ_FB_Frontend/src/utils/__tests__/pantryWeek.test.ts
@@ -1,0 +1,25 @@
+import { getWeekRanges, getWeekForDate } from '../pantryWeek';
+
+describe('getWeekRanges', () => {
+  test('splits May 2024 into weeks', () => {
+    expect(getWeekRanges(2024, 4)).toEqual([
+      { week: 1, startDate: '2024-05-01', endDate: '2024-05-05' },
+      { week: 2, startDate: '2024-05-06', endDate: '2024-05-12' },
+      { week: 3, startDate: '2024-05-13', endDate: '2024-05-19' },
+      { week: 4, startDate: '2024-05-20', endDate: '2024-05-26' },
+      { week: 5, startDate: '2024-05-27', endDate: '2024-05-31' },
+    ]);
+  });
+});
+
+describe('getWeekForDate', () => {
+  test('returns week info for a given date', () => {
+    expect(getWeekForDate('2024-05-06')).toEqual({
+      year: 2024,
+      month: 4,
+      week: 2,
+      startDate: '2024-05-06',
+      endDate: '2024-05-12',
+    });
+  });
+});

--- a/MJ_FB_Frontend/src/utils/pantryWeek.ts
+++ b/MJ_FB_Frontend/src/utils/pantryWeek.ts
@@ -1,0 +1,47 @@
+import type { ConfigType } from 'dayjs';
+import dayjs, { formatDate, toDayjs } from './date';
+
+export interface WeekRange {
+  week: number;
+  startDate: string;
+  endDate: string;
+}
+
+export function getWeekRanges(year: number, month: number): WeekRange[] {
+  const startOfMonth = dayjs({ year, month, day: 1 });
+  const endOfMonth = startOfMonth.endOf('month');
+  const dayOfWeek = startOfMonth.day();
+  const diff = (dayOfWeek + 6) % 7; // days to subtract to reach Monday
+  let current = startOfMonth.subtract(diff, 'day');
+
+  const ranges: WeekRange[] = [];
+  let week = 1;
+
+  while (current.isBefore(endOfMonth) || current.isSame(endOfMonth, 'day')) {
+    const start = current.isBefore(startOfMonth) ? startOfMonth : current;
+    const endCandidate = current.add(6, 'day');
+    const end = endCandidate.isAfter(endOfMonth) ? endOfMonth : endCandidate;
+    ranges.push({
+      week,
+      startDate: formatDate(start),
+      endDate: formatDate(end),
+    });
+    week += 1;
+    current = current.add(7, 'day');
+  }
+
+  return ranges;
+}
+
+export function getWeekForDate(date: ConfigType) {
+  const d = toDayjs(date);
+  const year = d.year();
+  const month = d.month();
+  const dateStr = formatDate(d);
+  const ranges = getWeekRanges(year, month);
+  const range = ranges.find(r => dateStr >= r.startDate && dateStr <= r.endDate);
+  if (!range) {
+    throw new Error('Date out of range');
+  }
+  return { year, month, week: range.week, startDate: range.startDate, endDate: range.endDate };
+}


### PR DESCRIPTION
## Summary
- add pantry week helper to get month week ranges and resolve week for a date
- test helper functions

## Testing
- `npm run test:frontend` *(fails: Unable to find element text, router context, useAuth errors, etc.)*
- `npm run test:backend` *(fails: client visit booking integration and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c09839f860832da4557646e99b5b35