### PR TITLE
Hide Edit Client button from client booking history

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientBookingHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientBookingHistory.test.tsx
@@ -1,0 +1,41 @@
+import { MemoryRouter } from 'react-router-dom';
+import { renderWithProviders, screen, waitFor } from '../../testUtils/renderWithProviders';
+import UserHistory from '../pages/staff/client-management/UserHistory';
+import { getBookingHistory, getSlots, cancelBooking, rescheduleBookingByToken } from '../api/bookings';
+import { deleteClientVisit } from '../api/clientVisits';
+
+jest.mock('../api/bookings', () => ({
+  getBookingHistory: jest.fn(),
+  getSlots: jest.fn(),
+  cancelBooking: jest.fn(),
+  rescheduleBookingByToken: jest.fn(),
+}));
+
+jest.mock('../api/clientVisits', () => ({
+  deleteClientVisit: jest.fn(),
+}));
+
+describe('Client booking history', () => {
+  beforeEach(() => {
+    (getBookingHistory as jest.Mock).mockResolvedValue([]);
+    (getSlots as jest.Mock).mockResolvedValue([]);
+    localStorage.setItem('role', 'shopper');
+    localStorage.setItem('name', 'Test Client');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('does not show Edit Client button for clients', async () => {
+    renderWithProviders(
+      <MemoryRouter>
+        <UserHistory initialUser={{ name: 'Test Client', client_id: 1 }} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: /Edit Client/i })).toBeNull();
+  });
+});

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -67,15 +67,21 @@ export default function UserHistory({
               getSlots={getSlots}
               onDeleteVisit={deleteClientVisit}
               showNotes={showNotes}
-              renderEditDialog={({ open, onClose, onUpdated }) => (
-                <EditClientDialog
-                  open={open}
-                  clientId={selected.client_id}
-                  onClose={onClose}
-                  onUpdated={onUpdated}
-                  onClientUpdated={name => setSelected({ ...selected, name })}
-                />
-              )}
+              renderEditDialog={
+                role === 'staff'
+                  ? ({ open, onClose, onUpdated }) => (
+                      <EditClientDialog
+                        open={open}
+                        clientId={selected.client_id}
+                        onClose={onClose}
+                        onUpdated={onUpdated}
+                        onClientUpdated={name =>
+                          setSelected({ ...selected, name })
+                        }
+                      />
+                    )
+                  : undefined
+              }
               renderDeleteVisitButton={(b, isSmall, open) =>
                 role === 'staff' && b.status === 'visited' && !b.slot_id ? (
                   <Button


### PR DESCRIPTION
## Summary
- Only show Edit Client button to staff in booking history
- Test that clients do not see Edit Client button

## Testing
- `npm test src/__tests__/ClientBookingHistory.test.tsx`
- `npm test` *(fails: VolunteerDashboard.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f355513c832da5322f68a53f3d10