### PR TITLE
Refine pantry aggregation exports and frontend handling

### DIFF
--- a/MJ_FB_Frontend/src/api/pantryAggregations.ts
+++ b/MJ_FB_Frontend/src/api/pantryAggregations.ts
@@ -1,7 +1,7 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
 
-export async function getPantryWeekly(year: number, week: number) {
-  const res = await apiFetch(`${API_BASE}/pantry-aggregations/weekly?year=${year}&week=${week}`);
+export async function getPantryWeekly(year: number, month: number) {
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/weekly?year=${year}&month=${month}`);
   return handleResponse(res);
 }
 


### PR DESCRIPTION
## Summary
- format pantry export spreadsheets with unified headers and sunshine bag metrics
- trigger export rebuilds and add table export on staff PantryAggregations page
- expose new weekly API signature accepting month parameter

## Testing
- `npm test` (backend) *(fails: Test Suites: 25 failed, 108 passed)*
- `npm test` (frontend) *(fails: VolunteerManagement shopper profile fails, more tests remain)*

------
https://chatgpt.com/codex/tasks/task_e_68c09cddda7c832d8e5448fa4df6766f