### PR TITLE
feat(frontend): confirm staff deletion

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
@@ -14,12 +14,14 @@ import ResponsiveTable from '../../components/ResponsiveTable';
 import { listStaff, deleteStaff, searchStaff } from '../../api/adminStaff';
 import type { Staff, StaffAccess } from '../../types';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import ConfirmDialog from '../../components/ConfirmDialog';
 
 export default function AdminStaffList() {
   const [staff, setStaff] = useState<Staff[]>([]);
   const [search, setSearch] = useState('');
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [toDelete, setToDelete] = useState<Staff | null>(null);
 
   const accessLabels: Record<StaffAccess, string> = {
     pantry: 'Pantry',
@@ -45,14 +47,16 @@ export default function AdminStaffList() {
     load();
   }, [search]);
 
-  async function handleDelete(id: number) {
+  async function handleDelete() {
+    if (!toDelete) return;
     try {
-      await deleteStaff(id);
+      await deleteStaff(toDelete.id);
       setSuccess('Staff deleted');
       load();
     } catch (err: any) {
       setError(err.message || String(err));
     }
+    setToDelete(null);
   }
 
   return (
@@ -93,7 +97,7 @@ export default function AdminStaffList() {
                     <IconButton component={RouterLink} to={`/admin/staff/${row.id}`} aria-label="edit">
                       <EditIcon />
                     </IconButton>
-                    <IconButton onClick={() => handleDelete(row.id)} aria-label="delete">
+                    <IconButton onClick={() => setToDelete(row)} aria-label="delete">
                       <DeleteIcon />
                     </IconButton>
                   </Box>
@@ -103,6 +107,13 @@ export default function AdminStaffList() {
             rows={staff}
             getRowKey={row => row.id}
           />
+          {toDelete && (
+            <ConfirmDialog
+              message={`Delete ${toDelete.firstName} ${toDelete.lastName}?`}
+              onConfirm={handleDelete}
+              onCancel={() => setToDelete(null)}
+            />
+          )}
         </Box>
       </Page>
     </ErrorBoundary>

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/AdminStaffList.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/AdminStaffList.test.tsx
@@ -1,0 +1,50 @@
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AdminStaffList from '../AdminStaffList';
+import { listStaff, deleteStaff, searchStaff } from '../../../api/adminStaff';
+import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
+
+jest.mock('../../../api/adminStaff', () => ({
+  ...jest.requireActual('../../../api/adminStaff'),
+  listStaff: jest.fn(),
+  deleteStaff: jest.fn(),
+  searchStaff: jest.fn(),
+}));
+
+const mockStaff = [
+  {
+    id: 1,
+    firstName: 'John',
+    lastName: 'Doe',
+    email: 'john@example.com',
+    access: ['admin'],
+  },
+];
+
+describe('AdminStaffList', () => {
+  beforeEach(() => {
+    (listStaff as jest.Mock).mockResolvedValue(mockStaff);
+    (searchStaff as jest.Mock).mockResolvedValue(mockStaff);
+    (deleteStaff as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('asks for confirmation before deleting staff', async () => {
+    renderWithProviders(
+      <MemoryRouter>
+        <AdminStaffList />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('John Doe')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('delete'));
+    expect(await screen.findByText('Delete John Doe?')).toBeInTheDocument();
+    expect(deleteStaff).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(deleteStaff).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ask for confirmation before deleting staff in admin staff list
- cover staff deletion confirmation with test

## Testing
- `npm test` *(fails: fetchWithRetry timeout, Jest parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c112f77d78832d95f4b14f3a1a526a