### PR TITLE
feat: add aria-label for password toggle

### DIFF
--- a/MJ_FB_Frontend/src/components/PasswordField.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordField.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
 import TextField, { type TextFieldProps } from '@mui/material/TextField';
-import { IconButton, InputAdornment } from '@mui/material';
+import { IconButton, type IconButtonProps, InputAdornment } from '@mui/material';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 
-export default function PasswordField({ InputProps, ...props }: TextFieldProps) {
+export default function PasswordField({
+  InputProps,
+  visibilityIconButtonProps,
+  ...props
+}: TextFieldProps & { visibilityIconButtonProps?: IconButtonProps }) {
   const [show, setShow] = useState(false);
 
   return (
@@ -19,6 +23,7 @@ export default function PasswordField({ InputProps, ...props }: TextFieldProps) 
               edge="end"
               onClick={() => setShow(!show)}
               aria-label={show ? 'Hide password' : 'Show password'}
+              {...visibilityIconButtonProps}
             >
               {show ? <VisibilityOff /> : <Visibility />}
             </IconButton>

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/AddClient.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/AddClient.test.tsx
@@ -101,7 +101,7 @@ test('includes password and omits sendPasswordLink when setting password', async
   fireEvent.change(screen.getByLabelText(/email/i), {
     target: { value: 'jane@example.com' },
   });
-  fireEvent.change(screen.getByLabelText(/password/i), {
+  fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
     target: { value: 'P@ssword1' },
   });
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -116,11 +116,12 @@ export default function AddClient() {
                 <Typography variant="body2" color="text.secondary">
                   An email invitation will be sent.
                 </Typography>
-              ) : (
+                ) : (
                 <PasswordField
                   label="Password"
                   value={password}
                   onChange={e => setPassword(e.target.value)}
+                  visibilityIconButtonProps={{ 'aria-label': 'Toggle password visibility' }}
                 />
               )}
             </>


### PR DESCRIPTION
## Summary
- add aria-label for password visibility toggle on AddClient password field
- allow PasswordField to accept IconButton props
- update AddClient tests to target password input specifically

## Testing
- `CI=true npm test src/pages/staff/__tests__/AddClient.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5f8e735d4832d9c070393d5250aa5