### PR TITLE
Inline no-bookings text in schedule cards

### DIFF
--- a/MJ_FB_Frontend/src/components/ScheduleCards.tsx
+++ b/MJ_FB_Frontend/src/components/ScheduleCards.tsx
@@ -1,6 +1,5 @@
 import { Card, CardContent, Typography, Box } from "@mui/material";
 import type { ReactNode } from "react";
-import i18n from "../i18n";
 
 interface Cell {
   content: ReactNode;
@@ -23,7 +22,7 @@ export default function ScheduleCards({ maxSlots, rows }: Props) {
   const safeMaxSlots = Math.max(1, maxSlots);
 
   if (rows.length === 0) {
-    return <Typography align="center">{i18n.t("no_bookings")}</Typography>;
+    return <Typography align="center">No bookings</Typography>;
   }
 
   return (


### PR DESCRIPTION
## Summary
- remove i18n usage from ScheduleCards and inline "No bookings" placeholder

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7d7a998832da322510be580227b