### PR TITLE
Include sunshine bag counts in pantry aggregates

### DIFF
--- a/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
@@ -45,13 +45,14 @@ export async function refreshPantryWeekly(year: number, month: number, week: num
   ]);
 
   const visitClients = Number(visitsRes.rows[0]?.visits ?? 0);
-  const adults = Number(visitsRes.rows[0]?.adults ?? 0);
+  const visitAdults = Number(visitsRes.rows[0]?.adults ?? 0);
   const children = Number(visitsRes.rows[0]?.children ?? 0);
   const visitWeight = Number(visitsRes.rows[0]?.weight ?? 0);
   const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
   const bagWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients;
+  const clients = visitClients + bagClients;
+  const adults = visitAdults + bagClients;
   const totalWeight = visitWeight + bagWeight;
 
   await pool.query(
@@ -89,13 +90,14 @@ export async function refreshPantryMonthly(year: number, month: number) {
   ]);
 
   const visitClients = Number(visitsRes.rows[0]?.visits ?? 0);
-  const adults = Number(visitsRes.rows[0]?.adults ?? 0);
+  const visitAdults = Number(visitsRes.rows[0]?.adults ?? 0);
   const children = Number(visitsRes.rows[0]?.children ?? 0);
   const visitWeight = Number(visitsRes.rows[0]?.weight ?? 0);
   const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
   const bagWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients;
+  const clients = visitClients + bagClients;
+  const adults = visitAdults + bagClients;
   const totalWeight = visitWeight + bagWeight;
 
   await pool.query(
@@ -133,13 +135,14 @@ export async function refreshPantryYearly(year: number) {
   ]);
 
   const visitClients = Number(visitsRes.rows[0]?.visits ?? 0);
-  const adults = Number(visitsRes.rows[0]?.adults ?? 0);
+  const visitAdults = Number(visitsRes.rows[0]?.adults ?? 0);
   const children = Number(visitsRes.rows[0]?.children ?? 0);
   const visitWeight = Number(visitsRes.rows[0]?.weight ?? 0);
   const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
   const bagWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients;
+  const clients = visitClients + bagClients;
+  const adults = visitAdults + bagClients;
   const totalWeight = visitWeight + bagWeight;
 
   await pool.query(

--- a/MJ_FB_Backend/tests/pantryAggregationController.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationController.test.ts
@@ -12,7 +12,7 @@ describe('pantryAggregationController totals', () => {
     (mockDb.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0 });
   });
 
-  it('excludes sunshine bag clients from total client counts', async () => {
+  it('includes sunshine bag clients in total client and adult counts', async () => {
     (mockDb.query as jest.Mock)
       .mockResolvedValueOnce({ rows: [{ visits: 5, adults: 3, children: 2, weight: 100 }] })
       .mockResolvedValueOnce({ rows: [{ clients: 2, weight: 30 }] })
@@ -23,7 +23,7 @@ describe('pantryAggregationController totals', () => {
     expect(mockDb.query).toHaveBeenNthCalledWith(
       3,
       expect.stringContaining('INSERT INTO pantry_monthly_overall'),
-      [2024, 5, 5, 3, 2, 130, 2, 30],
+      [2024, 5, 7, 5, 2, 130, 2, 30],
     );
   });
 });


### PR DESCRIPTION
## Summary
- include sunshine bag recipients when computing weekly, monthly, and yearly pantry client and adult totals
- maintain separate sunshine bag client and weight columns in upserts
- update pantry aggregation test to cover new totals

## Testing
- `npm test tests/pantryAggregationController.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0d28f81d8832d94247793381ff07b