### PR TITLE
feat: wire months and weeks for pantry aggregations

### DIFF
--- a/MJ_FB_Frontend/src/api/pantryAggregations.ts
+++ b/MJ_FB_Frontend/src/api/pantryAggregations.ts
@@ -20,6 +20,16 @@ export async function getPantryYears() {
   return handleResponse(res);
 }
 
+export async function getPantryMonths(year: number) {
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/months?year=${year}`);
+  return handleResponse(res);
+}
+
+export async function getPantryWeeks(year: number, month: number) {
+  const res = await apiFetch(`${API_BASE}/pantry-aggregations/weeks?year=${year}&month=${month}`);
+  return handleResponse(res);
+}
+
 export async function exportPantryAggregations(params: {
   period: 'weekly' | 'monthly' | 'yearly';
   year: number;


### PR DESCRIPTION
## Summary
- add client helpers for pantry aggregation months and weeks endpoints
- load months and weeks from API and guard export button when unavailable
- test pantry aggregation dropdown filtering

## Testing
- `npm test` *(fails: SyntaxError in PantryScheduleCapacity.test.tsx)*
- `npm test src/__tests__/PantryAggregations.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c0e8a2c288832d9d46bce161548b17