### PR TITLE
feat: hardcode breadcrumb text

### DIFF
--- a/MJ_FB_Frontend/src/components/Breadcrumbs.tsx
+++ b/MJ_FB_Frontend/src/components/Breadcrumbs.tsx
@@ -1,6 +1,5 @@
 import { Breadcrumbs as MuiBreadcrumbs, Link, Typography } from '@mui/material';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 
 function formatSegment(segment: string) {
   return segment
@@ -11,12 +10,11 @@ function formatSegment(segment: string) {
 export default function Breadcrumbs() {
   const location = useLocation();
   const pathnames = location.pathname.split('/').filter((x) => x);
-  const { t } = useTranslation();
 
   return (
-    <MuiBreadcrumbs aria-label={t('breadcrumb')} sx={{ mb: 2 }}>
+    <MuiBreadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
       <Link component={RouterLink} underline="hover" color="inherit" to="/">
-        {t('home')}
+        Home
       </Link>
       {pathnames.map((value, index) => {
         const to = `/${pathnames.slice(0, index + 1).join('/')}`;


### PR DESCRIPTION
## Summary
- remove i18n usage from Breadcrumbs component
- hardcode English breadcrumb label and Home link

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7cd81b4832d8724ed2df55eecab