### PR TITLE
Use ConfirmDialog for agency booking cancellation

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyClientHistory.test.tsx
@@ -60,7 +60,6 @@ describe('Agency ClientHistory', () => {
       },
     ]);
     (cancelBooking as jest.Mock).mockResolvedValue(undefined);
-    window.confirm = jest.fn(() => true);
 
     render(<ClientHistory />);
 
@@ -68,6 +67,7 @@ describe('Agency ClientHistory', () => {
     await screen.findByText(/Client One/);
     await screen.findByText('Cancel');
     fireEvent.click(screen.getByText('Cancel'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => expect(cancelBooking).toHaveBeenCalledWith('10'));
     expect(getBookingHistory).toHaveBeenCalledTimes(2);

--- a/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientHistory.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '@mui/material';
 import RescheduleDialog from '../../components/RescheduleDialog';
+import ConfirmDialog from '../../components/ConfirmDialog';
 import EntitySearch from '../../components/EntitySearch';
 import { toDate } from '../../utils/date';
 import { formatDate } from '../../utils/date';
@@ -34,6 +35,9 @@ export default function ClientHistory() {
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [page, setPage] = useState(1);
   const [rescheduleBooking, setRescheduleBooking] = useState<Booking | null>(
+    null,
+  );
+  const [cancelBookingItem, setCancelBookingItem] = useState<Booking | null>(
     null,
   );
   const [clients, setClients] = useState<User[]>([]);
@@ -169,7 +173,7 @@ export default function ClientHistory() {
               {t('reschedule')}
             </Button>
             <Button
-              onClick={() => handleCancel(b)}
+              onClick={() => setCancelBookingItem(b)}
               variant="outlined"
               color="error"
             >
@@ -180,18 +184,19 @@ export default function ClientHistory() {
     },
   ];
 
-  const handleCancel = async (b: Booking) => {
-    if (!window.confirm('Cancel this booking?')) return;
+  const handleCancel = async () => {
+    if (!cancelBookingItem) return;
     try {
-      await cancelBooking(String(b.id));
-      setSnackbar({ message: 'Booking cancelled', severity: 'success' });
+      await cancelBooking(String(cancelBookingItem.id));
+      setSnackbar({ message: t('booking_cancelled'), severity: 'success' });
       loadBookings();
     } catch (err: any) {
       setSnackbar({
-        message: err.message || 'Failed to cancel booking',
+        message: err.message || t('cancel_booking_failed'),
         severity: 'error',
       });
     }
+    setCancelBookingItem(null);
   };
 
   return (
@@ -272,6 +277,13 @@ export default function ClientHistory() {
             onRescheduled={() => {
               loadBookings();
             }}
+          />
+        )}
+        {cancelBookingItem && (
+          <ConfirmDialog
+            message={t('cancel_booking_question')}
+            onConfirm={handleCancel}
+            onCancel={() => setCancelBookingItem(null)}
           />
         )}
         <FeedbackSnackbar


### PR DESCRIPTION
## Summary
- replace `window.confirm` with `ConfirmDialog` in agency client history
- update tests to handle new confirmation dialog

## Testing
- `nvm use`
- `npm test` *(fails: TypeError: Cannot read properties of null (reading '_location'))*

------
https://chatgpt.com/codex/tasks/task_e_68c1141d8234832dae416cb8e4d429f2