### PR TITLE
feat: preserve request bodies across refresh retries

### DIFF
--- a/MJ_FB_Frontend/src/api/__tests__/clientBody.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/clientBody.test.ts
@@ -1,0 +1,39 @@
+import { apiFetch, API_BASE } from '../client';
+import { mockFetch, restoreFetch } from '../../../testUtils/mockFetch';
+
+let fetchMock: jest.Mock;
+
+describe('apiFetch preserves body on refresh', () => {
+  beforeEach(() => {
+    fetchMock = mockFetch();
+    document.cookie = 'csrfToken=test';
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    jest.resetAllMocks();
+  });
+
+  it('reuses multipart body after token refresh', async () => {
+    const form = new FormData();
+    form.append('a', '1');
+    const bodies: string[] = [];
+
+    fetchMock
+      .mockImplementationOnce(async (req: Request) => {
+        bodies.push(await req.text());
+        return new Response(null, { status: 401 });
+      })
+      .mockImplementationOnce(async () => new Response(null, { status: 200 }))
+      .mockImplementationOnce(async (req: Request) => {
+        bodies.push(await req.text());
+        return new Response(null, { status: 200 });
+      });
+
+    const res = await apiFetch(`${API_BASE}/upload`, { method: 'POST', body: form });
+    expect(res.status).toBe(200);
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).toBe(bodies[1]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- clone request bodies in `apiFetch` before initial fetch
- reuse preserved body when retrying after refresh
- add test ensuring multipart bodies survive refresh

## Testing
- `npm test` *(fails: existing test failures)*
- `npx jest --testPathPattern=src/api/__tests__/clientBody.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c102dda124832daaf9e5a41383ccaf