### PR TITLE
feat: add month filter to donation logs

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/DonorDonationLog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DonorDonationLog.test.tsx
@@ -25,7 +25,7 @@ describe('Donor Donation Log', () => {
     jest.clearAllMocks();
   });
 
-  it('loads donations for the selected date', async () => {
+  it('loads donations for the selected month', async () => {
     (getMonetaryDonors as jest.Mock).mockResolvedValue([
       { id: 1, firstName: 'John', lastName: 'Doe', email: 'john@example.com' },
     ]);

--- a/MJ_FB_Frontend/src/api/donations.ts
+++ b/MJ_FB_Frontend/src/api/donations.ts
@@ -8,8 +8,8 @@ export interface Donation {
   weight: number;
 }
 
-export async function getDonations(date: string): Promise<Donation[]> {
-  const res = await apiFetch(`${API_BASE}/donations?date=${date}`);
+export async function getDonations(month: string): Promise<Donation[]> {
+  const res = await apiFetch(`${API_BASE}/donations?month=${month}`);
   return handleResponse(res);
 }
 


### PR DESCRIPTION
## Summary
- allow backend donations endpoint to return all entries for a given month
- show month picker and monthly donation tables on staff donor and warehouse pages
- update donation log test for monthly view

## Testing
- `npm test` (backend) *(fails: volunteerRebookCancelled.test.ts etc)*
- `npm test` (frontend) *(fails: VolunteerManagement.test.tsx, PantrySchedule.test.tsx, etc)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d04c1a4c832db60cb6755f3d2222