### PR TITLE
Use savepoint when checking slot capacity

### DIFF
--- a/MJ_FB_Backend/tests/forUpdateFallback.test.ts
+++ b/MJ_FB_Backend/tests/forUpdateFallback.test.ts
@@ -8,18 +8,25 @@ describe('FOR UPDATE fallback', () => {
         .mockResolvedValueOnce({})
         .mockRejectedValueOnce({ code: '0A000' })
         .mockResolvedValueOnce({})
-        .mockResolvedValueOnce({})
         .mockResolvedValueOnce({
           rowCount: 1,
           rows: [{ max_capacity: 5, approved_count: 0 }],
-        }),
+        })
+        .mockResolvedValueOnce({}),
     };
     await expect(
       checkSlotCapacity(1, '2025-09-25', mockClient as any)
     ).resolves.toBeUndefined();
     expect(mockClient.query).toHaveBeenCalledTimes(5);
+    expect(mockClient.query.mock.calls[0][0]).toEqual('SAVEPOINT check_slot_capacity');
     expect(mockClient.query.mock.calls[1][0]).toContain('FOR UPDATE');
-    expect(mockClient.query.mock.calls[4][0]).not.toContain('FOR UPDATE');
+    expect(mockClient.query.mock.calls[2][0]).toEqual(
+      'ROLLBACK TO SAVEPOINT check_slot_capacity'
+    );
+    expect(mockClient.query.mock.calls[3][0]).not.toContain('FOR UPDATE');
+    expect(mockClient.query.mock.calls[4][0]).toEqual(
+      'RELEASE SAVEPOINT check_slot_capacity'
+    );
   });
 
   it('lockClientRow retries without FOR UPDATE when unsupported', async () => {


### PR DESCRIPTION
## Summary
- wrap slot capacity lock check in a savepoint and rollback on 0A000
- test savepoint fallback logic for slot capacity checks

## Testing
- `npm test`
- `npm test tests/forUpdateFallback.test.ts tests/bookingRepository.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c4ed0e3244832da5f9f5425ab59706