### PR TITLE
feat: update pantry aggregations path

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -376,12 +376,6 @@ export default function App() {
                   {showAggregations && (
                     <Route path="/aggregations/pantry" element={<PantryAggregations />} />
                   )}
-                  {showAggregations && (
-                    <Route
-                      path="/pantry/aggregations"
-                      element={<Navigate to="/aggregations/pantry" replace />}
-                    />
-                  )}
                   {isStaff && (
                     <Route path="/timesheet" element={<Timesheets />} />
                   )}

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -156,7 +156,7 @@ describe('App authentication persistence', () => {
 
   it('computes aggregations path for single aggregations access', () => {
     expect(getStaffRootPath(['aggregations'] as any)).toBe(
-      '/pantry/aggregations',
+      '/aggregations/pantry',
     );
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import PantryQuickLinks from '../components/PantryQuickLinks';
 

--- a/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
@@ -1,4 +1,4 @@
-import { Stack, Button } from '@mui/material';
+import { Button, Stack } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 
 export default function PantryQuickLinks() {


### PR DESCRIPTION
## Summary
- replace legacy pantry aggregations route with /aggregations/pantry
- update App utilities and tests to reference the new path

## Testing
- `npm test` *(fails: Exceeded timeout of 5000 ms for a test)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dd6b40c8832da5322ccd702fb1e1