### PR TITLE
chore: disambiguate donations text fields

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
@@ -73,7 +73,7 @@ describe('Aggregations page', () => {
     fireEvent.click(await screen.findByRole('button', { name: /insert aggregate/i }));
 
     fireEvent.change(screen.getByLabelText(/month/i), { target: { value: '5' } });
-    fireEvent.change(screen.getByLabelText(/donations/i), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText(/total donations/i), { target: { value: '1' } });
     fireEvent.change(screen.getByLabelText(/surplus/i), { target: { value: '2' } });
     fireEvent.change(screen.getByLabelText(/pig pound/i), { target: { value: '3' } });
     fireEvent.change(screen.getByLabelText(/outgoing donations/i), {

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -450,7 +450,7 @@ export default function Aggregations() {
                 size="medium"
               />
               <TextField
-                label="Donations"
+                label="Total Donations"
                 type="number"
                 value={insertDonations}
                 onChange={e => setInsertDonations(e.target.value)}


### PR DESCRIPTION
## Summary
- Give donations text field a unique label so tests can target it directly
- Update Aggregations tests to search for the new label

## Testing
- `CI=true npm test src/__tests__/Aggregations.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5f8e69fb8832db689859b2a21a68b