### PR TITLE
feat: add donor management quick links

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/DonorQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DonorQuickLinks.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DonorQuickLinks from '../components/DonorQuickLinks';
+
+describe('DonorQuickLinks', () => {
+  it('renders donor links', () => {
+    render(
+      <MemoryRouter>
+        <DonorQuickLinks />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole('link', { name: /Donor Log/i })
+    ).toHaveAttribute('href', '/donor-management/donation-log');
+    expect(
+      screen.getByRole('link', { name: /Mail Lists/i })
+    ).toHaveAttribute('href', '/donor-management/mail-lists');
+  });
+
+  it.each([
+    ['/donor-management/donation-log', /Donor Log/i],
+    ['/donor-management/mail-lists', /Mail Lists/i],
+  ])('disables current page link %s', (path, label) => {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <DonorQuickLinks />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+});
+

--- a/MJ_FB_Frontend/src/components/DonorQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/DonorQuickLinks.tsx
@@ -1,0 +1,37 @@
+import { Stack, Button } from '@mui/material';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
+
+export default function DonorQuickLinks() {
+  const { pathname } = useLocation();
+  const buttonSx = {
+    textTransform: 'none',
+    '&:hover': { color: 'primary.main' },
+  } as const;
+  const links = [
+    { to: '/donor-management/donation-log', label: 'Donor Log' },
+    { to: '/donor-management/mail-lists', label: 'Mail Lists' },
+  ];
+
+  return (
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      spacing={{ xs: 1, sm: 2 }}
+      sx={{ width: '100%', mb: 2 }}
+    >
+      {links.map(link => (
+        <Button
+          key={link.to}
+          variant="outlined"
+          sx={buttonSx}
+          component={RouterLink}
+          to={link.to}
+          disabled={pathname === link.to}
+          fullWidth
+        >
+          {link.label}
+        </Button>
+      ))}
+    </Stack>
+  );
+}
+

--- a/MJ_FB_Frontend/src/pages/donor-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonationLog.tsx
@@ -15,6 +15,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
+import DonorQuickLinks from '../../components/DonorQuickLinks';
 import {
   getMonetaryDonors,
   createMonetaryDonor,
@@ -201,36 +202,39 @@ export default function DonationLog() {
   }));
 
   return (
-    <Page title="Donation Log">
-      <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
-        <Button
-          variant="contained"
-          onClick={e => {
-            (e.currentTarget as HTMLButtonElement).blur();
-            setForm({ date: format(selectedDate), donorId: null, amount: '' });
-            setRecordOpen(true);
-          }}
-        >
-          Record Donation
-        </Button>
-        <Button
-          variant="outlined"
-          onClick={e => {
-            (e.currentTarget as HTMLButtonElement).blur();
-            setNewDonorOpen(true);
-          }}
-        >
-          Add Donor
-        </Button>
-      </Stack>
-      <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
+    <>
+      <DonorQuickLinks />
+      <Page title="Donation Log">
+        <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+          <Button
+            variant="contained"
+            onClick={e => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              setForm({ date: format(selectedDate), donorId: null, amount: '' });
+              setRecordOpen(true);
+            }}
+          >
+            Record Donation
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={e => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              setNewDonorOpen(true);
+            }}
+          >
+            Add Donor
+          </Button>
+        </Stack>
 
-      <Dialog
-        open={recordOpen}
-        onClose={() => setRecordOpen(false)}
-      >
-        <DialogCloseButton onClose={() => setRecordOpen(false)} />
-        <DialogTitle>Record Donation</DialogTitle>
+        <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
+
+        <Dialog
+          open={recordOpen}
+          onClose={() => setRecordOpen(false)}
+        >
+          <DialogCloseButton onClose={() => setRecordOpen(false)} />
+          <DialogTitle>Record Donation</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <Stack spacing={2} mt={1}>
             <TextField
