### PR TITLE
Broaden export table button for pantry exports on desktop

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -328,7 +328,7 @@ export default function PantryAggregations() {
           onClick={handleExportWeekly}
           disabled={exportLoading || !weekRanges.length}
           fullWidth
-          sx={{ width: { sm: 'auto' } }}
+          sx={{ width: { sm: 160 } }}
         >
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>
@@ -392,7 +392,7 @@ export default function PantryAggregations() {
           onClick={handleExportMonthly}
           disabled={exportLoading || !month}
           fullWidth
-          sx={{ width: { sm: 'auto' } }}
+          sx={{ width: { sm: 160 } }}
         >
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>
@@ -440,7 +440,7 @@ export default function PantryAggregations() {
           onClick={handleExportYearly}
           disabled={exportLoading || !yearlyYear}
           fullWidth
-          sx={{ width: { sm: 'auto' } }}
+          sx={{ width: { sm: 160 } }}
         >
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>


### PR DESCRIPTION
## Summary
- widen "Export Table" button on pantry aggregations page for larger desktop width

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68c0edf2e070832dab3076db6082b0fa