### PR TITLE
Handle booking reminder enqueue failures

### DIFF
--- a/MJ_FB_Backend/tests/bookingReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingReminderJob.test.ts
@@ -105,7 +105,14 @@ describe('sendNextDayBookingReminders', () => {
     (enqueueEmail as jest.Mock).mockRejectedValue(new Error('fail'));
 
     await expect(sendNextDayBookingReminders()).rejects.toThrow('fail');
-    expect(alertOps).toHaveBeenCalledWith(
+    expect(alertOps).toHaveBeenCalledTimes(2);
+    expect(alertOps).toHaveBeenNthCalledWith(
+      1,
+      'sendNextDayBookingReminders',
+      expect.any(Error),
+    );
+    expect(alertOps).toHaveBeenNthCalledWith(
+      2,
       'sendNextDayBookingReminders',
       expect.any(Error),
     );


### PR DESCRIPTION
## Summary
- wrap booking reminder email enqueues with try/catch to log, alert ops, and rethrow
- verify alertOps invoked and errors surface in booking reminder job tests

## Testing
- `npm test tests/bookingReminderJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c4e3501b0c832d8a35110eb8cc375b