### PR TITLE
Rename pantry aggregation clients column to orders

### DIFF
--- a/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
@@ -42,7 +42,7 @@ export async function refreshPantryWeekly(year: number, month: number, week: num
       [startStr, endStr],
     ),
     pool.query(
-      `SELECT COALESCE(SUM(client_count)::int,0) AS clients,
+      `SELECT COALESCE(SUM(client_count)::int,0) AS orders,
               COALESCE(SUM(weight)::int,0) AS weight
          FROM sunshine_bag_log
         WHERE date >= $1 AND date <= $2`,
@@ -50,44 +50,44 @@ export async function refreshPantryWeekly(year: number, month: number, week: num
     ),
   ]);
 
-  const visitClients = Number(visitsRes.rows[0]?.visits ?? 0);
+  const visitOrders = Number(visitsRes.rows[0]?.visits ?? 0);
   const visitAdults = Number(visitsRes.rows[0]?.adults ?? 0);
   const children = Number(visitsRes.rows[0]?.children ?? 0);
   const visitWeight = Number(visitsRes.rows[0]?.weight ?? 0);
-  const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
+  const bagOrders = Number(bagRes.rows[0]?.orders ?? 0);
   const sunshineWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients + bagClients;
-  const adults = visitAdults + bagClients;
+  const orders = visitOrders + bagOrders;
+  const adults = visitAdults + bagOrders;
   const people = adults + children;
   const weight = visitWeight + sunshineWeight;
 
   await pool.query(
-    `INSERT INTO pantry_weekly_overall (year, month, week, start_date, end_date, clients, adults, children, people, weight, sunshine_bags, sunshine_weight)
+    `INSERT INTO pantry_weekly_overall (year, month, week, start_date, end_date, orders, adults, children, people, weight, sunshine_bags, sunshine_weight)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        ON CONFLICT (year, month, week)
        DO UPDATE SET start_date = EXCLUDED.start_date,
                      end_date = EXCLUDED.end_date,
-                     clients = EXCLUDED.clients,
-                     adults = EXCLUDED.adults,
-                     children = EXCLUDED.children,
-                     people = EXCLUDED.people,
-                     weight = EXCLUDED.weight,
+        orders = EXCLUDED.orders,
+        adults = EXCLUDED.adults,
+        children = EXCLUDED.children,
+        people = EXCLUDED.people,
+        weight = EXCLUDED.weight,
                      sunshine_bags = EXCLUDED.sunshine_bags,
                      sunshine_weight = EXCLUDED.sunshine_weight`,
     [
       year,
       month,
       week,
-      startStr,
-      endStr,
-      clients,
-      adults,
-      children,
-      people,
-      weight,
-      bagClients,
-      sunshineWeight,
+        startStr,
+        endStr,
+        orders,
+        adults,
+        children,
+        people,
+        weight,
+        bagOrders,
+        sunshineWeight,
     ],
   );
 }
@@ -104,7 +104,7 @@ export async function refreshPantryMonthly(year: number, month: number) {
       [year, month],
     ),
     pool.query(
-      `SELECT COALESCE(SUM(client_count)::int,0) AS clients,
+      `SELECT COALESCE(SUM(client_count)::int,0) AS orders,
               COALESCE(SUM(weight)::int,0) AS weight
          FROM sunshine_bag_log
         WHERE EXTRACT(YEAR FROM date) = $1 AND EXTRACT(MONTH FROM date) = $2`,
@@ -112,30 +112,30 @@ export async function refreshPantryMonthly(year: number, month: number) {
     ),
   ]);
 
-  const visitClients = Number(visitsRes.rows[0]?.visits ?? 0);
+  const visitOrders = Number(visitsRes.rows[0]?.visits ?? 0);
   const visitAdults = Number(visitsRes.rows[0]?.adults ?? 0);
   const children = Number(visitsRes.rows[0]?.children ?? 0);
   const visitWeight = Number(visitsRes.rows[0]?.weight ?? 0);
-  const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
+  const bagOrders = Number(bagRes.rows[0]?.orders ?? 0);
   const sunshineWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients + bagClients;
-  const adults = visitAdults + bagClients;
+  const orders = visitOrders + bagOrders;
+  const adults = visitAdults + bagOrders;
   const people = adults + children;
   const weight = visitWeight + sunshineWeight;
 
   await pool.query(
-    `INSERT INTO pantry_monthly_overall (year, month, clients, adults, children, people, weight, sunshine_bags, sunshine_weight)
+    `INSERT INTO pantry_monthly_overall (year, month, orders, adults, children, people, weight, sunshine_bags, sunshine_weight)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
        ON CONFLICT (year, month)
-       DO UPDATE SET clients = EXCLUDED.clients,
+       DO UPDATE SET orders = EXCLUDED.orders,
                      adults = EXCLUDED.adults,
                      children = EXCLUDED.children,
                      people = EXCLUDED.people,
                      weight = EXCLUDED.weight,
                      sunshine_bags = EXCLUDED.sunshine_bags,
                      sunshine_weight = EXCLUDED.sunshine_weight`,
-    [year, month, clients, adults, children, people, weight, bagClients, sunshineWeight],
+    [year, month, orders, adults, children, people, weight, bagOrders, sunshineWeight],
   );
 }
 
