### PR TITLE
Use literal Close string in OnboardingModal test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/OnboardingModal.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/OnboardingModal.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import OnboardingModal from '../components/OnboardingModal';
-import i18n from '../i18n';
 
 describe('OnboardingModal', () => {
   beforeEach(() => localStorage.clear());
@@ -8,7 +7,7 @@ describe('OnboardingModal', () => {
   it('shows and stores flag on close', () => {
     render(<OnboardingModal storageKey="test" title="T" body="B" />);
     expect(screen.getByText('T')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: i18n.t('onboarding.close') }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
     expect(localStorage.getItem('test')).toBe('true');
   });
 });


### PR DESCRIPTION
## Summary
- remove i18n dependency from OnboardingModal test

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next' from 'src/pages/volunteer-management/VolunteerManagement.tsx')*
- `npm test src/__tests__/OnboardingModal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4bf0886ec832dbfe6557e40b48c77