### PR TITLE
feat: show sunshine bag question and formatted summary heading

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -37,15 +37,12 @@ import { getSunshineBag, saveSunshineBag } from '../../api/sunshineBags';
 import { addUser, getUserByClientId } from '../../api/users';
 import useAppConfig from '../../hooks/useAppConfig';
 import type { AlertColor } from '@mui/material';
-import { toDate, formatDate, formatLocaleDate, addDays } from '../../utils/date';
+import { toDate, formatDate, formatLocaleDate, addDays, toDayjs } from '../../utils/date';
 
 function startOfWeek(date: Date) {
-  const d = toDate(date);
-  const day = d.getDay();
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1); // Monday as first day
-  d.setDate(diff);
-  d.setHours(0, 0, 0, 0);
-  return d;
+  const d = toDayjs(date);
+  const day = d.day();
+  return d.subtract(day === 0 ? 6 : day - 1, 'day').startOf('day').toDate();
 }
 
 function format(date: Date) {
@@ -457,7 +454,7 @@ export default function PantryVisits() {
             month: 'short',
             day: 'numeric',
             year: 'numeric',
-          })}`}
+          })},`}
         </Typography>
         <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
           <Typography variant="body2">
@@ -574,7 +571,7 @@ export default function PantryVisits() {
             >
               <FormControlLabel value="regular" control={<Radio />} label="Regular visit" />
               <FormControlLabel value="anonymous" control={<Radio />} label="Anonymous visit" />
-              <FormControlLabel value="sunshine" control={<Radio />} label="Sunshine Bag" />
+              <FormControlLabel value="sunshine" control={<Radio />} label="Sunshine bag?" />
             </RadioGroup>
             {form.sunshineBag ? (
               <>

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -8,6 +8,7 @@ import {
 import '@testing-library/jest-dom';
 import PantryVisits from '../PantryVisits';
 import { MemoryRouter } from 'react-router-dom';
+import { formatLocaleDate } from '../../../utils/date';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -76,7 +77,7 @@ describe('PantryVisits', () => {
   });
 
   it('shows date in weekday tabs', async () => {
-    jest.useFakeTimers().setSystemTime(new Date('2024-05-13'));
+    jest.useFakeTimers().setSystemTime(new Date('2024-05-13T12:00:00Z'));
     (getClientVisits as jest.Mock).mockResolvedValue([]);
     (getAppConfig as jest.Mock).mockResolvedValue({ cartTare: 0 });
     (getSunshineBag as jest.Mock).mockResolvedValue(null);
@@ -84,7 +85,11 @@ describe('PantryVisits', () => {
     renderVisits();
 
     await screen.findByText('Record Visit');
-    expect(screen.getByText('May 13')).toBeInTheDocument();
+    const expectedTab = formatLocaleDate(new Date('2024-05-13T12:00:00Z'), {
+      month: 'short',
+      day: 'numeric',
+    });
+    expect(screen.getByText(expectedTab)).toBeInTheDocument();
 
     jest.useRealTimers();
   });
@@ -370,8 +375,14 @@ describe('PantryVisits', () => {
 
     await screen.findByText('Alice');
 
+    const expectedDate = formatLocaleDate('2024-05-13', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
     expect(
-      screen.getByRole('heading', { name: 'Summary of Mon, May 13, 2024' }),
+      screen.getByRole('heading', { name: `Summary of ${expectedDate},` }),
     ).toBeInTheDocument();
 
     jest.useRealTimers();


### PR DESCRIPTION
## Summary
- ask "Sunshine bag?" when recording visit type
- display summary heading with trailing comma and stable week start
- sync PantryVisits tests with localized date formatting

## Testing
- `CI=true npm test src/pages/staff/__tests__/PantryVisits.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5f5ddfa84832d8127dc87e6c8a275