### PR TITLE
Show Sign Up label for available volunteer slots

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -391,7 +391,7 @@ export default function VolunteerSchedule() {
               });
             } else {
               cells.push({
-                content: "",
+                content: null,
                 onClick: () => {
                   if (!isClosed) {
                     quickBook(slot);


### PR DESCRIPTION
## Summary
- Ensure available volunteer schedule cells display "Sign up"
- Adjust volunteer schedule test to account for Sign Up label and verify reschedule options fetch

## Testing
- `CI=true npm test src/__tests__/VolunteerSchedule.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5f5df012c832d84e5a8524443dc2a