### PR TITLE
Remove aggregations from pantry quick links

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryQuickLinks.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import PantryQuickLinks from '../components/PantryQuickLinks';
 
 describe('PantryQuickLinks', () => {
-  it('renders links to pantry routes including aggregations', () => {
+  it('renders pantry links only', () => {
     render(
       <MemoryRouter>
         <PantryQuickLinks />
@@ -21,9 +21,8 @@ describe('PantryQuickLinks', () => {
       'href',
       '/pantry/client-management?tab=history',
     );
-    expect(screen.getByRole('link', { name: /Aggregations/i })).toHaveAttribute(
-      'href',
-      '/aggregations/pantry',
-    );
+    expect(
+      screen.queryByRole('link', { name: /Aggregations/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/PantryQuickLinks.tsx
@@ -43,16 +43,6 @@ export default function PantryQuickLinks() {
       >
         Search Client
       </Button>
-      <Button
-
-        variant="outlined"
-        sx={buttonSx}
-        component={RouterLink}
-        to="/aggregations/pantry"
-        fullWidth
-      >
-        Aggregations
-      </Button>
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Remove Aggregations from pantry quick links
- Update PantryQuickLinks tests to reflect removal

## Testing
- `npm test` *(fails: PasswordSetup, PantryAggregations, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dffaca24832dbae0500405fcc0a5