@@ -261,47 +265,48 @@ export default function DonationLog() {
             Save
           </Button>
         </DialogActions>
-      </Dialog>
+        </Dialog>
 
-      <Dialog open={newDonorOpen} onClose={() => setNewDonorOpen(false)}>
-        <DialogCloseButton onClose={() => setNewDonorOpen(false)} />
-        <DialogTitle>Add Donor</DialogTitle>
-        <DialogContent sx={{ pt: 2 }}>
-          <Stack spacing={2} mt={1}>
-            <TextField
-              label="First Name"
-              value={donorForm.firstName}
-              onChange={e => setDonorForm({ ...donorForm, firstName: e.target.value })}
-            />
-            <TextField
-              label="Last Name"
-              value={donorForm.lastName}
-              onChange={e => setDonorForm({ ...donorForm, lastName: e.target.value })}
-            />
-            <TextField
-              label="Email"
-              type="email"
-              value={donorForm.email}
-              onChange={e => setDonorForm({ ...donorForm, email: e.target.value })}
-            />
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={handleAddDonor}
-            disabled={!donorForm.firstName || !donorForm.lastName || !donorForm.email}
-          >
-            Save
-          </Button>
-        </DialogActions>
-      </Dialog>
+        <Dialog open={newDonorOpen} onClose={() => setNewDonorOpen(false)}>
+          <DialogCloseButton onClose={() => setNewDonorOpen(false)} />
+          <DialogTitle>Add Donor</DialogTitle>
+          <DialogContent sx={{ pt: 2 }}>
+            <Stack spacing={2} mt={1}>
+              <TextField
+                label="First Name"
+                value={donorForm.firstName}
+                onChange={e => setDonorForm({ ...donorForm, firstName: e.target.value })}
+              />
+              <TextField
+                label="Last Name"
+                value={donorForm.lastName}
+                onChange={e => setDonorForm({ ...donorForm, lastName: e.target.value })}
+              />
+              <TextField
+                label="Email"
+                type="email"
+                value={donorForm.email}
+                onChange={e => setDonorForm({ ...donorForm, email: e.target.value })}
+              />
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={handleAddDonor}
+              disabled={!donorForm.firstName || !donorForm.lastName || !donorForm.email}
+            >
+              Save
+            </Button>
+          </DialogActions>
+        </Dialog>
 
-      <FeedbackSnackbar
-        open={snackbar.open}
-        onClose={() => setSnackbar({ open: false, message: '' })}
-        message={snackbar.message}
-      />
-    </Page>
+        <FeedbackSnackbar
+          open={snackbar.open}
+          onClose={() => setSnackbar({ open: false, message: '' })}
+          message={snackbar.message}
+        />
+      </Page>
+    </>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/donor-management/DonorDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonorDashboard.tsx
@@ -1,6 +1,12 @@
 import Page from '../../components/Page';
+import DonorQuickLinks from '../../components/DonorQuickLinks';
 
 export default function DonorDashboard() {
-  return <Page title="Donor Dashboard">{null}</Page>;
+  return (
+    <>
+      <DonorQuickLinks />
+      <Page title="Donor Dashboard">{null}</Page>
+    </>
+  );
 }
 

--- a/MJ_FB_Frontend/src/pages/donor-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonorProfile.tsx
@@ -23,6 +23,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { useQuery } from '@tanstack/react-query';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import DonorQuickLinks from '../../components/DonorQuickLinks';
 import {
   getMonetaryDonor,
   getMonetaryDonations,
@@ -132,8 +133,10 @@ export default function DonorProfile() {
   }
 
   return (
-    <Page title="Donor Profile">
-      <Stack spacing={2}>
+    <>
+      <DonorQuickLinks />
+      <Page title="Donor Profile">
+        <Stack spacing={2}>
         {donor && (
           <Stack spacing={0.5}>
             <Typography variant="h5">
@@ -234,5 +237,6 @@ export default function DonorProfile() {
         />
       </Stack>
     </Page>
+    </>
   );
 }

--- a/MJ_FB_Frontend/src/pages/donor-management/MailLists.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/MailLists.tsx
@@ -12,6 +12,7 @@ import {
 import type { AlertColor } from '@mui/material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import DonorQuickLinks from '../../components/DonorQuickLinks';
 import {
   getMailLists,
   sendMailListEmails,
@@ -64,8 +65,10 @@ export default function MailLists() {
   const noDonors = Boolean(lists && !RANGES.some(range => lists[range].length > 0));
 
   return (
-    <Page title="Mail Lists">
-      <Stack spacing={2}>
+    <>
+      <DonorQuickLinks />
+      <Page title="Mail Lists">
+        <Stack spacing={2}>
         <Stack direction="row" spacing={2} alignItems="center">
           <Typography>{`Month: ${month}`}</Typography>
           <Typography>{`Year: ${year}`}</Typography>
@@ -113,14 +116,15 @@ export default function MailLists() {
               </List>
             </Paper>
           ))}
-        <FeedbackSnackbar
-          open={snackbar.open}
-          onClose={() => setSnackbar(s => ({ ...s, open: false }))}
-          message={snackbar.message}
-          severity={snackbar.severity}
-        />
-      </Stack>
-    </Page>
+          <FeedbackSnackbar
+            open={snackbar.open}
+            onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+            message={snackbar.message}
+            severity={snackbar.severity}
+          />
+        </Stack>
+      </Page>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add DonorQuickLinks component with links to Donor Log and Mail Lists
- show donor quick links on donor dashboard, donation log, mail lists, and donor profile pages
- cover donor quick links with tests

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module, jsdom _location errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cff334f8832dadec54784b540196