### PR TITLE
feat: link privacy policy on login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@
 - The login page automatically prompts for passkeys via WebAuthn on supported devices.
 - Volunteers see an Install App button on their first visit to volunteer pages when the app isn't already installed. An onboarding modal explains offline use, and installations are tracked.
 - Client and volunteer dashboards show an onboarding modal with tips on first visit; a localStorage flag prevents repeat displays.
-- A privacy notice modal prompts for consent after login and stores acknowledgement in the `users` table and localStorage to avoid repeat prompts.
+ - A privacy notice modal prompts for consent after login and stores acknowledgement in the `users` table and localStorage to avoid repeat prompts.
+ - The privacy policy is publicly accessible without signing in, and the login page includes a link to it.
 - Update this `AGENTS.md` file and the repository `README.md` to reflect any new instructions or user-facing changes.
 - Pantry visits track daily sunshine bag weights and client counts via the `sunshine_bag_log` table. Sunshine bag recipients are recorded separately and excluded from total client counts.
 - Sunshine bag, surplus, pig pound, and outgoing donation logs roll up into monthly aggregates and raw log entries older than one year are purged every Jan 31.

--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -79,6 +79,20 @@ describe('App authentication persistence', () => {
     expect(await screen.findByText(/login/i)).toBeInTheDocument();
   });
 
+  it('allows access to privacy policy without login', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+    window.history.pushState({}, '', '/privacy');
+    renderWithProviders(<App />);
+    expect(
+      await screen.findByRole('heading', { name: /privacy policy/i })
+    ).toBeInTheDocument();
+  });
+
   it('keeps user logged in when role exists', () => {
     localStorage.setItem('role', 'shopper');
     localStorage.setItem('name', 'Test User');

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -108,4 +108,15 @@ describe('Login component', () => {
     (mui.useMediaQuery as jest.Mock).mockReturnValue(false);
   });
 
+  it('links to the privacy policy', () => {
+    const onLogin = jest.fn().mockResolvedValue('/');
+    render(
+      <MemoryRouter>
+        <Login onLogin={onLogin} />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole('link', { name: /privacy policy/i });
+    expect(link).toHaveAttribute('href', '/privacy');
+  });
+
 });

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -117,6 +117,9 @@ export default function Login({
               >
                 Login
               </LoadingButton>
+              <Link href="/privacy" underline="hover" textAlign="center">
+                Privacy Policy
+              </Link>
             </Stack>
           }
           centered={false}

--- a/MJ_FB_Frontend/src/pages/privacy/PrivacyPolicy.tsx
+++ b/MJ_FB_Frontend/src/pages/privacy/PrivacyPolicy.tsx
@@ -5,7 +5,7 @@ import VolunteerBottomNav from '../../components/VolunteerBottomNav';
 import { useAuth } from '../../hooks/useAuth';
 
 export default function PrivacyPolicy() {
-  const { role } = useAuth();
+  const { role, isAuthenticated } = useAuth();
   return (
     <Page title="Privacy Policy">
       <Stack spacing={2}>
@@ -46,7 +46,8 @@ export default function PrivacyPolicy() {
           </Link>
         </Typography>
       </Stack>
-      {role === 'volunteer' ? <VolunteerBottomNav /> : <ClientBottomNav />}
+      {isAuthenticated &&
+        (role === 'volunteer' ? <VolunteerBottomNav /> : <ClientBottomNav />)}
     </Page>
   );
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - All users sign in at a consolidated `/login` page using their client ID or email and password. The page offers contact and password reset guidance and notes that staff, volunteers, and agencies also sign in here.
 - The login page automatically surfaces passkey prompts via WebAuthn on supported devices.
 - A privacy notice prompts for consent after login; once agreed, it isn't shown again.
-- The profile menu links to a privacy policy page with contact information for account deletion requests.
+- The privacy policy page includes contact information for account deletion requests and is accessible without logging in; a link is available on the login screen and in the profile menu.
 - Password reset dialog prompts clients to enter their client ID and explains that a reset link will be emailed.
 - Input fields feature larger touch targets on mobile devices for easier tapping.
 - Staff dashboards include a Volunteer Coverage card; click a role to see which volunteers are on duty.


### PR DESCRIPTION
## Summary
- link to privacy policy from the login form
- hide bottom navigation on privacy page until users sign in
- document public privacy policy link

## Testing
- `npm test` *(fails: Unable to find an element with the text...)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c644ec5c832dace144ffa8d96985