### PR TITLE
Use dynamic dates in backend tests

### DIFF
--- a/MJ_FB_Backend/tests/donationAggregations.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregations.test.ts
@@ -8,6 +8,7 @@ jest.mock('jsonwebtoken');
 
 const app = express();
 app.use('/donations', donationsRoutes);
+const year = new Date().getFullYear();
 
 beforeAll(() => {
   process.env.JWT_SECRET = 'testsecret';
@@ -45,7 +46,7 @@ describe('GET /donations/aggregations', () => {
       .mockResolvedValueOnce({ rows });
 
     const res = await request(app)
-      .get('/donations/aggregations?year=2024')
+      .get(`/donations/aggregations?year=${year}`)
       .set('Authorization', 'Bearer token');
 
     expect(res.status).toBe(200);

--- a/MJ_FB_Backend/tests/donationAggregationsAccess.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregationsAccess.test.ts
@@ -4,15 +4,16 @@ import donationsRoutes from '../src/routes/warehouse/donations';
 
 const app = express();
 app.use('/donations', donationsRoutes);
+const year = new Date().getFullYear();
 
 describe('donation aggregations auth', () => {
   it('requires auth for aggregations', async () => {
-    const res = await request(app).get('/donations/aggregations?year=2024');
+    const res = await request(app).get(`/donations/aggregations?year=${year}`);
     expect(res.status).toBe(401);
   });
 
   it('requires auth for export', async () => {
-    const res = await request(app).get('/donations/aggregations/export?year=2024');
+    const res = await request(app).get(`/donations/aggregations/export?year=${year}`);
     expect(res.status).toBe(401);
   });
 

--- a/MJ_FB_Backend/tests/donationAggregationsManual.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregationsManual.test.ts
@@ -34,7 +34,8 @@ describe('POST /donations/aggregations/manual', () => {
       })
       .mockResolvedValueOnce({});
 
-    const body = { year: 2024, month: 5, donorEmail: 'alice@example.com', total: 100 };
+    const year = new Date().getFullYear();
+    const body = { year, month: 5, donorEmail: 'alice@example.com', total: 100 };
     const res = await request(app)
       .post('/donations/aggregations/manual')
       .set('Authorization', 'Bearer token')
@@ -44,7 +45,7 @@ describe('POST /donations/aggregations/manual', () => {
     expect(res.body).toEqual({ message: 'Saved' });
     expect(pool.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO donor_aggregations'),
-      [2024, 5, 'alice@example.com', 100],
+      [year, 5, 'alice@example.com', 100],
     );
   });
 });

--- a/MJ_FB_Backend/tests/donationsMonth.test.ts
+++ b/MJ_FB_Backend/tests/donationsMonth.test.ts
@@ -34,13 +34,16 @@ describe('GET /donations?month=', () => {
       type: 'staff',
       access: ['warehouse', 'donation_entry'],
     });
+    const year = new Date().getFullYear();
+    const month = '02';
+    const nextMonth = '03';
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 1, rows: [authRow] })
       .mockResolvedValueOnce({
         rows: [
           {
             id: 1,
-            date: '2024-02-01',
+            date: `${year}-${month}-01`,
             weight: 10,
             donorId: 2,
             firstName: 'Alice',
@@ -49,7 +52,7 @@ describe('GET /donations?month=', () => {
           },
           {
             id: 2,
-            date: '2024-02-10',
+            date: `${year}-${month}-10`,
             weight: 20,
             donorId: 3,
             firstName: 'Bob',
@@ -60,7 +63,7 @@ describe('GET /donations?month=', () => {
       });
 
     const res = await request(app)
-      .get('/donations?month=2024-02')
+      .get(`/donations?month=${year}-${month}`)
       .set('Authorization', 'Bearer token');
 
     expect(res.status).toBe(200);
@@ -75,12 +78,12 @@ describe('GET /donations?month=', () => {
               o.first_name as "firstName", o.last_name as "lastName", o.email
          FROM donations d JOIN donors o ON d.donor_id = o.id
          WHERE d.date >= $1 AND d.date < $2 ORDER BY d.date, d.id`,
-      ['2024-02-01', '2024-03-01'],
+      [`${year}-${month}-01`, `${year}-${nextMonth}-01`],
     );
     expect(res.body).toEqual([
       {
         id: 1,
-        date: '2024-02-01',
+        date: `${year}-${month}-01`,
         weight: 10,
         donorId: 2,
         firstName: 'Alice',
@@ -89,7 +92,7 @@ describe('GET /donations?month=', () => {
       },
       {
         id: 2,
-        date: '2024-02-10',
+        date: `${year}-${month}-10`,
         weight: 20,
         donorId: 3,
         firstName: 'Bob',

--- a/MJ_FB_Backend/tests/logCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/logCleanupJob.test.ts
@@ -14,14 +14,16 @@ describe('cleanupOldLogs', () => {
   });
 
   it('aggregates previous year and deletes old rows', async () => {
-    await cleanupOldLogs(new Date('2025-01-31T00:00:00Z'));
+    const nextYear = new Date().getFullYear() + 1;
+    await cleanupOldLogs(new Date(`${nextYear}-01-31T00:00:00Z`));
 
+    const previousYear = nextYear - 1;
     for (let month = 1; month <= 12; month++) {
-      expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, month);
-      expect(refreshSunshineBagOverall).toHaveBeenCalledWith(2024, month);
+      expect(refreshWarehouseOverall).toHaveBeenCalledWith(previousYear, month);
+      expect(refreshSunshineBagOverall).toHaveBeenCalledWith(previousYear, month);
     }
 
-    const cutoff = '2025-01-01';
+    const cutoff = `${nextYear}-01-01`;
     expect(mockPool.query).toHaveBeenCalledWith(
       'DELETE FROM sunshine_bag_log WHERE date < $1',
       [cutoff],

--- a/MJ_FB_Backend/tests/pantryAggregationController.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationController.test.ts
@@ -8,6 +8,8 @@ import {
   refreshPantryYearly,
 } from '../src/controllers/pantry/pantryAggregationController';
 
+const year = new Date().getFullYear();
+
 describe('pantryAggregationController totals', () => {
   beforeEach(() => {
     (mockPool.query as jest.Mock).mockReset();
@@ -20,17 +22,17 @@ describe('pantryAggregationController totals', () => {
       })
       .mockResolvedValue({} as any);
 
-    await refreshPantryMonthly(2024, 5);
+    await refreshPantryMonthly(year, 5);
 
     expect(mockPool.query).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining('FROM pantry_weekly_overall'),
-      [2024, 5],
+      [year, 5],
     );
     expect(mockPool.query).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('INSERT INTO pantry_monthly_overall'),
-      [2024, 5, 3, 5, 2, 7, 40],
+      [year, 5, 3, 5, 2, 7, 40],
     );
   });
 
@@ -41,17 +43,17 @@ describe('pantryAggregationController totals', () => {
       })
       .mockResolvedValue({} as any);
 
-    await refreshPantryYearly(2024);
+    await refreshPantryYearly(year);
 
     expect(mockPool.query).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining('FROM pantry_weekly_overall'),
-      [2024],
+      [year],
     );
     expect(mockPool.query).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('INSERT INTO pantry_yearly_overall'),
-      [2024, 10, 20, 5, 25, 100],
+      [year, 10, 20, 5, 25, 100],
     );
   });
 });

--- a/MJ_FB_Backend/tests/pantryAggregationRollup.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationRollup.test.ts
@@ -7,6 +7,8 @@ const {
   refreshPantryYearly,
 } = require('../src/controllers/pantry/pantryAggregationController');
 
+const year = new Date().getFullYear();
+
 describe('pantry aggregation roll-ups', () => {
   beforeEach(() => {
     (pool.query as jest.Mock).mockReset();
@@ -27,15 +29,15 @@ describe('pantry aggregation roll-ups', () => {
       .mockResolvedValueOnce({ rows: [{ orders: 0, weight: 0 }] })
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ rows: [{ month: 5, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 }] })
-      .mockResolvedValueOnce({ rows: [{ year: 2024, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 }] });
+      .mockResolvedValueOnce({ rows: [{ year, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 }] });
 
-    await refreshPantryWeekly(2024, 5, 1);
-    await refreshPantryWeekly(2024, 5, 2);
-    await refreshPantryMonthly(2024, 5);
-    await refreshPantryYearly(2024);
+    await refreshPantryWeekly(year, 5, 1);
+    await refreshPantryWeekly(year, 5, 2);
+    await refreshPantryMonthly(year, 5);
+    await refreshPantryYearly(year);
     const monthlyRes = await pool.query(
       'SELECT month, orders, adults, children, people, weight AS "foodWeight" FROM pantry_monthly_overall WHERE year = $1 ORDER BY month',
-      [2024],
+      [year],
     );
     const yearlyRes = await pool.query(
       'SELECT year, orders, adults, children, people, weight AS "foodWeight" FROM pantry_yearly_overall ORDER BY year',
@@ -44,7 +46,7 @@ describe('pantry aggregation roll-ups', () => {
       { month: 5, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 },
     ]);
     expect(yearlyRes.rows).toEqual([
-      { year: 2024, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 },
+      { year, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 },
     ]);
   });
 
@@ -63,7 +65,7 @@ describe('pantry aggregation roll-ups', () => {
       .mockResolvedValueOnce({ rows: [{ orders: 0, weight: 0 }] })
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ rows: [{ month: 5, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 }] })
-      .mockResolvedValueOnce({ rows: [{ year: 2024, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 }] })
+      .mockResolvedValueOnce({ rows: [{ year, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 }] })
       .mockResolvedValueOnce({ rows: [{ visits: 5, adults: 6, children: 7, weight: 40 }] })
       .mockResolvedValueOnce({ rows: [{ orders: 0, weight: 0 }] })
       .mockResolvedValueOnce({})
@@ -74,15 +76,15 @@ describe('pantry aggregation roll-ups', () => {
       .mockResolvedValueOnce({ rows: [{ orders: 0, weight: 0 }] })
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ rows: [{ month: 5, orders: 7, adults: 9, children: 11, people: 20, foodWeight: 60 }] })
-      .mockResolvedValueOnce({ rows: [{ year: 2024, orders: 7, adults: 9, children: 11, people: 20, foodWeight: 60 }] });
+      .mockResolvedValueOnce({ rows: [{ year, orders: 7, adults: 9, children: 11, people: 20, foodWeight: 60 }] });
 
-    await refreshPantryWeekly(2024, 5, 1);
-    await refreshPantryWeekly(2024, 5, 2);
-    await refreshPantryMonthly(2024, 5);
-    await refreshPantryYearly(2024);
+    await refreshPantryWeekly(year, 5, 1);
+    await refreshPantryWeekly(year, 5, 2);
+    await refreshPantryMonthly(year, 5);
+    await refreshPantryYearly(year);
     let res = await pool.query(
       'SELECT month, orders, adults, children, people, weight AS "foodWeight" FROM pantry_monthly_overall WHERE year = $1 ORDER BY month',
-      [2024],
+      [year],
     );
     expect(res.rows).toEqual([
       { month: 5, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 },
@@ -91,14 +93,14 @@ describe('pantry aggregation roll-ups', () => {
       'SELECT year, orders, adults, children, people, weight AS "foodWeight" FROM pantry_yearly_overall ORDER BY year',
     );
     expect(res.rows).toEqual([
-      { year: 2024, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 },
+      { year, orders: 3, adults: 5, children: 7, people: 12, foodWeight: 30 },
     ]);
-    await refreshPantryWeekly(2024, 5, 1);
-    await refreshPantryMonthly(2024, 5);
-    await refreshPantryYearly(2024);
+    await refreshPantryWeekly(year, 5, 1);
+    await refreshPantryMonthly(year, 5);
+    await refreshPantryYearly(year);
     res = await pool.query(
       'SELECT month, orders, adults, children, people, weight AS "foodWeight" FROM pantry_monthly_overall WHERE year = $1 ORDER BY month',
-      [2024],
+      [year],
     );
     expect(res.rows).toEqual([
       { month: 5, orders: 7, adults: 9, children: 11, people: 20, foodWeight: 60 },
@@ -107,7 +109,7 @@ describe('pantry aggregation roll-ups', () => {
       'SELECT year, orders, adults, children, people, weight AS "foodWeight" FROM pantry_yearly_overall ORDER BY year',
     );
     expect(res.rows).toEqual([
-      { year: 2024, orders: 7, adults: 9, children: 11, people: 20, foodWeight: 60 },
+      { year, orders: 7, adults: 9, children: 11, people: 20, foodWeight: 60 },
     ]);
   });
 });

--- a/MJ_FB_Backend/tests/pantryRetentionJob.test.ts
+++ b/MJ_FB_Backend/tests/pantryRetentionJob.test.ts
@@ -14,20 +14,22 @@ describe('cleanupOldPantryData', () => {
   });
 
   it('refreshes previous year and deletes old records', async () => {
-    jest.useFakeTimers().setSystemTime(new Date('2025-08-15'));
+    const nextYear = new Date().getFullYear() + 1;
+    jest.useFakeTimers().setSystemTime(new Date(`${nextYear}-08-15`));
 
     const mockClient = { query: jest.fn().mockResolvedValue({}), release: jest.fn() };
     (mockPool.connect as jest.Mock).mockResolvedValueOnce(mockClient);
 
     await cleanupOldPantryData();
 
+    const previousYear = nextYear - 1;
     for (let month = 1; month <= 12; month++) {
-      expect(refreshPantryMonthly).toHaveBeenCalledWith(2024, month);
+      expect(refreshPantryMonthly).toHaveBeenCalledWith(previousYear, month);
     }
     expect(refreshPantryMonthly).toHaveBeenCalledTimes(12);
-    expect(refreshPantryYearly).toHaveBeenCalledWith(2024);
+    expect(refreshPantryYearly).toHaveBeenCalledWith(previousYear);
 
-    const cutoff = '2025-01-01';
+    const cutoff = `${nextYear}-01-01`;
     expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
     expect(mockClient.query).toHaveBeenNthCalledWith(
       2,

--- a/MJ_FB_Backend/tests/refreshPantryWeekly.test.ts
+++ b/MJ_FB_Backend/tests/refreshPantryWeekly.test.ts
@@ -9,7 +9,8 @@ describe('refreshPantryWeekly', () => {
   });
 
   it('skips weeks starting outside the month', async () => {
-    await refreshPantryWeekly(2024, 4, 6); // April 2024 has only 5 weeks
+    const year = new Date().getFullYear();
+    await refreshPantryWeekly(year, 4, 6); // April has only 5 weeks
     expect(pool.query).not.toHaveBeenCalled();
   });
 });

--- a/MJ_FB_Backend/tests/topLists.test.ts
+++ b/MJ_FB_Backend/tests/topLists.test.ts
@@ -8,6 +8,7 @@ import pool from '../src/db';
 const app = express();
 app.use('/donors', donorsRoutes);
 app.use('/outgoing-receivers', outgoingReceiversRoutes);
+const year = new Date().getFullYear();
 
 beforeEach(() => {
   (pool.query as jest.Mock).mockReset();
@@ -16,32 +17,32 @@ beforeEach(() => {
 describe('GET /donors/top', () => {
   it('returns top donors for the year', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({
-      rows: [{ name: 'Alice', totalLbs: 100, lastDonationISO: '2024-01-10' }],
+      rows: [{ name: 'Alice', totalLbs: 100, lastDonationISO: `${year}-01-10` }],
     });
 
-    const res = await request(app).get('/donors/top?year=2024&limit=5');
+    const res = await request(app).get(`/donors/top?year=${year}&limit=5`);
     expect(res.status).toBe(200);
     expect(res.body).toEqual([
-      { name: 'Alice', totalLbs: 100, lastDonationISO: '2024-01-10' },
+      { name: 'Alice', totalLbs: 100, lastDonationISO: `${year}-01-10` },
     ]);
   });
 
   it('clamps limit to 100', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
-    const res = await request(app).get('/donors/top?year=2024&limit=150');
+    const res = await request(app).get(`/donors/top?year=${year}&limit=150`);
     expect(res.status).toBe(200);
-    expect((pool.query as jest.Mock).mock.calls[0][1]).toEqual([2024, 100]);
+    expect((pool.query as jest.Mock).mock.calls[0][1]).toEqual([year, 100]);
   });
 
   it('returns 400 for non-numeric limit', async () => {
-    const res = await request(app).get('/donors/top?year=2024&limit=abc');
+    const res = await request(app).get(`/donors/top?year=${year}&limit=abc`);
     expect(res.status).toBe(400);
     expect(pool.query).not.toHaveBeenCalled();
   });
 
   it('returns 400 for limit less than 1', async () => {
-    const res = await request(app).get('/donors/top?year=2024&limit=0');
+    const res = await request(app).get(`/donors/top?year=${year}&limit=0`);
     expect(res.status).toBe(400);
     expect(pool.query).not.toHaveBeenCalled();
   });
@@ -50,13 +51,13 @@ describe('GET /donors/top', () => {
 describe('GET /outgoing-receivers/top', () => {
   it('returns top receivers for the year', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({
-      rows: [{ name: 'Org', totalLbs: 50, lastPickupISO: '2024-02-15' }],
+      rows: [{ name: 'Org', totalLbs: 50, lastPickupISO: `${year}-02-15` }],
     });
 
-    const res = await request(app).get('/outgoing-receivers/top?year=2024&limit=5');
+    const res = await request(app).get(`/outgoing-receivers/top?year=${year}&limit=5`);
     expect(res.status).toBe(200);
     expect(res.body).toEqual([
-      { name: 'Org', totalLbs: 50, lastPickupISO: '2024-02-15' },
+      { name: 'Org', totalLbs: 50, lastPickupISO: `${year}-02-15` },
     ]);
     expect((pool.query as jest.Mock).mock.calls[0][0]).toMatch(/ORDER BY "totalLbs" DESC/);
   });

--- a/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
@@ -10,6 +10,7 @@ jest.mock('jsonwebtoken');
 
 const app = express();
 app.use('/warehouse-overall', warehouseOverallRoutes);
+const year = new Date().getFullYear();
 
 beforeAll(() => {
   process.env.JWT_SECRET = 'testsecret';
@@ -44,7 +45,7 @@ describe('GET /warehouse-overall/export', () => {
     (writeXlsxFile as jest.Mock).mockResolvedValueOnce(buffer);
 
     const res = await request(app)
-      .get('/warehouse-overall/export?year=2024')
+      .get(`/warehouse-overall/export?year=${year}`)
       .set('Authorization', 'Bearer token')
       .buffer()
       .parse((res, cb) => {

--- a/MJ_FB_Backend/tests/warehouseOverallManual.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallManual.test.ts
@@ -9,6 +9,7 @@ jest.mock('jsonwebtoken');
 const app = express();
 app.use(express.json());
 app.use('/warehouse-overall', warehouseOverallRoutes);
+const year = new Date().getFullYear();
 
 beforeAll(() => {
   process.env.JWT_SECRET = 'testsecret';
@@ -35,7 +36,7 @@ describe('POST /warehouse-overall/manual', () => {
       .mockResolvedValueOnce({});
 
     const body = {
-      year: 2024,
+      year,
       month: 5,
       donations: 10,
       surplus: 2,
@@ -52,7 +53,7 @@ describe('POST /warehouse-overall/manual', () => {
     expect(res.body).toEqual({ message: 'Saved' });
     expect(pool.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO warehouse_overall'),
-      [2024, 5, 10, 2, 1, 3],
+      [year, 5, 10, 2, 1, 3],
     );
   });
 
@@ -74,17 +75,17 @@ describe('POST /warehouse-overall/manual', () => {
     await request(app)
       .post('/warehouse-overall/manual')
       .set('Authorization', 'Bearer token')
-      .send({ year: 2024, month: 5, donations: 1, surplus: 2, pigPound: 3, outgoingDonations: 4 });
+      .send({ year, month: 5, donations: 1, surplus: 2, pigPound: 3, outgoingDonations: 4 });
 
     const res = await request(app)
       .post('/warehouse-overall/manual')
       .set('Authorization', 'Bearer token')
-      .send({ year: 2024, month: 5, donations: 5, surplus: 6, pigPound: 7, outgoingDonations: 8 });
+      .send({ year, month: 5, donations: 5, surplus: 6, pigPound: 7, outgoingDonations: 8 });
 
     expect(res.status).toBe(200);
     expect(pool.query).toHaveBeenLastCalledWith(
       expect.any(String),
-      [2024, 5, 5, 6, 7, 8],
+      [year, 5, 5, 6, 7, 8],
     );
   });
 

--- a/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallYears.test.ts
@@ -9,6 +9,7 @@ jest.mock('jsonwebtoken');
 
 const app = express();
 app.use('/warehouse-overall', warehouseOverallRoutes);
+const year = new Date().getFullYear();
 
 beforeAll(() => {
   process.env.JWT_SECRET = 'testsecret';
@@ -33,7 +34,7 @@ describe('GET /warehouse-overall/years', () => {
         rows: [{ id: 1, first_name: 'Test', last_name: 'User', email: 't@example.com', role: 'staff' }],
       })
       .mockResolvedValueOnce({
-        rows: [{ year: 2024 }, { year: 2023 }],
+        rows: [{ year }, { year: year - 1 }],
       });
 
     const res = await request(app)
@@ -41,7 +42,7 @@ describe('GET /warehouse-overall/years', () => {
       .set('Authorization', 'Bearer token');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([2024, 2023]);
+    expect(res.body).toEqual([year, year - 1]);
     expect(pool.query).toHaveBeenCalledWith(
       'SELECT DISTINCT year FROM warehouse_overall ORDER BY year DESC',
     );


### PR DESCRIPTION
## Summary
- replace hard-coded years in donation and pantry aggregation backend tests with dynamic values
- compute future/past dates relative to `new Date()` for cleanup and export tests
- update top donor and warehouse export tests to build date strings from current year

## Testing
- `npm test` *(fails: multiple existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cc4ea684832dbd7a14dedbff55ae