### PR TITLE
Use ConfirmDialog for agency client removal

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -20,6 +20,7 @@ import {
 import DeleteIcon from '@mui/icons-material/Delete';
 import EntitySearch from '../../components/EntitySearch';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import ConfirmDialog from '../../components/ConfirmDialog';
 import {
   addAgencyClient,
   removeAgencyClient,
@@ -42,6 +43,7 @@ export default function AgencyClientManager() {
   const [conflictAgency, setConflictAgency] = useState<string | null>(null);
   const [bookingClient, setBookingClient] = useState<AgencyClient | null>(null);
   const [bookingLoading, setBookingLoading] = useState(false);
+  const [removeClient, setRemoveClient] = useState<AgencyClient | null>(null);
 
   const load = async (id: number) => {
     try {
@@ -97,11 +99,14 @@ export default function AgencyClientManager() {
     }
   };
 
-  const handleRemove = async (clientId: number) => {
-    if (!agency) return;
-    if (!window.confirm('Remove this client from the agency?')) return;
+  const handleRemove = (client: AgencyClient) => {
+    setRemoveClient(client);
+  };
+
+  const confirmRemove = async () => {
+    if (!agency || !removeClient) return;
     try {
-      await removeAgencyClient(agency.id, clientId);
+      await removeAgencyClient(agency.id, removeClient.clientId);
       setSnackbar({ message: 'Client removed', severity: 'success' });
       load(agency.id);
     } catch (err: any) {
@@ -110,6 +115,7 @@ export default function AgencyClientManager() {
         severity: 'error',
       });
     }
+    setRemoveClient(null);
   };
   const handleBook = (client: AgencyClient) => {
     setBookingClient(client);
@@ -183,7 +189,7 @@ export default function AgencyClientManager() {
                           <IconButton
                             edge="end"
                             aria-label="remove"
-                            onClick={() => handleRemove(c.clientId)}
+                            onClick={() => handleRemove(c)}
                           >
                             <DeleteIcon />
                           </IconButton>
@@ -199,6 +205,13 @@ export default function AgencyClientManager() {
             </Card>
           </Grid>
         </Grid>
+      )}
+      {removeClient && (
+        <ConfirmDialog
+          message="Remove this client from the agency?"
+          onConfirm={confirmRemove}
+          onCancel={() => setRemoveClient(null)}
+        />
       )}
       <FeedbackSnackbar
         open={!!snackbar}

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/AgencyClientManager.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/AgencyClientManager.test.tsx
@@ -55,4 +55,30 @@ describe('AgencyClientManager', () => {
       expect.objectContaining({ shopperName: 'Client One', userId: 5 }),
     );
   });
+
+  it('removes a client after confirmation', async () => {
+    const { getAgencyClients, removeAgencyClient } =
+      require('../../../api/agencies');
+    (getAgencyClients as jest.Mock)
+      .mockResolvedValueOnce([
+        { client_id: 5, first_name: 'Client', last_name: 'One' },
+      ])
+      .mockResolvedValueOnce([]);
+
+    render(<AgencyClientManager />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Select Agency' }));
+    await screen.findByText('Client One');
+
+    await userEvent.click(screen.getByLabelText('remove'));
+
+    expect(
+      await screen.findByText('Remove this client from the agency?'),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(removeAgencyClient).toHaveBeenCalledWith(1, 5);
+    await screen.findByText('No clients assigned.');
+  });
 });


### PR DESCRIPTION
## Summary
- replace `window.confirm` with `ConfirmDialog` when removing agency clients
- test agency client removal using confirmation dialog

## Testing
- `nvm use`
- `npm test` *(fails: SyntaxError in PantryScheduleCapacity.test.tsx and other act warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c1141e3b18832da067ada833dca70c