### PR TITLE
fix: replace to_regclass lookup

### DIFF
--- a/MJ_FB_Backend/src/utils/dbUtils.ts
+++ b/MJ_FB_Backend/src/utils/dbUtils.ts
@@ -3,8 +3,11 @@ import { Queryable } from '../models/bookingRepository';
 
 export async function hasTable(table: string, client: Queryable = pool): Promise<boolean> {
   const res = await client.query(
-    "SELECT to_regclass($1) IS NOT NULL AS exists",
-    [`public.${table}`],
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = $1
+     ) AS exists`,
+    [table],
   );
   return res?.rows?.[0]?.exists ?? false;
 }


### PR DESCRIPTION
## Summary
- avoid unsupported `to_regclass` in pg-mem tests by checking `information_schema.tables`

## Testing
- `npm test tests/holidayCache.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5ef838d34832dbf275dd464d41034