### PR TITLE
fix pantry aggregation export filename test

### DIFF
--- a/MJ_FB_Backend/tests/pantryAggregations.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregations.test.ts
@@ -126,7 +126,7 @@ describe('pantry aggregation routes', () => {
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
     expect(res.headers['content-disposition']).toBe(
-      `attachment; filename=${year}_05_${year}-05-06_to_${year}-05-10_week_1_agggregation.xlsx`,
+      `attachment; filename=${year}_05_${year}-05-05_to_${year}-05-09_week_1_agggregation.xlsx`,
     );
     expect(res.body).toEqual(Buffer.from('test'));
   });


### PR DESCRIPTION
## Summary
- update pantry aggregations export test to expect correct weekly date range

## Testing
- `npm test` *(fails: Test Suites: 36 failed, 119 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e17107bc832d91cc38483796fe4d