### PR TITLE
Inline date labels in EventForm

### DIFF
--- a/MJ_FB_Frontend/src/components/EventForm.tsx
+++ b/MJ_FB_Frontend/src/components/EventForm.tsx
@@ -14,7 +14,6 @@ import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs, { formatReginaDate } from '../utils/date';
 import type { Dayjs } from 'dayjs';
-import { useTranslation } from 'react-i18next';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import { createEvent, updateEvent, type Event } from '../api/events';
 import DialogCloseButton from './DialogCloseButton';
@@ -35,7 +34,6 @@ const categories = [
 ];
 
 export default function EventForm({ open, onClose, onSaved, event }: EventFormProps) {
-  const { t } = useTranslation();
   const [title, setTitle] = useState('');
   const [details, setDetails] = useState('');
   const [category, setCategory] = useState('');
@@ -144,13 +142,13 @@ export default function EventForm({ open, onClose, onSaved, event }: EventFormPr
           </TextField>
           <LocalizationProvider dateAdapter={AdapterDayjs} dateLibInstance={dayjs}>
             <DatePicker
-              label={t('start_date')}
+              label="Start Date"
               value={startDate}
               onChange={value => setStartDate(value as Dayjs | null)}
               slotProps={{ textField: { fullWidth: true, margin: 'normal' } }}
             />
             <DatePicker
-              label={t('end_date')}
+              label="End Date"
               value={endDate}
               onChange={value => setEndDate(value as Dayjs | null)}
               slotProps={{ textField: { fullWidth: true, margin: 'normal' } }}


### PR DESCRIPTION
## Summary
- remove `useTranslation` from `EventForm`
- hardcode English "Start Date" and "End Date" labels for date pickers

## Testing
- `nvm use`
- `npm test` *(fails: FATAL ERROR Reached heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7c6bd44832d9b1222ebe51cafae