### PR TITLE
Include consent column in user query test

### DIFF
--- a/MJ_FB_Backend/tests/getUserByClientId.test.ts
+++ b/MJ_FB_Backend/tests/getUserByClientId.test.ts
@@ -46,7 +46,7 @@ describe('GET /users/id/:clientId', () => {
       hasPassword: true,
     });
     expect(pool.query).toHaveBeenCalledWith(
-      `SELECT client_id, first_name, last_name, email, phone, online_access, password\n       FROM clients WHERE client_id = $1`,
+      `SELECT client_id, first_name, last_name, email, phone, online_access, password, consent\n       FROM clients WHERE client_id = $1`,
       ['5'],
     );
   });


### PR DESCRIPTION
## Summary
- update getUserByClientId test to expect consent column

## Testing
- `npm test tests/getUserByClientId.test.ts`
- `npm test` *(fails: volunteerBookingConflict, volunteerBookingConcurrency, slots, volunteerRebookCancelled, emailQueueCleanupJob, bookingTelegramAlerts, newClientsMigration, holidaysAccess, noShowCleanupJob, volunteerShiftReminderJob, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f9e3c7d4832daa1f4769bb480f05