### PR TITLE
test: reset auth limiter for password reset flow

### DIFF
--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import express from 'express';
-import authRouter from '../src/routes/auth';
+import authRouter, { authLimiter } from '../src/routes/auth';
 import usersRouter from '../src/routes/users';
 import pool from '../src/db';
 import bcrypt from 'bcrypt';
@@ -158,6 +158,10 @@ describe('resendPasswordSetup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resendLimit.clear();
+    authLimiter.resetKey('::ffff:127.0.0.1');
+    authLimiter.resetKey('127.0.0.1');
+    authLimiter.resetKey('::1');
+    authLimiter.resetKey('::/56');
     jest.useFakeTimers();
   });
 


### PR DESCRIPTION
## Summary
- reset auth rate limiter between resend password setup tests
- import authLimiter for cleaner test setup

## Testing
- `cd MJ_FB_Backend && npm test tests/passwordResetFlow.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c5ca86ad98832db6abe883cfe628f5