### PR TITLE
test: add pantry aggregation coverage

### DIFF
--- a/MJ_FB_Backend/tests/pantryAggregations.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregations.test.ts
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import express from 'express';
+import pantryAggregationsRoutes from '../src/routes/pantry/aggregations';
+import pool from '../src/db';
+import './utils/mockDb';
+import 'write-excel-file/node';
+
+jest.mock('write-excel-file/node', () => jest.fn().mockResolvedValue(Buffer.from('test')));
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: any, _res: any, next: any) => next(),
+  authorizeAccess: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+const app = express();
+app.use('/pantry-aggregations', pantryAggregationsRoutes);
+
+describe('pantry aggregation routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists weekly aggregations', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ week: 1 }] });
+
+    const res = await request(app).get('/pantry-aggregations/weekly?year=2024&month=5');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('rebuilds aggregations', async () => {
+    const res = await request(app).post('/pantry-aggregations/rebuild');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Rebuilt' });
+  });
+
+  it('exports aggregations', async () => {
+    const buffer = Buffer.from('');
+    const res = await request(app)
+      .get('/pantry-aggregations/export?period=weekly&year=2024&month=5&week=1')
+      .buffer()
+      .parse((res, cb) => {
+        const data: Buffer[] = [];
+        res.on('data', chunk => data.push(chunk));
+        res.on('end', () => cb(null, Buffer.concat(data)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    expect(res.body).toEqual(buffer);
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
@@ -1,0 +1,73 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PantryAggregations from '../pages/staff/PantryAggregations';
+
+const mockGetPantryWeekly = jest.fn().mockResolvedValue([]);
+const mockGetPantryMonthly = jest.fn().mockResolvedValue([]);
+const mockGetPantryYearly = jest.fn().mockResolvedValue([]);
+const mockGetPantryYears = jest.fn().mockResolvedValue([new Date().getFullYear()]);
+const mockExportPantryAggregations = jest.fn().mockResolvedValue(new Blob());
+const mockRebuildPantryAggregations = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../api/pantryAggregations', () => ({
+  getPantryWeekly: (...args: unknown[]) => mockGetPantryWeekly(...args),
+  getPantryMonthly: (...args: unknown[]) => mockGetPantryMonthly(...args),
+  getPantryYearly: (...args: unknown[]) => mockGetPantryYearly(...args),
+  getPantryYears: (...args: unknown[]) => mockGetPantryYears(...args),
+  exportPantryAggregations: (...args: unknown[]) => mockExportPantryAggregations(...args),
+  rebuildPantryAggregations: (...args: unknown[]) => mockRebuildPantryAggregations(...args),
+}));
+
+describe('PantryAggregations page', () => {
+  beforeAll(() => {
+    // @ts-ignore
+    global.URL.createObjectURL = jest.fn();
+    // @ts-ignore
+    global.URL.revokeObjectURL = jest.fn();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads data for each tab', async () => {
+    render(
+      <MemoryRouter>
+        <PantryAggregations />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockGetPantryYears).toHaveBeenCalled());
+    await waitFor(() => expect(mockGetPantryWeekly).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('tab', { name: /monthly/i }));
+    await waitFor(() => expect(mockGetPantryMonthly).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('tab', { name: /yearly/i }));
+    await waitFor(() => expect(mockGetPantryYearly).toHaveBeenCalled());
+  });
+
+  it('exports weekly data', async () => {
+    const year = new Date().getFullYear();
+    render(
+      <MemoryRouter>
+        <PantryAggregations />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockGetPantryWeekly).toHaveBeenCalled());
+
+    const exportBtn = (await screen.findAllByRole('button', { name: /export/i }))[0];
+    fireEvent.click(exportBtn);
+
+    await waitFor(() => expect(mockRebuildPantryAggregations).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockExportPantryAggregations).toHaveBeenCalledWith({
+        period: 'weekly',
+        year,
+        month: 1,
+        week: 1,
+      }),
+    );
+  });
+});

--- a/MJ_FB_Frontend/src/utils/__tests__/pantryWeek.test.ts
+++ b/MJ_FB_Frontend/src/utils/__tests__/pantryWeek.test.ts
@@ -10,6 +10,17 @@ describe('getWeekRanges', () => {
       { week: 5, startDate: '2024-05-27', endDate: '2024-05-31' },
     ]);
   });
+
+  test('handles month starting on Sunday', () => {
+    expect(getWeekRanges(2024, 8)).toEqual([
+      { week: 1, startDate: '2024-09-01', endDate: '2024-09-01' },
+      { week: 2, startDate: '2024-09-02', endDate: '2024-09-08' },
+      { week: 3, startDate: '2024-09-09', endDate: '2024-09-15' },
+      { week: 4, startDate: '2024-09-16', endDate: '2024-09-22' },
+      { week: 5, startDate: '2024-09-23', endDate: '2024-09-29' },
+      { week: 6, startDate: '2024-09-30', endDate: '2024-09-30' },
+    ]);
+  });
 });
 
 describe('getWeekForDate', () => {


### PR DESCRIPTION
## Summary
- add backend tests for pantry aggregation routes including rebuild and export
- expand week range utility tests for Sunday month starts
- add frontend PantryAggregations page tests for API calls and exports

## Testing
- `npm test` (backend) *(fails: 28 failed, 106 passed, 134 total)*
- `npm test` (frontend) *(crashed: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68c09fc1de4c832d9818c0ac4dae0e68