### PR TITLE
test: verify pounds query

### DIFF
--- a/MJ_FB_Backend/tests/monetaryDonors.test.ts
+++ b/MJ_FB_Backend/tests/monetaryDonors.test.ts
@@ -182,6 +182,9 @@ describe('Mailing list generation', () => {
       expect.stringContaining('FROM pantry_monthly_overall'),
       [2024, 6],
     );
+    expect(pool.query.mock.calls[2][0]).toEqual(
+      expect.stringContaining('weight AS pounds'),
+    );
     expect(sendTemplatedEmail).toHaveBeenCalledTimes(3);
     expect((sendTemplatedEmail as jest.Mock).mock.calls[0][0]).toEqual({
       to: 'a@example.com',


### PR DESCRIPTION
## Summary
- assert `weight AS pounds` is included in mailing list stats query

## Testing
- `npm test tests/monetaryDonors.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0f0cd0370832dbc11593b6e19c35b