### PR TITLE
fix: export pantry refresh helpers

### DIFF
--- a/MJ_FB_Backend/src/controllers/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantryAggregationController.ts
@@ -16,7 +16,14 @@ import {
   refreshPantryYearly,
 } from './pantry/pantryAggregationController';
 
-export { listAvailableYears, listAvailableMonths, listAvailableWeeks };
+export {
+  listAvailableYears,
+  listAvailableMonths,
+  listAvailableWeeks,
+  refreshPantryWeekly,
+  refreshPantryMonthly,
+  refreshPantryYearly,
+};
 
 export async function listWeeklyAggregations(req: Request, res: Response, next: NextFunction) {
   return listPantryWeekly(req, res, next);


### PR DESCRIPTION
## Summary
- export pantry refresh helpers so sunshine bag updates trigger aggregation

## Testing
- `npm test` (fails: Test Suites: 22 failed, 118 passed, 140 total)

------
https://chatgpt.com/codex/tasks/task_e_68c0fc144450832d96efe9a8f89ecf80