### PR TITLE
Add Aggregations staff access option

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffForm.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffForm.test.tsx
@@ -11,6 +11,7 @@ describe('StaffForm', () => {
     fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'Smith' } });
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@example.com' } });
     fireEvent.click(screen.getByLabelText(/pantry/i));
+    fireEvent.click(screen.getByLabelText(/aggregations/i));
     fireEvent.click(screen.getByRole('button', { name: /Add/i }));
 
     await waitFor(() =>
@@ -18,7 +19,7 @@ describe('StaffForm', () => {
         firstName: 'Alice',
         lastName: 'Smith',
         email: 'a@example.com',
-        access: ['pantry'],
+        access: ['pantry', 'aggregations'],
       }),
     );
     expect(screen.getByText(/email invitation/i)).toBeInTheDocument();
@@ -30,7 +31,7 @@ describe('StaffForm', () => {
       firstName: 'Jane',
       lastName: 'Doe',
       email: 'jane@example.com',
-      access: ['pantry', 'warehouse'] as const,
+      access: ['pantry', 'warehouse', 'aggregations'] as const,
     };
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(<StaffForm initial={initial} submitLabel="Save" onSubmit={onSubmit} />);
@@ -40,5 +41,6 @@ describe('StaffForm', () => {
     expect(screen.getByLabelText(/email/i)).toHaveValue('jane@example.com');
     expect(screen.getByLabelText(/pantry/i)).toBeChecked();
     expect(screen.getByLabelText(/warehouse/i)).toBeChecked();
+    expect(screen.getByLabelText(/aggregations/i)).toBeChecked();
   });
 });

--- a/MJ_FB_Frontend/src/components/StaffForm.tsx
+++ b/MJ_FB_Frontend/src/components/StaffForm.tsx
@@ -135,6 +135,15 @@ export default function StaffForm({ initial, submitLabel, onSubmit }: StaffFormP
           label="Donor Management"
         />
         <FormControlLabel
+          control={
+            <Checkbox
+              checked={access.includes('aggregations')}
+              onChange={() => toggleAccess('aggregations')}
+            />
+          }
+          label="Aggregations"
+        />
+        <FormControlLabel
           control={<Checkbox checked={access.includes('admin')} onChange={() => toggleAccess('admin')} />}
           label="Admin"
         />

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
@@ -28,6 +28,7 @@ export default function AdminStaffList() {
     admin: 'Admin',
     donor_management: 'Donor Management',
     payroll_management: 'Payroll Management',
+    aggregations: 'Aggregations',
     donation_entry: 'Donation Entry',
   };
 

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -8,6 +8,7 @@ export type StaffAccess =
   | 'admin'
   | 'donor_management'
   | 'payroll_management'
+  | 'aggregations'
   | 'donation_entry';
 
 export interface Staff {


### PR DESCRIPTION
## Summary
- allow configuring Aggregations access for staff members
- show Aggregations label in staff list access badges
- test coverage for new staff access option

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68c0db1f8860832d89866a8169133752