### PR TITLE
Adjust weekly refresh count

### DIFF
--- a/MJ_FB_Backend/tests/pantryAggregations.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregations.test.ts
@@ -103,7 +103,7 @@ describe('pantry aggregation routes', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ message: 'Rebuilt' });
     expect(refreshPantryMonthly).toHaveBeenCalledTimes(12);
-    expect(refreshPantryWeekly).toHaveBeenCalledTimes(53);
+    expect(refreshPantryWeekly).toHaveBeenCalledTimes(52);
     const week6Calls = (refreshPantryWeekly as jest.Mock).mock.calls.filter(
       ([, , w]) => w === 6,
     );


### PR DESCRIPTION
## Summary
- expect weekly aggregation refresh to run 52 times and ensure no week 6 calls

## Testing
- `nvm use`
- `npm test tests/pantryAggregations.test.ts` *(fails: Expected vs Received filename and weekly range)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e16ee9a8832db10b13103b176feb