### PR TITLE
test: restore fetch after UserHistory tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/UserHistory.test.tsx
@@ -7,6 +7,7 @@ import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
 (global as any).clearImmediate = (global as any).clearImmediate || ((id: number) => clearTimeout(id));
 (global as any).performance = (global as any).performance || ({} as any);
 (global as any).performance.markResourceTiming = (global as any).performance.markResourceTiming || (() => {});
+const originalFetch = global.fetch;
 (global as any).fetch = jest.fn();
 
 jest.mock('../../../api/users', () => ({
@@ -22,6 +23,10 @@ describe('UserHistory search add shortcut', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    (global as any).fetch = originalFetch;
   });
 
   it('shows add button and navigates with id prefilled', async () => {


### PR DESCRIPTION
## Summary
- preserve original global fetch before mocking in UserHistory tests
- reset global fetch after tests to avoid cross-test pollution

## Testing
- `npm --prefix MJ_FB_Frontend test src/pages/staff/__tests__/UserHistory.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4c8d38bbc832dbedfc47a6cf6ea53