### PR TITLE
Standardize Shopping Appointment label

### DIFF
--- a/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
+++ b/MJ_FB_Frontend/src/api/__tests__/bookingsApi.test.ts
@@ -19,10 +19,13 @@ describe('bookings api', () => {
 
   it('calls no-show endpoint', async () => {
     await markBookingNoShow(5, 'reason');
-    expect(apiFetch).toHaveBeenCalledWith('/api/bookings/5/no-show', expect.objectContaining({
-      method: 'POST',
-      body: JSON.stringify({ reason: 'reason', type: 'shopping appointment' }),
-    }));
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/bookings/5/no-show',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ reason: 'reason', type: 'Shopping Appointment' }),
+      })
+    );
   });
 
   it('calls visited endpoint with note', async () => {
@@ -35,17 +38,28 @@ describe('bookings api', () => {
 
   it('creates booking with note', async () => {
     await createBooking('3', '2024-05-01', 'note');
-    expect(apiFetch).toHaveBeenCalledWith('/api/bookings', expect.objectContaining({
-      method: 'POST',
-      body: JSON.stringify({ slotId: 3, date: '2024-05-01', note: 'note', type: 'shopping appointment' }),
-    }));
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/bookings',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          slotId: 3,
+          date: '2024-05-01',
+          type: 'Shopping Appointment',
+          note: 'note',
+        }),
+      })
+    );
   });
 
   it('omits note when blank', async () => {
     await createBooking('4', '2024-05-01', '   ');
-    expect(apiFetch).toHaveBeenCalledWith('/api/bookings', expect.objectContaining({
-      method: 'POST',
-      body: JSON.stringify({ slotId: 4, date: '2024-05-01', type: 'shopping appointment' }),
-    }));
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/bookings',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ slotId: 4, date: '2024-05-01', type: 'Shopping Appointment' }),
+      })
+    );
   });
 });

--- a/MJ_FB_Frontend/src/api/bookings.ts
+++ b/MJ_FB_Frontend/src/api/bookings.ts
@@ -86,7 +86,7 @@ export async function createBooking(
   const body: CreateBookingBody = {
     slotId: Number(slotId),
     date,
-    type: 'shopping appointment',
+    type: 'Shopping Appointment',
   };
   if (note && note.trim()) body.note = note;
   if (userId) body.userId = userId;
@@ -278,7 +278,9 @@ export async function cancelBooking(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(reason ? { reason, type: 'shopping appointment' } : { type: 'shopping appointment' }),
+    body: JSON.stringify(
+      reason ? { reason, type: 'Shopping Appointment' } : { type: 'Shopping Appointment' }
+    ),
   });
   await handleResponse<void>(res);
 }
@@ -290,7 +292,9 @@ export async function markBookingNoShow(
   const res = await apiFetch(`${API_BASE}/bookings/${bookingId}/no-show`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(reason ? { reason, type: 'shopping appointment' } : { type: 'shopping appointment' }),
+    body: JSON.stringify(
+      reason ? { reason, type: 'Shopping Appointment' } : { type: 'Shopping Appointment' }
+    ),
   });
   await handleResponse<void>(res);
 }
@@ -322,7 +326,7 @@ export async function createBookingForUser(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ userId, slotId, date, isStaffBooking, type: 'shopping appointment' }),
+    body: JSON.stringify({ userId, slotId, date, isStaffBooking, type: 'Shopping Appointment' }),
   });
   await handleResponse<void>(res);
 }
@@ -337,7 +341,7 @@ export async function createBookingForNewClient(
   const res = await apiFetch(`${API_BASE}/bookings/new-client`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, email, phone, slotId, date, type: 'shopping appointment' }),
+    body: JSON.stringify({ name, email, phone, slotId, date, type: 'Shopping Appointment' }),
   });
   await handleResponse<void>(res);
 }
@@ -358,7 +362,7 @@ export async function rescheduleBookingByToken(
   const res = await apiFetch(`${API_BASE}/bookings/reschedule/${rescheduleToken}`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ slotId, date, type: 'shopping appointment' }),
+    body: JSON.stringify({ slotId, date, type: 'Shopping Appointment' }),
   });
   await handleResponse<void>(res);
 }
@@ -368,7 +372,7 @@ export async function cancelBookingByToken(token: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/bookings/cancel/${token}`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ type: 'shopping appointment' }),
+    body: JSON.stringify({ type: 'Shopping Appointment' }),
   });
   await handleResponse<void>(res);
 }


### PR DESCRIPTION
## Summary
- Use "Shopping Appointment" consistently in booking API requests
- Update API tests for the standardized booking type
- Verified backend email utility normalizes booking types

## Testing
- `npm test` *(fails: VolunteerSchedule, BookingUI, EditVolunteer, etc.)*
- `npm test src/api/__tests__/bookingsApi.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c10302a814832d9fba0ce6d79a78a7