### PR TITLE
Remove unused donor profile translation

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import { Box, Card, CardContent, Typography } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import {
@@ -14,7 +13,6 @@ import Page from '../../components/Page';
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 
 export default function DonorProfile() {
-  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const [donor, setDonor] = useState<DonorDetail | null>(null);
   const [donations, setDonations] = useState<DonorDonation[]>([]);
@@ -59,7 +57,7 @@ export default function DonorProfile() {
               Last Donation:{' '}
               {donor.lastDonationISO
                 ? formatLocaleDate(donor.lastDonationISO)
-                : t('not_applicable')}
+                : 'N/A'}
             </Typography>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- inline donor profile "N/A" text
- remove `useTranslation` hook

## Testing
- `nvm use`
- `npm test` *(fails: Cannot find module 'react-i18next' from 'src/pages/volunteer-management/VolunteerManagement.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68c4bf0348dc832d806841ed8fcd4adb