### PR TITLE
refactor: remove i18n from PasswordField

### DIFF
--- a/MJ_FB_Frontend/src/components/PasswordField.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordField.tsx
@@ -3,11 +3,9 @@ import TextField, { type TextFieldProps } from '@mui/material/TextField';
 import { IconButton, InputAdornment } from '@mui/material';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import { useTranslation } from 'react-i18next';
 
 export default function PasswordField({ InputProps, ...props }: TextFieldProps) {
   const [show, setShow] = useState(false);
-  const { t } = useTranslation();
 
   return (
     <TextField
@@ -20,7 +18,7 @@ export default function PasswordField({ InputProps, ...props }: TextFieldProps) 
             <IconButton
               edge="end"
               onClick={() => setShow(!show)}
-              aria-label={show ? t('hide_password') : t('show_password')}
+              aria-label={show ? 'Hide password' : 'Show password'}
             >
               {show ? <VisibilityOff /> : <Visibility />}
             </IconButton>


### PR DESCRIPTION
## Summary
- hardcode show/hide password labels in PasswordField

## Testing
- `nvm use`
- `npm test` *(fails: PantrySchedule add existing client workflow shows client ID in search results)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7c9e5bc832db2b86c837df013a0