### PR TITLE
refactor: inline English privacy policy text

### DIFF
--- a/MJ_FB_Frontend/src/pages/privacy/PrivacyPolicy.tsx
+++ b/MJ_FB_Frontend/src/pages/privacy/PrivacyPolicy.tsx
@@ -3,31 +3,46 @@ import Page from '../../components/Page';
 import ClientBottomNav from '../../components/ClientBottomNav';
 import VolunteerBottomNav from '../../components/VolunteerBottomNav';
 import { useAuth } from '../../hooks/useAuth';
-import { useTranslation } from 'react-i18next';
 
 export default function PrivacyPolicy() {
   const { role } = useAuth();
-  const { t } = useTranslation();
   return (
-    <Page title={t('privacy_policy')}>
+    <Page title="Privacy Policy">
       <Stack spacing={2}>
-        <Typography>{t('privacy_policy_page.intro')}</Typography>
-        <Typography>{t('privacy_policy_page.data_collected')}</Typography>
-        <Typography>{t('privacy_policy_page.pipeda')}</Typography>
-        <Typography>{t('privacy_policy_page.complaint_right')}</Typography>
-        <Typography variant="h6">
-          {t('privacy_policy_page.complaint_how')}
-        </Typography>
-        <Typography>{t('privacy_policy_page.complaint_contact')}</Typography>
-        <Typography>{t('privacy_policy_page.complaint_ack')}</Typography>
-        <Typography>{t('privacy_policy_page.complaint_measures')}</Typography>
         <Typography>
-          {t('privacy_policy_page.contact_heading')}
+          Moose Jaw Food Bank is committed to protecting your privacy. This policy
+          explains how we collect, use, and safeguard personal information.
+        </Typography>
+        <Typography>
+          We collect only the details needed to provide our services, such as your
+          name, contact information, and appointment history.
+        </Typography>
+        <Typography>
+          Our practices follow the Personal Information Protection and Electronic
+          Documents Act (PIPEDA) and all applicable laws.
+        </Typography>
+        <Typography>
+          You have the right to file a complaint if you believe your personal
+          information has been misused.
+        </Typography>
+        <Typography variant="h6">How to file a complaint</Typography>
+        <Typography>
+          Send your complaint in writing to our Privacy Officer.
+        </Typography>
+        <Typography>
+          We will acknowledge your complaint within ten business days.
+        </Typography>
+        <Typography>
+          If the complaint is valid, we will take appropriate steps to resolve the
+          issue.
+        </Typography>
+        <Typography>
+          Contact Information
           <br />
-          {t('privacy_policy_page.contact_name')}
+          Privacy Officer, Moose Jaw Food Bank
           <br />
-          <Link href={`mailto:${t('privacy_policy_page.contact_email')}`}>
-            {t('privacy_policy_page.contact_email')}
+          <Link href="mailto:privacy@mjfoodbank.org">
+            privacy@mjfoodbank.org
           </Link>
         </Typography>
       </Stack>


### PR DESCRIPTION
## Summary
- remove i18next usage from privacy policy page
- add plain English privacy policy content and contact info

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7ec6e20832dbd0a31d801f035c9