### PR TITLE
feat: add pantry aggregation page

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -95,6 +95,9 @@ const AdminStaffList = React.lazy(() => import('./pages/admin/AdminStaffList'));
 const AdminSettings = React.lazy(() => import('./pages/admin/AdminSettings'));
 const Events = React.lazy(() => import('./pages/events/Events'));
 const PantryVisits = React.lazy(() => import('./pages/staff/PantryVisits'));
+const PantryAggregations = React.lazy(() =>
+  import('./pages/staff/PantryAggregations')
+);
 const Timesheets = React.lazy(() => import('./pages/staff/timesheets'));
 const LeaveManagement = React.lazy(
   () => import('./pages/staff/LeaveManagement'),
@@ -363,7 +366,7 @@ export default function App() {
                     <Route path="/pantry/visits" element={<PantryVisits />} />
                   )}
                   {showStaff && (
-                    <Route path="/pantry/aggregations" element={<Aggregations />} />
+                    <Route path="/pantry/aggregations" element={<PantryAggregations />} />
                   )}
                   {isStaff && (
                     <Route path="/timesheet" element={<Timesheets />} />

--- a/MJ_FB_Frontend/src/api/pantryAggregations.ts
+++ b/MJ_FB_Frontend/src/api/pantryAggregations.ts
@@ -1,0 +1,35 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+
+export async function getPantryWeekly(year: number, week: number) {
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/weekly?year=${year}&week=${week}`);
+  return handleResponse(res);
+}
+
+export async function getPantryMonthly(year: number, month: number) {
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/monthly?year=${year}&month=${month}`);
+  return handleResponse(res);
+}
+
+export async function getPantryYearly(year: number) {
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/yearly?year=${year}`);
+  return handleResponse(res);
+}
+
+export async function getPantryYears() {
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/years`);
+  return handleResponse(res);
+}
+
+export async function exportPantryAggregations(params: { period: 'weekly' | 'monthly' | 'yearly'; year: number; month?: number; week?: number; }) {
+  const search = new URLSearchParams({ period: params.period, year: String(params.year) });
+  if (params.month != null) search.append('month', String(params.month));
+  if (params.week != null) search.append('week', String(params.week));
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/export?${search.toString()}`);
+  if (!res.ok) await handleResponse(res);
+  return res.blob();
+}
+
+export async function rebuildPantryAggregations() {
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/rebuild`, { method: 'POST' });
+  await handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -1,0 +1,321 @@
+import { useState, useEffect } from 'react';
+import {
+  TableContainer,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Stack,
+  Button,
+  CircularProgress,
+} from '@mui/material';
+import Page from '../../components/Page';
+import StyledTabs from '../../components/StyledTabs';
+import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
+import {
+  getPantryWeekly,
+  getPantryMonthly,
+  getPantryYearly,
+  getPantryYears,
+  exportPantryAggregations,
+} from '../../api/pantryAggregations';
+import { toDate } from '../../utils/date';
+
+export default function PantryAggregations() {
+  const currentYear = toDate().getFullYear();
+  const fallbackYears = Array.from({ length: 5 }, (_, i) => currentYear - i);
+  const [years, setYears] = useState<number[]>(fallbackYears);
+  const [tab, setTab] = useState(0);
+
+  const [weeklyYear, setWeeklyYear] = useState(fallbackYears[0]);
+  const [week, setWeek] = useState(1);
+  const [weeklyRows, setWeeklyRows] = useState<any[]>([]);
+  const [weeklyLoading, setWeeklyLoading] = useState(false);
+
+  const [monthlyYear, setMonthlyYear] = useState(fallbackYears[0]);
+  const [month, setMonth] = useState(1);
+  const [monthlyRows, setMonthlyRows] = useState<any[]>([]);
+  const [monthlyLoading, setMonthlyLoading] = useState(false);
+
+  const [yearlyYear, setYearlyYear] = useState(fallbackYears[0]);
+  const [yearlyRows, setYearlyRows] = useState<any[]>([]);
+  const [yearlyLoading, setYearlyLoading] = useState(false);
+
+  const [exportLoading, setExportLoading] = useState(false);
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' as 'success' | 'error' });
+
+  useEffect(() => {
+    getPantryYears()
+      .then(ys => {
+        if (ys.length) {
+          setYears(ys);
+          setWeeklyYear(ys[0]);
+          setMonthlyYear(ys[0]);
+          setYearlyYear(ys[0]);
+        }
+      })
+      .catch(() => {
+        setYears(fallbackYears);
+        setWeeklyYear(fallbackYears[0]);
+        setMonthlyYear(fallbackYears[0]);
+        setYearlyYear(fallbackYears[0]);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (tab !== 0) return;
+    setWeeklyLoading(true);
+    getPantryWeekly(weeklyYear, week)
+      .then(setWeeklyRows)
+      .catch(() => setWeeklyRows([]))
+      .finally(() => setWeeklyLoading(false));
+  }, [weeklyYear, week, tab]);
+
+  useEffect(() => {
+    if (tab !== 1) return;
+    setMonthlyLoading(true);
+    getPantryMonthly(monthlyYear, month)
+      .then(setMonthlyRows)
+      .catch(() => setMonthlyRows([]))
+      .finally(() => setMonthlyLoading(false));
+  }, [monthlyYear, month, tab]);
+
+  useEffect(() => {
+    if (tab !== 2) return;
+    setYearlyLoading(true);
+    getPantryYearly(yearlyYear)
+      .then(setYearlyRows)
+      .catch(() => setYearlyRows([]))
+      .finally(() => setYearlyLoading(false));
+  }, [yearlyYear, tab]);
+
+  const handleExportWeekly = async () => {
+    setExportLoading(true);
+    try {
+      const blob = await exportPantryAggregations({ period: 'weekly', year: weeklyYear, week });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `pantry-weekly-${weeklyYear}-w${week}.xlsx`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setSnackbar({ open: true, message: 'Failed to export', severity: 'error' });
+    } finally {
+      setExportLoading(false);
+    }
+  };
+
+  const handleExportMonthly = async () => {
+    setExportLoading(true);
+    try {
+      const blob = await exportPantryAggregations({ period: 'monthly', year: monthlyYear, month });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `pantry-monthly-${monthlyYear}-${month}.xlsx`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setSnackbar({ open: true, message: 'Failed to export', severity: 'error' });
+    } finally {
+      setExportLoading(false);
+    }
+  };
+
+  const handleExportYearly = async () => {
+    setExportLoading(true);
+    try {
+      const blob = await exportPantryAggregations({ period: 'yearly', year: yearlyYear });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `pantry-yearly-${yearlyYear}.xlsx`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setSnackbar({ open: true, message: 'Failed to export', severity: 'error' });
+    } finally {
+      setExportLoading(false);
+    }
+  };
+
+  const weeklyContent = (
+    <>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="weekly-year-label">Year</InputLabel>
+          <Select
+            labelId="weekly-year-label"
+            label="Year"
+            value={weeklyYear}
+            onChange={e => setWeeklyYear(Number(e.target.value))}
+          >
+            {years.map(y => (
+              <MenuItem key={y} value={y}>
+                {y}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="weekly-week-label">Week</InputLabel>
+          <Select
+            labelId="weekly-week-label"
+            label="Week"
+            value={week}
+            onChange={e => setWeek(Number(e.target.value))}
+          >
+            {Array.from({ length: 52 }, (_, i) => i + 1).map(w => (
+              <MenuItem key={w} value={w}>
+                {w}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button variant="contained" onClick={handleExportWeekly} disabled={exportLoading}>
+          {exportLoading ? <CircularProgress size={20} /> : 'Export'}
+        </Button>
+      </Stack>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        {weeklyLoading ? (
+          <Stack alignItems="center" py={2}>
+            <CircularProgress size={24} />
+          </Stack>
+        ) : (
+          <ResponsiveTable
+            columns={
+              weeklyRows.length
+                ? (Object.keys(weeklyRows[0]).map(key => ({ field: key, header: key })) as Column<any>[])
+                : []
+            }
+            rows={weeklyRows}
+            getRowKey={(_r, i) => String(i)}
+          />
+        )}
+      </TableContainer>
+    </>
+  );
+
+  const monthlyContent = (
+    <>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="monthly-year-label">Year</InputLabel>
+          <Select
+            labelId="monthly-year-label"
+            label="Year"
+            value={monthlyYear}
+            onChange={e => setMonthlyYear(Number(e.target.value))}
+          >
+            {years.map(y => (
+              <MenuItem key={y} value={y}>
+                {y}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="monthly-month-label">Month</InputLabel>
+          <Select
+            labelId="monthly-month-label"
+            label="Month"
+            value={month}
+            onChange={e => setMonth(Number(e.target.value))}
+          >
+            {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
+              <MenuItem key={m} value={m}>
+                {m}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button variant="contained" onClick={handleExportMonthly} disabled={exportLoading}>
+          {exportLoading ? <CircularProgress size={20} /> : 'Export'}
+        </Button>
+      </Stack>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        {monthlyLoading ? (
+          <Stack alignItems="center" py={2}>
+            <CircularProgress size={24} />
+          </Stack>
+        ) : (
+          <ResponsiveTable
+            columns={
+              monthlyRows.length
+                ? (Object.keys(monthlyRows[0]).map(key => ({ field: key, header: key })) as Column<any>[])
+                : []
+            }
+            rows={monthlyRows}
+            getRowKey={(_r, i) => String(i)}
+          />
+        )}
+      </TableContainer>
+    </>
+  );
+
+  const yearlyContent = (
+    <>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="yearly-year-label">Year</InputLabel>
+          <Select
+            labelId="yearly-year-label"
+            label="Year"
+            value={yearlyYear}
+            onChange={e => setYearlyYear(Number(e.target.value))}
+          >
+            {years.map(y => (
+              <MenuItem key={y} value={y}>
+                {y}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button variant="contained" onClick={handleExportYearly} disabled={exportLoading}>
+          {exportLoading ? <CircularProgress size={20} /> : 'Export'}
+        </Button>
+      </Stack>
+      <TableContainer sx={{ overflowX: 'auto' }}>
+        {yearlyLoading ? (
+          <Stack alignItems="center" py={2}>
+            <CircularProgress size={24} />
+          </Stack>
+        ) : (
+          <ResponsiveTable
+            columns={
+              yearlyRows.length
+                ? (Object.keys(yearlyRows[0]).map(key => ({ field: key, header: key })) as Column<any>[])
+                : []
+            }
+            rows={yearlyRows}
+            getRowKey={(_r, i) => String(i)}
+          />
+        )}
+      </TableContainer>
+    </>
+  );
+
+  const tabs = [
+    { label: 'Weekly', content: weeklyContent },
+    { label: 'Monthly', content: monthlyContent },
+    { label: 'Yearly', content: yearlyContent },
+  ];
+
+  return (
+    <>
+      <PantryQuickLinks />
+      <Page title="Aggregations">
+        <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
+        <FeedbackSnackbar
+          open={snackbar.open}
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+          message={snackbar.message}
+          severity={snackbar.severity}
+        />
+      </Page>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add pantry aggregation API helpers
- implement staff pantry aggregations page with weekly, monthly, and yearly tabs
- wire up pantry aggregations route in App

## Testing
- `npm test` *(fails: multiple test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c09b9b5b94832db86354e0ff7f79f3