### PR TITLE
refactor: remove i18n from manage booking dialog

### DIFF
--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import {
   Dialog,
   DialogTitle,
@@ -37,7 +36,6 @@ interface ManageBookingDialogProps {
 }
 
 export default function ManageBookingDialog({ open, booking, onClose, onUpdated }: ManageBookingDialogProps) {
-  const { t } = useTranslation();
   const [status, setStatus] = useState('');
   const [date, setDate] = useState('');
   const [slots, setSlots] = useState<Slot[]>([]);
@@ -266,13 +264,13 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
                 }}
               />
               <TextField
-                label={t('adults_label')}
+                label="Adults"
                 type="number"
                 value={adults}
                 onChange={e => setAdults(e.target.value)}
               />
               <TextField
-                label={t('children_label')}
+                label="Children"
                 type="number"
                 value={children}
                 onChange={e => setChildren(e.target.value)}
@@ -284,7 +282,7 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
                 onChange={e => setPetItem(e.target.value)}
               />
               <TextField
-                label={t('staff_note_label')}
+                label="Staff Note"
                 value={note}
                 onChange={e => setNote(e.target.value)}
                 multiline


### PR DESCRIPTION
## Summary
- remove useTranslation from manage booking dialog
- inline English labels for visit fields

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7cf7a6c832db090d86c3be709aa