### PR TITLE
Use in-app aggregation refreshers for sunshine bags

### DIFF
--- a/MJ_FB_Backend/src/controllers/sunshineBagController.ts
+++ b/MJ_FB_Backend/src/controllers/sunshineBagController.ts
@@ -6,7 +6,7 @@ import {
   refreshPantryWeekly,
   refreshPantryMonthly,
   refreshPantryYearly,
-} from './pantryStatsController';
+} from './pantryAggregationController';
 
 export async function refreshSunshineBagOverall(year: number, month: number) {
   const result = await pool.query(

--- a/MJ_FB_Backend/tests/sunshineBagController.test.ts
+++ b/MJ_FB_Backend/tests/sunshineBagController.test.ts
@@ -4,10 +4,10 @@ import {
   refreshPantryWeekly,
   refreshPantryMonthly,
   refreshPantryYearly,
-} from '../src/controllers/pantryStatsController';
+} from '../src/controllers/pantryAggregationController';
 import { upsertSunshineBag } from '../src/controllers/sunshineBagController';
 
-jest.mock('../src/controllers/pantryStatsController', () => ({
+jest.mock('../src/controllers/pantryAggregationController', () => ({
   refreshPantryWeekly: jest.fn(),
   refreshPantryMonthly: jest.fn(),
   refreshPantryYearly: jest.fn(),


### PR DESCRIPTION
## Summary
- Refresh pantry aggregates via in-app controller instead of relying on missing database stored procedures when saving sunshine bag logs
- Update sunshine bag controller tests accordingly

## Testing
- `npm test tests/sunshineBagController.test.ts`
- `npm test` *(fails: Test Suites: 24 failed, 116 passed, 140 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c0facacec8832db2aaa206ad03014b