### PR TITLE
refactor: remove translations from password checklist

### DIFF
--- a/MJ_FB_Frontend/src/components/PasswordChecklist.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordChecklist.tsx
@@ -4,35 +4,32 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
-import { useTranslation } from 'react-i18next';
 
 interface PasswordChecklistProps {
   password: string;
 }
 
 export default function PasswordChecklist({ password }: PasswordChecklistProps) {
-  const { t } = useTranslation();
-
   const rules = [
     {
       id: 'min_length',
       valid: password.length >= 8,
-      label: t('profile_page.password_checklist.min_length'),
+      label: 'Minimum length (8 characters)',
     },
     {
       id: 'uppercase',
       valid: /[A-Z]/.test(password),
-      label: t('profile_page.password_checklist.uppercase'),
+      label: 'Uppercase letter',
     },
     {
       id: 'lowercase',
       valid: /[a-z]/.test(password),
-      label: t('profile_page.password_checklist.lowercase'),
+      label: 'Lowercase letter',
     },
     {
       id: 'symbol',
       valid: /[^A-Za-z0-9]/.test(password),
-      label: t('profile_page.password_checklist.symbol'),
+      label: 'Special character',
     },
   ];
 


### PR DESCRIPTION
## Summary
- use static English labels for password requirements

## Testing
- `nvm use`
- `npm test` *(fails: unable to find labels and elements across multiple test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7c46f6c832d8c1375d141acc262