### PR TITLE
Handle transaction aborted errors in bookings

### DIFF
--- a/MJ_FB_Backend/tests/bookingTransactionAborted.test.ts
+++ b/MJ_FB_Backend/tests/bookingTransactionAborted.test.ts
@@ -1,0 +1,86 @@
+import request from 'supertest';
+import express from 'express';
+import bookingsRouter from '../src/routes/bookings';
+import pool from '../src/db';
+import jwt from 'jsonwebtoken';
+import logger from '../src/utils/logger';
+import * as bookingRepository from '../src/models/bookingRepository';
+import * as bookingUtils from '../src/utils/bookingUtils';
+
+jest.mock('../src/models/bookingRepository', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/models/bookingRepository'),
+  checkSlotCapacity: jest.fn(),
+  insertBooking: jest.fn(),
+  lockClientRow: jest.fn(),
+}));
+jest.mock('jsonwebtoken');
+jest.mock('../src/utils/bookingUtils', () => ({
+  isDateWithinCurrentOrNextMonth: jest.fn().mockReturnValue(true),
+  countVisitsAndBookingsForMonth: jest.fn().mockResolvedValue(0),
+  findUpcomingBooking: jest.fn().mockResolvedValue(null),
+  LIMIT_MESSAGE: 'limit',
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/bookings', bookingsRouter);
+// Global error handler to capture unhandled errors
+const errorHandler = jest.fn(
+  (err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err.status || 500).json({ message: err.message });
+  },
+);
+app.use(errorHandler);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+let mockClient: { query: jest.Mock; release: jest.Mock };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockClient = {
+    query: jest.fn().mockResolvedValue({ rows: [] }),
+    release: jest.fn(),
+  };
+  (pool.connect as jest.Mock).mockResolvedValue(mockClient);
+  (pool.query as jest.Mock).mockResolvedValue({ rows: [{ bookings_this_month: 0 }] });
+});
+
+describe('booking controller transaction aborted handling', () => {
+  it('returns 503 and rolls back on 25P02 errors', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'shopper', type: 'user' });
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [
+        {
+          client_id: 1,
+          first_name: 'Test',
+          last_name: 'User',
+          email: 'test@example.com',
+          role: 'shopper',
+          phone: '123',
+        },
+      ],
+    });
+    (bookingRepository.insertBooking as jest.Mock).mockRejectedValue({ code: '25P02' });
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const today = new Date().toLocaleDateString('en-CA');
+    const res = await request(app)
+      .post('/bookings')
+      .set('Authorization', 'Bearer token')
+      .send({ slotId: 1, date: today });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ message: 'Transaction aborted, please retry' });
+    expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(errorHandler).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- return HTTP 503 with "Transaction aborted, please retry" when database returns 25P02
- cover 25P02 scenario with booking controller test to ensure rollback

## Testing
- `npm test` *(fails: Test Suites: 27 failed, 129 passed, 156 total)*
- `npm test tests/bookingTransactionAborted.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c4eb747ad8832d8037061e0c866eeb