### PR TITLE
test: restore global fetch after ClientManagement tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ClientManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ClientManagement.test.tsx
@@ -4,6 +4,8 @@ import ClientManagement from '../ClientManagement';
 import { getNewClients, deleteNewClient } from '../../../api/users';
 import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
 
+const originalFetch = global.fetch;
+
 (global as any).clearImmediate = (global as any).clearImmediate || ((id: number) => clearTimeout(id));
 (global as any).performance = (global as any).performance || ({} as any);
 (global as any).performance.markResourceTiming = (global as any).performance.markResourceTiming || (() => {});
@@ -51,5 +53,9 @@ describe('ClientManagement New Clients tab', () => {
       expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
     });
   });
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
 });
 


### PR DESCRIPTION
## Summary
- save original `global.fetch` before mocking in ClientManagement tests
- restore `global.fetch` after tests complete

## Testing
- `npm --prefix MJ_FB_Frontend test src/pages/staff/__tests__/ClientManagement.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4ca3f62e8832d970db7973be5adc5