### PR TITLE
Add staff volunteer ranking tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerManagement.test.tsx
@@ -15,5 +15,8 @@ describe('VolunteerManagement tabs', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /add/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /delete/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', { name: /ranking/i })
+    ).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerRanking.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerRanking.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VolunteerRankings from '../../volunteer-management/VolunteerRankings';
+import { getVolunteerRoles, getVolunteerRankings } from '../../../api/volunteers';
+
+jest.mock('../../../api/volunteers', () => ({
+  getVolunteerRoles: jest.fn(),
+  getVolunteerRankings: jest.fn(),
+}));
+
+describe('VolunteerRanking', () => {
+  beforeEach(() => {
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'Greeter', category_name: 'Front Desk', shifts: [] },
+      { id: 2, name: 'Sorter', category_name: 'Warehouse', shifts: [] },
+    ]);
+    (getVolunteerRankings as jest.Mock).mockResolvedValue({
+      all: [
+        { id: 1, name: 'Alice', total: 10 },
+        { id: 2, name: 'Bob', total: 8 },
+        { id: 3, name: 'Cara', total: 7 },
+        { id: 4, name: 'Dan', total: 6 },
+        { id: 5, name: 'Eve', total: 5 },
+        { id: 6, name: 'Frank', total: 4 },
+      ],
+      departments: {
+        'Front Desk': [
+          { id: 1, name: 'Alice', total: 10 },
+          { id: 2, name: 'Bob', total: 8 },
+        ],
+        Warehouse: [
+          { id: 3, name: 'Cara', total: 7 },
+          { id: 4, name: 'Dan', total: 6 },
+          { id: 5, name: 'Eve', total: 5 },
+          { id: 6, name: 'Frank', total: 4 },
+        ],
+      },
+    });
+  });
+
+  it('shows top-five volunteers and department accordions', async () => {
+    render(
+      <MemoryRouter>
+        <VolunteerRankings />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalled());
+    await waitFor(() => expect(getVolunteerRankings).toHaveBeenCalled());
+
+    // Top-five list should exclude lower-ranked volunteers
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Eve')).toBeInTheDocument();
+    expect(screen.queryByText('Frank')).not.toBeInTheDocument();
+
+    // Department accordions should reveal respective volunteers
+    fireEvent.click(screen.getByRole('button', { name: /warehouse/i }));
+    expect(await screen.findByText('Frank')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /front desk/i }));
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- check for new Ranking tab in staff volunteer management
- cover volunteer ranking page with mocked role and ranking data

## Testing
- `npm test` *(fails: VolunteerDashboard, VolunteerSchedule, PantryScheduleCapacity, DonorDonationLog, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f9603e9c832d91287e946bcb82c7