### PR TITLE
test: mock ops alert in booking cancel test

### DIFF
--- a/MJ_FB_Backend/tests/bookingCancelTelegramAlert.test.ts
+++ b/MJ_FB_Backend/tests/bookingCancelTelegramAlert.test.ts
@@ -17,6 +17,7 @@ describe('booking cancel telegram alert', () => {
         updateBooking: jest.fn().mockResolvedValue(undefined),
       }));
       jest.doMock('../src/db', () => ({ __esModule: true, default: { query: jest.fn() } }));
+      jest.doMock('../src/utils/opsAlert', () => ({ notifyOps: jest.fn() }));
       cancelBooking = require('../src/controllers/bookingController').cancelBooking;
       fetchBookingById = require('../src/models/bookingRepository').fetchBookingById;
       updateBooking = require('../src/models/bookingRepository').updateBooking;


### PR DESCRIPTION
## Summary
- mock opsAlert in booking cancellation test and verify notification

## Testing
- `cd MJ_FB_Backend && npm test tests/bookingCancelTelegramAlert.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c5fb331fac832dafc0a36d4c83908c