### PR TITLE
fix volunteer coverage role mapping

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerCoverageCard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerCoverageCard.test.tsx
@@ -17,7 +17,13 @@ describe('VolunteerCoverageCard', () => {
   it('counts bookings for today without timezone shift', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-01-15T12:00:00Z'));
     (getVolunteerRoles as jest.Mock).mockResolvedValue([
-      { id: 1, name: 'Greeter', category_name: 'Front', max_volunteers: 2 },
+      {
+        id: 1,
+        name: 'Greeter',
+        category_name: 'Front',
+        max_volunteers: 2,
+        shifts: [{ id: 1 }],
+      },
     ]);
     (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([
       { status: 'approved', date: '2024-01-15' },
@@ -33,7 +39,13 @@ describe('VolunteerCoverageCard', () => {
   it('shows volunteers when a coverage entry is clicked', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-01-15T12:00:00Z'));
     (getVolunteerRoles as jest.Mock).mockResolvedValue([
-      { id: 1, name: 'Greeter', category_name: 'Front', max_volunteers: 2 },
+      {
+        id: 1,
+        name: 'Greeter',
+        category_name: 'Front',
+        max_volunteers: 2,
+        shifts: [{ id: 1 }],
+      },
     ]);
     (getVolunteerBookingsByRole as jest.Mock).mockResolvedValue([
       { status: 'approved', date: '2024-01-15', volunteer_name: 'Alice' },

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -53,7 +53,12 @@ export default function VolunteerCoverageCard({
       .then(roles =>
         Promise.all(
           roles.map(async r => {
-            const bookings = await getVolunteerBookingsByRole(r.id);
+            const shiftIds = (r.shifts ?? []).map((s: any) => s.id);
+            const bookings = (
+              await Promise.all(
+                shiftIds.map((id: number) => getVolunteerBookingsByRole(id)),
+              )
+            ).flat();
             const todayBookings = bookings.filter(
               (b: any) =>
                 b.status === 'approved' &&
@@ -67,7 +72,7 @@ export default function VolunteerCoverageCard({
               roleName: r.name,
               masterRole: r.category_name,
               filled,
-              total: r.max_volunteers,
+              total: r.max_volunteers * shiftIds.length,
               volunteers,
             };
           }),


### PR DESCRIPTION
## Summary
- fix volunteer coverage to aggregate bookings by shift (slot) id
- adjust test to include shifts

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module, useNavigate errors, multiple act warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b7c499a4832d98fecdeb61612096