### PR TITLE
Use server-provided years for warehouse exports

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Exports.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Exports.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Exports from '../pages/warehouse-management/Exports';
+import { getWarehouseOverallYears } from '../api/warehouseOverall';
+
+jest.mock('../api/warehouseOverall', () => ({
+  getWarehouseOverallYears: jest.fn(),
+  rebuildWarehouseOverall: jest.fn(),
+  exportWarehouseOverall: jest.fn(),
+}));
+jest.mock('../api/donations', () => ({
+  exportDonorAggregations: jest.fn(),
+}));
+
+describe('Exports page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads years from server and shows them in dropdown', async () => {
+    (getWarehouseOverallYears as jest.Mock).mockResolvedValue([2022, 2021]);
+    render(
+      <MemoryRouter>
+        <Exports />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getWarehouseOverallYears).toHaveBeenCalled());
+
+    fireEvent.mouseDown(screen.getByLabelText(/Year/i));
+    const options = await screen.findAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent('2022');
+    expect(options[1]).toHaveTextContent('2021');
+  });
+
+  it('disables exports when no years are available', async () => {
+    (getWarehouseOverallYears as jest.Mock).mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <Exports />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getWarehouseOverallYears).toHaveBeenCalled());
+
+    expect(screen.getByLabelText(/Year/i)).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Export Donor Aggregations/i })).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /Export Warehouse Overall Stats/i })
+    ).toBeDisabled();
+    expect(screen.getByText(/No years available/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- populate year dropdown in warehouse exports from `getWarehouseOverallYears`
- disable exports and show message when no years available
- test warehouse export dropdown uses server years only

## Testing
- `npm test` *(fails: useNavigate() may be used only in the context of a <Router> component, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e8a52744832da115a95be80234b8