### PR TITLE
Mock opsAlert in volunteer reschedule test

### DIFF
--- a/MJ_FB_Backend/tests/volunteerReschedule.test.ts
+++ b/MJ_FB_Backend/tests/volunteerReschedule.test.ts
@@ -1,3 +1,5 @@
+jest.mock('../src/utils/opsAlert', () => ({ notifyOps: jest.fn() }));
+
 import request from 'supertest';
 import express from 'express';
 import volunteerBookingsRouter from '../src/routes/volunteer/volunteerBookings';


### PR DESCRIPTION
## Summary
- mock opsAlert in volunteer reschedule test to verify alert calls

## Testing
- `nvm use`
- `npm test tests/volunteerReschedule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5fb341708832d8c0e3d2a39d8cd1b