### PR TITLE
feat: add accessible recurring booking selector

### DIFF
--- a/MJ_FB_Frontend/src/components/RecurringBookingsDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RecurringBookingsDialog.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from '@mui/material';
+import type { VolunteerRole } from '../types';
+
+interface Props {
+  open: boolean;
+  roles: VolunteerRole[];
+  onClose: () => void;
+  onSubmit: (roleId: number) => void;
+}
+
+export default function RecurringBookingsDialog({ open, roles, onClose, onSubmit }: Props) {
+  const [role, setRole] = useState('');
+
+  function handleSubmit() {
+    const id = Number(role);
+    if (!Number.isNaN(id)) {
+      onSubmit(id);
+    }
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} data-testid="recurring-bookings-dialog">
+      <DialogTitle>Recurring Booking</DialogTitle>
+      <DialogContent>
+        <FormControl fullWidth>
+          <InputLabel id="recurring-role-label">Role</InputLabel>
+          <Select
+            labelId="recurring-role-label"
+            id="recurring-role-select"
+            value={role}
+            label="Role"
+            onChange={e => setRole(e.target.value)}
+          >
+            <MenuItem value="">
+              <em>Select role</em>
+            </MenuItem>
+            {roles.map(r => (
+              <MenuItem key={r.id} value={r.id}>
+                {r.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleSubmit} variant="outlined" color="primary">
+          Submit
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add RecurringBookingsDialog with accessible role label and select
- update recurring booking tests for new role and department selectors

## Testing
- `CI=true npm test src/__tests__/RecurringBookings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5f5e103d4832daa69ebc7b77fa75d