### PR TITLE
Handle aggregations staff root path

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -106,6 +106,10 @@ describe('App authentication persistence', () => {
     expect(getStaffRootPath(['warehouse'] as any)).toBe('/warehouse-management');
   });
 
+  it('computes aggregations path for single aggregations access', () => {
+    expect(getStaffRootPath(['aggregations'] as any)).toBe('/aggregations/pantry');
+  });
+
   it('shows donor management nav links for donor_management access', async () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');

--- a/MJ_FB_Frontend/src/utils/staffRootPath.ts
+++ b/MJ_FB_Frontend/src/utils/staffRootPath.ts
@@ -7,6 +7,7 @@ export function getStaffRootPath(access: StaffAccess[]): string {
     if (first === 'volunteer_management') return '/volunteer-management';
     if (first === 'warehouse') return '/warehouse-management';
     if (first === 'donor_management') return '/donor-management';
+    if (first === 'aggregations') return '/aggregations/pantry';
   }
   return '/';
 }


### PR DESCRIPTION
## Summary
- handle `aggregations` staff access by routing to `/aggregations/pantry`
- test `getStaffRootPath` with `aggregations` access

## Testing
- `npm test` *(fails: e.g. Login component could not find login button)*

------
https://chatgpt.com/codex/tasks/task_e_68c0db26aca8832da095d1fb02102144