### PR TITLE
test: restore matchMedia after PantryVisits tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -43,6 +43,8 @@ const { getClientVisits, toggleClientVisitVerification } =
 const { getAppConfig } = jest.requireMock('../../../api/appConfig');
 const { getSunshineBag } = jest.requireMock('../../../api/sunshineBags');
 
+const originalMatchMedia = window.matchMedia;
+
 function renderVisits() {
   return renderWithProviders(
     <MemoryRouter>
@@ -62,6 +64,10 @@ describe('PantryVisits', () => {
         addEventListener: () => {},
         removeEventListener: () => {},
       })) as any);
+  });
+
+  afterAll(() => {
+    window.matchMedia = originalMatchMedia;
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- save window.matchMedia before polyfill in PantryVisits tests
- restore original matchMedia after tests complete

## Testing
- `nvm use`
- `npm --prefix MJ_FB_Frontend test src/pages/staff/__tests__/PantryVisits.test.tsx` *(fails: 2 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ca5387f8832dbb781a27c27c27da