### PR TITLE
feat: confirm agency client removal

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import ConfirmDialog from '../../components/ConfirmDialog';
 import {
   getMyAgencyClients,
   addAgencyClient,
@@ -32,6 +33,7 @@ export default function ClientList() {
   const [snackbar, setSnackbar] = useState<
     { message: string; severity: 'success' | 'error' } | null
   >(null);
+  const [confirmClient, setConfirmClient] = useState<AgencyClient | null>(null);
   useAuth(); // ensure auth context
 
   const load = async () => {
@@ -73,9 +75,10 @@ export default function ClientList() {
     }
   };
 
-  const handleRemove = async (id: number) => {
+  const handleRemove = async () => {
+    if (!confirmClient) return;
     try {
-      await removeAgencyClient('me', id);
+      await removeAgencyClient('me', confirmClient.id);
       setSnackbar({ message: 'Client removed', severity: 'success' });
       load();
     } catch (err: any) {
@@ -84,6 +87,7 @@ export default function ClientList() {
         severity: 'error',
       });
     }
+    setConfirmClient(null);
   };
 
   return (
@@ -101,7 +105,7 @@ export default function ClientList() {
                 <IconButton
                   edge="end"
                   aria-label="remove"
-                  onClick={() => handleRemove(c.id)}
+                  onClick={() => setConfirmClient(c)}
                 >
                   <DeleteIcon />
                 </IconButton>
@@ -137,6 +141,13 @@ export default function ClientList() {
         message={snackbar?.message || ''}
         severity={snackbar?.severity}
       />
+      {confirmClient && (
+        <ConfirmDialog
+          message={`Remove ${confirmClient.name}?`}
+          onConfirm={handleRemove}
+          onCancel={() => setConfirmClient(null)}
+        />
+      )}
     </Grid>
     </Page>
   );

--- a/MJ_FB_Frontend/src/pages/agency/__tests__/ClientList.test.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/__tests__/ClientList.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ClientList from '../ClientList';
+import { removeAgencyClient } from '../../../api/agencies';
+
+jest.mock('../../../hooks/useAuth', () => ({ useAuth: jest.fn() }));
+
+jest.mock('../../../api/agencies', () => ({
+  getMyAgencyClients: jest
+    .fn()
+    .mockResolvedValue([{ id: 1, name: 'Client One', email: 'c@example.com' }]),
+  addAgencyClient: jest.fn(),
+  removeAgencyClient: jest.fn(),
+}));
+
+describe('ClientList', () => {
+  it('confirms before removing client', async () => {
+    const user = userEvent.setup();
+    render(<ClientList />);
+
+    expect(await screen.findByText('Client One')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('remove'));
+    expect(screen.getByText('Remove Client One?')).toBeInTheDocument();
+    expect(removeAgencyClient).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(removeAgencyClient).toHaveBeenCalledWith('me', 1);
+  });
+});


### PR DESCRIPTION
## Summary
- add confirmation dialog before removing agency clients
- test confirmation behavior for agency client list

## Testing
- `nvm use`
- `npm test` *(fails: The given element does not have a value setter)*

------
https://chatgpt.com/codex/tasks/task_e_68c114173888832da6ee637621c57a6d