### PR TITLE
Add endpoints for available pantry months and weeks

### DIFF
--- a/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
@@ -241,6 +241,38 @@ export async function listAvailableYears(req: Request, res: Response, next: Next
   }
 }
 
+export async function listAvailableMonths(req: Request, res: Response, next: NextFunction) {
+  try {
+    const year = parseInt((req.query.year as string) ?? '', 10);
+    if (!year) return res.status(400).json({ message: 'Year required' });
+    const result = await pool.query(
+      'SELECT DISTINCT month FROM pantry_monthly_overall WHERE year = $1 ORDER BY month',
+      [year],
+    );
+    res.json(result.rows.map(r => r.month));
+  } catch (error) {
+    logger.error('Error listing pantry months:', error);
+    next(error);
+  }
+}
+
+export async function listAvailableWeeks(req: Request, res: Response, next: NextFunction) {
+  try {
+    const year = parseInt((req.query.year as string) ?? '', 10);
+    const month = parseInt((req.query.month as string) ?? '', 10);
+    if (!year || !month)
+      return res.status(400).json({ message: 'Year and month required' });
+    const result = await pool.query(
+      'SELECT DISTINCT week FROM pantry_weekly_overall WHERE year = $1 AND month = $2 ORDER BY week',
+      [year, month],
+    );
+    res.json(result.rows.map(r => r.week));
+  } catch (error) {
+    logger.error('Error listing pantry weeks:', error);
+    next(error);
+  }
+}
+
 export async function exportPantryWeekly(req: Request, res: Response, next: NextFunction) {
   try {
     const year = parseInt((req.query.year as string) ?? '', 10);

--- a/MJ_FB_Backend/src/controllers/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantryAggregationController.ts
@@ -6,6 +6,8 @@ import {
   listPantryMonthly,
   listPantryYearly,
   listAvailableYears,
+  listAvailableMonths,
+  listAvailableWeeks,
   exportPantryWeekly,
   exportPantryMonthly,
   exportPantryYearly,
@@ -14,7 +16,7 @@ import {
   refreshPantryYearly,
 } from './pantry/pantryAggregationController';
 
-export { listAvailableYears };
+export { listAvailableYears, listAvailableMonths, listAvailableWeeks };
 
 export async function listWeeklyAggregations(req: Request, res: Response, next: NextFunction) {
   return listPantryWeekly(req, res, next);

--- a/MJ_FB_Backend/src/routes/pantry/aggregations.ts
+++ b/MJ_FB_Backend/src/routes/pantry/aggregations.ts
@@ -4,6 +4,8 @@ import {
   listMonthlyAggregations,
   listYearlyAggregations,
   listAvailableYears,
+  listAvailableMonths,
+  listAvailableWeeks,
   exportAggregations,
   rebuildAggregations,
 } from '../../controllers/pantryAggregationController';
@@ -34,6 +36,18 @@ router.get(
   authMiddleware,
   authorizeAccess('pantry', 'aggregations'),
   listAvailableYears,
+);
+router.get(
+  '/months',
+  authMiddleware,
+  authorizeAccess('pantry', 'aggregations'),
+  listAvailableMonths,
+);
+router.get(
+  '/weeks',
+  authMiddleware,
+  authorizeAccess('pantry', 'aggregations'),
+  listAvailableWeeks,
 );
 router.get(
   '/export',

--- a/MJ_FB_Backend/tests/pantryAggregations.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregations.test.ts
@@ -44,6 +44,22 @@ describe('pantry aggregation routes', () => {
     expect(res.body).toEqual([{ week: 1 }]);
   });
 
+  it('lists available months', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ month: 5 }] });
+
+    const res = await request(app).get('/pantry-aggregations/months?year=2024');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([5]);
+  });
+
+  it('lists available weeks', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ week: 1 }] });
+
+    const res = await request(app).get('/pantry-aggregations/weeks?year=2024&month=5');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([1]);
+  });
+
   it('rebuilds aggregations', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ min_year: 2024, max_year: 2024 }] });
 

--- a/MJ_FB_Backend/tests/pantryAggregationsAuth.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationsAuth.test.ts
@@ -11,6 +11,16 @@ describe('pantry aggregations auth', () => {
     expect(res.status).toBe(401);
   });
 
+  it('requires auth for available months', async () => {
+    const res = await request(app).get('/pantry-aggregations/months');
+    expect(res.status).toBe(401);
+  });
+
+  it('requires auth for available weeks', async () => {
+    const res = await request(app).get('/pantry-aggregations/weeks');
+    expect(res.status).toBe(401);
+  });
+
   it('requires auth for export', async () => {
     const res = await request(app).get('/pantry-aggregations/export');
     expect(res.status).toBe(401);


### PR DESCRIPTION
## Summary
- list available months and weeks from pantry aggregation tables
- expose new pantry aggregation routes for months and weeks
- test pantry aggregation months/weeks and auth guards

## Testing
- `npm test` *(fails: Test Suites: 19 failed, 120 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e8a008e4832d9d062c345e628fa3