### PR TITLE
Remove i18n from client dashboard

### DIFF
--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -29,7 +29,6 @@ import SectionCard from '../../components/dashboard/SectionCard';
 import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 import Page from '../../components/Page';
-import { useTranslation } from 'react-i18next';
 import OnboardingModal from '../../components/OnboardingModal';
 
 interface NextSlot {
@@ -67,6 +66,21 @@ function statusColor(status: string):
   }
 }
 
+function statusLabel(status: string) {
+  switch (status) {
+    case 'approved':
+      return 'Approved';
+    case 'cancelled':
+      return 'Cancelled';
+    case 'visited':
+      return 'Visited';
+    case 'no_show':
+      return 'No Show';
+    default:
+      return status;
+  }
+}
+
 export default function ClientDashboard() {
   const navigate = useNavigate();
   const [bookings, setBookings] = useState<Booking[]>([]);
@@ -76,7 +90,6 @@ export default function ClientDashboard() {
   const [cancelId, setCancelId] = useState<number | null>(null);
   const [message, setMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
-  const { t } = useTranslation();
 
   useEffect(() => {
     getBookingHistory({ includeVisits: true })
@@ -127,11 +140,11 @@ export default function ClientDashboard() {
     if (cancelId === null) return;
     try {
       await cancelBooking(String(cancelId));
-      setMessage(t('booking_cancelled'));
+      setMessage('Booking cancelled');
       setSnackbarSeverity('success');
       setBookings(prev => prev.filter(b => b.id !== cancelId));
     } catch (err) {
-      setMessage(t('cancel_booking_failed'));
+      setMessage('Failed to cancel booking');
       setSnackbarSeverity('error');
     } finally {
       setCancelId(null);
@@ -139,11 +152,11 @@ export default function ClientDashboard() {
   }
 
   return (
-    <Page title={t('client_dashboard')}>
+    <Page title="Client Dashboard">
       <OnboardingModal
         storageKey="clientOnboarding"
-        title={t('onboarding.client.title')}
-        body={t('onboarding.client.body')}
+        title="Welcome!"
+        body="Use this dashboard to book, reschedule, or cancel appointments."
       />
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
@@ -151,7 +164,7 @@ export default function ClientDashboard() {
             <SectionCard
               title={
                 <Stack direction="row" spacing={1} alignItems="center">
-                  <span>{t('my_upcoming_appointment')}</span>
+                  <span>My Upcoming Appointment</span>
                 </Stack>
               }
               icon={<EventAvailable color="primary" />}
@@ -178,7 +191,7 @@ export default function ClientDashboard() {
                           sx={{ textTransform: 'none' }}
                           onClick={() => setCancelId(next.id)}
                         >
-                          {t('cancel')}
+                    Cancel
                         </Button>
                         <Button
 
@@ -190,7 +203,7 @@ export default function ClientDashboard() {
                           }
                           disabled={!next.reschedule_token}
                         >
-                          {t('reschedule')}
+                    Reschedule
                         </Button>
                       </Stack>
                     </Stack>
@@ -198,14 +211,14 @@ export default function ClientDashboard() {
                 </List>
               ) : (
                 <Stack spacing={1} alignItems="flex-start">
-                  <Typography>{t('no_appointment_booked')}</Typography>
+                  <Typography>No appointment booked</Typography>
                   <Button
 
                     variant="contained"
                     sx={{ textTransform: 'none' }}
                     onClick={() => navigate('/book-appointment')}
                   >
-                    {t('book_now')}
+                    Book now
                   </Button>
                 </Stack>
               )}
@@ -213,7 +226,7 @@ export default function ClientDashboard() {
             <SectionCard
               title={
                 <Stack direction="row" spacing={1} alignItems="center">
-                  <span>{t('booking_history')}</span>
+                  <span>Booking History</span>
                 </Stack>
               }
               icon={<History color="primary" />}
@@ -238,7 +251,7 @@ export default function ClientDashboard() {
                           }
                         />
                         <Chip
-                          label={t(b.status)}
+                          label={statusLabel(b.status)}
                           color={statusColor(b.status)}
                         />
                       </Stack>
@@ -252,7 +265,7 @@ export default function ClientDashboard() {
 
         <Grid size={{ xs: 12, md: 6 }}>
           <Stack spacing={2}>
-            <SectionCard title={t('quick_actions')}>
+              <SectionCard title="Quick Actions">
               <Stack
                 direction={{ xs: 'column', sm: 'row' }}
                 spacing={1}
@@ -267,7 +280,7 @@ export default function ClientDashboard() {
                   }}
                   onClick={() => navigate('/book-appointment')}
                 >
-                  {t('book_shopping_appointment')}
+                    Book shopping appointment
                 </Button>
                 <Button
 
@@ -282,7 +295,7 @@ export default function ClientDashboard() {
                   }
                   disabled={!next?.reschedule_token}
                 >
-                  {t('reschedule')}
+                  Reschedule
                 </Button>
                 <Button
                   
@@ -293,19 +306,19 @@ export default function ClientDashboard() {
                   }}
                   onClick={() => navigate('/booking-history')}
                 >
-                  {t('cancel')}
+                  Cancel
                 </Button>
               </Stack>
             </SectionCard>
 
-            <SectionCard
-              title={
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <span>{t('news_and_events')}</span>
-                </Stack>
-              }
-              icon={<Announcement color="primary" />}
-            >
+              <SectionCard
+                title={
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <span>News and Events</span>
+                  </Stack>
+                }
+                icon={<Announcement color="primary" />}
+              >
               <Stack spacing={2}>
                 <EventList events={[...events.today, ...events.upcoming]} limit={5} />
                 <List>
@@ -320,10 +333,10 @@ export default function ClientDashboard() {
               </Stack>
             </SectionCard>
 
-            <SectionCard
-              title={t('next_available_slots')}
-              icon={<EventAvailable color="primary" />}
-            >
+              <SectionCard
+                title="Next available slots"
+                icon={<EventAvailable color="primary" />}
+              >
               <List sx={{ '& .MuiListItem-root:not(:last-child)': { mb: 1 } }}>
                 {nextSlots.length ? (
                   nextSlots.map(s => (
@@ -341,7 +354,7 @@ export default function ClientDashboard() {
                           )}-${formatTime(s.slot.endTime)}`}
                         />
                         <Button
-                          
+
                           variant="contained"
                           sx={{
                             textTransform: 'none',
@@ -349,14 +362,14 @@ export default function ClientDashboard() {
                           }}
                           onClick={() => navigate('/book-appointment')}
                         >
-                          {t('book')}
+                          Book
                         </Button>
                       </Stack>
                     </ListItem>
                   ))
                 ) : (
                   <ListItem>
-                    <ListItemText primary={t('no_slots_available')} />
+                    <ListItemText primary="No slots available" />
                   </ListItem>
                 )}
               </List>
@@ -366,19 +379,19 @@ export default function ClientDashboard() {
       </Grid>
         <Dialog open={cancelId !== null} onClose={() => setCancelId(null)}>
           <DialogCloseButton onClose={() => setCancelId(null)} />
-          <DialogTitle>{t('cancel_booking')}</DialogTitle>
+          <DialogTitle>Cancel booking</DialogTitle>
           <DialogContent>
-            <Typography>{t('cancel_booking_question')}</Typography>
+            <Typography>Are you sure you want to cancel this booking?</Typography>
           </DialogContent>
           <DialogActions>
             <Button
-              
+
               color="error"
               variant="contained"
               sx={{ textTransform: 'none' }}
               onClick={confirmCancel}
             >
-              {t('cancel_booking')}
+              Cancel booking
             </Button>
           </DialogActions>
         </Dialog>


### PR DESCRIPTION
## Summary
- hard-code English strings on client dashboard
- map booking statuses to human-friendly labels

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7eb3a18832d9793ba81082554e2