### PR TITLE
feat(admin): confirm leave request rejection

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
@@ -14,6 +14,8 @@ import {
 import { formatLocaleDate } from '../../utils/date';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import type { LeaveRequest } from '../../api/leaveRequests';
 
 export default function AdminLeaveRequests() {
   const { t } = useTranslation();
@@ -21,6 +23,7 @@ export default function AdminLeaveRequests() {
   const [requests, setRequests] = useState(fetched);
   const approve = useApproveLeaveRequest();
   const reject = useRejectLeaveRequest();
+  const [rejecting, setRejecting] = useState<LeaveRequest | null>(null);
 
   useEffect(() => setRequests(fetched), [fetched]);
 
@@ -79,14 +82,9 @@ export default function AdminLeaveRequests() {
                 <Button
                   variant="contained"
                   color="error"
-                  
+
                   sx={{ width: { xs: '100%', sm: 'auto' } }}
-                  onClick={() =>
-                    reject.mutate(
-                      { requestId: r.id },
-                      { onSuccess: () => removeRequest(r.id) },
-                    )
-                  }
+                  onClick={() => setRejecting(r)}
                 >
                   {t('timesheets.reject_leave')}
                 </Button>
@@ -95,6 +93,19 @@ export default function AdminLeaveRequests() {
           </Card>
         );
       })}
+      {rejecting && (
+        <ConfirmDialog
+          message={`Reject leave request for ${rejecting.requester_name}?`}
+          onConfirm={() => {
+            reject.mutate(
+              { requestId: rejecting.id },
+              { onSuccess: () => removeRequest(rejecting.id) },
+            );
+            setRejecting(null);
+          }}
+          onCancel={() => setRejecting(null)}
+        />
+      )}
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/LeaveRequests.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/LeaveRequests.test.tsx
@@ -6,17 +6,19 @@ import LeaveRequests from '../LeaveRequests';
 const mockApprove = jest.fn((_, opts) => act(() => opts?.onSuccess?.()));
 const mockReject = jest.fn((_, opts) => act(() => opts?.onSuccess?.()));
 
+const REQUESTS = [
+  {
+    id: 1,
+    start_date: '2024-01-02',
+    end_date: '2024-01-03',
+    type: 'paid',
+    requester_name: 'Jane Doe',
+  },
+];
+
 jest.mock('../../../api/leaveRequests', () => ({
   useAllLeaveRequests: () => ({
-    requests: [
-      {
-        id: 1,
-        start_date: '2024-01-02',
-        end_date: '2024-01-03',
-        type: 'paid',
-        requester_name: 'Jane Doe',
-      },
-    ],
+    requests: REQUESTS,
     isLoading: false,
     error: null,
   }),
@@ -25,17 +27,36 @@ jest.mock('../../../api/leaveRequests', () => ({
 }));
 
 describe('AdminLeaveRequests', () => {
-  it('renders leave details and removes card after rejection', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows confirmation dialog before rejection and removes card on confirm', async () => {
     const user = userEvent.setup();
     renderWithProviders(<LeaveRequests />);
     expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
-    expect(screen.getByText(/Paid/)).toBeInTheDocument();
     const rejectBtn = screen.getByRole('button', { name: 'Reject' });
     await user.click(rejectBtn);
-    expect(mockReject).toHaveBeenCalledWith({ requestId: 1 }, expect.any(Object));
+    expect(
+      screen.getByText('Reject leave request for Jane Doe?'),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockReject).toHaveBeenCalledWith(
+      { requestId: 1 },
+      expect.any(Object),
+    );
     await waitFor(() =>
       expect(screen.queryByText(/Jane Doe/)).not.toBeInTheDocument(),
     );
+  });
+
+  it('closes dialog without rejecting when cancelled', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<LeaveRequests />);
+    await user.click(screen.getByRole('button', { name: 'Reject' }));
+    await user.click(screen.getByLabelText('close'));
+    expect(mockReject).not.toHaveBeenCalled();
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- ask for confirmation before rejecting a leave request
- test leave request rejection dialog behaviour

## Testing
- `nvm use`
- `npm test` *(fails: clearImmediate is not defined, markResourceTiming is not a function)*


------
https://chatgpt.com/codex/tasks/task_e_68c1141c2ff0832d9e2ab1e75346b585