### PR TITLE
Remove pantry visit import button

### DIFF
--- a/MJ_FB_Frontend/public/locales/am/translation.json
+++ b/MJ_FB_Frontend/public/locales/am/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/ar/translation.json
+++ b/MJ_FB_Frontend/public/locales/ar/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/en/translation.json
+++ b/MJ_FB_Frontend/public/locales/en/translation.json
@@ -237,15 +237,7 @@
       "adults": "Adults",
       "children": "Children",
       "sunshine_bag_weight": "Sunshine Bag Weight"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "booking_rescheduled": "Booking rescheduled",
   "reschedule_failed": "Failed to reschedule booking",

--- a/MJ_FB_Frontend/public/locales/es/translation.json
+++ b/MJ_FB_Frontend/public/locales/es/translation.json
@@ -225,15 +225,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/fa/translation.json
+++ b/MJ_FB_Frontend/public/locales/fa/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/fr/translation.json
+++ b/MJ_FB_Frontend/public/locales/fr/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/hi/translation.json
+++ b/MJ_FB_Frontend/public/locales/hi/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/ml/translation.json
+++ b/MJ_FB_Frontend/public/locales/ml/translation.json
@@ -228,15 +228,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/pa/translation.json
+++ b/MJ_FB_Frontend/public/locales/pa/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/ps/translation.json
+++ b/MJ_FB_Frontend/public/locales/ps/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/so/translation.json
+++ b/MJ_FB_Frontend/public/locales/so/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/sw/translation.json
+++ b/MJ_FB_Frontend/public/locales/sw/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/ta/translation.json
+++ b/MJ_FB_Frontend/public/locales/ta/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/ti/translation.json
+++ b/MJ_FB_Frontend/public/locales/ti/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/tl/translation.json
+++ b/MJ_FB_Frontend/public/locales/tl/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/uk/translation.json
+++ b/MJ_FB_Frontend/public/locales/uk/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/public/locales/zh/translation.json
+++ b/MJ_FB_Frontend/public/locales/zh/translation.json
@@ -223,15 +223,7 @@
       "sunshine_bag_weight": "Sunshine Bag Weight",
       "adults": "Adults",
       "children": "Children"
-    },
-    "import_visits": "Import Visits",
-    "import": "Import",
-    "import_success": "Visits imported",
-    "import_error": "Import failed",
-    "dry_run": "Dry-run",
-    "sheet_date": "Date",
-    "sheet_rows": "Rows",
-    "sheet_errors": "Errors"
+    }
   },
   "sunshine_bag_label": "Sunshine bag?",
   "sunshine_bag_weight_label": "Sunshine Bag Weight",

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -17,7 +17,6 @@ jest.mock('../../../api/clientVisits', () => ({
   createClientVisit: jest.fn(),
   updateClientVisit: jest.fn(),
   deleteClientVisit: jest.fn(),
-  importVisitsXlsx: jest.fn(),
   toggleClientVisitVerification: jest.fn(),
 }));
 
@@ -35,7 +34,7 @@ jest.mock('../../../api/sunshineBags', () => ({
   saveSunshineBag: jest.fn(),
 }));
 
-const { getClientVisits, importVisitsXlsx, toggleClientVisitVerification } =
+const { getClientVisits, toggleClientVisitVerification } =
   jest.requireMock('../../../api/clientVisits');
 const { getAppConfig } = jest.requireMock('../../../api/appConfig');
 const { getSunshineBag } = jest.requireMock('../../../api/sunshineBags');
@@ -341,62 +340,6 @@ describe('PantryVisits', () => {
     renderVisits();
 
     expect(await screen.findByText('No records')).toBeInTheDocument();
-  });
-
-  it('shows preview after dry-run', async () => {
-    (getClientVisits as jest.Mock).mockResolvedValue([]);
-    (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
-    (getSunshineBag as jest.Mock).mockResolvedValue(null);
-    (importVisitsXlsx as jest.Mock).mockResolvedValue({
-      sheets: [{ date: '2024-02-01', rows: 2, errors: ['bad row'] }],
-    });
-
-    renderVisits();
-
-    await screen.findByText('Record Visit');
-
-    fireEvent.click(screen.getByText('Import Visits'));
-    const input = screen.getByTestId('import-input') as HTMLInputElement;
-    const file = new File(['1'], 'visits.xlsx', {
-      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    });
-    fireEvent.change(input, { target: { files: [file] } });
-
-    fireEvent.click(screen.getByText('Dry-run'));
-
-    await waitFor(() =>
-      expect(importVisitsXlsx).toHaveBeenCalledWith(
-        expect.any(FormData),
-        true,
-      ),
-    );
-
-    expect(await screen.findByText('bad row')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
-  });
-
-  it('imports visits after selecting file', async () => {
-    (getClientVisits as jest.Mock).mockResolvedValue([]);
-    (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
-    (getSunshineBag as jest.Mock).mockResolvedValue(null);
-    (importVisitsXlsx as jest.Mock).mockResolvedValue(undefined);
-
-    renderVisits();
-
-    await screen.findByText('Record Visit');
-
-    fireEvent.click(screen.getByText('Import Visits'));
-    const input = screen.getByTestId('import-input') as HTMLInputElement;
-    const file = new File(['1'], 'visits.xlsx', {
-      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    });
-    fireEvent.change(input, { target: { files: [file] } });
-
-    fireEvent.click(screen.getByText('Import'));
-
-    await waitFor(() =>
-      expect(importVisitsXlsx).toHaveBeenCalledWith(expect.any(FormData)),
-    );
   });
 
   it('navigates to selected date', async () => {

--- a/docs/pantryVisits.md
+++ b/docs/pantryVisits.md
@@ -12,14 +12,6 @@ Add the following translation strings to locale files:
 - `pantry_visits.summary.sunshine_bag_weight`
 - `pantry_visits.summary.adults`
 - `pantry_visits.summary.children`
-- `pantry_visits.import_visits`
-- `pantry_visits.import`
-- `pantry_visits.import_success`
-- `pantry_visits.import_error`
-- `pantry_visits.dry_run`
-- `pantry_visits.sheet_date`
-- `pantry_visits.sheet_rows`
-- `pantry_visits.sheet_errors`
 
 ## Visit limits
 
@@ -51,5 +43,3 @@ If a visit already exists for the same client on a given date, the importer over
 ### Dry run
 
 Append `dryRun=true` to validate the spreadsheet and preview counts without creating any visits. After reviewing the response, rerun the request without `dryRun` to perform the import.
-
-Save the file as `.xlsx` and upload it using the **Import Visits** button on the Pantry Visits page. Use **Dry-run** to preview sheets before finalizing the import.


### PR DESCRIPTION
## Summary
- remove pantry visit import button and dialog
- drop related translation strings and docs references

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68c12648fc9c832d85eb1b6d5c97e939