### PR TITLE
feat: centralize aggregations navigation

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -140,6 +140,8 @@ export default function App() {
   const showAdmin = isStaff && access.includes('admin');
   const showDonationEntry = role === 'volunteer' && access.includes('donation_entry');
   const showDonationLog = showWarehouse || showDonationEntry;
+  const showAggregations =
+    isStaff && (hasAccess('aggregations') || hasAccess('pantry') || hasAccess('warehouse'));
 
   const staffRootPath = getStaffRootPath(access as StaffAccess[]);
   const singleAccessOnly = isStaff && staffRootPath !== '/';
@@ -172,7 +174,6 @@ export default function App() {
       { label: 'Pantry Visits', to: '/pantry/visits' },
       { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Agency Management', to: '/pantry/agency-management' },
-      { label: 'Aggregations', to: '/pantry/aggregations' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
@@ -208,10 +209,17 @@ export default function App() {
         to: '/warehouse-management/track-outgoing-donations',
       },
       { label: 'Track Surplus', to: '/warehouse-management/track-surplus' },
-      { label: 'Aggregations', to: '/warehouse-management/aggregations' },
       { label: 'Exports', to: '/warehouse-management/exports' },
     ];
     if (showWarehouse) navGroups.push({ label: 'Warehouse Management', links: warehouseLinks });
+    if (showAggregations)
+      navGroups.push({
+        label: 'Aggregations',
+        links: [
+          { label: 'Pantry Aggregations', to: '/aggregations/pantry' },
+          { label: 'Warehouse Aggregations', to: '/aggregations/warehouse' },
+        ],
+      });
     if (showAdmin)
       navGroups.push({
         label: 'Admin',
@@ -365,8 +373,14 @@ export default function App() {
                   {showStaff && (
                     <Route path="/pantry/visits" element={<PantryVisits />} />
                   )}
-                  {showStaff && (
-                    <Route path="/pantry/aggregations" element={<PantryAggregations />} />
+                  {showAggregations && (
+                    <Route path="/aggregations/pantry" element={<PantryAggregations />} />
+                  )}
+                  {showAggregations && (
+                    <Route
+                      path="/pantry/aggregations"
+                      element={<Navigate to="/aggregations/pantry" replace />}
+                    />
                   )}
                   {isStaff && (
                     <Route path="/timesheet" element={<Timesheets />} />
@@ -407,10 +421,16 @@ export default function App() {
                       element={<TrackSurplus />}
                     />
                   )}
-                  {showWarehouse && (
+                  {showAggregations && (
+                    <Route
+                      path="/aggregations/warehouse"
+                      element={<Aggregations />}
+                    />
+                  )}
+                  {showAggregations && (
                     <Route
                       path="/warehouse-management/aggregations"
-                      element={<Aggregations />}
+                      element={<Navigate to="/aggregations/warehouse" replace />}
                     />
                   )}
                   {showWarehouse && (

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -106,6 +106,10 @@ describe('App authentication persistence', () => {
     expect(getStaffRootPath(['warehouse'] as any)).toBe('/warehouse-management');
   });
 
+  it('computes aggregations path for single aggregations access', () => {
+    expect(getStaffRootPath(['aggregations'] as any)).toBe('/aggregations/pantry');
+  });
+
   it('shows donor management nav links for donor_management access', async () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');

--- a/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
@@ -23,7 +23,7 @@ describe('PantryQuickLinks', () => {
     );
     expect(screen.getByRole('link', { name: /Aggregations/i })).toHaveAttribute(
       'href',
-      '/pantry/aggregations',
+      '/aggregations/pantry',
     );
   });
 });

--- a/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
@@ -48,7 +48,7 @@ export default function PantryQuickLinks() {
         variant="outlined"
         sx={buttonSx}
         component={RouterLink}
-        to="/pantry/aggregations"
+        to="/aggregations/pantry"
         fullWidth
       >
         Aggregations

--- a/MJ_FB_Frontend/src/components/StaffForm.tsx
+++ b/MJ_FB_Frontend/src/components/StaffForm.tsx
@@ -117,6 +117,10 @@ export default function StaffForm({ initial, submitLabel, onSubmit }: StaffFormP
           label="Warehouse"
         />
         <FormControlLabel
+          control={<Checkbox checked={access.includes('aggregations')} onChange={() => toggleAccess('aggregations')} />}
+          label="Aggregations"
+        />
+        <FormControlLabel
           control={
             <Checkbox
               checked={access.includes('payroll_management')}

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
@@ -29,6 +29,7 @@ export default function AdminStaffList() {
     donor_management: 'Donor Management',
     payroll_management: 'Payroll Management',
     donation_entry: 'Donation Entry',
+    aggregations: 'Aggregations',
   };
 
   async function load() {

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -8,7 +8,8 @@ export type StaffAccess =
   | 'admin'
   | 'donor_management'
   | 'payroll_management'
-  | 'donation_entry';
+  | 'donation_entry'
+  | 'aggregations';
 
 export interface Staff {
   id: number;

--- a/MJ_FB_Frontend/src/utils/staffRootPath.ts
+++ b/MJ_FB_Frontend/src/utils/staffRootPath.ts
@@ -7,6 +7,7 @@ export function getStaffRootPath(access: StaffAccess[]): string {
     if (first === 'volunteer_management') return '/volunteer-management';
     if (first === 'warehouse') return '/warehouse-management';
     if (first === 'donor_management') return '/donor-management';
+    if (first === 'aggregations') return '/aggregations/pantry';
   }
   return '/';
 }


### PR DESCRIPTION
## Summary
- add new staff `Aggregations` nav group and showAggregations access gate
- update pantry quick links and route redirects for new aggregations paths
- extend staff access types with `aggregations`

## Testing
- `npm test` *(fails: Jest encountered numerous errors and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68c0db1362fc832d9c69d92217920042