### PR TITLE
refactor: inline volunteer management strings

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -56,7 +56,6 @@ import { formatDate, addDays } from '../../utils/date';
 import dayjs from '../../utils/date';
 import Page from '../../components/Page';
 import VolunteerQuickLinks from '../../components/VolunteerQuickLinks';
-import { useTranslation } from 'react-i18next';
 import EditVolunteerDialog from './EditVolunteerDialog';
 
 
@@ -87,7 +86,6 @@ interface VolunteerManagementProps {
 export default function VolunteerManagement({ initialTab }: VolunteerManagementProps = {}) {
   const { tab: tabParam } = useParams<{ tab?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { t } = useTranslation();
   const tab: 'dashboard' | 'schedule' | 'search' | 'create' =
     initialTab ??
     (tabParam === 'schedule' ||
@@ -96,7 +94,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
       ? (tabParam as 'schedule' | 'search' | 'create')
       : 'dashboard');
   const tabTitles: Record<typeof tab, string> = {
-    dashboard: t('dashboard'),
+    dashboard: 'Dashboard',
     schedule: 'Schedule',
     search: 'Search Volunteer',
     create: 'Create Volunteer',
@@ -994,7 +992,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
               <Box sx={{ width: { xs: 1, md: '67%' } }}>
                 <PageCard sx={{ width: 1 }}>
                   <Typography variant="h6" gutterBottom>
-                    {t('booking_history')}
+                    Booking History
                   </Typography>
                   {selectedVolunteer && (
                     <BookingManagementBase


### PR DESCRIPTION
## Summary
- replace i18n translation hooks in VolunteerManagement with inline English strings

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'i18next' from 'src/i18n.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68c4bef90b70832d92d239507ec724cc