### PR TITLE
Streamline client booking history view

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/ClientBookingHistory.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientBookingHistory.test.tsx
@@ -28,7 +28,7 @@ describe('Client booking history', () => {
     jest.clearAllMocks();
   });
 
-  it('does not show Edit Client button for clients', async () => {
+  it('hides staff-only controls for clients', async () => {
     renderWithProviders(
       <MemoryRouter>
         <UserHistory initialUser={{ name: 'Test Client', client_id: 1 }} />
@@ -37,5 +37,7 @@ describe('Client booking history', () => {
 
     await waitFor(() => expect(getBookingHistory).toHaveBeenCalled());
     expect(screen.queryByRole('button', { name: /Edit Client/i })).toBeNull();
+    expect(screen.queryByLabelText(/Filter/i)).toBeNull();
+    expect(screen.queryByText(/History for/i)).toBeNull();
   });
 });

--- a/MJ_FB_Frontend/src/components/BookingManagementBase.tsx
+++ b/MJ_FB_Frontend/src/components/BookingManagementBase.tsx
@@ -58,6 +58,8 @@ interface BookingManagementBaseProps {
     open: () => void,
   ) => React.ReactNode;
   showNotes?: boolean;
+  showFilter?: boolean;
+  showUserHeading?: boolean;
 }
 
 export default function BookingManagementBase({
@@ -70,6 +72,8 @@ export default function BookingManagementBase({
   renderEditDialog,
   renderDeleteVisitButton,
   showNotes,
+  showFilter = true,
+  showUserHeading = true,
 }: BookingManagementBaseProps) {
   const [filter, setFilter] = useState('all');
   const [bookings, setBookings] = useState<Booking[]>([]);
@@ -214,32 +218,38 @@ export default function BookingManagementBase({
   return (
     <div>
       <Box>
-        <Stack direction="row" spacing={1} alignItems="center" mb={1}>
-          {user.name && <h3>{`History for ${user.name}`}</h3>}
-          {renderEditDialog && (
-            <Button
-              variant="contained"
-              onClick={() => setEditOpen(true)}
+        {((showUserHeading && user.name) || renderEditDialog) && (
+          <Stack direction="row" spacing={1} alignItems="center" mb={1}>
+            {showUserHeading && user.name && (
+              <h3>{`History for ${user.name}`}</h3>
+            )}
+            {renderEditDialog && (
+              <Button
+                variant="contained"
+                onClick={() => setEditOpen(true)}
+              >
+                Edit Client
+              </Button>
+            )}
+          </Stack>
+        )}
+        {showFilter && (
+          <FormControl sx={{ minWidth: 160, mb: 1 }}>
+            <InputLabel id="filter-label">Filter</InputLabel>
+            <Select
+              labelId="filter-label"
+              value={filter}
+              label="Filter"
+              onChange={e => setFilter(e.target.value)}
             >
-              Edit Client
-            </Button>
-          )}
-        </Stack>
-        <FormControl sx={{ minWidth: 160, mb: 1 }}>
-          <InputLabel id="filter-label">Filter</InputLabel>
-          <Select
-            labelId="filter-label"
-            value={filter}
-            label="Filter"
-            onChange={e => setFilter(e.target.value)}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="approved">Approved</MenuItem>
-            <MenuItem value="visited">Visited</MenuItem>
-            <MenuItem value="no_show">No show</MenuItem>
-            <MenuItem value="past">Past</MenuItem>
-          </Select>
-        </FormControl>
+              <MenuItem value="all">All</MenuItem>
+              <MenuItem value="approved">Approved</MenuItem>
+              <MenuItem value="visited">Visited</MenuItem>
+              <MenuItem value="no_show">No show</MenuItem>
+              <MenuItem value="past">Past</MenuItem>
+            </Select>
+          </FormControl>
+        )}
         {showNotes && (
           <FormControlLabel
             control={

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -67,6 +67,8 @@ export default function UserHistory({
               getSlots={getSlots}
               onDeleteVisit={deleteClientVisit}
               showNotes={showNotes}
+              showFilter={!initialUser}
+              showUserHeading={!initialUser}
               renderEditDialog={
                 role === 'staff'
                   ? ({ open, onClose, onUpdated }) => (


### PR DESCRIPTION
## Summary
- Add props to BookingManagementBase to optionally hide user header and status filter
- Hide secondary title and filter for client booking history
- Ensure client booking history test covers absence of staff-only controls

## Testing
- `npm test` *(fails: Unable to find an element with the text: /Greeter •/ in VolunteerDashboard.test.tsx, and multiple other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f71f76a8832dae775ff64630f94d