### PR TITLE
Handle login for missing accounts with 404 and translations

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -151,7 +151,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
         });
       }
 
-      return res.status(401).json({ message: 'Invalid credentials' });
+      return res.status(404).json({ message: 'Account not found' });
     }
 
     if (clientId) {

--- a/MJ_FB_Backend/tests/login.test.ts
+++ b/MJ_FB_Backend/tests/login.test.ts
@@ -158,6 +158,13 @@ describe('POST /api/auth/login', () => {
 
     expect(res.status).toBe(401);
   });
+
+  it('returns 404 when account is not found', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'missing@example.com', password: 'secret' });
+    expect(res.status).toBe(404);
+  });
 });
 
 describe('GET /api/users/me', () => {

--- a/MJ_FB_Frontend/public/locales/am/translation.json
+++ b/MJ_FB_Frontend/public/locales/am/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "በስርዓታችን መለያ የለዎትም። መለያ ለመፍጠር እባክዎን ሙሉ ስምዎን ወደ harvestpantry@mjfoodbank.org ይላኩ።",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/ar/translation.json
+++ b/MJ_FB_Frontend/public/locales/ar/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "ليس لديك حساب في نظامنا. يرجى إرسال بريد إلكتروني إلى harvestpantry@mjfoodbank.org مع اسمك الكامل لإنشاء حساب.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/en/translation.json
+++ b/MJ_FB_Frontend/public/locales/en/translation.json
@@ -27,6 +27,7 @@
   "show_password": "Show password",
   "hide_password": "Hide password",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "You don’t have an account in our system. Please email harvestpantry@mjfoodbank.org with your full name to create an account.",
   "password_setup_expired": "Password setup link expired",
   "set_password": "Set Password",
   "back_to_login": "Back to login",

--- a/MJ_FB_Frontend/public/locales/es/translation.json
+++ b/MJ_FB_Frontend/public/locales/es/translation.json
@@ -27,6 +27,7 @@
   "show_password": "Show password",
   "hide_password": "Hide password",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "No tienes una cuenta en nuestro sistema. Envía un correo electrónico a harvestpantry@mjfoodbank.org con tu nombre completo para crear una cuenta.",
   "password_setup_expired": "El enlace de configuración de la contraseña ha expirado",
   "set_password": "Crear contraseña",
   "back_to_login": "Volver al inicio",

--- a/MJ_FB_Frontend/public/locales/fa/translation.json
+++ b/MJ_FB_Frontend/public/locales/fa/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "شما حسابی در سیستم ما ندارید. لطفاً نام کامل خود را به harvestpantry@mjfoodbank.org ایمیل کنید تا یک حساب ایجاد شود.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/fr/translation.json
+++ b/MJ_FB_Frontend/public/locales/fr/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "Vous n’avez pas de compte dans notre système. Veuillez envoyer un courriel à harvestpantry@mjfoodbank.org avec votre nom complet pour créer un compte.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/hi/translation.json
+++ b/MJ_FB_Frontend/public/locales/hi/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "आपका हमारे सिस्टम में खाता नहीं है। कृपया अपना पूरा नाम लिखकर harvestpantry@mjfoodbank.org पर ईमेल करें ताकि खाता बनाया जा सके।",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/ml/translation.json
+++ b/MJ_FB_Frontend/public/locales/ml/translation.json
@@ -250,6 +250,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "നിങ്ങൾക്ക് ഞങ്ങളുടെ സിസ്റ്റത്തിൽ ഒരു അക്കൗണ്ടില്ല. ദയവായി harvestpantry@mjfoodbank.org വിലാസത്തിൽ നിങ്ങളുടെ പൂർണ്ണ പേരോടെ ഇമെയിൽ അയച്ച് ഒരു അക്കൗണ്ട് സൃഷ്ടിക്കുക.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/pa/translation.json
+++ b/MJ_FB_Frontend/public/locales/pa/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "ਸਾਡੇ ਸਿਸਟਮ ਵਿੱਚ ਤੁਹਾਡਾ ਖਾਤਾ ਨਹੀਂ ਹੈ। ਕਿਰਪਾ ਕਰਕੇ ਆਪਣਾ ਪੂਰਾ ਨਾਮ ਲਿਖ ਕੇ harvestpantry@mjfoodbank.org 'ਤੇ ਈਮੇਲ ਕਰੋ ਤਾਂ ਜੋ ਖਾਤਾ ਬਣਾਇਆ ਜਾ ਸਕੇ।",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/ps/translation.json
+++ b/MJ_FB_Frontend/public/locales/ps/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "تاسو زموږ په سیستم کې حساب نه لرئ. مهرباني وکړئ خپل بشپړ نوم په harvestpantry@mjfoodbank.org بریښنالیک وکړئ ترڅو حساب جوړ شي.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/so/translation.json
+++ b/MJ_FB_Frontend/public/locales/so/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "Aad kuma lihid xisaab nidaamkeenna. Fadlan magacaa buuxa u soo dir harvestpantry@mjfoodbank.org si xisaab loo sameeyo.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/sw/translation.json
+++ b/MJ_FB_Frontend/public/locales/sw/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "Huna akaunti katika mfumo wetu. Tafadhali tuma barua pepe kwa harvestpantry@mjfoodbank.org ukiambatanisha jina lako kamili ili kuunda akaunti.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/ta/translation.json
+++ b/MJ_FB_Frontend/public/locales/ta/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "எங்கள் அமைப்பில் உங்களுக்கு கணக்கு இல்லை. கணக்கை உருவாக்க, உங்கள் முழுப் பெயருடன் harvestpantry@mjfoodbank.org க்கு மின்னஞ்சல் அனுப்பவும்.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/ti/translation.json
+++ b/MJ_FB_Frontend/public/locales/ti/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "ኣብ ስርዓትና ኣካውንት የለኻን። ብሙሉ ስምኻ ናብ harvestpantry@mjfoodbank.org ኢሜይል ላእኽ ኣካውንት ክትፍጠር ትኽእል።",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/tl/translation.json
+++ b/MJ_FB_Frontend/public/locales/tl/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "Wala kang account sa aming sistema. Mangyaring mag-email sa harvestpantry@mjfoodbank.org kasama ang iyong buong pangalan upang makagawa ng account.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/uk/translation.json
+++ b/MJ_FB_Frontend/public/locales/uk/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "У вас немає облікового запису в нашій системі. Будь ласка, надішліть електронний лист на harvestpantry@mjfoodbank.org із вашим повним ім’ям, щоб створити обліковий запис.",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/public/locales/zh/translation.json
+++ b/MJ_FB_Frontend/public/locales/zh/translation.json
@@ -245,6 +245,7 @@
   "agency_login": "Agency Login",
   "client_id_or_email": "Client ID or Email",
   "incorrect_id_password": "Incorrect ID or email or password",
+  "account_not_found": "我们的系统中没有您的帐户。请发送电子邮件至 harvestpantry@mjfoodbank.org，注明您的全名以创建帐户。",
   "sign_up": "Sign Up",
   "onboarding": {
     "client": {

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -58,6 +58,8 @@ export default function Login({
       } else if (apiErr?.status === 403) {
         setError(t('password_setup_expired'));
         setResendOpen(true);
+      } else if (apiErr?.status === 404) {
+        setError(t('account_not_found'));
       } else {
         setError(err instanceof Error ? err.message : String(err));
       }

--- a/MJ_FB_Frontend/src/pages/auth/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/__tests__/Login.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Login from '../Login';
+import { login } from '../../../api/users';
+
+jest.mock('../../../api/users', () => ({
+  ...jest.requireActual('../../../api/users'),
+  login: jest.fn(),
+}));
+
+describe('Login error handling', () => {
+  it('shows account not found message', async () => {
+    (login as jest.Mock).mockRejectedValue({ status: 404, message: 'Account not found' });
+    const onLogin = jest.fn().mockResolvedValue('/');
+    render(
+      <MemoryRouter>
+        <Login onLogin={onLogin} />
+      </MemoryRouter>,
+    );
+    fireEvent.change(screen.getByLabelText(/client id or email/i), { target: { value: 'missing@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/don’t have an account/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/docs/login.md
+++ b/docs/login.md
@@ -11,6 +11,7 @@ Add the following translation strings to locale files:
 - `client_login_notice_password` – advises clients to use the forgot password link if their password is not working
 - `client_login_notice_volunteer` – tells volunteers who want to shop to email harvestpantry@mjfoodbank.org so booking can be enabled from their volunteer account
 - `client_login_notice_close` – instructs users to close the modal to sign in
+- `account_not_found` – tells users they don’t have an account and to email harvestpantry@mjfoodbank.org with their full name to create one
 
 ## Login
 


### PR DESCRIPTION
## Summary
- return 404 from login API when no volunteer, staff, agency or client matches an email
- surface a friendly "account not found" message on the login page
- translate the new message in all locales and document the key

## Testing
- `npm test tests/login.test.ts` (backend)
- `npm test` *(fails: multiple existing frontend test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c19d8a2738832d91ff75e76ec1a2a4