### PR TITLE
Add pantry aggregations link for staff

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -169,6 +169,7 @@ export default function App() {
       { label: 'Pantry Visits', to: '/pantry/visits' },
       { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Agency Management', to: '/pantry/agency-management' },
+      { label: 'Aggregations', to: '/pantry/aggregations' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
@@ -360,6 +361,9 @@ export default function App() {
                   )}
                   {showStaff && (
                     <Route path="/pantry/visits" element={<PantryVisits />} />
+                  )}
+                  {showStaff && (
+                    <Route path="/pantry/aggregations" element={<Aggregations />} />
                   )}
                   {isStaff && (
                     <Route path="/timesheet" element={<Timesheets />} />

--- a/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
@@ -21,5 +21,9 @@ describe('PantryQuickLinks', () => {
       'href',
       '/pantry/client-management?tab=history',
     );
+    expect(screen.getByRole('link', { name: /Aggregations/i })).toHaveAttribute(
+      'href',
+      '/pantry/aggregations',
+    );
   });
 });

--- a/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
@@ -34,7 +34,7 @@ export default function PantryQuickLinks() {
         Record a Visit
       </Button>
       <Button
-        
+
         variant="outlined"
         sx={buttonSx}
         component={RouterLink}
@@ -42,6 +42,16 @@ export default function PantryQuickLinks() {
         fullWidth
       >
         Search Client
+      </Button>
+      <Button
+
+        variant="outlined"
+        sx={buttonSx}
+        component={RouterLink}
+        to="/pantry/aggregations"
+        fullWidth
+      >
+        Aggregations
       </Button>
     </Stack>
   );


### PR DESCRIPTION
## Summary
- add Aggregations link under Harvest Pantry navigation and routing
- expose Aggregations shortcut in pantry quick links and test

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68c0983f55e8832d841f9b32d2536173