### PR TITLE
Fix donor mail list month name timezone

### DIFF
--- a/MJ_FB_Backend/src/controllers/monetaryDonorController.ts
+++ b/MJ_FB_Backend/src/controllers/monetaryDonorController.ts
@@ -258,8 +258,9 @@ export async function sendMailLists(req: Request, res: Response, next: NextFunct
       '1001-10000': config.donorTemplateId1001To10000,
       '10001-30000': config.donorTemplateId10001To30000,
     };
-    const monthName = new Date(Date.UTC(year, month - 1)).toLocaleString('en-CA', {
+    const monthName = new Date(Date.UTC(year, month - 1, 1)).toLocaleString('en-CA', {
       month: 'long',
+      timeZone: 'UTC',
     });
     let sent = 0;
     for (const [range, donors] of Object.entries(groups)) {
@@ -394,8 +395,9 @@ export async function sendTestMailLists(req: Request, res: Response, next: NextF
       '10001-30000': { min: 10001, max: 30000, templateId: config.donorTemplateId10001To30000 },
     };
 
-    const monthName = new Date(Date.UTC(year, month - 1)).toLocaleString('en-CA', {
+    const monthName = new Date(Date.UTC(year, month - 1, 1)).toLocaleString('en-CA', {
       month: 'long',
+      timeZone: 'UTC',
     });
     let sent = 0;
     for (const [range, info] of Object.entries(ranges)) {


### PR DESCRIPTION
## Summary
- ensure donor email month names use Date.UTC with UTC locale formatting

## Testing
- `npm test tests/monetaryDonors.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5ef827eb4832d92a9d9937218327f