### PR TITLE
feat: display pantry aggregation tables

### DIFF
--- a/MJ_FB_Backend/src/controllers/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantryAggregationController.ts
@@ -1,47 +1,34 @@
 import { Request, Response, NextFunction } from 'express';
+import {
+  listPantryWeekly,
+  listPantryMonthly,
+  listPantryYearly,
+  listAvailableYears,
+  exportPantryWeekly,
+  exportPantryMonthly,
+  exportPantryYearly,
+} from './pantry/pantryAggregationController';
 
-export async function listWeeklyAggregations(_req: Request, res: Response, next: NextFunction) {
-  try {
-    res.json([]);
-  } catch (error) {
-    next(error);
-  }
+export { listAvailableYears };
+
+export async function listWeeklyAggregations(req: Request, res: Response, next: NextFunction) {
+  return listPantryWeekly(req, res, next);
 }
 
-export async function listMonthlyAggregations(_req: Request, res: Response, next: NextFunction) {
-  try {
-    res.json([]);
-  } catch (error) {
-    next(error);
-  }
+export async function listMonthlyAggregations(req: Request, res: Response, next: NextFunction) {
+  return listPantryMonthly(req, res, next);
 }
 
-export async function listYearlyAggregations(_req: Request, res: Response, next: NextFunction) {
-  try {
-    res.json([]);
-  } catch (error) {
-    next(error);
-  }
+export async function listYearlyAggregations(req: Request, res: Response, next: NextFunction) {
+  return listPantryYearly(req, res, next);
 }
 
-export async function listAvailableYears(_req: Request, res: Response, next: NextFunction) {
-  try {
-    res.json([]);
-  } catch (error) {
-    next(error);
-  }
-}
-
-export async function exportAggregations(_req: Request, res: Response, next: NextFunction) {
-  try {
-    res.setHeader(
-      'Content-Type',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    );
-    res.send(Buffer.from(''));
-  } catch (error) {
-    next(error);
-  }
+export async function exportAggregations(req: Request, res: Response, next: NextFunction) {
+  const period = req.query.period;
+  if (period === 'weekly') return exportPantryWeekly(req, res, next);
+  if (period === 'monthly') return exportPantryMonthly(req, res, next);
+  if (period === 'yearly') return exportPantryYearly(req, res, next);
+  return res.status(400).json({ message: 'Invalid period' });
 }
 
 export async function rebuildAggregations(_req: Request, res: Response, next: NextFunction) {

--- a/MJ_FB_Backend/tests/pantryAggregations.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregations.test.ts
@@ -25,7 +25,7 @@ describe('pantry aggregation routes', () => {
 
     const res = await request(app).get('/pantry-aggregations/weekly?year=2024&month=5');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([]);
+    expect(res.body).toEqual([{ week: 1 }]);
   });
 
   it('rebuilds aggregations', async () => {
@@ -35,7 +35,6 @@ describe('pantry aggregation routes', () => {
   });
 
   it('exports aggregations', async () => {
-    const buffer = Buffer.from('');
     const res = await request(app)
       .get('/pantry-aggregations/export?period=weekly&year=2024&month=5&week=1')
       .buffer()
@@ -49,6 +48,6 @@ describe('pantry aggregation routes', () => {
     expect(res.headers['content-type']).toBe(
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
-    expect(res.body).toEqual(buffer);
+    expect(res.body).toEqual(Buffer.from('test'));
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
@@ -28,6 +28,10 @@ describe('PantryAggregations page', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetPantryWeekly.mockResolvedValue([]);
+    mockGetPantryMonthly.mockResolvedValue([]);
+    mockGetPantryYearly.mockResolvedValue([]);
+    mockGetPantryYears.mockResolvedValue([new Date().getFullYear()]);
   });
 
   it('loads data for each tab', async () => {
@@ -45,6 +49,23 @@ describe('PantryAggregations page', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: /yearly/i }));
     await waitFor(() => expect(mockGetPantryYearly).toHaveBeenCalled());
+  });
+
+  it('displays weekly aggregations in a table', async () => {
+    mockGetPantryWeekly.mockResolvedValueOnce([{ week: 1, clients: 2 }]);
+
+    render(
+      <MemoryRouter>
+        <PantryAggregations />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockGetPantryWeekly).toHaveBeenCalled());
+
+    expect(screen.getByTestId('responsive-table-table')).toBeInTheDocument();
+    expect(screen.getByText('week')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 
   it('exports weekly data', async () => {


### PR DESCRIPTION
## Summary
- wire pantry aggregation routes to real aggregation logic
- test pantry export and weekly list responses
- ensure pantry aggregation page renders table rows

## Testing
- `npm test` (backend) *(fails: timesheets, bookings, volunteer flows, etc)*
- `npm test` (frontend) *(fails: PantryVisits, PantrySchedule, Booking UI, etc)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a325c9c0832d968e40ed7c8ee2fd