### PR TITLE
Add aggregations staff access role

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000038_add_aggregations_to_staff_access.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000038_add_aggregations_to_staff_access.ts
@@ -1,0 +1,15 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('staff', 'staff_access_check');
+  pgm.addConstraint('staff', 'staff_access_check', {
+    check: "access <@ ARRAY['pantry','volunteer_management','warehouse','admin','donor_management','payroll_management','aggregations']",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('staff', 'staff_access_check');
+  pgm.addConstraint('staff', 'staff_access_check', {
+    check: "access <@ ARRAY['pantry','volunteer_management','warehouse','admin','donor_management','payroll_management']",
+  });
+}

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Staff accounts may include any of the following access roles:
 - `volunteer_management`
 - `warehouse`
 - `admin`
-- `other`
+- `donor_management`
 - `payroll_management`
+- `aggregations`
 - `donation_entry` – volunteer-only access for the warehouse donation log
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.


### PR DESCRIPTION
## Summary
- allow staff aggregations access role via migration
- document new role in README

## Testing
- `npm test` *(fails: 25 failed, 110 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ddf387c8832d8a8465990aa47057