### PR TITLE
Add client visit verification toggle

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000039_add_verified_to_client_visits.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000039_add_verified_to_client_visits.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('client_visits', {
+    verified: { type: 'boolean', notNull: true, default: false },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('client_visits', 'verified');
+}

--- a/MJ_FB_Backend/src/routes/clientVisits.ts
+++ b/MJ_FB_Backend/src/routes/clientVisits.ts
@@ -7,6 +7,7 @@ import {
   bulkImportVisits,
   importVisitsFromXlsx,
   getVisitStats,
+  toggleVisitVerification,
 } from '../controllers/clientVisitController';
 import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
@@ -23,6 +24,7 @@ router.get('/', authMiddleware, authorizeAccess('pantry'), listVisits);
 router.get('/stats', authMiddleware, authorizeAccess('pantry'), getVisitStats);
 router.post('/', authMiddleware, authorizeAccess('pantry'), validate(addVisitSchema), addVisit);
 router.put('/:id', authMiddleware, authorizeAccess('pantry'), validate(updateVisitSchema), updateVisit);
+router.patch('/:id/verify', authMiddleware, authorizeAccess('pantry'), toggleVisitVerification);
 router.delete('/:id', authMiddleware, authorizeAccess('pantry'), deleteVisit);
 router.post('/import', authMiddleware, authorizeAccess('pantry'), upload.single('file'), bulkImportVisits);
 router.post(

--- a/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/clientVisitSchemas.ts
@@ -9,6 +9,7 @@ export const clientVisitSchema = z.object({
   adults: z.number().int().min(0),
   children: z.number().int().min(0),
   petItem: z.number().int().optional(),
+  verified: z.boolean().optional(),
   note: z.string().optional(),
 });
 

--- a/MJ_FB_Backend/tests/clientVisitController.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitController.test.ts
@@ -5,7 +5,7 @@ import {
   refreshPantryMonthly,
   refreshPantryYearly,
 } from '../src/controllers/pantryStatsController';
-import { deleteVisit } from '../src/controllers/clientVisitController';
+import { deleteVisit, toggleVisitVerification } from '../src/controllers/clientVisitController';
 
 jest.mock('../src/controllers/pantryStatsController', () => ({
   refreshPantryWeekly: jest.fn(),
@@ -41,5 +41,59 @@ describe('clientVisitController', () => {
     expect(refreshPantryWeekly).toHaveBeenCalledWith(year, month, week);
     expect(refreshPantryMonthly).toHaveBeenCalledWith(year, month);
     expect(refreshPantryYearly).toHaveBeenCalledWith(year);
+  });
+
+  it('toggles visit verification', async () => {
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            id: 1,
+            date: '2024-05-20',
+            clientId: 1,
+            weightWithCart: 0,
+            weightWithoutCart: 0,
+            petItem: 0,
+            anonymous: false,
+            note: null,
+            adults: 0,
+            children: 0,
+            verified: true,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            id: 1,
+            date: '2024-05-20',
+            clientId: 1,
+            weightWithCart: 0,
+            weightWithoutCart: 0,
+            petItem: 0,
+            anonymous: false,
+            note: null,
+            adults: 0,
+            children: 0,
+            verified: false,
+          },
+        ],
+      });
+
+    const req = { params: { id: '1' } } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+
+    await toggleVisitVerification(req, res, next);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ verified: true }),
+    );
+
+    await toggleVisitVerification(req, res, next);
+    expect(res.json).toHaveBeenLastCalledWith(
+      expect.objectContaining({ verified: false }),
+    );
   });
 });

--- a/MJ_FB_Frontend/src/api/clientVisits.ts
+++ b/MJ_FB_Frontend/src/api/clientVisits.ts
@@ -19,6 +19,7 @@ export async function createClientVisit(
       ...payload,
       adults: payload.adults,
       children: payload.children,
+      verified: payload.verified,
       note: payload.note ?? undefined,
     }),
   });
@@ -36,6 +37,7 @@ export async function updateClientVisit(
       ...payload,
       adults: payload.adults ?? undefined,
       children: payload.children ?? undefined,
+      verified: payload.verified ?? undefined,
       note: payload.note ?? undefined,
     }),
   });
@@ -47,6 +49,15 @@ export async function deleteClientVisit(id: number): Promise<void> {
     method: 'DELETE',
   });
   await handleResponse(res);
+}
+
+export async function toggleClientVisitVerification(
+  id: number,
+): Promise<ClientVisit> {
+  const res = await apiFetch(`${API_BASE}/client-visits/${id}/verify`, {
+    method: 'PATCH',
+  });
+  return handleResponse(res);
 }
 
 export interface VisitImportSheet {

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -20,6 +20,7 @@ import {
   Radio,
   RadioGroup,
   Typography,
+  Checkbox,
 } from '@mui/material';
 import Edit from '@mui/icons-material/Edit';
 import Delete from '@mui/icons-material/Delete';
@@ -35,6 +36,7 @@ import {
   updateClientVisit,
   deleteClientVisit,
   importVisitsXlsx,
+  toggleClientVisitVerification,
   type ClientVisit,
   type VisitImportSheet,
 } from '../../api/clientVisits';
@@ -310,6 +312,7 @@ export default function PantryVisits() {
       children: Number(form.children || 0),
       petItem: Number(form.petItem || 0),
       note: form.note.trim() || undefined,
+      verified: editing?.verified ?? false,
     };
     const action = editing
       ? updateClientVisit(editing.id, payload)
@@ -398,14 +401,40 @@ export default function PantryVisits() {
     { field: 'petItem', header: 'Pet Item', render: (v: ClientVisit) => v.petItem },
     { field: 'note', header: 'Note', render: (v: ClientVisit) => v.note || '' },
     {
+      field: 'verified',
+      header: 'Verified',
+      render: (v: ClientVisit) => (
+        <Checkbox
+          checked={v.verified}
+          onChange={() => {
+            toggleClientVisitVerification(v.id)
+              .then(u =>
+                setVisits(prev =>
+                  prev.map(vis => (vis.id === u.id ? u : vis)),
+                ),
+              )
+              .catch(() =>
+                setSnackbar({
+                  open: true,
+                  message: 'Error updating verification',
+                  severity: 'error',
+                }),
+              );
+          }}
+          inputProps={{ 'aria-label': 'Verify visit' }}
+        />
+      ),
+    },
+    {
       field: 'actions',
       header: 'Actions',
-      render: (v: ClientVisit) => (
-        <Stack direction="row" spacing={1}>
-          <IconButton
-            
-            onClick={() => {
-              setEditing(v);
+      render: (v: ClientVisit) =>
+        !v.verified && (
+          <Stack direction="row" spacing={1}>
+            <IconButton
+
+              onClick={() => {
+                setEditing(v);
               setForm({
                 date: formatDate(v.date),
                 anonymous: v.anonymous,
@@ -438,7 +467,7 @@ export default function PantryVisits() {
             <Delete fontSize="small" />
           </IconButton>
         </Stack>
-      ),
+        ),
     },
   ];
 

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -280,6 +280,7 @@ export interface ClientVisit {
   adults: number;
   children: number;
   petItem: number;
+  verified: boolean;
   note?: string;
 }
 


### PR DESCRIPTION
## Summary
- add `verified` flag to `client_visits` table
- expose API and UI controls to toggle verification
- track verification in types, schemas, and tests

## Testing
- `npm test` (backend) *(fails: Test Suites: 28 failed, 111 passed, 139 total)*
- `npm test` (frontend) *(fails: see errors in PantryVisits.test.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f0769c34832da039788f7524e4e2