### PR TITLE
Include client name when verifying visit

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -428,11 +428,22 @@ export async function toggleVisitVerification(
   try {
     const { id } = req.params;
     const result = await pool.query(
-      `UPDATE client_visits
+      `UPDATE client_visits v
        SET verified = NOT verified
-       WHERE id = $1
-       RETURNING id, to_char(date, 'YYYY-MM-DD') as date, client_id as "clientId", weight_with_cart as "weightWithCart",
-                 weight_without_cart as "weightWithoutCart", pet_item as "petItem", is_anonymous as "anonymous", note, adults, children, verified`,
+       FROM clients c
+       WHERE v.id = $1 AND v.client_id = c.client_id
+       RETURNING v.id,
+                 to_char(v.date, 'YYYY-MM-DD') as date,
+                 v.client_id as "clientId",
+                 c.first_name || ' ' || c.last_name as "clientName",
+                 v.weight_with_cart as "weightWithCart",
+                 v.weight_without_cart as "weightWithoutCart",
+                 v.pet_item as "petItem",
+                 v.is_anonymous as "anonymous",
+                 v.note,
+                 v.adults,
+                 v.children,
+                 v.verified`,
       [id],
     );
     if ((result.rowCount ?? 0) === 0)

--- a/MJ_FB_Backend/tests/clientVisitController.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitController.test.ts
@@ -58,6 +58,7 @@ describe('clientVisitController', () => {
             id: 1,
             date: '2024-05-20',
             clientId: 1,
+            clientName: 'Ann Client',
             weightWithCart: 0,
             weightWithoutCart: 0,
             petItem: 0,
@@ -76,6 +77,7 @@ describe('clientVisitController', () => {
             id: 1,
             date: '2024-05-20',
             clientId: 1,
+            clientName: 'Ann Client',
             weightWithCart: 0,
             weightWithoutCart: 0,
             petItem: 0,
@@ -94,12 +96,12 @@ describe('clientVisitController', () => {
 
     await toggleVisitVerification(req, res, next);
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ verified: true }),
+      expect.objectContaining({ verified: true, clientName: 'Ann Client' }),
     );
 
     await toggleVisitVerification(req, res, next);
     expect(res.json).toHaveBeenLastCalledWith(
-      expect.objectContaining({ verified: false }),
+      expect.objectContaining({ verified: false, clientName: 'Ann Client' }),
     );
   });
 

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -284,6 +284,7 @@ describe('PantryVisits', () => {
     await waitFor(() =>
       expect(toggleClientVisitVerification).toHaveBeenCalledTimes(1),
     );
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
     await waitFor(() =>
       expect(screen.queryByLabelText('Edit visit')).not.toBeInTheDocument(),
     );


### PR DESCRIPTION
## Summary
- join clients table in visit verification to return clientName
- ensure toggleVisitVerification tests handle clientName field
- keep PantryVisits tests confirming client name stays visible after verification

## Testing
- `npm test` (backend) *(fails: TypeError: argument handler must be a function, etc.)*
- `npm test` (frontend) *(fails: The given element does not have a value setter, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c11246a084832d9eb26caaa998b122