### PR TITLE
feat: skip dotenv config during tests

### DIFF
--- a/MJ_FB_Backend/src/config.ts
+++ b/MJ_FB_Backend/src/config.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 import { z } from 'zod';
 import logger from './utils/logger';
 
-dotenv.config();
+if (process.env.NODE_ENV !== 'test') dotenv.config();
 
 const envSchema = z.object({
   PG_USER: z.string(),


### PR DESCRIPTION
## Summary
- only call dotenv.config when NODE_ENV is not `test`

## Testing
- `npm run build`
- `npm test tests/config.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5ca886da8832db9fede1e0233e0b0