### PR TITLE
Remove translation hook from agency booking page

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
@@ -12,7 +12,6 @@ import BookingUI from '../BookingUI';
 import { searchAgencyClients } from '../../api/agencies';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import Page from '../../components/Page';
-import { useTranslation } from 'react-i18next';
 
 interface AgencyClient {
   id: number;
@@ -27,7 +26,6 @@ export default function AgencyBookAppointment() {
   const [snackbar, setSnackbar] = useState('');
   const [loading, setLoading] = useState(false);
   const [loadingClients, setLoadingClients] = useState(false);
-  const { t } = useTranslation();
 
   useEffect(() => {
     if (!search) {
@@ -70,7 +68,7 @@ export default function AgencyBookAppointment() {
   }, [search]);
 
   return (
-    <Page title={t('book_appointment')}>
+    <Page title="Book Appointment">
       <TextField
         label="Search Clients"
         value={search}


### PR DESCRIPTION
## Summary
- inline English "Book Appointment" label on agency booking page
- drop unused `react-i18next` import and hook

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next', 81 failed, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7e21e10832db67ad3f653fd3eea