### PR TITLE
Use month names in aggregation filters

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -237,7 +237,7 @@ export default function PantryAggregations() {
           >
             {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
               <MenuItem key={m} value={m}>
-                {m}
+                {monthNames[m - 1]}
               </MenuItem>
             ))}
           </Select>
@@ -313,7 +313,7 @@ export default function PantryAggregations() {
           >
             {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
               <MenuItem key={m} value={m}>
-                {m}
+                {monthNames[m - 1]}
               </MenuItem>
             ))}
           </Select>


### PR DESCRIPTION
## Summary
- Show month names instead of numbers in weekly and monthly aggregation filters
- Keep export filenames descriptive with month names

## Testing
- `npm test -- src/__tests__/PantryAggregations.test.tsx` *(fails: Found multiple elements with the text: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e1d68ffc832da79fed4919648654