### PR TITLE
Clarify login error messages

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -35,7 +35,7 @@ describe('Login component', () => {
     await waitFor(() => expect(onLogin).toHaveBeenCalled());
   });
 
-  it('shows friendly message on unauthorized error', async () => {
+  it('shows message on incorrect credentials', async () => {
     const apiErr = Object.assign(new Error('backend'), { status: 401 });
     (login as jest.Mock).mockRejectedValue(apiErr);
     const onLogin = jest.fn().mockResolvedValue('/');
@@ -57,7 +57,7 @@ describe('Login component', () => {
     expect(onLogin).not.toHaveBeenCalled();
   });
 
-  it('opens resend dialog on expired token error', async () => {
+  it('opens resend dialog when password setup link expired', async () => {
     const apiErr = Object.assign(new Error('expired'), { status: 410 });
     (login as jest.Mock).mockRejectedValue(apiErr);
     (resendPasswordSetup as jest.Mock).mockResolvedValue(undefined);

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -46,9 +46,9 @@ export default function Login({
     } catch (err: unknown) {
       const apiErr = err as ApiError;
       if (apiErr?.status === 401) {
-        setError('Incorrect ID or password');
+        setError('Incorrect ID or email or password');
       } else if (apiErr?.status === 410) {
-        setError('Your password setup link has expired.');
+        setError('Password setup link expired');
         setResendOpen(true);
       } else if (apiErr?.status === 404) {
         setError('Don’t have an account? Ask staff for help.');


### PR DESCRIPTION
## Summary
- show "Incorrect ID or email or password" when credentials are invalid
- show "Password setup link expired" and open resend dialog for expired setup links
- update login tests for new error phrasing

## Testing
- `CI=true npm test src/__tests__/Login.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5f5de06d8832db8e1aadf21d78194