### PR TITLE
test: restore global immediates

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/DonorDonationLog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DonorDonationLog.test.tsx
@@ -24,6 +24,8 @@ jest.mock('../api/monetaryDonors', () => ({
 describe('Donor Donation Log', () => {
   const fixedTime = new Date('2024-01-01T12:00:00Z').getTime();
   const realDateNow = Date.now;
+  const originalSetImmediate = (global as any).setImmediate;
+  const originalClearImmediate = (global as any).clearImmediate;
   beforeEach(() => {
     (global as any).setImmediate = _setImmediate;
     (global as any).clearImmediate = _clearImmediate;
@@ -31,6 +33,8 @@ describe('Donor Donation Log', () => {
   });
 
   afterEach(() => {
+    (global as any).setImmediate = originalSetImmediate;
+    (global as any).clearImmediate = originalClearImmediate;
     Date.now = realDateNow;
     jest.clearAllMocks();
   });


### PR DESCRIPTION
## Summary
- capture original setImmediate/clearImmediate in DonorDonationLog tests
- restore globals after each test

## Testing
- `npm --prefix MJ_FB_Frontend test src/__tests__/DonorDonationLog.test.tsx` *(fails: Unable to find an element with text: john@example.com)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ca46723c832d833dd51030c50c83