### PR TITLE
Add pantry data retention job and align booking retention policy

### DIFF
--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -29,6 +29,7 @@ import {
   stopTimesheetSeedJob,
 } from './utils/timesheetSeedJob';
 import { startRetentionJob, stopRetentionJob } from './utils/bookingRetentionJob';
+import { startPantryRetentionJob, stopPantryRetentionJob } from './utils/pantryRetentionJob';
 import {
   startPasswordTokenCleanupJob,
   stopPasswordTokenCleanupJob,
@@ -68,6 +69,7 @@ async function init() {
     await seedTimesheets();
     startTimesheetSeedJob();
     startRetentionJob();
+    startPantryRetentionJob();
     startPasswordTokenCleanupJob();
     startLogCleanupJob();
     startBlockedSlotCleanupJob();
@@ -90,6 +92,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   stopTimesheetSeedJob();
   stopPayPeriodCronJob();
   stopRetentionJob();
+  stopPantryRetentionJob();
   stopPasswordTokenCleanupJob();
   stopLogCleanupJob();
   stopBlockedSlotCleanupJob();

--- a/MJ_FB_Backend/src/utils/bookingRetentionJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingRetentionJob.ts
@@ -2,7 +2,7 @@ import pool from '../db';
 import logger from './logger';
 import scheduleDailyJob from './scheduleDailyJob';
 
-const RETENTION_YEARS = 2;
+const RETENTION_YEARS = 1;
 
 export async function cleanupOldRecords(): Promise<void> {
   const client = await pool.connect();

--- a/MJ_FB_Backend/src/utils/pantryRetentionJob.ts
+++ b/MJ_FB_Backend/src/utils/pantryRetentionJob.ts
@@ -1,0 +1,41 @@
+import { refreshPantryMonthly, refreshPantryYearly } from '../controllers/pantryStatsController';
+import pool from '../db';
+import logger from './logger';
+import scheduleDailyJob from './scheduleDailyJob';
+
+export async function cleanupOldPantryData(): Promise<void> {
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const previousYear = currentYear - 1;
+
+  for (let month = 1; month <= 12; month++) {
+    await refreshPantryMonthly(previousYear, month);
+  }
+  await refreshPantryYearly(previousYear);
+
+  const cutoff = `${currentYear}-01-01`;
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('DELETE FROM client_visits WHERE date < $1', [cutoff]);
+    await client.query('DELETE FROM bookings WHERE date < $1', [cutoff]);
+    await client.query('COMMIT');
+    logger.info('Old pantry data cleaned up');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    logger.error('Failed to clean up old pantry data', err);
+  } finally {
+    client.release();
+  }
+}
+
+const pantryRetentionJob = scheduleDailyJob(
+  cleanupOldPantryData,
+  '0 3 31 1 *',
+  false,
+);
+
+export const startPantryRetentionJob = pantryRetentionJob.start;
+export const stopPantryRetentionJob = pantryRetentionJob.stop;
+

--- a/MJ_FB_Backend/tests/pantryRetentionJob.test.ts
+++ b/MJ_FB_Backend/tests/pantryRetentionJob.test.ts
@@ -1,0 +1,45 @@
+import mockPool from './utils/mockDb';
+import { cleanupOldPantryData } from '../src/utils/pantryRetentionJob';
+import { refreshPantryMonthly, refreshPantryYearly } from '../src/controllers/pantryStatsController';
+
+jest.mock('../src/controllers/pantryStatsController');
+
+describe('cleanupOldPantryData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('refreshes previous year and deletes old records', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-08-15'));
+
+    const mockClient = { query: jest.fn().mockResolvedValue({}), release: jest.fn() };
+    (mockPool.connect as jest.Mock).mockResolvedValueOnce(mockClient);
+
+    await cleanupOldPantryData();
+
+    for (let month = 1; month <= 12; month++) {
+      expect(refreshPantryMonthly).toHaveBeenCalledWith(2024, month);
+    }
+    expect(refreshPantryMonthly).toHaveBeenCalledTimes(12);
+    expect(refreshPantryYearly).toHaveBeenCalledWith(2024);
+
+    const cutoff = '2025-01-01';
+    expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      2,
+      'DELETE FROM client_visits WHERE date < $1',
+      [cutoff],
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      3,
+      'DELETE FROM bookings WHERE date < $1',
+      [cutoff],
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(4, 'COMMIT');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add scheduled pantry retention job to aggregate last year's data and purge stale pantry records
- register pantry retention job at server startup and shutdown
- retain only one year of bookings to match policy
- test pantry retention job refreshes and deletes with correct cutoff

## Testing
- `npm test tests/pantryRetentionJob.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c0f773b6b8832da1597305fc18ea45