### PR TITLE
refactor: move pantry aggregations route

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -172,7 +172,7 @@ export default function App() {
       { label: 'Pantry Visits', to: '/pantry/visits' },
       { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Agency Management', to: '/pantry/agency-management' },
-      { label: 'Aggregations', to: '/pantry/aggregations' },
+      { label: 'Aggregations', to: '/aggregations/pantry' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
@@ -366,7 +366,7 @@ export default function App() {
                     <Route path="/pantry/visits" element={<PantryVisits />} />
                   )}
                   {showStaff && (
-                    <Route path="/pantry/aggregations" element={<PantryAggregations />} />
+                    <Route path="/aggregations/pantry" element={<PantryAggregations />} />
                   )}
                   {isStaff && (
                     <Route path="/timesheet" element={<Timesheets />} />

--- a/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
@@ -23,7 +23,7 @@ describe('PantryQuickLinks', () => {
     );
     expect(screen.getByRole('link', { name: /Aggregations/i })).toHaveAttribute(
       'href',
-      '/pantry/aggregations',
+      '/aggregations/pantry',
     );
   });
 });

--- a/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
@@ -48,7 +48,7 @@ export default function PantryQuickLinks() {
         variant="outlined"
         sx={buttonSx}
         component={RouterLink}
-        to="/pantry/aggregations"
+        to="/aggregations/pantry"
         fullWidth
       >
         Aggregations


### PR DESCRIPTION
## Summary
- move pantry aggregations links to `/aggregations/pantry`
- adjust router and tests for new pantry aggregations path

## Testing
- `npm test` *(fails: VolunteerCoverageCard test timeout, PantrySchedule test parse error, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c0db2dcf58832da60ee6dd727b3797