### PR TITLE
test: clarify timezone in date util test

### DIFF
--- a/MJ_FB_Frontend/src/utils/__tests__/date.test.ts
+++ b/MJ_FB_Frontend/src/utils/__tests__/date.test.ts
@@ -1,8 +1,8 @@
 import { formatReginaDate, normalizeDate } from '../date';
 
-describe('toDayjs with Date input', () => {
+describe('toDayjs with ISO string input', () => {
   test('converts from system timezone to Regina', () => {
-    const d = new Date('2024-09-02');
+    const d = '2024-09-02T00:00:00Z';
     expect(formatReginaDate(d)).toBe('2024-09-01');
   });
 });


### PR DESCRIPTION
## Summary
- use explicit UTC date string in formatReginaDate unit test

## Testing
- `npm test` *(fails: jest worker process terminated; many suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4dd7a0790832db99976f01feee4a6