### PR TITLE
feat: show sunshine bag client totals

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -246,8 +246,7 @@ export default function PantryVisits() {
   }
 
   const summary = useMemo(() => {
-    const clients =
-      visits.filter(v => !v.anonymous).length + sunshineBagClients;
+    const clients = visits.filter(v => !v.anonymous).length;
     const totalWeight =
       visits.reduce((sum, v) => sum + v.weightWithoutCart, 0) + sunshineBagWeight;
     const adults = visits.reduce((sum, v) => sum + (v.anonymous ? 0 : v.adults), 0);
@@ -256,7 +255,7 @@ export default function PantryVisits() {
       0,
     );
     return { clients, totalWeight, adults, children };
-  }, [visits, sunshineBagWeight, sunshineBagClients]);
+  }, [visits, sunshineBagWeight]);
 
   function handleSaveVisit() {
     if (form.sunshineBag) {
@@ -481,6 +480,9 @@ export default function PantryVisits() {
           </Typography>
           <Typography variant="body2">
             {`${t('pantry_visits.summary.children')}: ${summary.children}`}
+          </Typography>
+          <Typography variant="body2">
+            {`Sunshine Bag Clients: ${sunshineBagClients}`}
           </Typography>
           <Typography variant="body2">
             {`${t('pantry_visits.summary.sunshine_bag_weight')}: ${sunshineBagWeight}`}

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -214,6 +214,7 @@ describe('PantryVisits', () => {
     expect(await screen.findByText('111')).toBeInTheDocument();
     expect(screen.getByText('222 (ANONYMOUS)')).toBeInTheDocument();
     expect(screen.getByText('Clients: 1')).toBeInTheDocument();
+    expect(screen.getByText('Sunshine Bag Clients: 2')).toBeInTheDocument();
     expect(screen.getByText('Total Weight: 32')).toBeInTheDocument();
     expect(screen.getByText('Adults: 1')).toBeInTheDocument();
     expect(screen.getByText('Children: 2')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- separate sunshine bag clients from visit counts
- display sunshine bag client totals in pantry visit summary
- test that summary excludes sunshine bag clients

## Testing
- `npm test` *(fails: useNavigate may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d2943718832d93ea02f8cdefb1d1