### PR TITLE
fix: reload volunteer search quick link

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerQuickLinks.test.tsx
@@ -22,4 +22,15 @@ describe('VolunteerQuickLinks', () => {
       '/volunteer-management/daily',
     );
   });
+
+  it('keeps links enabled on the current page', () => {
+    render(
+      <MemoryRouter initialEntries={['/volunteer-management/volunteers']}>
+        <VolunteerQuickLinks />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole('link', { name: /Search Volunteer/i }),
+    ).not.toHaveAttribute('aria-disabled');
+  });
 });

--- a/MJ_FB_Frontend/src/components/VolunteerQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerQuickLinks.tsx
@@ -1,8 +1,9 @@
 import { Stack, Button } from '@mui/material';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 
 export default function VolunteerQuickLinks() {
   const { pathname } = useLocation();
+  const navigate = useNavigate();
   const buttonSx = {
     textTransform: 'none',
     '&:hover': { color: 'primary.main' },
@@ -26,7 +27,9 @@ export default function VolunteerQuickLinks() {
           sx={buttonSx}
           component={RouterLink}
           to={link.to}
-          disabled={pathname === link.to}
+          onClick={() => {
+            if (pathname === link.to) navigate(0);
+          }}
           fullWidth
         >
           {link.label}


### PR DESCRIPTION
## Summary
- allow volunteer quick links to reload current page
- test that quick links are always enabled

## Testing
- `npm test src/__tests__/VolunteerQuickLinks.test.tsx`
- `npm test` *(fails: Unable to find a label with the text of: /role/i)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f75cd8c8832dbe8ec747b0379d83