### PR TITLE
Use pantry aggregation controller for visit refresh

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -12,7 +12,7 @@ import {
   refreshPantryWeekly,
   refreshPantryMonthly,
   refreshPantryYearly,
-} from './pantryStatsController';
+} from './pantryAggregationController';
 import { refreshSunshineBagOverall } from './sunshineBagController';
 
 export async function refreshClientVisitCount(

--- a/MJ_FB_Backend/tests/clientVisitController.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitController.test.ts
@@ -4,7 +4,7 @@ import {
   refreshPantryWeekly,
   refreshPantryMonthly,
   refreshPantryYearly,
-} from '../src/controllers/pantryStatsController';
+} from '../src/controllers/pantryAggregationController';
 import {
   addVisit,
   deleteVisit,
@@ -12,7 +12,7 @@ import {
   getVisitStats,
 } from '../src/controllers/clientVisitController';
 
-jest.mock('../src/controllers/pantryStatsController', () => ({
+jest.mock('../src/controllers/pantryAggregationController', () => ({
   refreshPantryWeekly: jest.fn(),
   refreshPantryMonthly: jest.fn(),
   refreshPantryYearly: jest.fn(),


### PR DESCRIPTION
## Summary
- route client visit refreshes through pantry aggregation controller instead of pantry stats controller
- update client visit controller tests to mock new aggregation controller

## Testing
- `npm test tests/clientVisitController.test.ts`
- `npm test` *(fails: 14 failed, 126 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1079e8ff0832da8ee231e9b73757b