### PR TITLE
test: restore password setup TTL env after tests

### DIFF
--- a/MJ_FB_Backend/tests/passwordSetupUtils.test.ts
+++ b/MJ_FB_Backend/tests/passwordSetupUtils.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 
+const originalTTL = process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS;
 
 let pool: any;
 
@@ -52,5 +53,13 @@ describe('passwordSetupUtils', () => {
     });
     const row = await verifyPasswordSetupToken(token);
     expect(row).toMatchObject({ id: 2, user_type: 'staff', user_id: 5 });
+  });
+
+  afterAll(() => {
+    if (originalTTL === undefined) {
+      delete process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS;
+    } else {
+      process.env.PASSWORD_SETUP_TOKEN_TTL_HOURS = originalTTL;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- preserve existing PASSWORD_SETUP_TOKEN_TTL_HOURS in passwordSetupUtils tests

## Testing
- `nvm use`
- `npm --prefix MJ_FB_Backend test tests/passwordSetupUtils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c4c8dc573c832d9ec7ee02310c7df4