### PR TITLE
Fix volunteer booking category type and date picker

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/VolunteerDailyBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/VolunteerDailyBookings.tsx
@@ -15,6 +15,7 @@ import {
 import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs, { formatDate } from '../../utils/date';
+import type { Dayjs } from 'dayjs';
 import { formatTime } from '../../utils/time';
 import {
   getVolunteerBookingsByDate,
@@ -28,7 +29,7 @@ import RescheduleDialog from '../../components/VolunteerRescheduleDialog';
 type Grouped = Map<string, Map<string, Map<string, VolunteerBooking[]>>>;
 
 export default function VolunteerDailyBookings() {
-  const [date, setDate] = useState(dayjs());
+  const [date, setDate] = useState<Dayjs>(dayjs());
   const [bookings, setBookings] = useState<VolunteerBooking[]>([]);
   const [message, setMessage] = useState('');
   const [reschedule, setReschedule] = useState<VolunteerBooking | null>(null);
@@ -106,7 +107,7 @@ export default function VolunteerDailyBookings() {
       <LocalizationProvider dateAdapter={AdapterDayjs} dateLibInstance={dayjs}>
         <DatePicker
           value={date}
-          onChange={d => d && setDate(d)}
+          onChange={d => d && setDate(d as Dayjs)}
           slotProps={{ textField: { fullWidth: true } }}
         />
       </LocalizationProvider>

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -126,6 +126,7 @@ export interface VolunteerBooking {
   start_time: string;
   end_time: string;
   role_name: string;
+  category_name?: string;
   volunteer_id?: number;
   volunteer_name?: string;
   status_color?: string;


### PR DESCRIPTION
## Summary
- add optional `category_name` to `VolunteerBooking` type
- type VolunteerDailyBookings date picker with Dayjs

## Testing
- `npm test` *(fails: Cannot read properties of null (reading '_location'))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1c6ac52c0832db6a3194871f936e8