### PR TITLE
Clarify aggregation page titles and remove quicklinks

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -14,7 +14,6 @@ import Page from '../../components/Page';
 import StyledTabs from '../../components/StyledTabs';
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import PantryQuickLinks from '../../components/PantryQuickLinks';
 import {
   getPantryWeekly,
   getPantryMonthly,
@@ -474,17 +473,14 @@ export default function PantryAggregations() {
   ];
 
   return (
-    <>
-      <PantryQuickLinks />
-      <Page title="Aggregations">
-        <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
-        <FeedbackSnackbar
-          open={snackbar.open}
-          onClose={() => setSnackbar({ ...snackbar, open: false })}
-          message={snackbar.message}
-          severity={snackbar.severity}
-        />
-      </Page>
-    </>
+    <Page title="Pantry Aggregations">
+      <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
+      <FeedbackSnackbar
+        open={snackbar.open}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        message={snackbar.message}
+        severity={snackbar.severity}
+      />
+    </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -18,7 +18,6 @@ import {
 } from '../../api/warehouseOverall';
 import { getDonorAggregations, type DonorAggregation } from '../../api/donations';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import { toDate } from '../../utils/date';
 import { exportTableToExcel } from '../../utils/exportTableToExcel';
@@ -308,17 +307,14 @@ export default function Aggregations() {
   ];
 
     return (
-      <>
-        <WarehouseQuickLinks />
-        <Page title="Aggregations">
-          <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
-          <FeedbackSnackbar
-            open={snackbar.open}
-            onClose={() => setSnackbar({ ...snackbar, open: false })}
-            message={snackbar.message}
-            severity={snackbar.severity}
-          />
-        </Page>
-      </>
+      <Page title="Warehouse Aggregations">
+        <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
+        <FeedbackSnackbar
+          open={snackbar.open}
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+          message={snackbar.message}
+          severity={snackbar.severity}
+        />
+      </Page>
     );
-}
+  }


### PR DESCRIPTION
## Summary
- Rename pantry aggregation page title and drop quicklinks
- Rename warehouse aggregation page title and drop quicklinks

## Testing
- `npm test` *(fails: Jest encountered unexpected token in PantrySchedule and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f3da79d8832dbb580439d29f3c97