### PR TITLE
Lock booking duplicate check within transactions

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000052_add_bookings_user_date_unique_index.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000052_add_bookings_user_date_unique_index.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addConstraint('bookings', 'bookings_user_id_date_unique', {
+    unique: ['user_id', 'date'],
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('bookings', 'bookings_user_id_date_unique');
+}

--- a/MJ_FB_Backend/src/utils/bookingUtils.ts
+++ b/MJ_FB_Backend/src/utils/bookingUtils.ts
@@ -121,8 +121,9 @@ export async function countVisitsAndBookingsForMonth(
 
 export async function findUpcomingBooking(
   userId: number,
+  client: Queryable = pool,
 ): Promise<{ date: string; start_time: string; status: string } | null> {
-  const res = await pool.query(
+  const res = await client.query(
     `SELECT b.date, s.start_time, b.status
        FROM bookings b
        INNER JOIN slots s ON b.slot_id = s.id

--- a/MJ_FB_Backend/tests/bookingLimit.test.ts
+++ b/MJ_FB_Backend/tests/bookingLimit.test.ts
@@ -85,7 +85,10 @@ describe('booking monthly limits', () => {
         },
       );
     });
-    (pool.connect as jest.Mock).mockResolvedValue({ query: jest.fn(), release: jest.fn() });
+    (pool.connect as jest.Mock).mockResolvedValue({
+      query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: jest.fn(),
+    });
     (pool.query as jest.Mock).mockResolvedValue({ rows: [{ bookings_this_month: 0 }] });
     (bookingRepository.checkSlotCapacity as jest.Mock).mockResolvedValue(undefined);
     (bookingRepository.insertBooking as jest.Mock).mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- run `findUpcomingBooking` inside transactions in booking controller
- enforce `(user_id, date)` uniqueness for bookings via migration
- adjust tests for new booking flow

## Testing
- `npm test tests/bookingController.test.ts`
- `npm test` *(fails: passwordResetFlow, bookingReminderJob, clientVisitBookingStatus, bookingLimit, volunteerBookingConflict)*

------
https://chatgpt.com/codex/tasks/task_e_68c4edcf9400832daccd29cafa074e06