### PR TITLE
Compact pantry aggregation filter selects

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -212,7 +212,7 @@ export default function PantryAggregations() {
   const weeklyContent = (
     <>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-        <FormControl sx={{ minWidth: 120 }}>
+        <FormControl size="small" sx={{ minWidth: 90 }}>
           <InputLabel id="weekly-year-label">Year</InputLabel>
           <Select
             labelId="weekly-year-label"
@@ -227,7 +227,7 @@ export default function PantryAggregations() {
             ))}
           </Select>
         </FormControl>
-        <FormControl sx={{ minWidth: 120 }}>
+        <FormControl size="small" sx={{ minWidth: 90 }}>
           <InputLabel id="weekly-month-label">Month</InputLabel>
           <Select
             labelId="weekly-month-label"
@@ -242,7 +242,7 @@ export default function PantryAggregations() {
             ))}
           </Select>
         </FormControl>
-        <FormControl sx={{ minWidth: 120 }}>
+        <FormControl size="small" sx={{ minWidth: 90 }}>
           <InputLabel id="weekly-week-label">Week</InputLabel>
           <Select
             labelId="weekly-week-label"
@@ -288,7 +288,7 @@ export default function PantryAggregations() {
   const monthlyContent = (
     <>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-        <FormControl sx={{ minWidth: 120 }}>
+        <FormControl size="small" sx={{ minWidth: 90 }}>
           <InputLabel id="monthly-year-label">Year</InputLabel>
           <Select
             labelId="monthly-year-label"
@@ -303,7 +303,7 @@ export default function PantryAggregations() {
             ))}
           </Select>
         </FormControl>
-        <FormControl sx={{ minWidth: 120 }}>
+        <FormControl size="small" sx={{ minWidth: 90 }}>
           <InputLabel id="monthly-month-label">Month</InputLabel>
           <Select
             labelId="monthly-month-label"
@@ -349,7 +349,7 @@ export default function PantryAggregations() {
   const yearlyContent = (
     <>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
-        <FormControl sx={{ minWidth: 120 }}>
+        <FormControl size="small" sx={{ minWidth: 90 }}>
           <InputLabel id="yearly-year-label">Year</InputLabel>
           <Select
             labelId="yearly-year-label"


### PR DESCRIPTION
## Summary
- shrink weekly, monthly, and yearly aggregation filter selects so buttons fit on screen

## Testing
- `npm test -- --watchAll=false` *(fails: multiple existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e1e64a58832d8ae8229a40641126