### PR TITLE
cache holidays for unauthenticated access

### DIFF
--- a/MJ_FB_Backend/src/utils/holidayCache.ts
+++ b/MJ_FB_Backend/src/utils/holidayCache.ts
@@ -4,6 +4,11 @@ import { formatReginaDate } from './dateUtils';
 import { hasTable } from './dbUtils';
 import logger from './logger';
 
+interface Holiday {
+  date: string;
+  reason: string;
+}
+
 let holidays: Map<string, string> | null = null;
 
 async function loadHolidays(client: Queryable = pool) {
@@ -32,6 +37,12 @@ async function loadHolidays(client: Queryable = pool) {
 }
 
 export async function getHolidays(client: Queryable = pool) {
+  if (holidays !== null) {
+    return Array.from(holidays.entries()).map(([date, reason]) => ({
+      date,
+      reason,
+    }));
+  }
   const map = await loadHolidays(client);
   return Array.from(map.entries()).map(([date, reason]) => ({ date, reason }));
 }
@@ -47,6 +58,12 @@ export async function isHoliday(date: string | Date, client?: Queryable) {
   return map.has(key);
 }
 
-export function setHolidays(value: Map<string, string> | null) {
-  holidays = value;
+export function setHolidays(value: Map<string, string> | Holiday[] | null) {
+  if (value === null) {
+    holidays = null;
+  } else if (Array.isArray(value)) {
+    holidays = new Map(value.map(h => [h.date, h.reason]));
+  } else {
+    holidays = value;
+  }
 }

--- a/MJ_FB_Backend/tests/holidaysAccess.test.ts
+++ b/MJ_FB_Backend/tests/holidaysAccess.test.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import holidaysRouter from '../src/routes/holidays';
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
+import { setHolidays } from '../src/utils/holidayCache';
 
 jest.mock('jsonwebtoken');
 
@@ -17,84 +18,25 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  setHolidays([{ date: '2024-12-24', reason: 'Christmas' }]);
 });
 
 describe('GET /holidays', () => {
   it('allows users to fetch holidays', async () => {
     (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'shopper', type: 'user' });
-    (pool.query as jest.Mock)
-      .mockResolvedValueOnce({
-        rowCount: 1,
-        rows: [
-          {
-            client_id: 1,
-            first_name: 'Test',
-            last_name: 'User',
-            email: 'test@example.com',
-            role: 'shopper',
-            phone: '123',
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ date: new Date('2024-12-25'), reason: 'Christmas' }],
-      });
-
-    const res = await request(app)
-      .get('/holidays')
-      .set('Authorization', 'Bearer token');
-
-    expect(res.status).toBe(200);
-      expect(res.body).toEqual([{ date: '2024-12-24', reason: 'Christmas' }]);
-  });
-
-  it('allows staff to fetch holidays', async () => {
-    (jwt.verify as jest.Mock).mockReturnValue({
-      id: 1,
-      role: 'coordinator',
-      type: 'staff',
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [
+        {
+          client_id: 1,
+          first_name: 'Test',
+          last_name: 'User',
+          email: 'test@example.com',
+          role: 'shopper',
+          phone: '123',
+        },
+      ],
     });
-    (pool.query as jest.Mock)
-      .mockResolvedValueOnce({
-        rowCount: 1,
-        rows: [
-          {
-            id: 1,
-            first_name: 'Test',
-            last_name: 'Staff',
-            email: 'staff@example.com',
-            role: 'coordinator',
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ date: new Date('2024-12-25'), reason: 'Christmas' }],
-      });
-
-    const res = await request(app)
-      .get('/holidays')
-      .set('Authorization', 'Bearer token');
-
-    expect(res.status).toBe(200);
-      expect(res.body).toEqual([{ date: '2024-12-24', reason: 'Christmas' }]);
-    });
-
-  it('allows agencies to fetch holidays', async () => {
-    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'agency', type: 'agency' });
-    (pool.query as jest.Mock)
-      .mockResolvedValueOnce({
-        rowCount: 1,
-        rows: [
-          {
-            id: 1,
-            name: 'Test Agency',
-            email: 'agency@example.com',
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ date: new Date('2024-12-25'), reason: 'Christmas' }],
-      });
 
     const res = await request(app)
       .get('/holidays')
@@ -103,4 +45,52 @@ describe('GET /holidays', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual([{ date: '2024-12-24', reason: 'Christmas' }]);
   });
+
+  it('allows staff to fetch holidays', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({
+      id: 1,
+      role: 'coordinator',
+      type: 'staff',
+    });
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [
+        {
+          id: 1,
+          first_name: 'Test',
+          last_name: 'Staff',
+          email: 'staff@example.com',
+          role: 'coordinator',
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/holidays')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ date: '2024-12-24', reason: 'Christmas' }]);
   });
+
+  it('allows agencies to fetch holidays', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'agency', type: 'agency' });
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [
+        {
+          id: 1,
+          name: 'Test Agency',
+          email: 'agency@example.com',
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/holidays')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ date: '2024-12-24', reason: 'Christmas' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- allow holiday cache to return pre-set holidays without a DB lookup
- seed holiday cache in holidays access tests

## Testing
- `npm test tests/holidaysAccess.test.ts tests/holidayCache.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5f9e06a2c832d9d570446d16425b2