### PR TITLE
feat: support conditional webauthn login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - `/slots/range` returns 90 days of availability by default so the pantry schedule can load slots three months ahead.
 - Staff can add existing clients to the app from the pantry schedule's Assign User modal by entering a client ID. The client is created as a shopper with online access disabled and immediately assigned to the selected slot.
 - A unified `/login` page serves clients, staff, volunteers, and agencies; everyone signs in with their client ID or email and password.
-- The login page on mobile offers a **Use biometrics** button for WebAuthn-based sign in.
+- The login page automatically prompts for passkeys via WebAuthn on supported devices.
 - Volunteers see an Install App button on their first visit to volunteer pages when the app isn't already installed. An onboarding modal explains offline use, and installations are tracked.
 - Client and volunteer dashboards show an onboarding modal with tips on first visit; a localStorage flag prevents repeat displays.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.

--- a/MJ_FB_Backend/src/models/webauthn.ts
+++ b/MJ_FB_Backend/src/models/webauthn.ts
@@ -17,6 +17,18 @@ export async function getCredential(
   return { userIdentifier: row.user_identifier, credentialId: row.credential_id };
 }
 
+export async function getCredentialById(
+  credentialId: string,
+): Promise<WebAuthnCredential | null> {
+  const res = await pool.query(
+    'SELECT user_identifier, credential_id FROM webauthn_credentials WHERE credential_id = $1',
+    [credentialId],
+  );
+  if ((res.rowCount ?? 0) === 0) return null;
+  const row = res.rows[0];
+  return { userIdentifier: row.user_identifier, credentialId: row.credential_id };
+}
+
 export async function saveCredential(
   userIdentifier: string,
   credentialId: string,

--- a/MJ_FB_Backend/tests/webauthnController.test.ts
+++ b/MJ_FB_Backend/tests/webauthnController.test.ts
@@ -1,0 +1,42 @@
+import request from 'supertest';
+import express from 'express';
+import webauthnRoutes from '../src/routes/webauthn';
+import pool from '../src/db';
+
+jest.mock('../src/db');
+jest.mock('../src/utils/authUtils', () => ({ __esModule: true, default: jest.fn(() => Promise.resolve()) }));
+
+const app = express();
+app.use(express.json());
+app.use('/api/webauthn', webauthnRoutes);
+
+describe('webauthn routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a challenge without identifier', async () => {
+    const res = await request(app).post('/api/webauthn/challenge').send({});
+    expect(res.status).toBe(200);
+    expect(res.body.challenge).toBeDefined();
+    expect(res.body.registered).toBeUndefined();
+  });
+
+  it('verifies credential by id', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ user_identifier: '123', credential_id: 'abc' }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ client_id: 123, first_name: 'John', last_name: 'Doe', role: 'shopper' }] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const res = await request(app).post('/api/webauthn/verify').send({ credentialId: 'abc' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ role: 'shopper', name: 'John Doe', id: 123 });
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/WHERE credential_id = \$1/);
+  });
+
+  it('returns 401 for unknown credential', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const res = await request(app).post('/api/webauthn/verify').send({ credentialId: 'missing' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Pantry stats can be recomputed for all historical data via `POST /api/pantry-aggregations/rebuild`.
 - Past blocked slots are cleared nightly, with `/api/blocked-slots/cleanup` available for admins to trigger a manual cleanup.
 - All users sign in at a consolidated `/login` page using their client ID or email and password. The page offers contact and password reset guidance and notes that staff, volunteers, and agencies also sign in here.
-- A **Use biometrics** option on the mobile login page lets users sign in with platform authenticators via WebAuthn.
+- The login page automatically surfaces passkey prompts via WebAuthn on supported devices.
 - Password reset dialog prompts clients to enter their client ID and explains that a reset link will be emailed.
 - Input fields feature larger touch targets on mobile devices for easier tapping.
 - Staff dashboards include a Volunteer Coverage card; click a role to see which volunteers are on duty.


### PR DESCRIPTION
## Summary
- show conditional passkey prompt on login and remove biometrics button
- allow backend WebAuthn challenge without identifier and verify by credential ID
- document automatic passkey login

## Testing
- `npm test tests/webauthnController.test.ts`
- `npm test` *(fails: "bookingController.test.ts" et al., needs investigation)*
- `npm test` *(MJ_FB_Frontend; fails: VolunteerManagement & VolunteerSchedule tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dbba6284832da58c414b6c05a6af