### PR TITLE
fix: add accessible cancel button for volunteer recurring bookings

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffRecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffRecurringBookings.test.tsx
@@ -103,7 +103,8 @@ describe('StaffRecurringBookings', () => {
     ]);
     render(<StaffRecurringBookings />);
     fireEvent.click(screen.getByText('Select Volunteer'));
-    const cancelOccur = await screen.findByRole('button', { name: 'Cancel' });
+    fireEvent.click(screen.getByRole('tab', { name: /manage recurring shifts/i }));
+    const cancelOccur = await screen.findByRole('button', { name: /cancel occurrence/i });
     fireEvent.click(cancelOccur);
     await waitFor(() => expect(cancelVolunteerBooking).toHaveBeenCalledWith(1));
     fireEvent.click(screen.getByRole('button', { name: /cancel series/i }));

--- a/MJ_FB_Frontend/src/pages/volunteer-management/StaffRecurringBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/StaffRecurringBookings.tsx
@@ -294,7 +294,7 @@ export default function StaffRecurringBookings() {
                             onClick={() => cancelOccurrence(o.id)}
                             variant="outlined"
                             color="primary"
-                            
+                            aria-label="Cancel occurrence"
                           >
                             Cancel
                           </Button>


### PR DESCRIPTION
## Summary
- improve accessibility of occurrence cancellation button for staff recurring shifts
- update tests to switch to manage tab and match new aria-label

## Testing
- `CI=true npm test src/__tests__/StaffRecurringBookings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5f5dfb0f0832da72804da58b7480c