### PR TITLE
Use pantry monthly aggregations for donor mail stats

### DIFF
--- a/MJ_FB_Backend/src/controllers/monetaryDonorController.ts
+++ b/MJ_FB_Backend/src/controllers/monetaryDonorController.ts
@@ -213,14 +213,14 @@ export async function sendMailLists(req: Request, res: Response, next: NextFunct
     );
 
     const statsRes = await pool.query(
-      `SELECT COUNT(DISTINCT client_id)::int AS families,
-              COALESCE(SUM(children),0)::int AS children,
-              COALESCE(SUM(COALESCE(weight_without_cart, weight_with_cart - cart_tare)),0)::int AS pounds
-       FROM client_visits
-       WHERE date >= $1 AND date < $2`,
-      [startDate, endDate],
+      `SELECT clients AS families,
+              children,
+              total_weight AS pounds
+         FROM pantry_monthly_overall
+        WHERE year = $1 AND month = $2`,
+      [year, month],
     );
-    const { families, children, pounds } = statsRes.rows[0];
+    const { families = 0, children = 0, pounds = 0 } = statsRes.rows[0] || {};
 
     const groups: Record<string, any[]> = { '1-100': [], '101-500': [], '501+': [] };
     for (const row of donorsRes.rows) {

--- a/MJ_FB_Backend/tests/monetaryDonors.test.ts
+++ b/MJ_FB_Backend/tests/monetaryDonors.test.ts
@@ -179,8 +179,8 @@ describe('Mailing list generation', () => {
     );
     expect(pool.query).toHaveBeenNthCalledWith(
       3,
-      expect.stringContaining('date >= $1 AND date < $2'),
-      ['2024-06-01', '2024-07-01'],
+      expect.stringContaining('FROM pantry_monthly_overall'),
+      [2024, 6],
     );
     expect(sendTemplatedEmail).toHaveBeenCalledTimes(3);
     expect((sendTemplatedEmail as jest.Mock).mock.calls[0][0]).toEqual({


### PR DESCRIPTION
## Summary
- Pull donor email stats from `pantry_monthly_overall` instead of querying raw visits
- Adjust monetary donor mail list test for new aggregation query

## Testing
- `npm test` *(fails: Test Suites: 25 failed, 108 passed, 133 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a000aeec832db6886fe483fa22c3