### PR TITLE
Load volunteer booking history in staff editor

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteer.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteer.test.tsx
@@ -6,6 +6,7 @@ import {
   createVolunteerShopperProfile,
   removeVolunteerShopperProfile,
   getVolunteerById,
+  getVolunteerBookingHistory,
 } from '../../../api/volunteers';
 
 jest.mock('../../../api/volunteers', () => {
@@ -17,6 +18,7 @@ jest.mock('../../../api/volunteers', () => {
     createVolunteerShopperProfile: jest.fn(),
     removeVolunteerShopperProfile: jest.fn(),
     getVolunteerById: jest.fn(),
+    getVolunteerBookingHistory: jest.fn(),
   };
 });
 
@@ -40,6 +42,7 @@ jest.mock('../../../components/EntitySearch', () => (props: any) => (
 describe('EditVolunteer volunteer info display', () => {
   beforeEach(() => {
     (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
+    (getVolunteerBookingHistory as jest.Mock).mockResolvedValue([]);
     mockVolunteer.hasPassword = false;
   });
 
@@ -91,6 +94,7 @@ describe('EditVolunteer shopper profile', () => {
     (createVolunteerShopperProfile as jest.Mock).mockReset();
     (removeVolunteerShopperProfile as jest.Mock).mockReset();
     (getVolunteerById as jest.Mock).mockReset();
+    (getVolunteerBookingHistory as jest.Mock).mockResolvedValue([]);
     mockVolunteer.hasPassword = false;
   });
 
@@ -169,6 +173,7 @@ describe('EditVolunteer role selection', () => {
     (createVolunteerShopperProfile as jest.Mock).mockReset();
     (removeVolunteerShopperProfile as jest.Mock).mockReset();
     (getVolunteerById as jest.Mock).mockReset();
+    (getVolunteerBookingHistory as jest.Mock).mockResolvedValue([]);
     mockVolunteer.hasPassword = false;
   });
 
@@ -288,5 +293,37 @@ describe('EditVolunteer role selection', () => {
 
     const grid = chipA.parentElement?.parentElement;
     expect(grid).toHaveClass('MuiGrid-container');
+  });
+});
+
+describe('EditVolunteer history', () => {
+  beforeEach(() => {
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
+    (getVolunteerBookingHistory as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        role_id: 1,
+        role_name: 'Role A',
+        date: '2024-01-01',
+        start_time: '09:00:00',
+        end_time: '10:00:00',
+        status: 'approved',
+      },
+    ]);
+  });
+
+  it('loads history when volunteer is selected', async () => {
+    render(
+      <MemoryRouter>
+        <EditVolunteer />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText('Select Volunteer'));
+    const historyAccordion = await screen.findByText('History');
+    fireEvent.click(historyAccordion);
+
+    expect(await screen.findByText('Role A')).toBeInTheDocument();
+    expect(getVolunteerBookingHistory).toHaveBeenCalledWith(1);
   });
 });

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
@@ -6,16 +6,19 @@ import {
   getVolunteerById,
   createVolunteerShopperProfile,
   removeVolunteerShopperProfile,
+  getVolunteerBookingHistory,
   type VolunteerSearchResult,
 } from '../../../api/volunteers';
 import { getApiErrorMessage } from '../../../api/helpers';
-import type { VolunteerRoleWithShifts } from '../../../types';
+import type { VolunteerRoleWithShifts, VolunteerBooking } from '../../../types';
 import {
-  Box,
-  Button,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
   Card,
   CardContent,
-  CardHeader,
+  Box,
+  Button,
   Checkbox,
   Chip,
   Container,
@@ -36,9 +39,11 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import ExpandMore from '@mui/icons-material/ExpandMore';
 import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
 import slugify from '../../../utils/slugify';
 import type { SelectChangeEvent } from '@mui/material/Select';
+import BookingHistoryTable from '../../../components/BookingHistoryTable';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import ConfirmDialog from '../../../components/ConfirmDialog';
 import DialogCloseButton from '../../../components/DialogCloseButton';
@@ -58,6 +63,7 @@ export default function EditVolunteer() {
   const [shopperEmail, setShopperEmail] = useState('');
   const [shopperPhone, setShopperPhone] = useState('');
   const [removeShopperOpen, setRemoveShopperOpen] = useState(false);
+  const [history, setHistory] = useState<VolunteerBooking[]>([]);
 
   useEffect(() => {
     getVolunteerRoles()
@@ -106,6 +112,9 @@ export default function EditVolunteer() {
       .filter((n): n is string => !!n);
     setSelected(names);
     setInitialSelected(names);
+    getVolunteerBookingHistory(v.id)
+      .then(h => setHistory(Array.isArray(h) ? h : [h]))
+      .catch(() => setHistory([]));
   }
 
   function handleRoleChange(e: SelectChangeEvent<string[]>) {
@@ -243,10 +252,12 @@ export default function EditVolunteer() {
             </CardContent>
           </Card>
           {volunteer && (
-            <>
-              <Card>
-                <CardHeader title="Profile" />
-                <CardContent>
+            <Stack spacing={2}>
+              <Accordion defaultExpanded>
+                <AccordionSummary expandIcon={<ExpandMore />}>
+                  <Typography>Profile</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
                   <Stack spacing={2}>
                     <FormControl component="fieldset">
                       <FormControlLabel
@@ -265,11 +276,13 @@ export default function EditVolunteer() {
                       </FormHelperText>
                     </FormControl>
                   </Stack>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader title="Roles" />
-                <CardContent>
+                </AccordionDetails>
+              </Accordion>
+              <Accordion>
+                <AccordionSummary expandIcon={<ExpandMore />}>
+                  <Typography>Roles</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
                   <FormControl fullWidth>
                     <InputLabel id="role-select-label">Roles</InputLabel>
                     <Select
@@ -317,9 +330,21 @@ export default function EditVolunteer() {
                       </Grid>
                     ))}
                   </Grid>
-                </CardContent>
-              </Card>
-            </>
+                </AccordionDetails>
+              </Accordion>
+              <Accordion>
+                <AccordionSummary expandIcon={<ExpandMore />}>
+                  <Typography>History</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  {history.length ? (
+                    <BookingHistoryTable rows={history} showRole />
+                  ) : (
+                    <Typography>No bookings</Typography>
+                  )}
+                </AccordionDetails>
+              </Accordion>
+            </Stack>
           )}
         </Stack>
       </Container>


### PR DESCRIPTION
## Summary
- fetch volunteer booking history once a volunteer is selected
- replace profile/roles cards with accordion panels and add a History panel
- test that selecting a volunteer loads their booking history

## Testing
- `npm test` *(fails: VolunteerDashboard, VolunteerSchedule, RecurringBookings, VolunteerDashboard, ... multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f8f2ec14832d96d19761f6c6ea2b