### PR TITLE
test: update slot label matchers

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/BookingUI.test.tsx
@@ -129,7 +129,7 @@ describe('SlotRow', () => {
         loadingConfirm={false}
       />,
     );
-    const listButton = screen.getByLabelText(/select .* time slot/i);
+    const listButton = screen.getByLabelText(/select time slot from/i);
     expect(listButton).toHaveStyle({ marginBottom: '0px' });
     expect(
       screen.queryByRole('button', { name: /book selected slot/i }),
@@ -193,7 +193,7 @@ describe('Booking confirmation', () => {
 
     await renderUI();
     await waitFor(() => expect(getSlots).toHaveBeenCalled());
-    const slot = await screen.findByLabelText(/select .* time slot/i);
+    const slot = await screen.findByLabelText(/select time slot from/i);
     fireEvent.click(slot);
     const bookButton = within(slot.closest('li')!).getByRole('button', {
       name: /book selected slot/i,
@@ -210,7 +210,7 @@ describe('Booking confirmation', () => {
 
     await renderUI();
     await waitFor(() => expect(getSlots).toHaveBeenCalled());
-    const slot = await screen.findByLabelText(/select .* time slot/i);
+    const slot = await screen.findByLabelText(/select time slot from/i);
     fireEvent.click(slot);
     const bookButton = within(slot.closest('li')!).getByRole('button', {
       name: /book selected slot/i,
@@ -239,7 +239,7 @@ describe('Booking confirmation', () => {
 
     await renderUI();
     await waitFor(() => expect(getSlots).toHaveBeenCalled());
-    const slot = await screen.findByLabelText(/select .* time slot/i);
+    const slot = await screen.findByLabelText(/select time slot from/i);
     fireEvent.click(slot);
     const bookButton = within(slot.closest('li')!).getByRole('button', {
       name: /book selected slot/i,
@@ -262,7 +262,7 @@ describe('Booking confirmation', () => {
 
     await renderUI();
     await waitFor(() => expect(getSlots).toHaveBeenCalled());
-    const slot = await screen.findByLabelText(/select .* time slot/i);
+    const slot = await screen.findByLabelText(/select time slot from/i);
     fireEvent.click(slot);
     const bookButton = within(slot.closest('li')!).getByRole('button', {
       name: /book selected slot/i,


### PR DESCRIPTION
## Summary
- adjust BookingUI tests for new "Select time slot from" wording

## Testing
- `npm test -- src/__tests__/BookingUI.test.tsx` *(fails: Unable to find label /select time slot from/i)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e615589c832dac1324e6a5aad347