### PR TITLE
Refactor pantry aggregation exports

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
@@ -6,7 +6,9 @@ const mockGetPantryWeekly = jest.fn().mockResolvedValue([]);
 const mockGetPantryMonthly = jest.fn().mockResolvedValue([]);
 const mockGetPantryYearly = jest.fn().mockResolvedValue([]);
 const mockGetPantryYears = jest.fn().mockResolvedValue([new Date().getFullYear()]);
-const mockExportPantryAggregations = jest.fn().mockResolvedValue(new Blob());
+const mockExportPantryAggregations = jest
+  .fn()
+  .mockResolvedValue({ blob: new Blob(), fileName: 'test.xlsx' });
 const mockRebuildPantryAggregations = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../api/pantryAggregations', () => ({
@@ -78,7 +80,7 @@ describe('PantryAggregations page', () => {
 
     await waitFor(() => expect(mockGetPantryWeekly).toHaveBeenCalled());
 
-    const exportBtn = (await screen.findAllByRole('button', { name: /export/i }))[0];
+    const exportBtn = await screen.findByRole('button', { name: /export table/i });
     fireEvent.click(exportBtn);
 
     await waitFor(() => expect(mockRebuildPantryAggregations).toHaveBeenCalled());

--- a/MJ_FB_Frontend/src/api/pantryAggregations.ts
+++ b/MJ_FB_Frontend/src/api/pantryAggregations.ts
@@ -20,13 +20,22 @@ export async function getPantryYears() {
   return handleResponse(res);
 }
 
-export async function exportPantryAggregations(params: { period: 'weekly' | 'monthly' | 'yearly'; year: number; month?: number; week?: number; }) {
+export async function exportPantryAggregations(params: {
+  period: 'weekly' | 'monthly' | 'yearly';
+  year: number;
+  month?: number;
+  week?: number;
+}): Promise<{ blob: Blob; fileName: string }> {
   const search = new URLSearchParams({ period: params.period, year: String(params.year) });
   if (params.month != null) search.append('month', String(params.month));
   if (params.week != null) search.append('week', String(params.week));
   const res = await apiFetch(`${API_BASE}/pantry-aggregations/export?${search.toString()}`);
   if (!res.ok) await handleResponse(res);
-  return res.blob();
+  const blob = await res.blob();
+  const disposition = res.headers.get('Content-Disposition') ?? '';
+  const match = disposition.match(/filename="?([^";]+)"?/i);
+  const fileName = match ? match[1] : 'pantry_aggregations.xlsx';
+  return { blob, fileName };
 }
 
 export async function rebuildPantryAggregations() {


### PR DESCRIPTION
## Summary
- drop unused table export handlers and refs on pantry aggregations page
- call rebuild before yearly export and use API-provided filenames for all exports
- rename export buttons to "Export Table"

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68c0e550cbec832dbf7a13f9f07d4d52