### PR TITLE
Capture inserted booking IDs

### DIFF
--- a/MJ_FB_Backend/src/models/bookingRepository.ts
+++ b/MJ_FB_Backend/src/models/bookingRepository.ts
@@ -112,9 +112,9 @@ export async function insertBooking(
   newClientId: number | null = null,
   note: string | null = null,
   client: Queryable = pool,
-) {
+): Promise<number> {
   const reginaDate = formatReginaDate(date);
-  const res = await client.query(
+  const res = await client.query<{ id: number }>(
     `INSERT INTO bookings (user_id, new_client_id, slot_id, status, request_data, note, date, is_staff_booking, reschedule_token)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
     [


### PR DESCRIPTION
## Summary
- return inserted IDs from `insertBooking`
- capture booking ID directly in booking creation controllers
- drop redundant lookup by reschedule token

## Testing
- `npm test` *(fails: 29 failed, 127 passed, 156 total)*

------
https://chatgpt.com/codex/tasks/task_e_68c4edd2d7b0832d9a50f725ecf0b9bc