### PR TITLE
Implement pantry aggregation rebuild endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
   to other sections.
 - Email templates display times in 12-hour AM/PM format.
 - Sunshine bag recipients are tracked separately and excluded from total client counts.
+- Pantry stats can be recomputed for all historical data via `POST /api/pantry-aggregations/rebuild`.
 - Past blocked slots are cleared nightly, with `/api/blocked-slots/cleanup` available for admins to trigger a manual cleanup.
 - All users sign in at a consolidated `/login` page using their client ID or email and password. The page offers contact and password reset guidance and notes that staff, volunteers, and agencies also sign in here.
 - A **Use biometrics** option on the mobile login page lets users sign in with platform authenticators via WebAuthn.


### PR DESCRIPTION
## Summary
- allow pantry stats rebuild endpoint to recompute weekly, monthly, and yearly totals across all history
- document pantry aggregation rebuild endpoint in README
- add tests for rebuild behavior

## Testing
- `npm test tests/pantryAggregations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c0ce2d7f50832daf0da8f475423aca