### PR TITLE
feat: add custom date parsing

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -35,7 +35,7 @@ import {
 import { useTheme } from '@mui/material/styles';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import AccessTime from '@mui/icons-material/AccessTime';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs, { Dayjs } from '../utils/date';
 import { useQuery } from '@tanstack/react-query';
 import type { Slot, Holiday, BookingActionResponse } from '../types';
 import { getSlots, createBooking } from '../api/bookings';

--- a/MJ_FB_Frontend/src/utils/date.ts
+++ b/MJ_FB_Frontend/src/utils/date.ts
@@ -1,13 +1,15 @@
 
 import dayjs from 'dayjs';
-import type { ConfigType } from 'dayjs';
+import type { ConfigType, Dayjs } from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import objectSupport from 'dayjs/plugin/objectSupport';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(objectSupport);
+dayjs.extend(customParseFormat);
 
 export const REGINA_TIMEZONE = 'America/Regina';
 
@@ -82,3 +84,4 @@ export function normalizeDate(input?: ConfigType | null): string {
 }
 
 export default dayjs;
+export type { Dayjs };


### PR DESCRIPTION
## Summary
- extend dayjs with customParseFormat for flexible time parsing
- use centralized dayjs import in BookingUI

## Testing
- `npm test` *(fails: Unable to find an element with the text: /Greeter •/ and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e6190b38832d80a403f7c99da821