### PR TITLE
Validate visit metrics and test negative inputs

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -447,6 +447,20 @@ export async function markBookingVisited(req: Request, res: Response, next: Next
   const note = req.body?.note as string | undefined;
   const adults = req.body?.adults as number | undefined;
   const children = req.body?.children as number | undefined;
+  const fields: [string, number | undefined | null][] = [
+    ['weightWithCart', weightWithCart],
+    ['weightWithoutCart', weightWithoutCart],
+    ['petItem', petItem],
+    ['adults', adults],
+    ['children', children],
+  ];
+  for (const [name, value] of fields) {
+    if (value !== undefined && value !== null) {
+      if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+        return res.status(400).json({ message: `${name} must be a non-negative number` });
+      }
+    }
+  }
   try {
     const dup = await pool.query(
       `SELECT 1 FROM client_visits v

--- a/MJ_FB_Backend/tests/bookingController.test.ts
+++ b/MJ_FB_Backend/tests/bookingController.test.ts
@@ -410,4 +410,44 @@ describe('markBookingVisited', () => {
       "SELECT value FROM app_config WHERE key = 'cart_tare'",
     );
   });
+
+  describe('validation', () => {
+    it.each([
+      ['weightWithCart'],
+      ['weightWithoutCart'],
+      ['petItem'],
+      ['adults'],
+      ['children'],
+    ])('returns 400 for negative %s', async (field) => {
+      const req = { params: { id: '123' }, body: { [field]: -1 } } as unknown as Request;
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      await markBookingVisited(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: `${field} must be a non-negative number` });
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(updateBooking).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['weightWithCart'],
+      ['weightWithoutCart'],
+      ['petItem'],
+      ['adults'],
+      ['children'],
+    ])('returns 400 for non-numeric %s', async (field) => {
+      const req = { params: { id: '123' }, body: { [field]: 'abc' } } as unknown as Request;
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      await markBookingVisited(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: `${field} must be a non-negative number` });
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(updateBooking).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- validate visit metrics in markBookingVisited ensuring non-negative numbers
- add tests for negative and non-numeric visit metrics

## Testing
- `npm test` *(fails: 19 failed, 121 passed)*
- `npm test tests/bookingController.test.ts` *(fails: 1 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c102f4ec10832db510502f1cf165b9