### PR TITLE
Filter pantry aggregation selectors to existing data

### DIFF
--- a/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
@@ -246,10 +246,26 @@ export async function listAvailableMonths(req: Request, res: Response, next: Nex
     const year = parseInt((req.query.year as string) ?? '', 10);
     if (!year) return res.status(400).json({ message: 'Year required' });
     const result = await pool.query(
-      'SELECT DISTINCT month FROM pantry_monthly_overall WHERE year = $1 ORDER BY month',
+      `SELECT month, clients, adults, children, weight,
+              sunshine_bags AS "sunshineBags",
+              sunshine_weight AS "sunshineWeight"
+         FROM pantry_monthly_overall
+        WHERE year = $1
+        ORDER BY month`,
       [year],
     );
-    res.json(result.rows.map(r => r.month));
+    const months = result.rows
+      .filter(
+        r =>
+          r.clients > 0 ||
+          r.adults > 0 ||
+          r.children > 0 ||
+          r.weight > 0 ||
+          r.sunshineBags > 0 ||
+          r.sunshineWeight > 0,
+      )
+      .map(r => r.month);
+    res.json(months);
   } catch (error) {
     logger.error('Error listing pantry months:', error);
     next(error);
@@ -263,10 +279,26 @@ export async function listAvailableWeeks(req: Request, res: Response, next: Next
     if (!year || !month)
       return res.status(400).json({ message: 'Year and month required' });
     const result = await pool.query(
-      'SELECT DISTINCT week FROM pantry_weekly_overall WHERE year = $1 AND month = $2 ORDER BY week',
+      `SELECT week, clients, adults, children, weight,
+              sunshine_bags AS "sunshineBags",
+              sunshine_weight AS "sunshineWeight"
+         FROM pantry_weekly_overall
+        WHERE year = $1 AND month = $2
+        ORDER BY week`,
       [year, month],
     );
-    res.json(result.rows.map(r => r.week));
+    const weeks = result.rows
+      .filter(
+        r =>
+          r.clients > 0 ||
+          r.adults > 0 ||
+          r.children > 0 ||
+          r.weight > 0 ||
+          r.sunshineBags > 0 ||
+          r.sunshineWeight > 0,
+      )
+      .map(r => r.week);
+    res.json(weeks);
   } catch (error) {
     logger.error('Error listing pantry weeks:', error);
     next(error);

--- a/MJ_FB_Backend/tests/pantryAggregations.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregations.test.ts
@@ -45,7 +45,28 @@ describe('pantry aggregation routes', () => {
   });
 
   it('lists available months', async () => {
-    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ month: 5 }] });
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          month: 4,
+          clients: 0,
+          adults: 0,
+          children: 0,
+          weight: 0,
+          sunshineBags: 0,
+          sunshineWeight: 0,
+        },
+        {
+          month: 5,
+          clients: 1,
+          adults: 0,
+          children: 0,
+          weight: 0,
+          sunshineBags: 0,
+          sunshineWeight: 0,
+        },
+      ],
+    });
 
     const res = await request(app).get('/pantry-aggregations/months?year=2024');
     expect(res.status).toBe(200);
@@ -53,11 +74,32 @@ describe('pantry aggregation routes', () => {
   });
 
   it('lists available weeks', async () => {
-    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ week: 1 }] });
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          week: 1,
+          clients: 0,
+          adults: 0,
+          children: 0,
+          weight: 0,
+          sunshineBags: 0,
+          sunshineWeight: 0,
+        },
+        {
+          week: 2,
+          clients: 1,
+          adults: 0,
+          children: 0,
+          weight: 0,
+          sunshineBags: 0,
+          sunshineWeight: 0,
+        },
+      ],
+    });
 
     const res = await request(app).get('/pantry-aggregations/weeks?year=2024&month=5');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([1]);
+    expect(res.body).toEqual([2]);
   });
 
   it('rebuilds aggregations', async () => {


### PR DESCRIPTION
## Summary
- only return months and weeks with non-zero pantry aggregation data
- cover zero-value filtering in pantry aggregation route tests

## Testing
- `npm test` *(backend partial: 21 failed, 66 passed)*
- `npm test tests/pantryAggregations.test.ts`
- `npm test` *(frontend partial: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ebbd5a74832dbccab5fd7ea4dc7a