### PR TITLE
test: handle no bookings punctuation

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -120,7 +120,7 @@ describe("VolunteerSchedule", () => {
     });
     expect(prev).toBeDisabled();
 
-    expect(await screen.findByText("No bookings")).toBeInTheDocument();
+    expect(await screen.findByText(/No bookings\.?/)).toBeInTheDocument();
   });
 
   it("shows only available slots in reschedule dialog", async () => {
@@ -240,7 +240,7 @@ describe("VolunteerSchedule", () => {
     fireEvent.mouseDown(screen.getByLabelText('Department'));
     fireEvent.click(await screen.findByText('Front'));
 
-    expect(await screen.findByText("No bookings")).toBeInTheDocument();
+    expect(await screen.findByText(/No bookings\.?/)).toBeInTheDocument();
     expect(screen.queryByRole("table")).toBeNull();
     mq.mockRestore();
   });


### PR DESCRIPTION
## Summary
- accept optional period in VolunteerSchedule's no bookings messages

## Testing
- `npm test -- VolunteerSchedule.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5ea184694832d83858a2927e4b26d