### PR TITLE
Exclude sunshine bag orders from adult totals

### DIFF
--- a/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
+++ b/MJ_FB_Backend/src/controllers/pantry/pantryAggregationController.ts
@@ -69,8 +69,8 @@ export async function refreshPantryWeekly(year: number, month: number, week: num
   const sunshineWeight = Number(bagRes.rows[0]?.weight ?? 0);
 
   const orders = visitOrders + bagOrders;
-  const adults = visitAdults + bagOrders;
-  const people = visitAdults + children;
+  const adults = visitAdults;
+  const people = adults + children;
   const weight = visitWeight + sunshineWeight;
 
   await pool.query(


### PR DESCRIPTION
## Summary
- Prevent sunshine bag orders from inflating adult or people counts in weekly pantry aggregations
- Add regression test ensuring sunshine bag orders don't affect adult or people totals

## Testing
- `npm test tests/pantryAggregationController.test.ts tests/refreshPantryWeekly.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5fb33416c832db5b07248d8434437