### PR TITLE
refactor: use plain text in leave requests

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
@@ -12,13 +12,17 @@ import {
   useRejectLeaveRequest,
 } from '../../api/leaveRequests';
 import { formatLocaleDate } from '../../utils/date';
-import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import type { LeaveRequest } from '../../api/leaveRequests';
 
+const typeMap: Record<'paid' | 'personal' | 'sick', string> = {
+  paid: 'Paid',
+  personal: 'Personal',
+  sick: 'Sick',
+};
+
 export default function AdminLeaveRequests() {
-  const { t } = useTranslation();
   const { requests: fetched } = useAllLeaveRequests();
   const [requests, setRequests] = useState(fetched);
   const approve = useApproveLeaveRequest();
@@ -31,7 +35,7 @@ export default function AdminLeaveRequests() {
     setRequests(prev => prev.filter(r => r.id !== id));
 
   return (
-    <Page title={t('leave.title')}>
+    <Page title="Leave Requests">
       {requests.map(r => {
         const days =
           Math.round(
@@ -55,7 +59,7 @@ export default function AdminLeaveRequests() {
                   {formatLocaleDate(r.start_date!)} – {formatLocaleDate(r.end_date!)} ({
                     days
                   }{' '}
-                  days) • {r.type ? t(`leave.type.${r.type}`) : ''}
+                  days) • {r.type ? typeMap[r.type] : ''}
                 </Typography>
               </Box>
               <Box
@@ -77,7 +81,7 @@ export default function AdminLeaveRequests() {
                     )
                   }
                 >
-                  {t('timesheets.approve_leave')}
+                  Approve Leave
                 </Button>
                 <Button
                   variant="contained"
@@ -86,7 +90,7 @@ export default function AdminLeaveRequests() {
                   sx={{ width: { xs: '100%', sm: 'auto' } }}
                   onClick={() => setRejecting(r)}
                 >
-                  {t('timesheets.reject_leave')}
+                  Reject Leave
                 </Button>
               </Box>
             </CardContent>


### PR DESCRIPTION
## Summary
- replace translation hooks in admin leave requests with plain English strings

## Testing
- `nvm use`
- `npm test` *(fails: Console errors, AggregateError, missing i18next instance, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7dfd798832db0183b2c397eea88