### PR TITLE
fix: use type-only import for MigrationBuilder

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000052_add_note_to_volunteer_bookings.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000052_add_note_to_volunteer_bookings.ts
@@ -1,4 +1,4 @@
-import { MigrationBuilder } from 'node-pg-migrate';
+import type { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.addColumn('volunteer_bookings', {


### PR DESCRIPTION
## Summary
- use type-only import for node-pg-migrate MigrationBuilder to avoid runtime module export error

## Testing
- `npm test tests/passwordResetFlow.test.ts` *(fails: Expected 400 Received 429)*
- `npm test tests/clientVisitBookingStatus.test.ts` *(fails: Expected 201 Received 409)*
- `npm test tests/pantryAggregationRollup.test.ts` *(fails: Expected data did not match)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f0fb9318832d843a9ec568e8a814