### PR TITLE
test: mock logger in setup and verify db pool error handling

### DIFF
--- a/MJ_FB_Backend/tests/dbPoolErrorHandler.test.ts
+++ b/MJ_FB_Backend/tests/dbPoolErrorHandler.test.ts
@@ -2,16 +2,18 @@ import { EventEmitter } from 'events';
 import logger from '../src/utils/logger';
 
 describe('PG pool error handler', () => {
+  beforeEach(() => {
+    (logger.error as jest.Mock).mockReset();
+  });
+
   it('logs idle client errors', () => {
     const err = new Error('idle client error');
-    const spy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
 
     // Simulate an idle client error using a mock EventEmitter-based pool
     const emitter = new EventEmitter();
     emitter.on('error', (e) => logger.error('Unexpected PG pool error', e));
     emitter.emit('error', err);
 
-    expect(spy).toHaveBeenCalledWith('Unexpected PG pool error', err);
-    spy.mockRestore();
+    expect(logger.error).toHaveBeenCalledWith('Unexpected PG pool error', err);
   });
 });

--- a/MJ_FB_Backend/tests/setupTests.ts
+++ b/MJ_FB_Backend/tests/setupTests.ts
@@ -6,6 +6,15 @@ jest.mock('../src/utils/opsAlert', () => ({
   alertOps: jest.fn(),
   notifyOps: jest.fn(),
 }));
+jest.mock('../src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
 jest.mock('../src/utils/configCache', () => ({
   getCartTare: jest.fn().mockResolvedValue(0),
   refreshCartTare: jest.fn(),


### PR DESCRIPTION
## Summary
- globally mock `src/utils/logger` in backend test setup
- assert error logging in `dbPoolErrorHandler` test using shared mock

## Testing
- `npm test -- tests/dbPoolErrorHandler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5ea8c0260832da8bec6805097bc5b