### PR TITLE
test: await role before opening My Booking

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -192,7 +192,8 @@ describe("VolunteerSchedule", () => {
     fireEvent.mouseDown(screen.getByLabelText('Department'));
     fireEvent.click(await screen.findByText('Front'));
 
-    fireEvent.click(await screen.findByText("My Booking"));
+    await screen.findByText("Greeter");
+    fireEvent.click(await screen.findByText(/My Booking/i));
     fireEvent.click(await screen.findByRole("button", { name: /reschedule/i }));
 
     fireEvent.change(screen.getByLabelText(/date/i), {


### PR DESCRIPTION
## Summary
- wait for role label before triggering My Booking in VolunteerSchedule test

## Testing
- `npm test -- src/__tests__/VolunteerSchedule.test.tsx -t "shows only available slots in reschedule dialog"` *(fails: Unable to find an element with the text: /My Booking/i)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ea18c83c832db2f20ee63ce65272