### PR TITLE
feat: confirm capacity increase on volunteer booking

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/__tests__/VolunteerManagement.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import VolunteerManagement from '../VolunteerManagement';
+import {
+  getVolunteerRoles,
+  searchVolunteers,
+  getVolunteerBookingsByRole,
+  updateVolunteerTrainedAreas,
+  createVolunteerBookingForVolunteer,
+} from '../../../api/volunteers';
+
+jest.mock('../../../api/volunteers', () => ({
+  getVolunteerRoles: jest.fn(),
+  searchVolunteers: jest.fn(),
+  getVolunteerBookingsByRole: jest.fn(),
+  updateVolunteerTrainedAreas: jest.fn(),
+  createVolunteerBookingForVolunteer: jest.fn(),
+}));
+
+describe('VolunteerManagement force booking', () => {
+  beforeEach(() => {
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        category_id: 1,
+        category_name: 'Front',
+        name: 'Greeter',
+        start_time: '09:00:00',
+        end_time: '10:00:00',
+        max_volunteers: 1,
+        has_shifts: true,
+      },
+    ]);
+    (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([]);
+    (searchVolunteers as jest.Mock).mockResolvedValue([
+      {
+        id: 5,
+        name: 'Test Vol',
+        trainedAreas: [1],
+      },
+    ]);
+    (createVolunteerBookingForVolunteer as jest.Mock)
+      .mockRejectedValueOnce(new Error('Role is full'))
+      .mockResolvedValueOnce(undefined);
+  });
+
+  it('confirms increasing capacity before forcing booking', async () => {
+    render(
+      <MemoryRouter initialEntries={['/volunteers/schedule']}>
+        <Routes>
+          <Route path="/volunteers/:tab" element={<VolunteerManagement />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.mouseDown(screen.getByLabelText('Role'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Greeter' }));
+
+    fireEvent.click(await screen.findByText('Available'));
+
+    await userEvent.type(await screen.findByLabelText('Search'), 'Test');
+    fireEvent.click(await screen.findByRole('button', { name: 'Assign' }));
+
+    expect(
+      await screen.findByText('Role is full. Force booking and increase capacity?'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(createVolunteerBookingForVolunteer).toHaveBeenNthCalledWith(
+        1,
+        5,
+        1,
+        expect.any(String),
+        false,
+      );
+      expect(createVolunteerBookingForVolunteer).toHaveBeenNthCalledWith(
+        2,
+        5,
+        1,
+        expect.any(String),
+        true,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- use `ConfirmDialog` instead of `window.confirm` when forcing volunteer bookings
- cover capacity override with a dedicated test

## Testing
- `nvm use`
- `npm test` (fails: Jest encountered an unexpected token and multiple test suite errors)


------
https://chatgpt.com/codex/tasks/task_e_68c1141f9d34832d8b30a1360175fab3