### PR TITLE
refactor: remove translation provider from test utils

### DIFF
--- a/MJ_FB_Frontend/testUtils/renderWithProviders.tsx
+++ b/MJ_FB_Frontend/testUtils/renderWithProviders.tsx
@@ -1,7 +1,5 @@
 import { render, type RenderOptions } from '@testing-library/react';
 import { AuthProvider } from '../src/hooks/useAuth';
-import { I18nextProvider } from 'react-i18next';
-import i18n from '../src/i18n';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import { theme } from '../src/theme';
@@ -24,21 +22,19 @@ export function renderWithProviders(
 
   function Wrapper({ children }: ProvidersProps): ReactElement {
     return (
-      <I18nextProvider i18n={i18n}>
-        <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <LocalizationProvider
-              dateAdapter={AdapterDayjs}
-              dateLibInstance={dayjs}
-            >
-              <ThemeProvider theme={theme}>
-                <CssBaseline />
-                {children}
-              </ThemeProvider>
-            </LocalizationProvider>
-          </AuthProvider>
-        </QueryClientProvider>
-      </I18nextProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <LocalizationProvider
+            dateAdapter={AdapterDayjs}
+            dateLibInstance={dayjs}
+          >
+            <ThemeProvider theme={theme}>
+              <CssBaseline />
+              {children}
+            </ThemeProvider>
+          </LocalizationProvider>
+        </AuthProvider>
+      </QueryClientProvider>
     );
   }
 


### PR DESCRIPTION
## Summary
- render tests without a translation provider

## Testing
- `npm test src/__tests__/BookingUI.test.tsx` *(fails: Unable to find an element with the text: /Booking for: Test/)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b59665d8832d9834f17ae45e8067