### PR TITLE
Use literal close label in onboarding modal

### DIFF
--- a/MJ_FB_Frontend/src/components/OnboardingModal.tsx
+++ b/MJ_FB_Frontend/src/components/OnboardingModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
-import i18n from '../i18n';
 
 interface OnboardingModalProps {
   storageKey: string;
@@ -30,7 +29,7 @@ export default function OnboardingModal({ storageKey, title, body }: OnboardingM
         <Typography>{body}</Typography>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose}>{i18n.t('onboarding.close')}</Button>
+        <Button onClick={handleClose}>Close</Button>
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- remove unused i18n import from OnboardingModal
- hardcode "Close" button text

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7d9d6bc832db1bcedf14d6ffe16