### PR TITLE
fix: keep export table button text visible

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -330,7 +330,7 @@ export default function PantryAggregations() {
           onClick={handleExportWeekly}
           disabled={exportLoading || !weekRanges.length}
           fullWidth
-          sx={{ width: { sm: 160 } }}
+          sx={{ minWidth: { sm: 160 }, flexShrink: 0, textTransform: 'none' }}
         >
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>
@@ -394,7 +394,7 @@ export default function PantryAggregations() {
           onClick={handleExportMonthly}
           disabled={exportLoading || !month}
           fullWidth
-          sx={{ width: { sm: 160 } }}
+          sx={{ minWidth: { sm: 160 }, flexShrink: 0, textTransform: 'none' }}
         >
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>
@@ -442,7 +442,7 @@ export default function PantryAggregations() {
           onClick={handleExportYearly}
           disabled={exportLoading || !yearlyYear}
           fullWidth
-          sx={{ width: { sm: 160 } }}
+          sx={{ minWidth: { sm: 160 }, flexShrink: 0, textTransform: 'none' }}
         >
           {exportLoading ? <CircularProgress size={20} /> : 'Export Table'}
         </Button>


### PR DESCRIPTION
## Summary
- prevent Export Table button text from shrinking out of view on Pantry Aggregations page

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider; useNavigate() may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f1270178832dbf0db5a2fbe8919f