### PR TITLE
feat: add aggregations staff access

### DIFF
--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -7,7 +7,8 @@ export type StaffAccess =
   | 'admin'
   | 'donor_management'
   | 'payroll_management'
-  | 'donation_entry';
+  | 'donation_entry'
+  | 'aggregations';
 
 export interface Staff {
   id: number;

--- a/MJ_FB_Backend/src/routes/pantry/aggregations.ts
+++ b/MJ_FB_Backend/src/routes/pantry/aggregations.ts
@@ -16,7 +16,7 @@ router.get('/monthly', listMonthlyAggregations);
 router.get('/yearly', listYearlyAggregations);
 router.get('/years', listAvailableYears);
 router.get('/export', exportAggregations);
-router.post('/rebuild', authMiddleware, authorizeAccess('pantry'), rebuildAggregations);
+router.post('/rebuild', authMiddleware, authorizeAccess('pantry', 'aggregations'), rebuildAggregations);
 
 export default router;
 

--- a/MJ_FB_Backend/src/routes/warehouse/donations.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/donations.ts
@@ -14,7 +14,12 @@ import { addDonationSchema, updateDonationSchema } from '../../schemas/warehouse
 const router = Router();
 
 router.get('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), listDonations);
-router.get('/aggregations', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), donorAggregations);
+router.get(
+  '/aggregations',
+  authMiddleware,
+  authorizeAccess('warehouse', 'donation_entry', 'aggregations'),
+  donorAggregations,
+);
 router.get('/aggregations/export', exportDonorAggregations);
 router.post('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), validate(addDonationSchema), addDonation);
 router.put('/:id', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), validate(updateDonationSchema), updateDonation);

--- a/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
@@ -10,7 +10,12 @@ import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware
 const router = Router();
 
 router.get('/', listWarehouseOverall);
-router.post('/rebuild', authMiddleware, authorizeAccess('warehouse'), rebuildWarehouseOverall);
+router.post(
+  '/rebuild',
+  authMiddleware,
+  authorizeAccess('warehouse', 'aggregations'),
+  rebuildWarehouseOverall,
+);
 router.get('/export', exportWarehouseOverall);
 router.get('/years', listAvailableYears);
 

--- a/MJ_FB_Backend/src/schemas/admin/staffSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/admin/staffSchemas.ts
@@ -8,6 +8,7 @@ export const staffAccessEnum = z.enum([
   'admin',
   'donor_management',
   'payroll_management',
+  'aggregations',
 ]);
 
 export const createStaffSchema = z.object({

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -149,4 +149,10 @@ describe('App authentication persistence', () => {
       '/donor-management',
     );
   });
+
+  it('computes aggregations path for single aggregations access', () => {
+    expect(getStaffRootPath(['aggregations'] as any)).toBe(
+      '/pantry/aggregations',
+    );
+  });
 });

--- a/MJ_FB_Frontend/src/components/StaffForm.tsx
+++ b/MJ_FB_Frontend/src/components/StaffForm.tsx
@@ -135,6 +135,15 @@ export default function StaffForm({ initial, submitLabel, onSubmit }: StaffFormP
           label="Donor Management"
         />
         <FormControlLabel
+          control={
+            <Checkbox
+              checked={access.includes('aggregations')}
+              onChange={() => toggleAccess('aggregations')}
+            />
+          }
+          label="Aggregations"
+        />
+        <FormControlLabel
           control={<Checkbox checked={access.includes('admin')} onChange={() => toggleAccess('admin')} />}
           label="Admin"
         />

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
@@ -28,6 +28,7 @@ export default function AdminStaffList() {
     admin: 'Admin',
     donor_management: 'Donor Management',
     payroll_management: 'Payroll Management',
+    aggregations: 'Aggregations',
     donation_entry: 'Donation Entry',
   };
 

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -8,7 +8,8 @@ export type StaffAccess =
   | 'admin'
   | 'donor_management'
   | 'payroll_management'
-  | 'donation_entry';
+  | 'donation_entry'
+  | 'aggregations';
 
 export interface Staff {
   id: number;

--- a/MJ_FB_Frontend/src/utils/staffRootPath.ts
+++ b/MJ_FB_Frontend/src/utils/staffRootPath.ts
@@ -7,6 +7,7 @@ export function getStaffRootPath(access: StaffAccess[]): string {
     if (first === 'volunteer_management') return '/volunteer-management';
     if (first === 'warehouse') return '/warehouse-management';
     if (first === 'donor_management') return '/donor-management';
+    if (first === 'aggregations') return '/pantry/aggregations';
   }
   return '/';
 }


### PR DESCRIPTION
## Summary
- allow `aggregations` in StaffAccess types
- wire aggregations access through staff admin forms and navigation helpers
- permit aggregations access on relevant backend routes

## Testing
- `npm test` (backend) *(fails: 25 failed, 110 passed, 135 total)*
- `npm test` (frontend) *(crashed with jsdom TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68c0db18ac0c832d9f5bd04a116a3272