### PR TITLE
refactor: hard-code client dialog strings

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Dialog, DialogTitle } from '@mui/material';
 import type { AlertColor } from '@mui/material';
-import { useTranslation } from 'react-i18next';
 import DialogCloseButton from '../../../components/DialogCloseButton';
 import { getUserByClientId, updateUserInfo, requestPasswordReset } from '../../../api/users';
 import getApiErrorMessage from '../../../utils/getApiErrorMessage';
@@ -22,7 +21,6 @@ export async function handleSave(
   data: EditClientFormData,
   onClientUpdated: (name: string) => void,
   onUpdated: (message: string, severity: AlertColor) => void,
-  t: (key: string) => string,
   onClose: () => void,
 ): Promise<boolean> {
   try {
@@ -35,7 +33,7 @@ export async function handleSave(
       ...(data.onlineAccess && data.password ? { password: data.password } : {}),
     });
     onClientUpdated(`${data.firstName} ${data.lastName}`);
-    onUpdated(t('client_updated'), 'success');
+    onUpdated('Client updated', 'success');
     onClose();
     return true;
   } catch (err: unknown) {
@@ -49,10 +47,9 @@ export async function handleSendReset(
   data: EditClientFormData,
   onClientUpdated: (name: string) => void,
   onUpdated: (message: string, severity: AlertColor) => void,
-  t: (key: string) => string,
   onClose: () => void,
 ) {
-  const ok = await handleSave(clientId, data, onClientUpdated, onUpdated, t, onClose);
+  const ok = await handleSave(clientId, data, onClientUpdated, onUpdated, onClose);
   if (!ok) return;
   try {
     await requestPasswordReset({ clientId: String(clientId) });
@@ -72,7 +69,6 @@ export default function EditClientDialog({
   onUpdated,
   onClientUpdated,
 }: Props) {
-  const { t } = useTranslation();
   const [form, setForm] = useState<EditClientFormData>({
     firstName: '',
     lastName: '',
@@ -109,8 +105,8 @@ export default function EditClientDialog({
       <EditClientForm
         open={open}
         initialData={form}
-        onSave={data => handleSave(clientId, data, onClientUpdated, onUpdated, t, onClose)}
-        onSendReset={data => handleSendReset(clientId, data, onClientUpdated, onUpdated, t, onClose)}
+        onSave={data => handleSave(clientId, data, onClientUpdated, onUpdated, onClose)}
+        onSendReset={data => handleSendReset(clientId, data, onClientUpdated, onUpdated, onClose)}
       />
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- replace i18n-driven success message with hard-coded English text in EditClientDialog
- drop `useTranslation` hook from staff client edit dialog

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7f03a2c832d9a50b422979271a4