### PR TITLE
Clamp negative client visit weights

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -483,6 +483,9 @@ export async function markBookingVisited(req: Request, res: Response, next: Next
     if (weightWithoutCartVal == null && weightWithCartVal != null) {
       weightWithoutCartVal = weightWithCartVal - cartTare;
     }
+    if (weightWithoutCartVal != null && weightWithoutCartVal < 0) {
+      weightWithoutCartVal = 0;
+    }
     const insertRes = await pool.query(
       `INSERT INTO client_visits (date, client_id, weight_with_cart, weight_without_cart, pet_item, is_anonymous, note, adults, children)
        SELECT b.date, b.user_id, $1, $2, COALESCE($3,0), false, $4, COALESCE($5,0), COALESCE($6,0)

--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -187,6 +187,9 @@ export async function addVisit(req: Request, res: Response, next: NextFunction) 
     if (weightWithCart != null && weightWithoutCart == null) {
       weightWithoutCartAdjusted = weightWithCart - cartTare;
     }
+    if (weightWithoutCartAdjusted != null && weightWithoutCartAdjusted < 0) {
+      weightWithoutCartAdjusted = 0;
+    }
     let insertRes;
     try {
       insertRes = await client.query(
@@ -319,6 +322,9 @@ export async function updateVisit(req: Request, res: Response, next: NextFunctio
     let weightWithoutCartAdjusted = weightWithoutCart;
     if (weightWithCart != null && weightWithoutCart == null) {
       weightWithoutCartAdjusted = weightWithCart - cartTare;
+    }
+    if (weightWithoutCartAdjusted != null && weightWithoutCartAdjusted < 0) {
+      weightWithoutCartAdjusted = 0;
     }
     const result = await pool.query(
       `UPDATE client_visits


### PR DESCRIPTION
## Summary
- prevent negative pantry visit weights
- test clamping of negative weight values

## Testing
- `npm test tests/clientVisitController.test.ts`
- `npm test tests/bookingController.test.ts` *(fails: cancelBooking > sends cancellation email when staff provides reason)*

------
https://chatgpt.com/codex/tasks/task_e_68c107474bac832dae672b8aaf1c96a5