### PR TITLE
Handle missing rows in hasTable and update volunteer role tests

### DIFF
--- a/MJ_FB_Backend/src/utils/dbUtils.ts
+++ b/MJ_FB_Backend/src/utils/dbUtils.ts
@@ -6,5 +6,5 @@ export async function hasTable(table: string, client: Queryable = pool): Promise
     "SELECT to_regclass($1) IS NOT NULL AS exists",
     [`public.${table}`],
   );
-  return res.rows[0]?.exists ?? false;
+  return res?.rows?.[0]?.exists ?? false;
 }

--- a/MJ_FB_Backend/tests/volunteerRolesMine.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesMine.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import express from 'express';
 import volunteerRolesRouter from '../src/routes/volunteer/volunteerRoles';
 import pool from '../src/db';
+import { setHolidays } from '../src/utils/holidayCache';
 
 jest.mock('../src/middleware/authMiddleware', () => ({
   authMiddleware: (req: any, _res: express.Response, next: express.NextFunction) => {
@@ -16,10 +17,12 @@ app.use(express.json());
 app.use('/volunteer-roles', volunteerRolesRouter);
 
 describe('GET /volunteer-roles/mine', () => {
+  beforeEach(() => setHolidays(null));
+
   it('excludes restricted categories on weekends', async () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rows: [{ role_id: 1 }], rowCount: 1 })
-      .mockResolvedValueOnce({ rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [{ exists: false }], rowCount: 1 })
       .mockResolvedValueOnce({
         rows: [
           {
@@ -49,7 +52,7 @@ describe('GET /volunteer-roles/mine', () => {
   it('allows gardening roles on weekends', async () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rows: [{ role_id: 1 }], rowCount: 1 })
-      .mockResolvedValueOnce({ rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [{ exists: false }], rowCount: 1 })
       .mockResolvedValueOnce({
         rows: [
           {
@@ -97,7 +100,10 @@ describe('GET /volunteer-roles/mine', () => {
   it('excludes restricted categories on holidays', async () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rows: [{ role_id: 1 }], rowCount: 1 })
-      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 })
+      .mockResolvedValueOnce({
+        rows: [{ date: '2025-01-01', reason: 'Holiday' }],
+      })
       .mockResolvedValueOnce({
         rows: [
           {


### PR DESCRIPTION
## Summary
- Safeguard `hasTable` against missing query rows
- Reset holiday cache and expand mocks in volunteer role tests

## Testing
- `npm test tests/volunteerRolesMine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5ca89d1b8832daa4844e14645b6ee