### PR TITLE
Fix BookingUI test failure and key warning

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -463,6 +463,7 @@ export default function BookingUI<T = Slot>({
     const selected = selectedSlotId === slot.id;
     return (
       <SlotRow
+        key={slot.id}
         slot={slot}
         selected={selected}
         onSelect={() => setSelectedSlotId(slot.id)}
@@ -604,7 +605,7 @@ export default function BookingUI<T = Slot>({
           {showUsageNotes && (
             <>
               <Typography>
-                {`Visits this month ${usage ?? 0}`}
+                {`Visits this month: ${usage ?? 0}`}
               </Typography>
               <TextField
                 fullWidth


### PR DESCRIPTION
## Summary
- add missing key to SlotRow list items
- show colon in BookingUI's usage note

## Testing
- `npm test src/__tests__/BookingUI.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5c73e85f4832dbbc845fa8daf3330