### PR TITLE
Streamline booking reminder email failure handling

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -54,7 +54,6 @@ export async function sendNextDayBookingReminders(
           });
         } catch (err) {
           logger.error('Failed to enqueue booking reminder email', err);
-          await alertOps('sendNextDayBookingReminders', err);
           errors.push(err);
         }
       });


### PR DESCRIPTION
## Summary
- Log individual booking reminder email enqueue failures without spamming ops alerts
- Alert ops once when aggregate booking reminder enqueue errors occur and add tests for new behavior

## Testing
- `npm test tests/bookingReminderJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5d4b36be0832d9c6a86fbc90f23b5