### PR TITLE
Exclude sunshine bag recipients from client totals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - Client and volunteer dashboards show an onboarding modal with tips on first visit; a localStorage flag prevents repeat displays.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Provide translations only for client-visible pages (e.g., client dashboard, navbar and submenus, profile, booking, booking history). Internal or staff-only features should remain untranslated unless explicitly requested. Document these translation strings in `docs/` and update `MJ_FB_Frontend/public/locales` when client-visible text is added.
-- Pantry visits track daily sunshine bag weights and client counts via the `sunshine_bag_log` table.
+- Pantry visits track daily sunshine bag weights and client counts via the `sunshine_bag_log` table. Sunshine bag recipients are recorded separately and excluded from total client counts.
 - Sunshine bag, surplus, pig pound, and outgoing donation logs roll up into monthly aggregates and raw log entries older than one year are purged every Jan 31.
 - Anonymous pantry visits display "(ANONYMOUS)" after the client ID and their family size is excluded from the summary counts.
 - Bulk pantry visit imports use the `POST /client-visits/import` endpoint (also available at `/visits/import`) and overwrite existing visits when client/date duplicates are found; see `docs/pantryVisits.md` for sheet naming and dry-run options.

--- a/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
@@ -51,7 +51,7 @@ export async function refreshPantryWeekly(year: number, month: number, week: num
   const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
   const bagWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients + bagClients;
+  const clients = visitClients;
   const totalWeight = visitWeight + bagWeight;
 
   await pool.query(
@@ -95,7 +95,7 @@ export async function refreshPantryMonthly(year: number, month: number) {
   const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
   const bagWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients + bagClients;
+  const clients = visitClients;
   const totalWeight = visitWeight + bagWeight;
 
   await pool.query(
@@ -139,7 +139,7 @@ export async function refreshPantryYearly(year: number) {
   const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
   const bagWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients + bagClients;
+  const clients = visitClients;
   const totalWeight = visitWeight + bagWeight;
 
   await pool.query(

--- a/MJ_FB_Backend/tests/pantryAggregationController.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationController.test.ts
@@ -1,0 +1,29 @@
+import mockDb from './utils/mockDb';
+import { refreshPantryMonthly } from '../src/controllers/pantry/pantryAggregationController';
+
+describe('pantryAggregationController totals', () => {
+  beforeEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (mockDb.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  afterEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (mockDb.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  it('excludes sunshine bag clients from total client counts', async () => {
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ visits: 5, adults: 3, children: 2, weight: 100 }] })
+      .mockResolvedValueOnce({ rows: [{ clients: 2, weight: 30 }] })
+      .mockResolvedValueOnce({});
+
+    await refreshPantryMonthly(2024, 5);
+
+    expect(mockDb.query).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('INSERT INTO pantry_monthly_overall'),
+      [2024, 5, 5, 3, 2, 130, 2, 30],
+    );
+  });
+});

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Public cancel and reschedule pages include the client bottom navigation for quick access
   to other sections.
 - Email templates display times in 12-hour AM/PM format.
+- Sunshine bag recipients are tracked separately and excluded from total client counts.
 - Past blocked slots are cleared nightly, with `/api/blocked-slots/cleanup` available for admins to trigger a manual cleanup.
 - All users sign in at a consolidated `/login` page using their client ID or email and password. The page offers contact and password reset guidance and notes that staff, volunteers, and agencies also sign in here.
 - A **Use biometrics** option on the mobile login page lets users sign in with platform authenticators via WebAuthn.


### PR DESCRIPTION
## Summary
- keep sunshine bag recipients out of pantry client totals while still tracking them separately
- document sunshine bag counting behavior in AGENTS and README
- test monthly aggregation to ensure sunshine bag clients aren’t counted in totals

## Testing
- `npm test` *(fails: Test Suites: 28 failed, 107 passed, 135 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a3a06bb0832daaaac52b0ec7bc12