### PR TITLE
test: reset matchMedia after tests

### DIFF
--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -22,6 +22,7 @@ if (!process.env.VITE_API_BASE) {
 (globalThis as any).VITE_API_BASE = process.env.VITE_API_BASE;
 
 // Polyfill matchMedia for testing environment with modern and legacy listeners
+const originalMatchMedia = window.matchMedia;
 if (!window.matchMedia) {
   (window as any).matchMedia = (query: string) => ({
     matches: false,
@@ -34,6 +35,9 @@ if (!window.matchMedia) {
     dispatchEvent: jest.fn(),
   });
 }
+afterAll(() => {
+  window.matchMedia = originalMatchMedia;
+});
 
 beforeAll(() => {
   (global as any).fetch = fetch;


### PR DESCRIPTION
## Summary
- reset matchMedia to original after Jest suite

## Testing
- `npm --prefix MJ_FB_Frontend test src/__tests__/ManageBookingDialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4ca4a0b10832daf65aa58b94b7fa7