### PR TITLE
feat: confirm removal in availability management

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailability.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailability.test.tsx
@@ -1,18 +1,23 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ManageAvailability from '../ManageAvailability';
-import { removeHoliday } from '../../../api/bookings';
+import {
+  removeHoliday,
+  removeBlockedSlot,
+  removeBreak,
+  getBlockedSlots,
+  getBreaks,
+  getHolidays,
+} from '../../../api/bookings';
 
 jest.mock('../../../api/slots', () => ({
   getAllSlots: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('../../../api/bookings', () => ({
-  getBreaks: jest.fn().mockResolvedValue([]),
+  getBreaks: jest.fn(),
   getRecurringBlockedSlots: jest.fn().mockResolvedValue([]),
-  getBlockedSlots: jest.fn().mockResolvedValue([]),
-  getHolidays: jest.fn().mockResolvedValue([
-    { date: '2024-01-01', reason: 'Holiday' },
-  ]),
+  getBlockedSlots: jest.fn(),
+  getHolidays: jest.fn(),
   addHoliday: jest.fn(),
   removeHoliday: jest.fn(),
   addBlockedSlot: jest.fn(),
@@ -23,15 +28,62 @@ jest.mock('../../../api/bookings', () => ({
   removeBreak: jest.fn(),
 }));
 
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getHolidays as jest.Mock).mockResolvedValue([]);
+  (getBreaks as jest.Mock).mockResolvedValue([]);
+  (getBlockedSlots as jest.Mock).mockResolvedValue([]);
+});
+
 describe('ManageAvailability', () => {
-  it('calls API when removing a holiday', async () => {
+  it('confirms before removing a holiday', async () => {
+    (getHolidays as jest.Mock).mockResolvedValue([{ date: '2024-01-01', reason: 'Holiday' }]);
     render(<ManageAvailability />);
 
     const removeBtn = await screen.findByLabelText('remove');
     fireEvent.click(removeBtn);
 
+    expect(await screen.findByText('Remove holiday?')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Confirm'));
+
     await waitFor(() => {
       expect(removeHoliday).toHaveBeenCalledWith('2024-01-01');
+    });
+  });
+
+  it('confirms before removing a blocked slot', async () => {
+    (getBlockedSlots as jest.Mock).mockResolvedValue([
+      { date: '2024-02-01', slotId: 1, reason: '' },
+    ]);
+    render(<ManageAvailability />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /blocked slots/i }));
+    const removeBtn = await screen.findByLabelText('remove');
+    fireEvent.click(removeBtn);
+
+    expect(await screen.findByText('Remove blocked slot?')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(removeBlockedSlot).toHaveBeenCalledWith('2024-02-01', 1);
+    });
+  });
+
+  it('confirms before removing a break', async () => {
+    (getBreaks as jest.Mock).mockResolvedValue([
+      { dayOfWeek: 0, slotId: 1, reason: '' },
+    ]);
+    render(<ManageAvailability />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /staff breaks/i }));
+    const removeBtn = await screen.findByLabelText('remove');
+    fireEvent.click(removeBtn);
+
+    expect(await screen.findByText('Remove break?')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(removeBreak).toHaveBeenCalledWith(0, 1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- prompt staff to confirm before deleting holidays, blocked slots, or breaks
- test confirmation flows for holiday, blocked slot, and break removal

## Testing
- `nvm use`
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68c11419e048832d808a218e06d983e5