### PR TITLE
Validate slot ID as integer for bookings

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -909,7 +909,7 @@ export async function createBookingForUser(
   }
 
   const slotIdNum = Number(slotId);
-  if (Number.isNaN(slotIdNum)) {
+  if (!Number.isInteger(slotIdNum)) {
     return res.status(400).json({ message: 'Please select a valid time slot' });
   }
 


### PR DESCRIPTION
## Summary
- enforce integer slot IDs when staff create bookings
- test staff booking route rejects non-integer slot IDs

## Testing
- `npm test` *(fails: passwordResetFlow.test.ts, login.test.ts, pantryAggregationRollup.test.ts, volunteerBookingConflict.test.ts, volunteerBookingConcurrency.test.ts, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c4eddb6ac8832daa8ce9e003650336