### PR TITLE
feat: confirm client deletion

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ClientManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ClientManagement.test.tsx
@@ -4,6 +4,11 @@ import ClientManagement from '../ClientManagement';
 import { getNewClients, deleteNewClient } from '../../../api/users';
 import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
 
+(global as any).clearImmediate = (global as any).clearImmediate || ((id: number) => clearTimeout(id));
+(global as any).performance = (global as any).performance || ({} as any);
+(global as any).performance.markResourceTiming = (global as any).performance.markResourceTiming || (() => {});
+(global as any).fetch = jest.fn();
+
 jest.mock('../../../api/users', () => ({
   ...jest.requireActual('../../../api/users'),
   getNewClients: jest.fn(),
@@ -39,11 +44,12 @@ describe('ClientManagement New Clients tab', () => {
 
     const deleteBtn = await screen.findByLabelText('delete');
     fireEvent.click(deleteBtn);
+    fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
 
     await waitFor(() => {
       expect(deleteNewClient).toHaveBeenCalledWith(1);
+      expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
     });
-    expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
   });
 });
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/NewClients.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/NewClients.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Box, IconButton, Typography } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ConfirmDialog from '../../../components/ConfirmDialog';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import ResponsiveTable, { type Column } from '../../../components/ResponsiveTable';
 import { getNewClients, deleteNewClient, type NewClient } from '../../../api/users';
@@ -13,6 +14,7 @@ export default function NewClients() {
     message: string;
     severity: AlertColor;
   } | null>(null);
+  const [confirm, setConfirm] = useState<NewClient | null>(null);
 
   useEffect(() => {
     load();
@@ -51,8 +53,7 @@ export default function NewClients() {
       render: c => (
         <IconButton
           aria-label="delete"
-          onClick={() => handleDelete(c.id)}
-          
+          onClick={() => setConfirm(c)}
         >
           <DeleteIcon />
         </IconButton>
@@ -66,6 +67,16 @@ export default function NewClients() {
         New Clients
       </Typography>
       <ResponsiveTable columns={columns} rows={clients} getRowKey={c => c.id} />
+      {confirm && (
+        <ConfirmDialog
+          message={`Delete ${confirm.name}?`}
+          onConfirm={async () => {
+            await handleDelete(confirm.id);
+            setConfirm(null);
+          }}
+          onCancel={() => setConfirm(null)}
+        />
+      )}
       <FeedbackSnackbar
         open={!!snackbar}
         onClose={() => setSnackbar(null)}


### PR DESCRIPTION
## Summary
- require confirmation before deleting a new client
- test client deletion flow with confirmation

## Testing
- `nvm use`
- `npm test` *(fails: markResourceTiming is not a function, Node.js v22.19.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c11414aae4832db8d4b40b648387aa