### PR TITLE
feat: default to current period in pantry aggregations

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
@@ -1,13 +1,18 @@
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import PantryAggregations from '../pages/staff/PantryAggregations';
+import { getWeekForDate } from '../utils/pantryWeek';
+
+const currentYear = new Date().getFullYear();
+const currentMonth = new Date().getMonth() + 1;
+const currentWeek = getWeekForDate(new Date()).week;
 
 const mockGetPantryWeekly = jest.fn().mockResolvedValue([]);
 const mockGetPantryMonthly = jest.fn().mockResolvedValue([]);
 const mockGetPantryYearly = jest.fn().mockResolvedValue([]);
-const mockGetPantryYears = jest.fn().mockResolvedValue([new Date().getFullYear()]);
-const mockGetPantryMonths = jest.fn().mockResolvedValue([1]);
-const mockGetPantryWeeks = jest.fn().mockResolvedValue([1]);
+const mockGetPantryYears = jest.fn().mockResolvedValue([currentYear]);
+const mockGetPantryMonths = jest.fn().mockResolvedValue([currentMonth]);
+const mockGetPantryWeeks = jest.fn().mockResolvedValue([currentWeek]);
 const mockExportPantryAggregations = jest
   .fn()
   .mockResolvedValue({ blob: new Blob(), fileName: 'test.xlsx' });
@@ -37,9 +42,9 @@ describe('PantryAggregations page', () => {
     mockGetPantryWeekly.mockResolvedValue([]);
     mockGetPantryMonthly.mockResolvedValue([]);
     mockGetPantryYearly.mockResolvedValue([]);
-    mockGetPantryYears.mockResolvedValue([new Date().getFullYear()]);
-    mockGetPantryMonths.mockResolvedValue([1]);
-    mockGetPantryWeeks.mockResolvedValue([1]);
+    mockGetPantryYears.mockResolvedValue([currentYear]);
+    mockGetPantryMonths.mockResolvedValue([currentMonth]);
+    mockGetPantryWeeks.mockResolvedValue([currentWeek]);
   });
 
   it('loads data for each tab', async () => {
@@ -62,7 +67,7 @@ describe('PantryAggregations page', () => {
   });
 
   it('displays weekly aggregations in a table', async () => {
-    mockGetPantryWeekly.mockResolvedValueOnce([{ week: 1, clients: 2 }]);
+    mockGetPantryWeekly.mockResolvedValueOnce([{ week: currentWeek, clients: 2 }]);
 
     render(
       <MemoryRouter>
@@ -74,12 +79,12 @@ describe('PantryAggregations page', () => {
 
     expect(screen.getByTestId('responsive-table-table')).toBeInTheDocument();
     expect(screen.getByText('week')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getAllByText(String(currentWeek)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('2').length).toBeGreaterThan(0);
   });
 
   it('exports weekly data', async () => {
-    const year = new Date().getFullYear();
+    const year = currentYear;
     render(
       <MemoryRouter>
         <PantryAggregations />
@@ -97,8 +102,8 @@ describe('PantryAggregations page', () => {
       expect(mockExportPantryAggregations).toHaveBeenCalledWith({
         period: 'weekly',
         year,
-        month: 1,
-        week: 1,
+        month: currentMonth,
+        week: currentWeek,
       }),
     );
   });

--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -25,7 +25,7 @@ import {
   rebuildPantryAggregations,
 } from '../../api/pantryAggregations';
 import dayjs, { formatDate } from '../../utils/date';
-import { getWeekRanges } from '../../utils/pantryWeek';
+import { getWeekRanges, getWeekForDate } from '../../utils/pantryWeek';
 
 export default function PantryAggregations() {
   const [years, setYears] = useState<number[]>([]);
@@ -99,8 +99,17 @@ export default function PantryAggregations() {
           r !== null && weeklyWeeks.includes(r.week),
       );
 
+    const today = dayjs();
+    const current = getWeekForDate(today);
+    const defaultWeek =
+      weeklyYear === today.year() &&
+      Number(weeklyMonth) - 1 === current.month &&
+      weeklyWeeks.includes(current.week)
+        ? current.week
+        : ranges[0]?.week ?? '';
+
     setWeekRanges(ranges);
-    setWeek(ranges[0]?.week ?? '');
+    setWeek(defaultWeek);
   }, [weeklyYear, weeklyMonth, weeklyWeeks]);
 
   useEffect(() => {
@@ -108,9 +117,11 @@ export default function PantryAggregations() {
       .then(ys => {
         setYears(ys);
         if (ys.length) {
-          setWeeklyYear(ys[0]);
-          setMonthlyYear(ys[0]);
-          setYearlyYear(ys[0]);
+          const currentYear = dayjs().year();
+          const defaultYear = ys.includes(currentYear) ? currentYear : ys[0];
+          setWeeklyYear(defaultYear);
+          setMonthlyYear(defaultYear);
+          setYearlyYear(defaultYear);
         }
       })
       .catch(() => {
@@ -127,7 +138,8 @@ export default function PantryAggregations() {
     getPantryMonths(weeklyYear)
       .then(ms => {
         setWeeklyMonths(ms);
-        setWeeklyMonth(ms[0] ?? '');
+        const currentMonth = dayjs().month() + 1;
+        setWeeklyMonth(ms.includes(currentMonth) ? currentMonth : ms[0] ?? '');
       })
       .catch(() => {
         setWeeklyMonths([]);
@@ -144,7 +156,8 @@ export default function PantryAggregations() {
     getPantryMonths(monthlyYear)
       .then(ms => {
         setMonthlyMonths(ms);
-        setMonth(ms[0] ?? '');
+        const currentMonth = dayjs().month() + 1;
+        setMonth(ms.includes(currentMonth) ? currentMonth : ms[0] ?? '');
       })
       .catch(() => {
         setMonthlyMonths([]);


### PR DESCRIPTION
## Summary
- default pantry aggregation filters to current year/month/week
- update pantry aggregation tests for dynamic current date defaults

## Testing
- `npm test PantryAggregations.test.tsx`
- `npm test` *(fails: useNavigate may be used only in the context of a <Router> component, and other setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c0eb643bf0832dbc7607fd0de7076f