### PR TITLE
Log 4xx errors with warnings

### DIFF
--- a/MJ_FB_Backend/src/utils/errorResponse.ts
+++ b/MJ_FB_Backend/src/utils/errorResponse.ts
@@ -39,7 +39,11 @@ export function buildErrorResponse(err: unknown): ErrorResponse {
       ? (err as any).code
       : 'UNKNOWN';
 
-  logger.error('Unhandled error:', originalMessage, err);
+  if (status >= 500) {
+    logger.error('Unhandled error:', originalMessage, err);
+  } else if (status >= 400) {
+    logger.warn(originalMessage, err);
+  }
 
   const safeMessage = status === 500 ? 'Internal Server Error' : originalMessage;
 

--- a/MJ_FB_Backend/tests/errorResponse.test.ts
+++ b/MJ_FB_Backend/tests/errorResponse.test.ts
@@ -8,15 +8,50 @@ describe('buildErrorResponse', () => {
       code: 'E_TEST',
     });
 
-    const spy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+    const errorSpy = jest
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined);
+    const warnSpy = jest
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
 
     const { status, body } = buildErrorResponse(err);
 
     expect(status).toBe(500);
     expect(body.message).toBe('Internal Server Error');
     expect(body.message).not.toContain('Sensitive internal details');
-    expect(spy).toHaveBeenCalledWith('Unhandled error:', 'Sensitive internal details', err);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unhandled error:',
+      'Sensitive internal details',
+      err,
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
 
-    spy.mockRestore();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('logs 4xx errors with warn instead of error', () => {
+    const err = Object.assign(new Error('Bad request'), {
+      status: 400,
+      code: 'E_TEST',
+    });
+
+    const errorSpy = jest
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined);
+    const warnSpy = jest
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
+
+    const { status, body } = buildErrorResponse(err);
+
+    expect(status).toBe(400);
+    expect(body.message).toBe('Bad request');
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith('Bad request', err);
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- log 4xx errors with `logger.warn` and reserve `logger.error` for 5xx issues
- test error response logging for both 4xx and 5xx cases

## Testing
- `npm test` *(fails: Test Suites: 24 failed, 134 passed, 158 of 159 total)*
- `npm test tests/errorResponse.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5d4b0a42c832dadb1b829e173e830