### PR TITLE
Use weight column in donor mail stats

### DIFF
--- a/MJ_FB_Backend/src/controllers/monetaryDonorController.ts
+++ b/MJ_FB_Backend/src/controllers/monetaryDonorController.ts
@@ -215,7 +215,7 @@ export async function sendMailLists(req: Request, res: Response, next: NextFunct
     const statsRes = await pool.query(
       `SELECT clients AS families,
               children,
-              total_weight AS pounds
+              weight AS pounds
          FROM pantry_monthly_overall
         WHERE year = $1 AND month = $2`,
       [year, month],


### PR DESCRIPTION
## Summary
- use weight column in donor mail list stats

## Testing
- `npm test tests/monetaryDonors.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0f0c814e8832d9a83c7265ed7a404