### PR TITLE
Mock logger in backend tests

### DIFF
--- a/MJ_FB_Backend/tests/errorResponse.test.ts
+++ b/MJ_FB_Backend/tests/errorResponse.test.ts
@@ -7,16 +7,15 @@ describe('buildErrorResponse', () => {
       status: 500,
       code: 'E_TEST',
     });
-
-    const spy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
-
     const { status, body } = buildErrorResponse(err);
 
     expect(status).toBe(500);
     expect(body.message).toBe('Internal Server Error');
     expect(body.message).not.toContain('Sensitive internal details');
-    expect(spy).toHaveBeenCalledWith('Unhandled error:', 'Sensitive internal details', err);
-
-    spy.mockRestore();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Unhandled error:',
+      'Sensitive internal details',
+      err,
+    );
   });
 });

--- a/MJ_FB_Backend/tests/setupTests.ts
+++ b/MJ_FB_Backend/tests/setupTests.ts
@@ -21,12 +21,26 @@ jest.mock('../src/controllers/pantry/pantryAggregationController', () => ({
   manualPantryAggregate: jest.fn(),
   firstMondayOfMonth: jest.fn(),
 }));
+jest.mock('../src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
 import { notifyOps } from '../src/utils/opsAlert';
+import logger from '../src/utils/logger';
 
 beforeEach(() => {
   (mockPool.query as jest.Mock).mockReset();
   setQueryResults({ rows: [], rowCount: 0 });
   (notifyOps as jest.Mock).mockReset();
+  (logger.info as jest.Mock).mockReset();
+  (logger.warn as jest.Mock).mockReset();
+  (logger.error as jest.Mock).mockReset();
+  (logger.debug as jest.Mock).mockReset();
 });
 
 export {};


### PR DESCRIPTION
## Summary
- mock backend logger in tests and reset spies each run
- assert error logging in errorResponse test

## Testing
- `npm test` (fails: volunteerBookingConflict, volunteerBookingConcurrency, volunteerRolesMine, slots, volunteerShiftReminderJob, bookingTelegramAlerts, volunteerNoShowCleanupJob, bookingNewClient, volunteerRolesMine etc.)

------
https://chatgpt.com/codex/tasks/task_e_68c5d4b19970832db236e41059da14c1