### PR TITLE
Protect aggregation routes with auth

### DIFF
--- a/MJ_FB_Backend/src/routes/pantry/aggregations.ts
+++ b/MJ_FB_Backend/src/routes/pantry/aggregations.ts
@@ -11,11 +11,36 @@ import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware
 
 const router = Router();
 
-router.get('/weekly', listWeeklyAggregations);
-router.get('/monthly', listMonthlyAggregations);
-router.get('/yearly', listYearlyAggregations);
-router.get('/years', listAvailableYears);
-router.get('/export', exportAggregations);
+router.get(
+  '/weekly',
+  authMiddleware,
+  authorizeAccess('pantry', 'aggregations'),
+  listWeeklyAggregations,
+);
+router.get(
+  '/monthly',
+  authMiddleware,
+  authorizeAccess('pantry', 'aggregations'),
+  listMonthlyAggregations,
+);
+router.get(
+  '/yearly',
+  authMiddleware,
+  authorizeAccess('pantry', 'aggregations'),
+  listYearlyAggregations,
+);
+router.get(
+  '/years',
+  authMiddleware,
+  authorizeAccess('pantry', 'aggregations'),
+  listAvailableYears,
+);
+router.get(
+  '/export',
+  authMiddleware,
+  authorizeAccess('pantry', 'aggregations'),
+  exportAggregations,
+);
 router.post('/rebuild', authMiddleware, authorizeAccess('pantry', 'aggregations'), rebuildAggregations);
 
 export default router;

--- a/MJ_FB_Backend/src/routes/warehouse/donations.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/donations.ts
@@ -20,7 +20,12 @@ router.get(
   authorizeAccess('warehouse', 'donation_entry', 'aggregations'),
   donorAggregations,
 );
-router.get('/aggregations/export', exportDonorAggregations);
+router.get(
+  '/aggregations/export',
+  authMiddleware,
+  authorizeAccess('warehouse', 'donation_entry', 'aggregations'),
+  exportDonorAggregations,
+);
 router.post('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), validate(addDonationSchema), addDonation);
 router.put('/:id', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), validate(updateDonationSchema), updateDonation);
 router.delete('/:id', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), deleteDonation);

--- a/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
@@ -9,14 +9,29 @@ import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware
 
 const router = Router();
 
-router.get('/', listWarehouseOverall);
+router.get(
+  '/',
+  authMiddleware,
+  authorizeAccess('warehouse', 'aggregations'),
+  listWarehouseOverall,
+);
 router.post(
   '/rebuild',
   authMiddleware,
   authorizeAccess('warehouse', 'aggregations'),
   rebuildWarehouseOverall,
 );
-router.get('/export', exportWarehouseOverall);
-router.get('/years', listAvailableYears);
+router.get(
+  '/export',
+  authMiddleware,
+  authorizeAccess('warehouse', 'aggregations'),
+  exportWarehouseOverall,
+);
+router.get(
+  '/years',
+  authMiddleware,
+  authorizeAccess('warehouse', 'aggregations'),
+  listAvailableYears,
+);
 
 export default router;

--- a/MJ_FB_Backend/tests/donationAggregationsAccess.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregationsAccess.test.ts
@@ -1,0 +1,18 @@
+import request from 'supertest';
+import express from 'express';
+import donationsRoutes from '../src/routes/warehouse/donations';
+
+const app = express();
+app.use('/donations', donationsRoutes);
+
+describe('donation aggregations auth', () => {
+  it('requires auth for aggregations', async () => {
+    const res = await request(app).get('/donations/aggregations?year=2024');
+    expect(res.status).toBe(401);
+  });
+
+  it('requires auth for export', async () => {
+    const res = await request(app).get('/donations/aggregations/export?year=2024');
+    expect(res.status).toBe(401);
+  });
+});

--- a/MJ_FB_Backend/tests/pantryAggregationsAuth.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationsAuth.test.ts
@@ -1,0 +1,18 @@
+import request from 'supertest';
+import express from 'express';
+import pantryAggregationsRoutes from '../src/routes/pantry/aggregations';
+
+const app = express();
+app.use('/pantry-aggregations', pantryAggregationsRoutes);
+
+describe('pantry aggregations auth', () => {
+  it('requires auth for weekly aggregations', async () => {
+    const res = await request(app).get('/pantry-aggregations/weekly');
+    expect(res.status).toBe(401);
+  });
+
+  it('requires auth for export', async () => {
+    const res = await request(app).get('/pantry-aggregations/export');
+    expect(res.status).toBe(401);
+  });
+});

--- a/MJ_FB_Backend/tests/warehouseOverallAuth.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallAuth.test.ts
@@ -1,0 +1,23 @@
+import request from 'supertest';
+import express from 'express';
+import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';
+
+const app = express();
+app.use('/warehouse-overall', warehouseOverallRoutes);
+
+describe('warehouse overall auth', () => {
+  it('requires auth for list', async () => {
+    const res = await request(app).get('/warehouse-overall');
+    expect(res.status).toBe(401);
+  });
+
+  it('requires auth for export', async () => {
+    const res = await request(app).get('/warehouse-overall/export?year=2024');
+    expect(res.status).toBe(401);
+  });
+
+  it('requires auth for years', async () => {
+    const res = await request(app).get('/warehouse-overall/years');
+    expect(res.status).toBe(401);
+  });
+});

--- a/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
@@ -2,18 +2,43 @@ import request from 'supertest';
 import express from 'express';
 import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';
 import pool from '../src/db';
+import jwt from 'jsonwebtoken';
 
+
+jest.mock('jsonwebtoken');
 
 const app = express();
 app.use('/warehouse-overall', warehouseOverallRoutes);
 
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('GET /warehouse-overall/years', () => {
   it('lists available years in descending order', async () => {
-    (pool.query as jest.Mock).mockResolvedValueOnce({
-      rows: [{ year: 2024 }, { year: 2023 }],
+    (jwt.verify as jest.Mock).mockReturnValue({
+      id: 1,
+      role: 'staff',
+      type: 'staff',
+      access: ['warehouse'],
     });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 1, first_name: 'Test', last_name: 'User', email: 't@example.com', role: 'staff' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ year: 2024 }, { year: 2023 }],
+      });
 
-    const res = await request(app).get('/warehouse-overall/years');
+    const res = await request(app)
+      .get('/warehouse-overall/years')
+      .set('Authorization', 'Bearer token');
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual([2024, 2023]);


### PR DESCRIPTION
## Summary
- require authentication and pantry aggregations access for all pantry aggregation GET routes
- extend donation aggregation routes to demand aggregations access and protect export with auth
- secure warehouse overall routes and add tests enforcing authentication

## Testing
- `npm test` *(fails: Test Suites: 26 failed, 112 passed, 138 total)*
- `npm test tests/warehouseOverallYears.test.ts tests/warehouseOverallExport.test.ts tests/donationAggregationsAccess.test.ts tests/pantryAggregationsAuth.test.ts tests/warehouseOverallAuth.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0ddf11ee8832d98150296e5684da6