### PR TITLE
Show client ID in assign user results

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -544,7 +544,7 @@ export default function PantrySchedule({
                     </Button>
                   }
                 >
-                  <ListItemText primary={`${u.name} (${u.email})`} />
+                  <ListItemText primary={`${u.name} (${u.client_id})`} />
                 </ListItem>
               ))}
               {searchTerm.length >= 3 && userResults.length === 0 && (

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantrySchedule.test.tsx
@@ -56,6 +56,37 @@ describe('PantrySchedule add existing client workflow', () => {
     expect(await screen.findByText('[NEW CLIENT] New Person')).toBeInTheDocument();
   });
 
+  it('shows client ID in search results', async () => {
+    (bookingApi.getBookings as jest.Mock).mockResolvedValue([]);
+    const searchUsersMock = jest
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          name: 'Test User',
+          email: 'test@example.com',
+          phone: null,
+          client_id: 123,
+          hasPassword: false,
+        },
+      ]);
+    render(
+      <MemoryRouter>
+        <PantrySchedule searchUsersFn={searchUsersMock} />
+      </MemoryRouter>,
+    );
+
+    const rows = await screen.findAllByRole('row');
+    const cells = within(rows[1]).getAllByRole('cell');
+    fireEvent.click(cells[1]);
+
+    fireEvent.change(
+      screen.getByLabelText('Search users by name/email/phone/client ID'),
+      { target: { value: 'Tes' } },
+    );
+
+    expect(await screen.findByText('Test User (123)')).toBeInTheDocument();
+  });
+
   it('adds existing client to the app when search returns none', async () => {
     (bookingApi.getBookings as jest.Mock).mockResolvedValue([]);
     (usersApi.addClientById as jest.Mock).mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- Display client ID instead of email when listing users in PantrySchedule Assign User dialog
- Test search results for client ID formatting in pantry schedule

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68c1131b33d8832db2ec57a03822df87