### PR TITLE
feat: add new clients migration

### DIFF
--- a/MJ_FB_Backend/src/migrations/1699999999998_create_new_clients.ts
+++ b/MJ_FB_Backend/src/migrations/1699999999998_create_new_clients.ts
@@ -1,0 +1,24 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('new_clients', {
+    id: 'id',
+    name: { type: 'text', notNull: true },
+    email: { type: 'text' },
+    phone: { type: 'text' },
+    created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
+  });
+
+  pgm.addColumn('bookings', {
+    new_client_id: {
+      type: 'integer',
+      references: 'new_clients',
+      onDelete: 'set null',
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('bookings', 'new_client_id');
+  pgm.dropTable('new_clients');
+}

--- a/MJ_FB_Backend/tests/newClientsMigration.test.ts
+++ b/MJ_FB_Backend/tests/newClientsMigration.test.ts
@@ -4,7 +4,9 @@ import path from 'path';
 describe('new_clients migration', () => {
   it('creates table and booking column', () => {
     const dir = path.join(__dirname, '../src/migrations');
-    const file = fs.readdirSync(dir).find(f => f.includes('new_clients'));
+    const file = fs
+      .readdirSync(dir)
+      .find(f => f.includes('create_new_clients'));
     expect(file).toBeDefined();
     const content = fs.readFileSync(path.join(dir, file as string), 'utf8');
     expect(content).toMatch(/createTable\(['"]new_clients['"]/);


### PR DESCRIPTION
## Summary
- create `new_clients` table and add `new_client_id` to bookings
- update migration test to look for `create_new_clients` file

## Testing
- `npm test tests/newClientsMigration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5f9df682c832d89e800a357e0f691