### PR TITLE
Fix people totals in pantry aggregations

### DIFF
--- a/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
@@ -59,7 +59,7 @@ export async function refreshPantryWeekly(year: number, month: number, week: num
 
   const orders = visitOrders + bagOrders;
   const adults = visitAdults + bagOrders;
-  const people = adults + children;
+  const people = visitAdults + children;
   const weight = visitWeight + sunshineWeight;
 
   await pool.query(
@@ -121,7 +121,7 @@ export async function refreshPantryMonthly(year: number, month: number) {
 
   const orders = visitOrders + bagOrders;
   const adults = visitAdults + bagOrders;
-  const people = adults + children;
+  const people = visitAdults + children;
   const weight = visitWeight + sunshineWeight;
 
   await pool.query(
@@ -168,7 +168,7 @@ export async function refreshPantryYearly(year: number) {
 
   const orders = visitOrders + bagOrders;
   const adults = visitAdults + bagOrders;
-  const people = adults + children;
+  const people = visitAdults + children;
   const weight = visitWeight + sunshineWeight;
 
   await pool.query(

--- a/MJ_FB_Backend/tests/pantryAggregationController.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationController.test.ts
@@ -1,29 +1,24 @@
-import mockDb from './utils/mockDb';
+import pool from '../src/db';
 import { refreshPantryMonthly } from '../src/controllers/pantry/pantryAggregationController';
 
 describe('pantryAggregationController totals', () => {
-  beforeEach(() => {
-    (mockDb.query as jest.Mock).mockReset();
-    (mockDb.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0 });
-  });
-
   afterEach(() => {
-    (mockDb.query as jest.Mock).mockReset();
-    (mockDb.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0 });
+    jest.restoreAllMocks();
   });
 
-  it('includes sunshine bag clients in total client and adult counts', async () => {
-    (mockDb.query as jest.Mock)
+  it('includes sunshine bag clients in total order and adult counts and sums people correctly', async () => {
+    const queryMock = jest
+      .spyOn(pool, 'query')
       .mockResolvedValueOnce({ rows: [{ visits: 5, adults: 3, children: 2, weight: 100 }] })
       .mockResolvedValueOnce({ rows: [{ orders: 2, weight: 30 }] })
-      .mockResolvedValueOnce({});
+      .mockResolvedValue({} as any);
 
     await refreshPantryMonthly(2024, 5);
 
-    expect(mockDb.query).toHaveBeenNthCalledWith(
+    expect(queryMock).toHaveBeenNthCalledWith(
       3,
       expect.stringContaining('INSERT INTO pantry_monthly_overall'),
-      [2024, 5, 7, 5, 2, 7, 130, 2, 30],
+      [2024, 5, 7, 5, 2, 5, 130, 2, 30],
     );
   });
 });


### PR DESCRIPTION
## Summary
- compute people counts from adult and child totals in pantry aggregations
- adjust pantry aggregation test expectations

## Testing
- `npm test` *(fails: expect(...) to have been called, Number of calls: 0)*
- `npm test tests/pantryAggregationController.test.ts` *(fails: expect(...) to have been called, Number of calls: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c60e0054832daeb6f8623afb872d