### PR TITLE
Fix week dropdown in pantry aggregations

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
@@ -81,6 +81,7 @@ describe('PantryAggregations page', () => {
     await waitFor(() => expect(mockGetPantryWeekly).toHaveBeenCalled());
 
     const exportBtn = await screen.findByRole('button', { name: /export table/i });
+    await waitFor(() => expect(exportBtn).not.toBeDisabled());
     fireEvent.click(exportBtn);
 
     await waitFor(() => expect(mockRebuildPantryAggregations).toHaveBeenCalled());

--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -48,7 +48,7 @@ export default function PantryAggregations() {
 
   const [weeklyYear, setWeeklyYear] = useState(fallbackYears[0]);
   const [weeklyMonth, setWeeklyMonth] = useState(1);
-  const [week, setWeek] = useState(1);
+  const [week, setWeek] = useState<number | ''>('');
   const [weekRanges, setWeekRanges] = useState<{ week: number; label: string }[]>([]);
   const [weeklyRows, setWeeklyRows] = useState<any[]>([]);
   const [weeklyLoading, setWeeklyLoading] = useState(false);
@@ -91,6 +91,8 @@ export default function PantryAggregations() {
     setWeekRanges(ranges);
     if (ranges.length) {
       setWeek(ranges[0].week);
+    } else {
+      setWeek('');
     }
   }, [weeklyYear, weeklyMonth]);
 
@@ -147,7 +149,7 @@ export default function PantryAggregations() {
         period: 'weekly',
         year: weeklyYear,
         month: weeklyMonth,
-        week,
+        week: week as number,
       });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -237,7 +239,10 @@ export default function PantryAggregations() {
             labelId="weekly-week-label"
             label="Week"
             value={week}
-            onChange={e => setWeek(Number(e.target.value))}
+            onChange={e =>
+              setWeek(e.target.value === '' ? '' : Number(e.target.value))
+            }
+            disabled={!weekRanges.length}
           >
             {weekRanges.map(range => (
               <MenuItem key={range.week} value={range.week}>
@@ -246,7 +251,11 @@ export default function PantryAggregations() {
             ))}
           </Select>
         </FormControl>
-        <Button variant="contained" onClick={handleExportWeekly} disabled={exportLoading}>
+        <Button
+          variant="contained"
+          onClick={handleExportWeekly}
+          disabled={exportLoading || week === ''}
+        >
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>
       </Stack>

--- a/MJ_FB_Frontend/src/utils/date.ts
+++ b/MJ_FB_Frontend/src/utils/date.ts
@@ -3,9 +3,11 @@ import dayjs from 'dayjs';
 import type { ConfigType } from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import objectSupport from 'dayjs/plugin/objectSupport';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(objectSupport);
 
 export const REGINA_TIMEZONE = 'America/Regina';
 


### PR DESCRIPTION
## Summary
- load dayjs object support so week ranges are generated
- initialise week dropdown safely and disable export until a week is selected
- adjust pantry aggregation tests for new behaviour

## Testing
- `npm test src/__tests__/PantryAggregations.test.tsx`
- `npm test` *(fails: useNavigate may be used only in the context of a <Router> component, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c0e713d1c4832d991d6be88f93054a