### PR TITLE
Expose Content-Disposition header for export responses

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -58,6 +58,7 @@ app.use(
   cors({
     origin: config.frontendOrigins,
     credentials: true,
+    exposedHeaders: ['Content-Disposition'],
   })
 );
 


### PR DESCRIPTION
## Summary
- allow CORS to expose `Content-Disposition` header so clients can read filenames from export responses

## Testing
- `npm test` *(fails: cancel booking, client visit booking integration, startBookingReminderJob/stopBookingReminderJob, slots, user preference, blockedSlotCleanupJob, timesheetSeedJob, newClients migration, dbPoolErrorHandler, dateParser)*


------
https://chatgpt.com/codex/tasks/task_e_68c0f61cf0f0832db4b4105b2f63ec0b