### PR TITLE
Remove monthly totals column from warehouse yearly export

### DIFF
--- a/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
+++ b/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
@@ -143,29 +143,32 @@ export async function exportWarehouseOverall(req: Request, res: Response, next: 
         { value: 'Surplus', ...headerStyle },
         { value: 'Pig Pound', ...headerStyle },
         { value: 'Outgoing Donations', ...headerStyle },
-        { value: 'Total', ...headerStyle },
       ],
     ];
 
-    let totals = { donations: 0, surplus: 0, pigPound: 0, outgoingDonations: 0, total: 0 };
+    let totals = { donations: 0, surplus: 0, pigPound: 0, outgoingDonations: 0 };
 
     for (let m = 1; m <= 12; m++) {
-      const row = dataByMonth.get(m) || { donations: 0, surplus: 0, pigPound: 0, outgoingDonations: 0 };
-      const monthTotal = row.donations + row.surplus + row.pigPound + row.outgoingDonations;
+      const row =
+        dataByMonth.get(m) || {
+          donations: 0,
+          surplus: 0,
+          pigPound: 0,
+          outgoingDonations: 0,
+        };
       rows.push([
         { value: monthNames[m - 1] },
         { value: row.donations },
         { value: row.surplus },
         { value: row.pigPound },
         { value: row.outgoingDonations },
-        { value: monthTotal },
       ]);
       totals = {
         donations: totals.donations + row.donations,
         surplus: totals.surplus + row.surplus,
         pigPound: totals.pigPound + row.pigPound,
-        outgoingDonations: totals.outgoingDonations + row.outgoingDonations,
-        total: totals.total + monthTotal,
+        outgoingDonations:
+          totals.outgoingDonations + row.outgoingDonations,
       };
     }
 
@@ -175,7 +178,6 @@ export async function exportWarehouseOverall(req: Request, res: Response, next: 
       { value: totals.surplus, fontWeight: 'bold' },
       { value: totals.pigPound, fontWeight: 'bold' },
       { value: totals.outgoingDonations, fontWeight: 'bold' },
-      { value: totals.total, fontWeight: 'bold' },
     ]);
 
     const buffer = await writeXlsxFile(rows, {

--- a/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
@@ -67,11 +67,10 @@ describe('GET /warehouse-overall/export', () => {
       'Surplus',
       'Pig Pound',
       'Outgoing Donations',
-      'Total',
     ]);
-    expect(values[1]).toEqual(['January', 10, 2, 1, 0, 13]);
-    expect(values[2]).toEqual(['February', 5, 3, 0, 1, 9]);
-    expect(values[3]).toEqual(['March', 0, 0, 0, 0, 0]);
-    expect(values[13]).toEqual(['Total', 15, 5, 1, 1, 22]);
+    expect(values[1]).toEqual(['January', 10, 2, 1, 0]);
+    expect(values[2]).toEqual(['February', 5, 3, 0, 1]);
+    expect(values[3]).toEqual(['March', 0, 0, 0, 0]);
+    expect(values[13]).toEqual(['Total', 15, 5, 1, 1]);
   });
 });


### PR DESCRIPTION
## Summary
- drop redundant monthly total column from warehouse yearly overall export
- adjust export test expectations

## Testing
- `npm test` *(fails: 24 failing, 115 passing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e82c95e4832d9c7e16bfd4bb736f