### PR TITLE
Handle missing volunteer slot query rows

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -352,14 +352,16 @@ export async function listVolunteerRolesForVolunteer(
          WHERE status='approved' AND date = $1
          GROUP BY slot_id
        ) b ON vs.slot_id = b.slot_id
-       WHERE vs.role_id = ANY($2::int[])
-        AND vs.is_active
-        AND (vs.is_wednesday_slot = false OR EXTRACT(DOW FROM $1::date) = 3)
-       ORDER BY vs.start_time`,
+      WHERE vs.role_id = ANY($2::int[])
+       AND vs.is_active
+       AND (vs.is_wednesday_slot = false OR EXTRACT(DOW FROM $1::date) = 3)
+      ORDER BY vs.start_time`,
       [reginaDate, roleIds]
     );
 
-    const roles = result.rows
+    const rows = result?.rows ?? [];
+
+    const roles = rows
       .filter(
         (row: any) =>
           !(isWeekend || isHolidayDate) ||


### PR DESCRIPTION
## Summary
- avoid TypeError when volunteer slot query returns undefined rows
- reset holiday cache between volunteer role tests and stub DB accordingly

## Testing
- `npm test tests/volunteerRolesMine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5ca8b22b0832d94c2dfece1e11d33