### PR TITLE
Fix failing pantry rollup and booking status tests

### DIFF
--- a/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitBookingStatus.test.ts
@@ -191,6 +191,7 @@ describe('client visit booking integration', () => {
     const queryMock = jest
       .fn()
       .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // duplicate check
       .mockResolvedValueOnce({
         rows: [
           {


### PR DESCRIPTION
## Summary
- ensure pantry aggregation rollup tests use real controller and properly ordered query mocks
- add missing duplicate check result in client visit booking status test

## Testing
- `npm test tests/pantryAggregationRollup.test.ts tests/clientVisitBookingStatus.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5c8125948832d8c0b9eed6d5a8b50