### PR TITLE
Use accordions in volunteer edit form

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteer.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteer.test.tsx
@@ -81,6 +81,7 @@ describe('EditVolunteer volunteer info display', () => {
     );
 
     fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.click(screen.getByText('Roles'));
     expect(await screen.findByText('No roles assigned yet')).toBeInTheDocument();
   });
 });
@@ -114,6 +115,7 @@ describe('EditVolunteer shopper profile', () => {
     );
 
     fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.click(screen.getByText('Roles'));
     const toggle = screen.getByTestId('shopper-toggle');
     fireEvent.click(toggle);
     fireEvent.change(screen.getByLabelText(/client id/i), { target: { value: '123' } });
@@ -152,6 +154,7 @@ describe('EditVolunteer shopper profile', () => {
     );
 
     fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.click(screen.getByText('Roles'));
     const toggle = screen.getByTestId('shopper-toggle');
     fireEvent.click(toggle);
     fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
@@ -200,6 +203,7 @@ describe('EditVolunteer role selection', () => {
     );
 
     fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.click(screen.getByText('Roles'));
     expect(screen.getByTestId('roles-select')).toBeInTheDocument();
     expect(screen.getByTestId('save-button')).toBeDisabled();
     expect(screen.getByText('No roles assigned yet')).toBeInTheDocument();
@@ -235,6 +239,7 @@ describe('EditVolunteer role selection', () => {
     );
 
     fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.click(screen.getByText('Roles'));
     fireEvent.mouseDown(
       screen.getByTestId('roles-select').querySelector('[role="combobox"]')!
     );
@@ -281,6 +286,7 @@ describe('EditVolunteer role selection', () => {
 
     await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalled());
     fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.click(screen.getByText('Roles'));
     const chipA = await screen.findByTestId('role-chip-role-a');
     const chipB = await screen.findByTestId('role-chip-role-b');
     expect(chipA).toBeInTheDocument();

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteerSaveButton.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteerSaveButton.test.tsx
@@ -47,6 +47,7 @@ describe('EditVolunteer save button', () => {
     );
 
     fireEvent.click(screen.getByText('Select Volunteer'));
+    fireEvent.click(screen.getByText('Roles'));
     const saveBtn = await screen.findByTestId('save-button');
     expect(saveBtn).toBeDisabled();
 

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
@@ -11,11 +11,13 @@ import {
 import { getApiErrorMessage } from '../../../api/helpers';
 import type { VolunteerRoleWithShifts } from '../../../types';
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
   Card,
   CardContent,
-  CardHeader,
   Checkbox,
   Chip,
   Container,
@@ -36,6 +38,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
 import slugify from '../../../utils/slugify';
 import type { SelectChangeEvent } from '@mui/material/Select';
@@ -58,6 +61,7 @@ export default function EditVolunteer() {
   const [shopperEmail, setShopperEmail] = useState('');
   const [shopperPhone, setShopperPhone] = useState('');
   const [removeShopperOpen, setRemoveShopperOpen] = useState(false);
+  const [expanded, setExpanded] = useState<'profile' | 'roles' | false>('profile');
 
   useEffect(() => {
     getVolunteerRoles()
@@ -244,9 +248,16 @@ export default function EditVolunteer() {
           </Card>
           {volunteer && (
             <>
-              <Card>
-                <CardHeader title="Profile" />
-                <CardContent>
+              <Accordion
+                expanded={expanded === 'profile'}
+                onChange={(_, isExpanded) =>
+                  setExpanded(isExpanded ? 'profile' : false)
+                }
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography>Profile</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
                   <Stack spacing={2}>
                     <FormControl component="fieldset">
                       <FormControlLabel
@@ -265,11 +276,18 @@ export default function EditVolunteer() {
                       </FormHelperText>
                     </FormControl>
                   </Stack>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader title="Roles" />
-                <CardContent>
+                </AccordionDetails>
+              </Accordion>
+              <Accordion
+                expanded={expanded === 'roles'}
+                onChange={(_, isExpanded) =>
+                  setExpanded(isExpanded ? 'roles' : false)
+                }
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography>Roles</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
                   <FormControl fullWidth>
                     <InputLabel id="role-select-label">Roles</InputLabel>
                     <Select
@@ -317,8 +335,8 @@ export default function EditVolunteer() {
                       </Grid>
                     ))}
                   </Grid>
-                </CardContent>
-              </Card>
+                </AccordionDetails>
+              </Accordion>
             </>
           )}
         </Stack>


### PR DESCRIPTION
## Summary
- Replace Profile and Roles cards with MUI Accordions that allow only one panel open at a time
- Adjust tests for new accordion layout in volunteer editor

## Testing
- `npm test` *(fails: VolunteerDashboard.test.tsx, PantryVisits.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f8fa96e4832d99054ac24782fe2a