@@ -151,7 +151,7 @@ export async function refreshPantryYearly(year: number) {
       [year],
     ),
     pool.query(
-      `SELECT COALESCE(SUM(client_count)::int,0) AS clients,
+      `SELECT COALESCE(SUM(client_count)::int,0) AS orders,
               COALESCE(SUM(weight)::int,0) AS weight
          FROM sunshine_bag_log
         WHERE EXTRACT(YEAR FROM date) = $1`,
@@ -159,30 +159,30 @@ export async function refreshPantryYearly(year: number) {
     ),
   ]);
 
-  const visitClients = Number(visitsRes.rows[0]?.visits ?? 0);
+  const visitOrders = Number(visitsRes.rows[0]?.visits ?? 0);
   const visitAdults = Number(visitsRes.rows[0]?.adults ?? 0);
   const children = Number(visitsRes.rows[0]?.children ?? 0);
   const visitWeight = Number(visitsRes.rows[0]?.weight ?? 0);
-  const bagClients = Number(bagRes.rows[0]?.clients ?? 0);
+    const bagOrders = Number(bagRes.rows[0]?.orders ?? 0);
   const sunshineWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
-  const clients = visitClients + bagClients;
-  const adults = visitAdults + bagClients;
+  const orders = visitOrders + bagOrders;
+  const adults = visitAdults + bagOrders;
   const people = adults + children;
   const weight = visitWeight + sunshineWeight;
 
   await pool.query(
-    `INSERT INTO pantry_yearly_overall (year, clients, adults, children, people, weight, sunshine_bags, sunshine_weight)
+    `INSERT INTO pantry_yearly_overall (year, orders, adults, children, people, weight, sunshine_bags, sunshine_weight)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        ON CONFLICT (year)
-       DO UPDATE SET clients = EXCLUDED.clients,
+       DO UPDATE SET orders = EXCLUDED.orders,
                      adults = EXCLUDED.adults,
                      children = EXCLUDED.children,
                      people = EXCLUDED.people,
                      weight = EXCLUDED.weight,
                      sunshine_bags = EXCLUDED.sunshine_bags,
                      sunshine_weight = EXCLUDED.sunshine_weight`,
-    [year, clients, adults, children, people, weight, bagClients, sunshineWeight],
+    [year, orders, adults, children, people, weight, bagOrders, sunshineWeight],
   );
 }
 
