### PR TITLE
docs: add Android PWA install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,9 +475,9 @@ A daily database bloat monitor job warns when `pg_stat_user_tables.n_dead_tup` e
 - Staff dashboard dates display weekday, month, day, and year (e.g., 'Tue, Jan 2, 2024').
 - Staff dashboard includes a pantry visit trend line chart showing monthly totals for clients, adults, and children.
 - Includes a reusable `FeedbackSnackbar` component for concise user notifications.
-- Volunteers see an Install App button on their first visit to volunteer pages if the app isn't already installed. An onboarding modal explains offline benefits, and installs are tracked. iOS users should use Safari's **Add to Home Screen**.
+- Volunteers see an Install App button on their first visit to volunteer pages if the app isn't already installed. An onboarding modal explains offline benefits, and installs are tracked. On Android, tapping the button shows Chrome's install prompt; iOS users should use Safari's **Add to Home Screen**.
 - Client and volunteer dashboards display onboarding tips on first visit and store a local flag to avoid repeat prompts.
-- An Install App button appears when the app is installable and not already installed; iOS users should use Safari's **Add to Home Screen**.
+- An Install App button appears when the app is installable and not already installed. On Android, the button opens Chrome's install prompt; iOS users should use Safari's **Add to Home Screen**.
 - A Workbox service worker caches built assets plus schedule, booking history, and profile API responses, provides an offline fallback page, and queues offline booking actions for background sync.
 - Booking confirmations include links to add appointments to Google Calendar or download an ICS file.
 - Warehouse dashboard aggregates donations and shipments in real time, so manual rebuilds are no longer needed.

--- a/docs/installApp.md
+++ b/docs/installApp.md
@@ -1,8 +1,18 @@
 # Install App
 
 The Install App button appears on volunteer pages when the `beforeinstallprompt`
-event fires or on iOS devices. On iOS, selecting the button shows instructions
-for using Safari's **Add to Home Screen** option.
+event fires or on iOS devices.
+
+## Android
+
+1. Open the app URL in Chrome.
+2. Tap the **Install App** button or use the browser menu and choose **Install app**.
+3. Confirm the install and add the icon to the home screen.
+4. Launch the app from the home screen and verify it opens full screen.
+
+## iOS
+
+Selecting the button shows instructions for using Safari's **Add to Home Screen** option.
 
 ## Localization
 


### PR DESCRIPTION
## Summary
- document Android-specific PWA install steps for volunteers
- note Chrome install prompt in README

## Testing
- `npm run test:backend` (failed: 23 failed, 112 passed)
- `npm run test:frontend` (failed: SyntaxError: Cannot use 'import.meta' outside a module)


------
https://chatgpt.com/codex/tasks/task_e_68c0db847494832d8e6176a59536beaf