### PR TITLE
test: restore global fetch after UserHistory tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/UserHistory.test.tsx
@@ -26,7 +26,7 @@ describe('UserHistory search add shortcut', () => {
   });
 
   afterAll(() => {
-    (global as any).fetch = originalFetch;
+    global.fetch = originalFetch;
   });
 
   it('shows add button and navigates with id prefilled', async () => {


### PR DESCRIPTION
## Summary
- ensure UserHistory tests save original `fetch` and restore it after all tests

## Testing
- `npm --prefix MJ_FB_Frontend test src/pages/staff/__tests__/UserHistory.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4ca42be90832d9e95cfb08db4e2af