### PR TITLE
chore: hard-code volunteer bottom nav labels

### DIFF
--- a/MJ_FB_Frontend/src/components/VolunteerBottomNav.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerBottomNav.tsx
@@ -5,7 +5,6 @@ import AccountCircle from '@mui/icons-material/AccountCircle';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import type { Role } from '../types';
-import { useTranslation } from 'react-i18next';
 
 export default function VolunteerBottomNav() {
   let role: Role | '' = '';
@@ -16,7 +15,6 @@ export default function VolunteerBottomNav() {
   if (role !== 'volunteer') return null;
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const { t } = useTranslation();
   let value: 'dashboard' | 'schedule' | 'bookings' | 'profile' = 'dashboard';
   if (pathname.startsWith('/volunteer/schedule')) value = 'schedule';
   else if (pathname.startsWith('/book-appointment') || pathname.startsWith('/booking-history'))
@@ -39,28 +37,22 @@ export default function VolunteerBottomNav() {
           if (newValue === 'profile') navigate('/profile');
         }}
       >
-        <BottomNavigationAction
-          label={t('dashboard')}
-          value="dashboard"
-          icon={<Dashboard aria-label={t('dashboard')} />}
-        />
-        <BottomNavigationAction
-          label={t('volunteer_shift')}
-          value="schedule"
-          icon={<CalendarToday aria-label={t('volunteer_shift')} />}
-        />
+        <BottomNavigationAction label="Dashboard" value="dashboard" icon={<Dashboard />} aria-label="dashboard" />
+        <BottomNavigationAction label="Shifts" value="schedule" icon={<CalendarToday />} aria-label="shifts" />
         {userRole === 'shopper' && [
           <BottomNavigationAction
             key="bookings"
-            label={t('book_shopping')}
+            label="Book Shopping"
             value="bookings"
-            icon={<CalendarToday aria-label={t('book_shopping')} />}
+            icon={<CalendarToday />}
+            aria-label="book shopping"
           />,
           <BottomNavigationAction
             key="profile"
-            label={t('profile')}
+            label="Profile"
             value="profile"
-            icon={<AccountCircle aria-label={t('profile')} />}
+            icon={<AccountCircle />}
+            aria-label="profile"
           />,
         ]}
       </BottomNavigation>


### PR DESCRIPTION
## Summary
- remove `useTranslation` from volunteer bottom nav
- hard-code dashboard, shift, booking, and profile labels

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next' from various components)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7d149c4832d8c32184de6787c1a