### PR TITLE
test: restore matchMedia after tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/__tests__/PantryScheduleCapacity.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/PantryScheduleCapacity.test.tsx
@@ -21,6 +21,8 @@ jest.mock('../../../components/RescheduleDialog', () => () => null);
 
 const { getSlots, getBookings, getHolidays } = jest.requireMock('../../../api/bookings');
 
+const originalMatchMedia = window.matchMedia;
+
 function hexToRgb(color: string) {
   if (color.startsWith('rgb')) return color;
   const sanitized = color.replace('#', '');
@@ -48,6 +50,7 @@ describe('PantrySchedule status colors', () => {
 
   afterAll(() => {
     jest.useRealTimers();
+    window.matchMedia = originalMatchMedia;
   });
 
   it('renders cells with colors for each status', async () => {


### PR DESCRIPTION
## Summary
- cache original `window.matchMedia` in PantryScheduleCapacity test and restore after tests

## Testing
- `npm --prefix MJ_FB_Frontend test src/pages/admin/__tests__/PantryScheduleCapacity.test.tsx` *(fails: expect(received).toBe(expected))*


------
https://chatgpt.com/codex/tasks/task_e_68c4ca58b088832d81ed6ca8199d8010