### PR TITLE
docs: document aggregations access and navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@
 - Profile pages let clients and volunteers toggle email reminders from `/users/me/preferences`.
 - Staff can delete client and volunteer accounts from their respective management pages; update help content when these features change.
 - Donation management pages are accessible only to staff with donor_management access.
+- Aggregations pages are accessible only to staff with aggregations access.
 
 See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/AGENTS.md` for frontend-specific guidance.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Input fields feature larger touch targets on mobile devices for easier tapping.
 - Staff dashboards include a Volunteer Coverage card; click a role to see which volunteers are on duty.
 
+- Staff with `aggregations` access see an **Aggregations** navigation item with **Pantry Aggregations** and **Warehouse Aggregations** pages for reporting.
+
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 `/leave-requests` from the profile menu once logged in. Admin users also see
 **Timesheets** at `/admin/timesheet` and **Leave Requests** at
@@ -45,6 +47,7 @@ Staff accounts may include any of the following access roles:
 - `admin`
 - `other`
 - `payroll_management`
+- `aggregations`
 - `donation_entry` – volunteer-only access for the warehouse donation log
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.


### PR DESCRIPTION
## Summary
- document Aggregations navigation with Pantry and Warehouse pages
- add `aggregations` to staff access roles
- note that Aggregations pages require aggregations access

## Testing
- `nvm use`
- `npm run test:backend` *(fails: Test Suites: 24 failed, 111 passed)*
- `npm run test:frontend` *(fails with multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ddf90c64832db920fa6cfcd85007