@@ -192,7 +192,7 @@ export async function listPantryWeekly(req: Request, res: Response, next: NextFu
     const month = parseInt((req.query.month as string) ?? '', 10);
     if (!year || !month) return res.status(400).json({ message: 'Year and month required' });
     const result = await pool.query(
-      `SELECT week, clients, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
+      `SELECT week, orders, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
          FROM pantry_weekly_overall
         WHERE year = $1 AND month = $2
         ORDER BY week`,
@@ -211,7 +211,7 @@ export async function listPantryMonthly(req: Request, res: Response, next: NextF
       parseInt((req.query.year as string) ?? '', 10) ||
       new Date(reginaStartOfDayISO(new Date())).getUTCFullYear();
     const result = await pool.query(
-      `SELECT month, clients, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
+      `SELECT month, orders, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
          FROM pantry_monthly_overall
         WHERE year = $1
         ORDER BY month`,
@@ -227,7 +227,7 @@ export async function listPantryMonthly(req: Request, res: Response, next: NextF
 export async function listPantryYearly(req: Request, res: Response, next: NextFunction) {
   try {
     const result = await pool.query(
-      `SELECT year, clients, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
+      `SELECT year, orders, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
          FROM pantry_yearly_overall
         ORDER BY year`,
     );
@@ -253,7 +253,7 @@ export async function listAvailableMonths(req: Request, res: Response, next: Nex
     const year = parseInt((req.query.year as string) ?? '', 10);
     if (!year) return res.status(400).json({ message: 'Year required' });
     const result = await pool.query(
-      `SELECT month, clients, adults, children, people, weight,
+      `SELECT month, orders, adults, children, people, weight,
               sunshine_bags AS "sunshineBags",
               sunshine_weight AS "sunshineWeight"
          FROM pantry_monthly_overall
@@ -264,7 +264,7 @@ export async function listAvailableMonths(req: Request, res: Response, next: Nex
     const months = result.rows
       .filter(
         r =>
-          r.clients > 0 ||
+          r.orders > 0 ||
           r.adults > 0 ||
           r.children > 0 ||
           r.people > 0 ||
@@ -287,7 +287,7 @@ export async function listAvailableWeeks(req: Request, res: Response, next: Next
     if (!year || !month)
       return res.status(400).json({ message: 'Year and month required' });
     const result = await pool.query(
-      `SELECT week, clients, adults, children, people, weight,
+      `SELECT week, orders, adults, children, people, weight,
               sunshine_bags AS "sunshineBags",
               sunshine_weight AS "sunshineWeight"
          FROM pantry_weekly_overall
@@ -298,7 +298,7 @@ export async function listAvailableWeeks(req: Request, res: Response, next: Next
     const weeks = result.rows
       .filter(
         r =>
-          r.clients > 0 ||
+          r.orders > 0 ||
           r.adults > 0 ||
           r.children > 0 ||
           r.people > 0 ||
@@ -323,7 +323,7 @@ export async function exportPantryWeekly(req: Request, res: Response, next: Next
       return res.status(400).json({ message: 'Year, month and week required' });
     await refreshPantryWeekly(year, month, week);
     const result = await pool.query(
-      `SELECT start_date AS "startDate", end_date AS "endDate", clients, adults, children, people,
+      `SELECT start_date AS "startDate", end_date AS "endDate", orders, adults, children, people,
               weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
          FROM pantry_weekly_overall
         WHERE year = $1 AND month = $2 AND week = $3`,
@@ -334,7 +334,7 @@ export async function exportPantryWeekly(req: Request, res: Response, next: Next
       result.rows[0] || {
         startDate: null,
         endDate: null,
-        clients: 0,
+        orders: 0,
         adults: 0,
         children: 0,
         people: 0,
@@ -358,7 +358,7 @@ export async function exportPantryWeekly(req: Request, res: Response, next: Next
     const rows: Row[] = [
       [
         { value: 'Range/Month/Year', ...headerStyle },
-        { value: 'Clients', ...headerStyle },
+        { value: 'Orders', ...headerStyle },
         { value: 'Adults', ...headerStyle },
         { value: 'Children', ...headerStyle },
         { value: 'People', ...headerStyle },
@@ -368,7 +368,7 @@ export async function exportPantryWeekly(req: Request, res: Response, next: Next
       ],
       [
         { value: startDate && endDate ? `${startDate} - ${endDate}` : `Week ${week}` },
-        { value: row.clients },
+        { value: row.orders },
         { value: row.adults },
         { value: row.children },
         { value: row.people },
@@ -407,7 +407,7 @@ export async function exportPantryMonthly(req: Request, res: Response, next: Nex
     if (!year || !month) return res.status(400).json({ message: 'Year and month required' });
     await refreshPantryMonthly(year, month);
     const result = await pool.query(
-      `SELECT clients, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
+      `SELECT orders, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
          FROM pantry_monthly_overall
         WHERE year = $1 AND month = $2`,
       [year, month],
@@ -415,7 +415,7 @@ export async function exportPantryMonthly(req: Request, res: Response, next: Nex
 
     const row =
       result.rows[0] || {
-        clients: 0,
+        orders: 0,
         adults: 0,
         children: 0,
         people: 0,
@@ -442,7 +442,7 @@ export async function exportPantryMonthly(req: Request, res: Response, next: Nex
     const rows: Row[] = [
       [
         { value: 'Range/Month/Year', ...headerStyle },
-        { value: 'Clients', ...headerStyle },
+        { value: 'Orders', ...headerStyle },
         { value: 'Adults', ...headerStyle },
         { value: 'Children', ...headerStyle },
         { value: 'People', ...headerStyle },
@@ -452,7 +452,7 @@ export async function exportPantryMonthly(req: Request, res: Response, next: Nex
       ],
       [
         { value: monthNames[month - 1] },
-        { value: row.clients },
+        { value: row.orders },
         { value: row.adults },
         { value: row.children },
         { value: row.people },
@@ -490,7 +490,7 @@ export async function exportPantryYearly(req: Request, res: Response, next: Next
     if (!year) return res.status(400).json({ message: 'Year required' });
     await refreshPantryYearly(year);
     const result = await pool.query(
-      `SELECT clients, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
+      `SELECT orders, adults, children, people, weight AS "foodWeight", sunshine_bags AS "sunshineBags", sunshine_weight AS "sunshineWeight"
          FROM pantry_yearly_overall
         WHERE year = $1`,
       [year],
@@ -498,7 +498,7 @@ export async function exportPantryYearly(req: Request, res: Response, next: Next
 
     const row =
       result.rows[0] || {
-        clients: 0,
+        orders: 0,
         adults: 0,
         children: 0,
         people: 0,
@@ -510,7 +510,7 @@ export async function exportPantryYearly(req: Request, res: Response, next: Next
     const rows: Row[] = [
       [
         { value: 'Range/Month/Year', ...headerStyle },
-        { value: 'Clients', ...headerStyle },
+        { value: 'Orders', ...headerStyle },
         { value: 'Adults', ...headerStyle },
         { value: 'Children', ...headerStyle },
         { value: 'People', ...headerStyle },
@@ -520,7 +520,7 @@ export async function exportPantryYearly(req: Request, res: Response, next: Next
       ],
       [
         { value: year },
-        { value: row.clients },
+        { value: row.orders },
         { value: row.adults },
         { value: row.children },
         { value: row.people },

--- a/MJ_FB_Backend/src/migrations/1700000000042_rename_clients_to_orders_in_pantry_overall.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000042_rename_clients_to_orders_in_pantry_overall.ts
@@ -1,0 +1,13 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.renameColumn('pantry_weekly_overall', 'clients', 'orders');
+  pgm.renameColumn('pantry_monthly_overall', 'clients', 'orders');
+  pgm.renameColumn('pantry_yearly_overall', 'clients', 'orders');
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.renameColumn('pantry_yearly_overall', 'orders', 'clients');
+  pgm.renameColumn('pantry_monthly_overall', 'orders', 'clients');
+  pgm.renameColumn('pantry_weekly_overall', 'orders', 'clients');
+}

--- a/MJ_FB_Backend/tests/pantryAggregationController.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationController.test.ts
@@ -15,7 +15,7 @@ describe('pantryAggregationController totals', () => {
   it('includes sunshine bag clients in total client and adult counts', async () => {
     (mockDb.query as jest.Mock)
       .mockResolvedValueOnce({ rows: [{ visits: 5, adults: 3, children: 2, weight: 100 }] })
-      .mockResolvedValueOnce({ rows: [{ clients: 2, weight: 30 }] })
+      .mockResolvedValueOnce({ rows: [{ orders: 2, weight: 30 }] })
       .mockResolvedValueOnce({});
 
     await refreshPantryMonthly(2024, 5);

--- a/MJ_FB_Backend/tests/pantryAggregations.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregations.test.ts
@@ -49,7 +49,7 @@ describe('pantry aggregation routes', () => {
       rows: [
         {
           month: 4,
-          clients: 0,
+          orders: 0,
           adults: 0,
           children: 0,
           weight: 0,
@@ -58,7 +58,7 @@ describe('pantry aggregation routes', () => {
         },
         {
           month: 5,
-          clients: 1,
+          orders: 1,
           adults: 0,
           children: 0,
           weight: 0,
@@ -78,7 +78,7 @@ describe('pantry aggregation routes', () => {
       rows: [
         {
           week: 1,
-          clients: 0,
+          orders: 0,
           adults: 0,
           children: 0,
           weight: 0,
@@ -87,7 +87,7 @@ describe('pantry aggregation routes', () => {
         },
         {
           week: 2,
-          clients: 1,
+          orders: 1,
           adults: 0,
           children: 0,
           weight: 0,

--- a/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantryAggregations.test.tsx
@@ -68,7 +68,7 @@ describe('PantryAggregations page', () => {
   });
 
   it('displays weekly aggregations in a table', async () => {
-    mockGetPantryWeekly.mockResolvedValueOnce([{ week: currentWeek, clients: 2, people: 4 }]);
+    mockGetPantryWeekly.mockResolvedValueOnce([{ week: currentWeek, orders: 2, people: 4 }]);
 
     render(
       <MemoryRouter>


### PR DESCRIPTION
## Summary
- rename pantry_overall `clients` columns to `orders`
- update pantry aggregation controller and exports to use `orders`
- adjust related tests for `orders`

## Testing
- `npm test tests/pantryAggregations.test.ts tests/pantryAggregationController.test.ts`
- `npm test src/__tests__/PantryAggregations.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c199e34e38832d944d909501c5a1c4