### PR TITLE
test: restore navigator sendBeacon

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/InstallAppButton.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/InstallAppButton.test.tsx
@@ -55,14 +55,32 @@ describe('InstallAppButton', () => {
         <InstallAppButton />
       </MemoryRouter>,
     );
+    const originalSendBeacon = navigator.sendBeacon;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      'sendBeacon',
+    );
     const sendBeacon = jest.fn();
     Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
       writable: true,
       value: sendBeacon,
     });
 
-    fireEvent(window, new Event('appinstalled'));
-    expect(sendBeacon).toHaveBeenCalledWith('/api/v1/pwa-install');
+    try {
+      fireEvent(window, new Event('appinstalled'));
+      expect(sendBeacon).toHaveBeenCalledWith('/api/v1/pwa-install');
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(navigator, 'sendBeacon', originalDescriptor);
+      } else {
+        Object.defineProperty(navigator, 'sendBeacon', {
+          configurable: true,
+          writable: true,
+          value: originalSendBeacon,
+        });
+      }
+    }
   });
 
   it('hides button when app already installed', () => {


### PR DESCRIPTION
## Summary
- ensure `navigator.sendBeacon` overrides are configurable in `InstallAppButton` tests
- save and restore the original `sendBeacon` descriptor after the test

## Testing
- `npm --prefix MJ_FB_Frontend test src/__tests__/InstallAppButton.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4c7859b3c832d8ff9facd4ae97032