### PR TITLE
feat: allow editing volunteer profile

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteerSaveButton.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteerSaveButton.test.tsx
@@ -1,17 +1,26 @@
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import EditVolunteer from '../volunteer-management/EditVolunteer';
-import { getVolunteerRoles, getVolunteerById } from '../../../api/volunteers';
+import {
+  getVolunteerRoles,
+  getVolunteerById,
+  updateVolunteer,
+} from '../../../api/volunteers';
 
 jest.mock('../../../api/volunteers', () => ({
   getVolunteerRoles: jest.fn(),
   updateVolunteerTrainedAreas: jest.fn(),
   getVolunteerById: jest.fn(),
+  updateVolunteer: jest.fn(),
 }));
 
 const mockVolunteer: any = {
   id: 1,
   name: 'John Doe',
+  firstName: 'John',
+  lastName: 'Doe',
+  email: undefined,
+  phone: undefined,
   trainedAreas: [],
   hasShopper: false,
   hasPassword: false,
@@ -46,11 +55,15 @@ describe('EditVolunteer save button', () => {
       </MemoryRouter>,
     );
 
+    await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalled());
+
     fireEvent.click(screen.getByText('Select Volunteer'));
     const saveBtn = await screen.findByTestId('save-button');
     expect(saveBtn).toBeDisabled();
 
-    fireEvent.mouseDown(screen.getByLabelText(/roles/i));
+    fireEvent.mouseDown(
+      screen.getByTestId('roles-select').querySelector('[role="combobox"]')!,
+    );
     const listbox = await screen.findByRole('listbox');
     fireEvent.click(within(listbox).getByText('Role A'));
     fireEvent.keyDown(listbox, { key: 'Escape' });


### PR DESCRIPTION
## Summary
- add profile editing state for volunteers with first/last name, email, phone
- save profile updates via new accordion panel
- test email updates through updateVolunteer

## Testing
- `npm test` *(fails: VolunteerDashboard.test.tsx, PantryVisits.test.tsx, VolunteerSchedule.test.tsx, BookingUI.test.tsx, ClientDashboard.test.tsx, DonorDonationLog.test.tsx and others)*
- `npm test src/pages/staff/__tests__/EditVolunteer.test.tsx src/pages/staff/__tests__/EditVolunteerSaveButton.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c4f8f66a24832d8bb96cb46289fec5