### PR TITLE
feat(frontend): add password checklist

### DIFF
--- a/MJ_FB_Frontend/public/locales/am/translation.json
+++ b/MJ_FB_Frontend/public/locales/am/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ar/translation.json
+++ b/MJ_FB_Frontend/public/locales/ar/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/en/translation.json
+++ b/MJ_FB_Frontend/public/locales/en/translation.json
@@ -100,7 +100,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/es/translation.json
+++ b/MJ_FB_Frontend/public/locales/es/translation.json
@@ -100,7 +100,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/fa/translation.json
+++ b/MJ_FB_Frontend/public/locales/fa/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/fr/translation.json
+++ b/MJ_FB_Frontend/public/locales/fr/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/hi/translation.json
+++ b/MJ_FB_Frontend/public/locales/hi/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ml/translation.json
+++ b/MJ_FB_Frontend/public/locales/ml/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "എന്റെ വരാനിരിക്കുന്ന അപ്പോയിന്റ്മെന്റ്",
   "my_upcoming_appointments": "എന്റെ വരാനിരിക്കുന്ന അപ്പോയിന്റ്മെന്റുകൾ",

--- a/MJ_FB_Frontend/public/locales/pa/translation.json
+++ b/MJ_FB_Frontend/public/locales/pa/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ps/translation.json
+++ b/MJ_FB_Frontend/public/locales/ps/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/so/translation.json
+++ b/MJ_FB_Frontend/public/locales/so/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/sw/translation.json
+++ b/MJ_FB_Frontend/public/locales/sw/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ta/translation.json
+++ b/MJ_FB_Frontend/public/locales/ta/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/ti/translation.json
+++ b/MJ_FB_Frontend/public/locales/ti/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/tl/translation.json
+++ b/MJ_FB_Frontend/public/locales/tl/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/uk/translation.json
+++ b/MJ_FB_Frontend/public/locales/uk/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/public/locales/zh/translation.json
+++ b/MJ_FB_Frontend/public/locales/zh/translation.json
@@ -98,7 +98,13 @@
     "password_symbol": "Password must include a symbol.",
     "notifications": "Notifications",
     "email_reminders": "Email reminders",
-    "preferences_saved": "Preferences saved."
+    "preferences_saved": "Preferences saved.",
+    "password_checklist": {
+      "min_length": "≥8 characters",
+      "uppercase": "Uppercase letter",
+      "lowercase": "Lowercase letter",
+      "symbol": "Symbol"
+    }
   },
   "my_upcoming_appointment": "My Upcoming Appointment",
   "my_upcoming_appointments": "My Upcoming Appointments",

