### PR TITLE
Show aggregations menu for donor management staff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
 - Profile pages let clients and volunteers toggle email reminders from `/users/me/preferences`.
 - Staff can delete client and volunteer accounts from their respective management pages; update help content when these features change.
 - Donation management pages are accessible to staff with donor_management access and admins.
-- Aggregations pages are accessible only to staff with aggregations access.
+- Aggregations pages are accessible to staff with aggregations or donor_management access.
 
 See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/AGENTS.md` for frontend-specific guidance.
 

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -144,7 +144,11 @@ export default function App() {
   const showDonationEntry = role === 'volunteer' && access.includes('donation_entry');
   const showDonationLog = showWarehouse || showDonationEntry;
   const showAggregations =
-    isStaff && (hasAccess('aggregations') || hasAccess('pantry') || hasAccess('warehouse'));
+    isStaff &&
+    (hasAccess('aggregations') ||
+      hasAccess('pantry') ||
+      hasAccess('warehouse') ||
+      hasAccess('donor_management'));
 
   const staffRootPath = getStaffRootPath(access as StaffAccess[]);
   const singleAccessOnly = isStaff && staffRootPath !== '/';

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -140,6 +140,16 @@ describe('App authentication persistence', () => {
     expect(screen.getByText('Warehouse Aggregations')).toBeInTheDocument();
   });
 
+  it('shows aggregations nav links for donor management access', async () => {
+    localStorage.setItem('role', 'staff');
+    localStorage.setItem('name', 'Test Staff');
+    localStorage.setItem('access', JSON.stringify(['donor_management']));
+    renderWithProviders(<App />);
+    fireEvent.click(await screen.findByText('Aggregations'));
+    expect(await screen.findByText('Pantry Aggregations')).toBeInTheDocument();
+    expect(screen.getByText('Warehouse Aggregations')).toBeInTheDocument();
+  });
+
   it('routes to donor donation log page', async () => {
     localStorage.setItem('role', 'staff');
     localStorage.setItem('name', 'Test Staff');

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Input fields feature larger touch targets on mobile devices for easier tapping.
 - Staff dashboards include a Volunteer Coverage card; click a role to see which volunteers are on duty.
 
-- Staff with `aggregations` access see an **Aggregations** navigation item with **Pantry Aggregations** and **Warehouse Aggregations** pages for reporting.
+- Staff with `aggregations` or `donor_management` access see an **Aggregations** navigation item with **Pantry Aggregations** and **Warehouse Aggregations** pages for reporting.
 
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 `/leave-requests` from the profile menu once logged in. Admin users also see


### PR DESCRIPTION
## Summary
- Display Aggregations navigation group when staff have donor management access
- Document that donor-management staff can access Aggregations
- Test Aggregations nav with donor-management access

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module; useNavigate may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c82b7bdc832d9bdc728da1752622