### PR TITLE
test: restore matchMedia after overrides

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ManageVolunteerShiftDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ManageVolunteerShiftDialog.test.tsx
@@ -18,7 +18,7 @@ const {
   updateVolunteerBookingStatus,
 } = jest.requireMock('../api/volunteers');
 
-const originalMatchMedia = window.matchMedia;
+let originalMatchMedia: typeof window.matchMedia;
 
 describe('ManageVolunteerShiftDialog', () => {
   const booking: VolunteerBookingDetail = {
@@ -36,8 +36,9 @@ describe('ManageVolunteerShiftDialog', () => {
   };
 
   beforeAll(() => {
+    originalMatchMedia = window.matchMedia;
     window.matchMedia =
-      window.matchMedia ||
+      originalMatchMedia ||
       ((query: string): MediaQueryList => ({
         matches: false,
         media: query,


### PR DESCRIPTION
## Summary
- Capture window.matchMedia before tests and restore it in afterAll

## Testing
- `npm --prefix MJ_FB_Frontend test src/__tests__/ManageVolunteerShiftDialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4ca4f0400832db6d7292a06430ef1