### PR TITLE
Avoid full reload when switching volunteer quick links

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerQuickLinks.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import * as Router from 'react-router-dom';
 import VolunteerQuickLinks from '../components/VolunteerQuickLinks';
 
 describe('VolunteerQuickLinks', () => {
   it('renders volunteer management links', () => {
     render(
-      <MemoryRouter>
+      <Router.MemoryRouter>
         <VolunteerQuickLinks />
-      </MemoryRouter>
+      </Router.MemoryRouter>
     );
     expect(screen.getByRole('link', { name: /Search Volunteer/i })).toHaveAttribute(
       'href',
@@ -29,12 +30,31 @@ describe('VolunteerQuickLinks', () => {
 
   it('keeps links enabled on the current page', () => {
     render(
-      <MemoryRouter initialEntries={['/volunteer-management/volunteers']}>
+      <Router.MemoryRouter initialEntries={['/volunteer-management/volunteers']}>
         <VolunteerQuickLinks />
-      </MemoryRouter>,
+      </Router.MemoryRouter>,
     );
     expect(
       screen.getByRole('link', { name: /Search Volunteer/i }),
     ).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('does not reload when switching tabs', async () => {
+    const user = userEvent.setup();
+    const navigate = jest.fn();
+    const spy = jest
+      .spyOn(Router, 'useNavigate')
+      .mockReturnValue(navigate);
+
+    render(
+      <Router.MemoryRouter initialEntries={['/volunteer-management/volunteers?tab=ranking']}>
+        <VolunteerQuickLinks />
+      </Router.MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('link', { name: /Search Volunteer/i }));
+    expect(navigate).not.toHaveBeenCalled();
+
+    spy.mockRestore();
   });
 });

--- a/MJ_FB_Frontend/src/components/VolunteerQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerQuickLinks.tsx
@@ -2,7 +2,7 @@ import { Stack, Button } from '@mui/material';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 
 export default function VolunteerQuickLinks() {
-  const { pathname } = useLocation();
+  const { pathname, search, hash } = useLocation();
   const navigate = useNavigate();
   const buttonSx = {
     textTransform: 'none',
@@ -32,7 +32,8 @@ export default function VolunteerQuickLinks() {
           component={RouterLink}
           to={link.to}
           onClick={() => {
-            if (pathname === link.to) navigate(0);
+            const current = `${pathname}${search}${hash}`;
+            if (current === link.to) navigate(0);
           }}
           fullWidth
         >


### PR DESCRIPTION
## Summary
- Stop Volunteer quick links from reloading the page when navigating between tabs
- Add regression test ensuring no reload when switching from Ranking to Search tab

## Testing
- `npm test` *(fails: A jest worker process was terminated by SIGTERM)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fd427a90832dbe93b84206e0c61c