### PR TITLE
feat: add volunteer daily bookings page

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -68,6 +68,9 @@ const VolunteerRankings = React.lazy(() =>
 const VolunteerAdmin = React.lazy(() =>
   import('./pages/staff/VolunteerManagement')
 );
+const VolunteerDailyBookings = React.lazy(() =>
+  import('./pages/staff/VolunteerDailyBookings')
+);
 const WarehouseDashboard = React.lazy(() =>
   import('./pages/warehouse-management/WarehouseDashboard')
 );
@@ -182,6 +185,7 @@ export default function App() {
         links: [
           { label: t('dashboard'), to: '/volunteer-management' },
           { label: 'Schedule', to: '/volunteer-management/schedule' },
+          { label: 'Daily Bookings', to: '/volunteer-management/daily' },
           { label: 'Recurring Shifts', to: '/volunteer-management/recurring' },
           {
             label: 'Volunteers',
@@ -533,6 +537,10 @@ export default function App() {
                       <Route
                         path="/volunteer-management/volunteers"
                         element={<VolunteerAdmin />}
+                      />
+                      <Route
+                        path="/volunteer-management/daily"
+                        element={<VolunteerDailyBookings />}
                       />
                       <Route
                         path="/volunteer-management/rankings"

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -370,6 +370,16 @@ export async function getVolunteerBookings(): Promise<VolunteerBooking[]> {
   return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
 }
 
+export async function getVolunteerBookingsByDate(
+  date: string,
+): Promise<VolunteerBooking[]> {
+  const res = await apiFetch(
+    `${API_BASE}/volunteer-bookings/by-date?date=${date}`,
+  );
+  const data = await handleResponse(res);
+  return Array.isArray(data) ? data.map(normalizeVolunteerBooking) : data;
+}
+
 export async function getUnmarkedVolunteerBookings(): Promise<VolunteerBooking[]> {
   const res = await apiFetch(`${API_BASE}/volunteer-bookings/unmarked`);
   const data = await handleResponse(res);

--- a/MJ_FB_Frontend/src/pages/staff/VolunteerDailyBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/VolunteerDailyBookings.tsx
@@ -1,0 +1,194 @@
+import { useState, useEffect, useMemo } from 'react';
+import Page from '../../components/Page';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Stack,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+} from '@mui/material';
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs, { formatDate } from '../../utils/date';
+import { formatTime } from '../../utils/time';
+import {
+  getVolunteerBookingsByDate,
+  updateVolunteerBookingStatus,
+  rescheduleVolunteerBookingByToken,
+} from '../../api/volunteers';
+import type { VolunteerBooking, VolunteerBookingStatus } from '../../types';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import RescheduleDialog from '../../components/VolunteerRescheduleDialog';
+
+type Grouped = Map<string, Map<string, Map<string, VolunteerBooking[]>>>;
+
+export default function VolunteerDailyBookings() {
+  const [date, setDate] = useState(dayjs());
+  const [bookings, setBookings] = useState<VolunteerBooking[]>([]);
+  const [message, setMessage] = useState('');
+  const [reschedule, setReschedule] = useState<VolunteerBooking | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const d = formatDate(date);
+        const data = await getVolunteerBookingsByDate(d);
+        setBookings(data);
+      } catch {
+        setBookings([]);
+      }
+    })();
+  }, [date]);
+
+  const grouped: Grouped = useMemo(() => {
+    const map: Grouped = new Map();
+    bookings.forEach(b => {
+      const cat = b.category_name || 'Other';
+      let catMap = map.get(cat);
+      if (!catMap) {
+        catMap = new Map();
+        map.set(cat, catMap);
+      }
+      const role = b.role_name;
+      let roleMap = catMap.get(role);
+      if (!roleMap) {
+        roleMap = new Map();
+        catMap.set(role, roleMap);
+      }
+      const shiftKey = `${b.start_time}-${b.end_time}`;
+      const list = roleMap.get(shiftKey) || [];
+      list.push(b);
+      roleMap.set(shiftKey, list);
+    });
+    return map;
+  }, [bookings]);
+
+  async function handleStatusChange(
+    booking: VolunteerBooking,
+    status: VolunteerBookingStatus,
+  ) {
+    try {
+      await updateVolunteerBookingStatus(booking.id, status);
+      setBookings(prev =>
+        prev.map(b => (b.id === booking.id ? { ...b, status } : b)),
+      );
+      setMessage('Status updated');
+    } catch (e: any) {
+      setMessage(e.message || 'Update failed');
+    }
+  }
+
+  async function handleRescheduleSubmit(newDate: string, roleId: number) {
+    if (!reschedule) return;
+    try {
+      await rescheduleVolunteerBookingByToken(
+        reschedule.reschedule_token || '',
+        roleId,
+        newDate,
+      );
+      setMessage('Booking rescheduled');
+      setReschedule(null);
+      const d = formatDate(date);
+      const data = await getVolunteerBookingsByDate(d);
+      setBookings(data);
+    } catch (e: any) {
+      setMessage(e.message || 'Reschedule failed');
+    }
+  }
+
+  return (
+    <Page title="Volunteer Daily Bookings">
+      <LocalizationProvider dateAdapter={AdapterDayjs} dateLibInstance={dayjs}>
+        <DatePicker
+          value={date}
+          onChange={d => d && setDate(d)}
+          slotProps={{ textField: { fullWidth: true } }}
+        />
+      </LocalizationProvider>
+
+      <Box mt={2}>
+        {Array.from(grouped.entries()).map(([cat, roleMap]) => (
+          <Box key={cat} mb={2}>
+            <Typography variant="h5" gutterBottom>
+              {cat}
+            </Typography>
+            {Array.from(roleMap.entries()).map(([role, shiftMap]) => (
+              <Box key={role} ml={2} mb={2}>
+                <Typography variant="h6">{role}</Typography>
+                {Array.from(shiftMap.entries()).map(([shiftKey, list]) => {
+                  const [start, end] = shiftKey.split('-');
+                  return (
+                    <Card key={shiftKey} sx={{ mt: 1 }}>
+                      <CardContent>
+                        <Typography gutterBottom>
+                          {formatTime(start)} - {formatTime(end)}
+                        </Typography>
+                        <Stack spacing={1}>
+                          {list.map(b => (
+                            <Stack
+                              key={b.id}
+                              direction="row"
+                              spacing={2}
+                              alignItems="center"
+                            >
+                              <Typography sx={{ flexGrow: 1 }}>
+                                {b.volunteer_name}
+                              </Typography>
+                              <FormControl sx={{ minWidth: 150 }} size="medium">
+                                <InputLabel id={`status-${b.id}`}>Status</InputLabel>
+                                <Select
+                                  labelId={`status-${b.id}`}
+                                  label="Status"
+                                  value={b.status}
+                                  onChange={e =>
+                                    handleStatusChange(
+                                      b,
+                                      e.target.value as VolunteerBookingStatus,
+                                    )
+                                  }
+                                >
+                                  <MenuItem value="completed">Completed</MenuItem>
+                                  <MenuItem value="no_show">No Show</MenuItem>
+                                  <MenuItem value="cancelled">Cancelled</MenuItem>
+                                </Select>
+                              </FormControl>
+                              {b.reschedule_token && (
+                                <Button
+                                  variant="outlined"
+                                  onClick={() => setReschedule(b)}
+                                >
+                                  Reschedule
+                                </Button>
+                              )}
+                            </Stack>
+                          ))}
+                        </Stack>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </Box>
+            ))}
+          </Box>
+        ))}
+      </Box>
+      <RescheduleDialog
+        open={!!reschedule}
+        onClose={() => setReschedule(null)}
+        onSubmit={handleRescheduleSubmit}
+      />
+      <FeedbackSnackbar
+        open={!!message}
+        message={message}
+        onClose={() => setMessage('')}
+        severity="success"
+      />
+    </Page>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerDailyBookings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerDailyBookings.test.tsx
@@ -1,0 +1,100 @@
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '../../../../testUtils/renderWithProviders';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerDailyBookings from '../VolunteerDailyBookings';
+import {
+  getVolunteerBookingsByDate,
+  updateVolunteerBookingStatus,
+} from '../../../api/volunteers';
+
+jest.mock('../../../api/volunteers', () => ({
+  getVolunteerBookingsByDate: jest.fn(),
+  updateVolunteerBookingStatus: jest.fn(),
+}));
+
+const sampleBookings = [
+  {
+    id: 1,
+    status: 'approved',
+    role_id: 1,
+    date: '2024-01-01',
+    start_time: '09:00:00',
+    end_time: '10:00:00',
+    role_name: 'Stocking',
+    category_name: 'Pantry',
+    volunteer_name: 'Alice',
+  },
+  {
+    id: 2,
+    status: 'approved',
+    role_id: 1,
+    date: '2024-01-01',
+    start_time: '09:00:00',
+    end_time: '10:00:00',
+    role_name: 'Stocking',
+    category_name: 'Pantry',
+    volunteer_name: 'Bob',
+  },
+  {
+    id: 3,
+    status: 'approved',
+    role_id: 2,
+    date: '2024-01-01',
+    start_time: '10:00:00',
+    end_time: '11:00:00',
+    role_name: 'Serving',
+    category_name: 'Pantry',
+    volunteer_name: 'Carol',
+  },
+  {
+    id: 4,
+    status: 'approved',
+    role_id: 3,
+    date: '2024-01-01',
+    start_time: '09:00:00',
+    end_time: '10:00:00',
+    role_name: 'Sorting',
+    category_name: 'Warehouse',
+    volunteer_name: 'Dave',
+  },
+];
+
+describe('VolunteerDailyBookings', () => {
+  it('groups bookings by category, role, and shift', async () => {
+    (getVolunteerBookingsByDate as jest.Mock).mockResolvedValue(sampleBookings);
+    renderWithProviders(
+      <MemoryRouter>
+        <VolunteerDailyBookings />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Pantry')).toBeInTheDocument();
+    expect(screen.getByText('Stocking')).toBeInTheDocument();
+    expect(screen.getByText('9:00 AM - 10:00 AM')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Warehouse')).toBeInTheDocument();
+  });
+
+  it('updates status via API', async () => {
+    (getVolunteerBookingsByDate as jest.Mock).mockResolvedValue([sampleBookings[0]]);
+    (updateVolunteerBookingStatus as jest.Mock).mockResolvedValue(undefined);
+    renderWithProviders(
+      <MemoryRouter>
+        <VolunteerDailyBookings />
+      </MemoryRouter>,
+    );
+
+    const select = await screen.findByLabelText('Status');
+    fireEvent.change(select, { target: { value: 'completed' } });
+
+    await waitFor(() =>
+      expect(updateVolunteerBookingStatus).toHaveBeenCalledWith(1, 'completed'),
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add API wrapper to retrieve volunteer bookings by date
- introduce staff-facing VolunteerDailyBookings page with status and reschedule controls
- wire navigation and routing for daily volunteer bookings
- cover grouping and status updates with tests

## Testing
- `npm test` (backend) *(fails: Test Suites: 24 failed, 114 passed, 138 total)*
- `npm test` (frontend) *(fails: Jest encountered an unexpected token; SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c15fd5e8832d961356159e2722c3