### PR TITLE
Fix weekly pantry refresh to pass month

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -252,7 +252,7 @@ export async function addVisit(req: Request, res: Response, next: NextFunction) 
     await client.query('COMMIT');
     const { week, month, year } = getWeekForDate(date);
     await Promise.all([
-      refreshPantryWeekly(year, week),
+      refreshPantryWeekly(year, month, week),
       refreshPantryMonthly(year, month),
       refreshPantryYearly(year),
     ]);
@@ -338,14 +338,14 @@ export async function updateVisit(req: Request, res: Response, next: NextFunctio
     if (clientId && clientId !== prevClientId) await refreshClientVisitCount(clientId);
     const { week, month, year } = getWeekForDate(date);
     await Promise.all([
-      refreshPantryWeekly(year, week),
+      refreshPantryWeekly(year, month, week),
       refreshPantryMonthly(year, month),
       refreshPantryYearly(year),
     ]);
     if (prevDate && prevDate !== date) {
       const prev = getWeekForDate(prevDate);
       await Promise.all([
-        refreshPantryWeekly(prev.year, prev.week),
+        refreshPantryWeekly(prev.year, prev.month, prev.week),
         refreshPantryMonthly(prev.year, prev.month),
         refreshPantryYearly(prev.year),
       ]);
@@ -386,7 +386,7 @@ export async function deleteVisit(req: Request, res: Response, next: NextFunctio
     if (date) {
       const { week, month, year } = getWeekForDate(date);
       await Promise.all([
-        refreshPantryWeekly(year, week),
+        refreshPantryWeekly(year, month, week),
         refreshPantryMonthly(year, month),
         refreshPantryYearly(year),
       ]);
@@ -509,7 +509,7 @@ export async function bulkImportVisits(req: Request, res: Response, next: NextFu
       const { week, month, year } = getWeekForDate(d);
       const dt = new Date(reginaStartOfDayISO(d));
       await Promise.all([
-        refreshPantryWeekly(year, week),
+        refreshPantryWeekly(year, month, week),
         refreshPantryMonthly(year, month),
         refreshPantryYearly(year),
         refreshSunshineBagOverall(dt.getUTCFullYear(), dt.getUTCMonth() + 1),
@@ -693,7 +693,7 @@ export async function importVisitsFromXlsx(
         const { week, month, year } = getWeekForDate(d);
         const dt = new Date(reginaStartOfDayISO(d));
         await Promise.all([
-          refreshPantryWeekly(year, week),
+          refreshPantryWeekly(year, month, week),
           refreshPantryMonthly(year, month),
           refreshPantryYearly(year),
           refreshSunshineBagOverall(dt.getUTCFullYear(), dt.getUTCMonth() + 1),

--- a/MJ_FB_Backend/src/controllers/pantryStatsController.ts
+++ b/MJ_FB_Backend/src/controllers/pantryStatsController.ts
@@ -1,7 +1,7 @@
 import pool from '../db';
 
-export async function refreshPantryWeekly(year: number, week: number) {
-  await pool.query('SELECT refresh_pantry_weekly($1,$2)', [year, week]);
+export async function refreshPantryWeekly(year: number, month: number, week: number) {
+  await pool.query('SELECT refresh_pantry_weekly($1,$2,$3)', [year, month, week]);
 }
 
 export async function refreshPantryMonthly(year: number, month: number) {

--- a/MJ_FB_Backend/src/controllers/sunshineBagController.ts
+++ b/MJ_FB_Backend/src/controllers/sunshineBagController.ts
@@ -58,7 +58,7 @@ export async function upsertSunshineBag(req: Request, res: Response, next: NextF
     await refreshSunshineBagOverall(dt.getUTCFullYear(), dt.getUTCMonth() + 1);
     const { week, month, year } = getWeekForDate(date);
     await Promise.all([
-      refreshPantryWeekly(year, week),
+      refreshPantryWeekly(year, month, week),
       refreshPantryMonthly(year, month),
       refreshPantryYearly(year),
     ]);

--- a/MJ_FB_Backend/tests/clientVisitController.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitController.test.ts
@@ -38,7 +38,7 @@ describe('clientVisitController', () => {
 
     await deleteVisit(req, res, next);
     const { week, month, year } = getWeekForDate('2024-05-20');
-    expect(refreshPantryWeekly).toHaveBeenCalledWith(year, week);
+    expect(refreshPantryWeekly).toHaveBeenCalledWith(year, month, week);
     expect(refreshPantryMonthly).toHaveBeenCalledWith(year, month);
     expect(refreshPantryYearly).toHaveBeenCalledWith(year);
   });

--- a/MJ_FB_Backend/tests/pantryStatsController.test.ts
+++ b/MJ_FB_Backend/tests/pantryStatsController.test.ts
@@ -11,8 +11,8 @@ describe('pantryStatsController', () => {
   });
 
   it('refreshPantryWeekly calls stored procedure', async () => {
-    await refreshPantryWeekly(2024, 10);
-    expect(mockDb.query).toHaveBeenCalledWith('SELECT refresh_pantry_weekly($1,$2)', [2024, 10]);
+    await refreshPantryWeekly(2024, 5, 10);
+    expect(mockDb.query).toHaveBeenCalledWith('SELECT refresh_pantry_weekly($1,$2,$3)', [2024, 5, 10]);
   });
 
   it('refreshPantryMonthly calls stored procedure', async () => {

--- a/MJ_FB_Backend/tests/sunshineBagController.test.ts
+++ b/MJ_FB_Backend/tests/sunshineBagController.test.ts
@@ -35,7 +35,7 @@ describe('sunshineBagController', () => {
     const next = jest.fn();
     await upsertSunshineBag(req, res, next);
     const { week, month, year } = getWeekForDate('2024-05-20');
-    expect(refreshPantryWeekly).toHaveBeenCalledWith(year, week);
+    expect(refreshPantryWeekly).toHaveBeenCalledWith(year, month, week);
     expect(refreshPantryMonthly).toHaveBeenCalledWith(year, month);
     expect(refreshPantryYearly).toHaveBeenCalledWith(year);
   });


### PR DESCRIPTION
## Summary
- add month argument to weekly pantry stats refresh
- adjust sunshine bag and client visit controllers to supply month
- update tests for new refresh signature

## Testing
- `npm test` (fails: Test Suites: 23 failed, 116 passed)

------
https://chatgpt.com/codex/tasks/task_e_68c0ea21d6e4832d896f446a6c27fd27