### PR TITLE
test: update profile nav bottom nav text

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ProfileNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ProfileNav.test.tsx
@@ -36,11 +36,7 @@ jest.mock('../api/volunteers', () => ({
 }));
 
 jest.mock('../hooks/useAuth', () => ({
-  useAuth: () => ({ userRole: 'shopper' }),
-}));
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (s: string) => s }),
+  useAuth: () => ({ role: 'volunteer', userRole: 'shopper' }),
 }));
 
 describe('Profile bottom nav', () => {
@@ -50,7 +46,7 @@ describe('Profile bottom nav', () => {
         <Profile role="volunteer" />
       </MemoryRouter>,
     );
-    expect(await screen.findByRole('button', { name: /schedule/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /shifts/i })).toBeInTheDocument();
   });
 
   it('does not show schedule option for shoppers', () => {
@@ -59,7 +55,7 @@ describe('Profile bottom nav', () => {
         <Profile role="shopper" />
       </MemoryRouter>,
     );
-    expect(screen.queryByRole('button', { name: /schedule/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /shifts/i })).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- adjust profile nav test to expect `Shifts` button for volunteers

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next' from 'src/pages/volunteer-management/VolunteerManagement.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68c4bf05f580832d9685d35f945411d2