--- a/MJ_FB_Frontend/src/components/PasswordChecklist.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordChecklist.tsx
@@ -1,0 +1,55 @@
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import { useTranslation } from 'react-i18next';
+
+interface PasswordChecklistProps {
+  password: string;
+}
+
+export default function PasswordChecklist({ password }: PasswordChecklistProps) {
+  const { t } = useTranslation();
+
+  const rules = [
+    {
+      id: 'min_length',
+      valid: password.length >= 8,
+      label: t('profile_page.password_checklist.min_length'),
+    },
+    {
+      id: 'uppercase',
+      valid: /[A-Z]/.test(password),
+      label: t('profile_page.password_checklist.uppercase'),
+    },
+    {
+      id: 'lowercase',
+      valid: /[a-z]/.test(password),
+      label: t('profile_page.password_checklist.lowercase'),
+    },
+    {
+      id: 'symbol',
+      valid: /[^A-Za-z0-9]/.test(password),
+      label: t('profile_page.password_checklist.symbol'),
+    },
+  ];
+
+  return (
+    <List dense>
+      {rules.map(rule => (
+        <ListItem key={rule.id}>
+          <ListItemIcon>
+            {rule.valid ? (
+              <CheckIcon color="success" data-testid={`${rule.id}-check`} />
+            ) : (
+              <CloseIcon color="error" data-testid={`${rule.id}-close`} />
+            )}
+          </ListItemIcon>
+          <ListItemText primary={rule.label} />
+        </ListItem>
+      ))}
+    </List>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
@@ -5,6 +5,7 @@ import PasswordField from '../../components/PasswordField';
 import Page from '../../components/Page';
 import FormCard from '../../components/FormCard';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import PasswordChecklist from '../../components/PasswordChecklist';
 import {
   setPassword as setPasswordApi,
   getPasswordSetupInfo,
@@ -41,6 +42,18 @@ export default function PasswordSetup() {
     e.preventDefault();
     if (!token) {
       setError(t('invalid_or_expired_token'));
+      return;
+    }
+    if (password.length < 8) {
+      setError(t('profile_page.password_min_length'));
+      return;
+    }
+    if (!/[A-Z]/.test(password) || !/[a-z]/.test(password)) {
+      setError(t('profile_page.password_number'));
+      return;
+    }
+    if (!/[^A-Za-z0-9]/.test(password)) {
+      setError(t('profile_page.password_symbol'));
       return;
     }
     try {
@@ -84,7 +97,9 @@ export default function PasswordSetup() {
           onChange={e => setPassword(e.target.value)}
           fullWidth
           required
+          helperText={t('profile_page.password_requirements')}
         />
+        <PasswordChecklist password={password} />
         <Button
           component={RouterLink}
           to={info ? loginPathMap[info.userType] : '/login'}

--- a/MJ_FB_Frontend/src/pages/auth/__tests__/PasswordSetup.test.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/__tests__/PasswordSetup.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import PasswordSetup from '../PasswordSetup';
+import { setPassword, getPasswordSetupInfo } from '../../../api/users';
+
+jest.mock('../../../api/users', () => ({
+  ...jest.requireActual('../../../api/users'),
+  setPassword: jest.fn(),
+  getPasswordSetupInfo: jest.fn(),
+}));
+
+describe('PasswordSetup checklist', () => {
+  beforeEach(() => {
+    (getPasswordSetupInfo as jest.Mock).mockResolvedValue({});
+    (setPassword as jest.Mock).mockResolvedValue('/login');
+  });
+
+  function setup() {
+    render(
+      <MemoryRouter initialEntries={["/set-password?token=tok"]}>
+        <Routes>
+          <Route path="/set-password" element={<PasswordSetup />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    return screen.getByLabelText(/password/i, { selector: 'input' });
+  }
+
+  it('updates checklist as user types', () => {
+    const input = setup();
+    expect(screen.getByTestId('min_length-close')).toBeInTheDocument();
+    expect(screen.getByTestId('uppercase-close')).toBeInTheDocument();
+    expect(screen.getByTestId('lowercase-close')).toBeInTheDocument();
+    expect(screen.getByTestId('symbol-close')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'Abcdefg' } });
+    expect(screen.getByTestId('min_length-close')).toBeInTheDocument();
+    expect(screen.getByTestId('uppercase-check')).toBeInTheDocument();
+    expect(screen.getByTestId('lowercase-check')).toBeInTheDocument();
+    expect(screen.getByTestId('symbol-close')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'Abcdefg@' } });
+    expect(screen.getByTestId('min_length-check')).toBeInTheDocument();
+    expect(screen.getByTestId('symbol-check')).toBeInTheDocument();
+  });
+
+  it('shows validation errors', async () => {
+    const input = setup();
+    fireEvent.change(input, { target: { value: 'Abcdefgh' } });
+    fireEvent.click(screen.getByRole('button', { name: /set password/i }));
+
+    await waitFor(() => expect(setPassword).not.toHaveBeenCalled());
+    expect(
+      await screen.findByText(/password must include a symbol/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -10,6 +10,11 @@ Add the following translation strings to locale files:
 - `hide_password`
 - `email_or_client_id` – label for the password reset field
 - `password_reset_instructions` – instructs users to enter their email or client ID and submit to receive a reset link via email
+- `profile_page.password_requirements` – helper text describing password rules
+- `profile_page.password_checklist.min_length` – checklist item for minimum length
+- `profile_page.password_checklist.uppercase` – checklist item for an uppercase letter
+- `profile_page.password_checklist.lowercase` – checklist item for a lowercase letter
+- `profile_page.password_checklist.symbol` – checklist item for a symbol
 
 ## Password setup identifier
 


### PR DESCRIPTION
## Summary
- show password requirements and live checklist on setup page
- validate password before submitting and cover with tests
- document password checklist translations

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fed19f0c832db94315da67632e09