### PR TITLE
chore: remove legacy pantry functions

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000040_drop_refresh_pantry_functions.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000040_drop_refresh_pantry_functions.ts
@@ -1,0 +1,34 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('DROP FUNCTION IF EXISTS refresh_pantry_weekly(integer, integer, integer);');
+  pgm.sql('DROP FUNCTION IF EXISTS refresh_pantry_monthly(integer, integer);');
+  pgm.sql('DROP FUNCTION IF EXISTS refresh_pantry_yearly(integer);');
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    CREATE FUNCTION refresh_pantry_weekly(year integer, month integer, week integer)
+    RETURNS void AS $$
+    BEGIN
+      RETURN;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  pgm.sql(`
+    CREATE FUNCTION refresh_pantry_monthly(year integer, month integer)
+    RETURNS void AS $$
+    BEGIN
+      RETURN;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  pgm.sql(`
+    CREATE FUNCTION refresh_pantry_yearly(year integer)
+    RETURNS void AS $$
+    BEGIN
+      RETURN;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+}


### PR DESCRIPTION
## Summary
- remove legacy pantry refresh functions via migration

## Testing
- `npm test` *(fails: relation "volunteers" does not exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c106b1f098832d81bb9e44699ed53e