### PR TITLE
Allow staff login during maintenance mode

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -288,11 +288,14 @@ export default function App() {
   const AppContent = ({ maintenanceNotice }: { maintenanceNotice?: string }) => {
     const location = useLocation();
     const path = location.pathname;
+    const showOverlay =
+      maintenanceMode && !(isStaff || path === '/login');
     useEffect(() => {
       console.log('Navigated to', path);
     }, [path]);
     return (
       <>
+        {showOverlay && <MaintenanceOverlay />}
         <div className="app-container">
           <FeedbackSnackbar
             open={!!error}
@@ -617,7 +620,6 @@ export default function App() {
 
   return (
     <BrowserRouter>
-      {maintenanceMode && <MaintenanceOverlay />}
       <InstallAppButton />
       <AppContent maintenanceNotice={notice} />
     </BrowserRouter>

--- a/MJ_FB_Frontend/src/__tests__/MaintenanceDisplay.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/MaintenanceDisplay.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { renderWithProviders } from '../../testUtils/renderWithProviders';
 import MaintenanceOverlay from '../components/MaintenanceOverlay';
 import MaintenanceBanner from '../components/MaintenanceBanner';
 import useMaintenance from '../hooks/useMaintenance';
 import { getMaintenance } from '../api/maintenance';
+import { useAuth } from '../hooks/useAuth';
 
 jest.mock('../api/maintenance', () => ({
   getMaintenance: jest.fn(),
@@ -47,6 +49,35 @@ describe('MaintenanceDisplay', () => {
       screen.queryByText('We are under maintenance. Please check back later.'),
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Test notice')).not.toBeInTheDocument();
+  });
+
+  it('does not show overlay on the login page', async () => {
+    (getMaintenance as jest.Mock).mockResolvedValue({ maintenanceMode: true, notice: undefined });
+
+    function OverlayWithRoute() {
+      const { maintenanceMode } = useMaintenance();
+      const { role, access } = useAuth();
+      const location = useLocation();
+      const isStaff = role === 'staff' || access.includes('admin');
+      return (
+        <>
+          {maintenanceMode && !(isStaff || location.pathname === '/login') && (
+            <MaintenanceOverlay />
+          )}
+        </>
+      );
+    }
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/login']}>
+        <OverlayWithRoute />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getMaintenance).toHaveBeenCalled());
+    expect(
+      screen.queryByText('We are under maintenance. Please check back later.'),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Admin Settings → Donor tab manages test email addresses used for Mail Lists
   testing, and the Mail Lists page provides a Send test emails button to email
   each tier to the configured addresses.
-- Admin Settings → Maintenance lets admins schedule downtime and enable maintenance mode, displaying upcoming or active maintenance notices to clients.
+- Admin Settings → Maintenance lets admins schedule downtime and enable maintenance mode, displaying upcoming or active maintenance notices to clients. Staff can still sign in during maintenance to turn it off.
 - Public cancel and reschedule pages include the client bottom navigation for quick access
   to other sections.
 - Email templates display times in 12-hour AM/PM format.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,7 +1,7 @@
 # Maintenance Mode
 
 Admin users can schedule downtime and toggle maintenance mode from **Admin → Maintenance**.
-When active, maintenance mode prevents normal access and shows a message to clients.
+When active, maintenance mode prevents normal access and shows a message to clients. Staff can still sign in to disable maintenance.
 A scheduled window displays an upcoming maintenance banner to clients.
 
 ## Translation keys


### PR DESCRIPTION
## Summary
- hide maintenance overlay for staff and on the login page so staff can sign in during maintenance
- document that staff can still log in when maintenance mode is enabled
- add tests covering login access when maintenance mode is active

## Testing
- `npm test` *(fails: VolunteerDashboard, VolunteerSchedule, etc.)*
- `npm test` (backend) *(fails: bookingController, passwordResetFlow, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ea4e493c832da3388711d924d60f