### PR TITLE
Refactor pantry aggregation exports and update tests

### DIFF
--- a/MJ_FB_Backend/tests/pantryAggregations.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregations.test.ts
@@ -69,6 +69,9 @@ describe('pantry aggregation routes', () => {
     expect(res.headers['content-type']).toBe(
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
+    expect(res.headers['content-disposition']).toBe(
+      'attachment; filename=2024_May_week1_pantry_stats.xlsx',
+    );
     expect(res.body).toEqual(Buffer.from('test'));
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
@@ -6,7 +6,9 @@ const mockGetPantryWeekly = jest.fn().mockResolvedValue([]);
 const mockGetPantryMonthly = jest.fn().mockResolvedValue([]);
 const mockGetPantryYearly = jest.fn().mockResolvedValue([]);
 const mockGetPantryYears = jest.fn().mockResolvedValue([new Date().getFullYear()]);
-const mockExportPantryAggregations = jest.fn().mockResolvedValue(new Blob());
+const mockExportPantryAggregations = jest
+  .fn()
+  .mockResolvedValue({ blob: new Blob(), fileName: 'test.xlsx' });
 const mockRebuildPantryAggregations = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../api/pantryAggregations', () => ({
@@ -78,7 +80,7 @@ describe('PantryAggregations page', () => {
 
     await waitFor(() => expect(mockGetPantryWeekly).toHaveBeenCalled());
 
-    const exportBtn = (await screen.findAllByRole('button', { name: /export/i }))[0];
+    const exportBtn = await screen.findByRole('button', { name: /export table/i });
     fireEvent.click(exportBtn);
 
     await waitFor(() => expect(mockRebuildPantryAggregations).toHaveBeenCalled());

--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -24,7 +24,6 @@ import {
 } from '../../api/pantryAggregations';
 import dayjs, { formatDate, toDate } from '../../utils/date';
 import { getWeekRanges } from '../../utils/pantryWeek';
-import { exportTableToExcel } from '../../utils/exportTableToExcel';
 
 export default function PantryAggregations() {
   const currentYear = toDate().getFullYear();
@@ -147,7 +146,7 @@ export default function PantryAggregations() {
     setExportLoading(true);
     try {
       await rebuildPantryAggregations();
-      const blob = await exportPantryAggregations({
+      const { blob, fileName } = await exportPantryAggregations({
         period: 'weekly',
         year: weeklyYear,
         month: weeklyMonth,
@@ -156,7 +155,7 @@ export default function PantryAggregations() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${weeklyYear}_${monthNames[weeklyMonth - 1]}_week${week}_pantry_stats.xlsx`;
+      a.download = fileName;
       a.click();
       URL.revokeObjectURL(url);
     } catch {
@@ -170,11 +169,15 @@ export default function PantryAggregations() {
     setExportLoading(true);
     try {
       await rebuildPantryAggregations();
-      const blob = await exportPantryAggregations({ period: 'monthly', year: monthlyYear, month });
+      const { blob, fileName } = await exportPantryAggregations({
+        period: 'monthly',
+        year: monthlyYear,
+        month,
+      });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${monthlyYear}_${monthNames[month - 1]}_pantry_stats.xlsx`;
+      a.download = fileName;
       a.click();
       URL.revokeObjectURL(url);
     } catch {
@@ -187,11 +190,11 @@ export default function PantryAggregations() {
   const handleExportYearly = async () => {
     setExportLoading(true);
     try {
-      const blob = await exportPantryAggregations({ period: 'yearly', year: yearlyYear });
+      const { blob, fileName } = await exportPantryAggregations({ period: 'yearly', year: yearlyYear });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${yearlyYear}_pantry_yearly_stats.xlsx`;
+      a.download = fileName;
       a.click();
       URL.revokeObjectURL(url);
     } catch {
@@ -199,45 +202,6 @@ export default function PantryAggregations() {
     } finally {
       setExportLoading(false);
     }
-  };
-
-  const handleExportWeeklyTable = async () => {
-    if (!weeklyTableRef.current) return;
-    const success = await exportTableToExcel(
-      weeklyTableRef.current,
-      `${weeklyYear}_${monthNames[weeklyMonth - 1]}_weekly_list`,
-    );
-    setSnackbar({
-      open: true,
-      message: success ? 'Export ready' : 'Failed to export',
-      severity: success ? 'success' : 'error',
-    });
-  };
-
-  const handleExportMonthlyTable = async () => {
-    if (!monthlyTableRef.current) return;
-    const success = await exportTableToExcel(
-      monthlyTableRef.current,
-      `${monthlyYear}_${monthNames[month - 1]}_monthly_list`,
-    );
-    setSnackbar({
-      open: true,
-      message: success ? 'Export ready' : 'Failed to export',
-      severity: success ? 'success' : 'error',
-    });
-  };
-
-  const handleExportYearlyTable = async () => {
-    if (!yearlyTableRef.current) return;
-    const success = await exportTableToExcel(
-      yearlyTableRef.current,
-      `${yearlyYear}_yearly_list`,
-    );
-    setSnackbar({
-      open: true,
-      message: success ? 'Export ready' : 'Failed to export',
-      severity: success ? 'success' : 'error',
-    });
   };
 
   const weeklyContent = (
@@ -289,9 +253,6 @@ export default function PantryAggregations() {
           </Select>
         </FormControl>
         <Button variant="contained" onClick={handleExportWeekly} disabled={exportLoading}>
-          {exportLoading ? <CircularProgress size={20} /> : 'Export'}
-        </Button>
-        <Button variant="contained" onClick={handleExportWeeklyTable} disabled={exportLoading}>
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>
       </Stack>
@@ -350,9 +311,6 @@ export default function PantryAggregations() {
           </Select>
         </FormControl>
         <Button variant="contained" onClick={handleExportMonthly} disabled={exportLoading}>
-          {exportLoading ? <CircularProgress size={20} /> : 'Export'}
-        </Button>
-        <Button variant="contained" onClick={handleExportMonthlyTable} disabled={exportLoading}>
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>
       </Stack>
@@ -396,9 +354,6 @@ export default function PantryAggregations() {
           </Select>
         </FormControl>
         <Button variant="contained" onClick={handleExportYearly} disabled={exportLoading}>
-          {exportLoading ? <CircularProgress size={20} /> : 'Export'}
-        </Button>
-        <Button variant="contained" onClick={handleExportYearlyTable} disabled={exportLoading}>
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>
       </Stack>


### PR DESCRIPTION
## Summary
- remove separate table export buttons and adopt new export API returning filename
- adjust PantryAggregations test to mock new export object and target single "Export Table" button
- verify export route sends updated filename in content-disposition header

## Testing
- `cd MJ_FB_Frontend && npm test src/__tests__/PantryAggregations.test.tsx`
- `cd MJ_FB_Backend && npm test tests/pantryAggregations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0e55708a8832d9927bbffab41bb36