### PR TITLE
Inline English text in staff leave management

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
@@ -11,7 +11,6 @@ import {
   Select,
   TextField,
 } from '@mui/material';
-import { useTranslation } from 'react-i18next';
 import Page from '../../components/Page';
 import { useTimesheets } from '../../api/timesheets';
 import {
@@ -24,7 +23,6 @@ import { formatLocaleDate } from '../../utils/date';
 import { useState } from 'react';
 
 export default function LeaveManagement() {
-  const { t } = useTranslation();
   const { timesheets } = useTimesheets();
   const current =
     timesheets.find(p => !p.approved_at) || timesheets[timesheets.length - 1];
@@ -32,43 +30,54 @@ export default function LeaveManagement() {
   const { requests } = useLeaveRequests(current?.staff_id);
   const [open, setOpen] = useState(false);
 
+  const typeLabels: Record<string, string> = {
+    paid: 'Paid',
+    personal: 'Personal',
+    sick: 'Sick',
+  };
+
+  const statusLabels: Record<LeaveRequest['status'], string> = {
+    pending: 'Pending',
+    approved: 'Approved',
+    rejected: 'Rejected',
+  };
+
   const columns: Column<LeaveRequest>[] = [
     {
       field: 'start_date',
-      header: t('leave.start_date'),
+      header: 'Start date',
       render: (r: LeaveRequest) =>
         formatLocaleDate(r.start_date ?? r.work_date),
     },
     {
       field: 'end_date',
-      header: t('leave.end_date'),
+      header: 'End date',
       render: (r: LeaveRequest) =>
         formatLocaleDate(r.end_date ?? r.work_date),
     },
     {
       field: 'type',
-      header: t('leave.type_label'),
-      render: (r: LeaveRequest) =>
-        r.type ? t(`leave.type.${r.type}`) : '',
+      header: 'Type',
+      render: (r: LeaveRequest) => (r.type ? typeLabels[r.type] ?? r.type : ''),
     },
     {
       field: 'status',
-      header: t('leave.status_label'),
-      render: (r: LeaveRequest) => t(`leave.status.${r.status}`),
+      header: 'Status',
+      render: (r: LeaveRequest) => statusLabels[r.status],
     },
   ];
 
   return (
-    <Page title={t('leave.title')}>
+    <Page title="Leave Requests">
       {current && (
         <Box sx={{ mt: 2 }}>
           <Button
             variant="contained"
-            
+
             onClick={() => setOpen(true)}
             sx={{ mb: 3 }}
           >
-            {t('leave.request_vacation')}
+            Request Vacation
           </Button>
           <Dialog open={open} onClose={() => setOpen(false)}>
             <Box
@@ -90,52 +99,48 @@ export default function LeaveManagement() {
                 );
               }}
             >
-              <DialogTitle>{t('leave.request_vacation')}</DialogTitle>
+              <DialogTitle>Request Vacation</DialogTitle>
               <DialogContent
                 sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
               >
                 <FormControl>
-                  <InputLabel id="leave-type-label">
-                    {t('leave.type_label')}
-                  </InputLabel>
+                  <InputLabel id="leave-type-label">Type</InputLabel>
                   <Select
                     labelId="leave-type-label"
                     name="type"
-                    label={t('leave.type_label')}
+                    label="Type"
                     defaultValue="paid"
                   >
-                    <MenuItem value="paid">{t('leave.type.paid')}</MenuItem>
-                    <MenuItem value="personal">
-                      {t('leave.type.personal')}
-                    </MenuItem>
-                    <MenuItem value="sick">{t('leave.type.sick')}</MenuItem>
+                    <MenuItem value="paid">Paid</MenuItem>
+                    <MenuItem value="personal">Personal</MenuItem>
+                    <MenuItem value="sick">Sick</MenuItem>
                   </Select>
                 </FormControl>
                 <TextField
                   name="start"
                   type="date"
-                  
-                  label={t('leave.start_date')}
+
+                  label="Start date"
                   InputLabelProps={{ shrink: true }}
                 />
                 <TextField
                   name="end"
                   type="date"
-                  
-                  label={t('leave.end_date')}
+
+                  label="End date"
                   InputLabelProps={{ shrink: true }}
                 />
               </DialogContent>
               <DialogActions>
                 <Button
-                  
+
                   onClick={() => setOpen(false)}
                   color="inherit"
                 >
-                  {t('cancel')}
+                  Cancel
                 </Button>
                 <Button type="submit" variant="contained">
-                  {t('submit')}
+                  Submit
                 </Button>
               </DialogActions>
             </Box>


### PR DESCRIPTION
## Summary
- Remove i18n hooks from staff leave management page and inline English labels
- Map leave types and statuses to readable text

## Testing
- `nvm use`
- `npm test` *(fails: Unable to find role "button" and name "previous" in VolunteerSchedule tests, among others)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7ed59e0832d98cea490aa4cf278