### PR TITLE
test: relax booking reminder notifyOps match

### DIFF
--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -71,8 +71,9 @@ describe('sendNextDayBookingReminders', () => {
       }),
     );
     expect(notifyOps).toHaveBeenCalledWith(
-      'sendNextDayBookingReminders queued reminders for user@example.com',
+      expect.stringContaining('sendNextDayBookingReminders queued reminders for'),
     );
+    expect((notifyOps as jest.Mock).mock.calls[0][0]).toContain('user@example.com');
     expect(db.query).toHaveBeenCalledWith(
       'UPDATE bookings SET reminder_sent = true WHERE id = $1',
       [1],


### PR DESCRIPTION
## Summary
- loosen notifyOps assert in bookingReminderJob test to use `expect.stringContaining`
- ensure reminder log contains the recipient email

## Testing
- `npm test tests/bookingReminderJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0f2406adc832d99881c833f179398