### PR TITLE
Handle aborted transactions in slot capacity check

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -49,6 +49,8 @@ export async function checkSlotCapacity(
   } catch (err: any) {
     if (err.code === '0A000') {
       res = await client.query(baseQuery, params);
+    } else if (err.code === '25P02') {
+      throw new SlotCapacityError('Transaction aborted, please retry', 503);
     } else {
       throw err;
     }


### PR DESCRIPTION
## Summary
- throw SlotCapacityError with retry message when transaction is aborted during slot capacity check
- test that checkSlotCapacity reports aborted transaction and update capacity check test mocks

## Testing
- `npm test tests/bookingCapacity.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c4e766f848832da8285d66b09811f8