### PR TITLE
feat: add quick-view pantry aggregation tables

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
@@ -1,0 +1,40 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PantryAggregations from '../pages/staff/PantryAggregations';
+
+const mockGetPantryWeekly = jest.fn().mockResolvedValue([]);
+const mockGetPantryMonthly = jest.fn().mockResolvedValue([]);
+const mockGetPantryYearly = jest.fn().mockResolvedValue([]);
+const mockGetPantryYears = jest.fn().mockResolvedValue([new Date().getFullYear()]);
+
+jest.mock('../api/pantryAggregations', () => ({
+  getPantryWeekly: (...args: unknown[]) => mockGetPantryWeekly(...args),
+  getPantryMonthly: (...args: unknown[]) => mockGetPantryMonthly(...args),
+  getPantryYearly: (...args: unknown[]) => mockGetPantryYearly(...args),
+  getPantryYears: (...args: unknown[]) => mockGetPantryYears(...args),
+  exportPantryAggregations: jest.fn(),
+  rebuildPantryAggregations: jest.fn(),
+}));
+
+describe('PantryAggregations page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads data for each tab when selected', async () => {
+    render(
+      <MemoryRouter>
+        <PantryAggregations />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockGetPantryWeekly).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('tab', { name: /monthly/i }));
+    await waitFor(() => expect(mockGetPantryMonthly).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('tab', { name: /yearly/i }));
+    await waitFor(() => expect(mockGetPantryYearly).toHaveBeenCalledTimes(1));
+  });
+});
+

--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -88,6 +88,7 @@ export default function PantryAggregations() {
   useEffect(() => {
     if (tab !== 0) return;
     setWeeklyLoading(true);
+    setWeeklyRows([]);
     getPantryWeekly(weeklyYear, weeklyMonth)
       .then(setWeeklyRows)
       .catch(() => setWeeklyRows([]))
@@ -97,6 +98,7 @@ export default function PantryAggregations() {
   useEffect(() => {
     if (tab !== 1) return;
     setMonthlyLoading(true);
+    setMonthlyRows([]);
     getPantryMonthly(monthlyYear, month)
       .then(setMonthlyRows)
       .catch(() => setMonthlyRows([]))
@@ -106,6 +108,7 @@ export default function PantryAggregations() {
   useEffect(() => {
     if (tab !== 2) return;
     setYearlyLoading(true);
+    setYearlyRows([]);
     getPantryYearly(yearlyYear)
       .then(setYearlyRows)
       .catch(() => setYearlyRows([]))


### PR DESCRIPTION
## Summary
- clear and reload weekly, monthly, yearly rows so pantry aggregation tables show current data
- add test covering pantry aggregation tab loading

## Testing
- `npm test src/__tests__/PantryAggregations.test.tsx`
- `npm test` *(fails: Unable to find an element with text "Clients: 1" and other router-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a085b4ec832dbc933f686b2a397b