### PR TITLE
feat: schedule timesheet seed job

### DIFF
--- a/MJ_FB_Backend/src/utils/timesheetSeedJob.ts
+++ b/MJ_FB_Backend/src/utils/timesheetSeedJob.ts
@@ -1,16 +1,26 @@
-import scheduleDailyJob from './scheduleDailyJob';
+import cron from 'node-cron';
 import seedTimesheets from './timesheetSeeder';
 
 /**
  * Ensure timesheets exist for active staff each day.
  */
-const timesheetSeedJob = scheduleDailyJob(
-  () => seedTimesheets(),
-  '5 0 * * *',
-  false,
-  true,
-);
+let task: cron.ScheduledTask | undefined;
 
-export const startTimesheetSeedJob = timesheetSeedJob.start;
-export const stopTimesheetSeedJob = timesheetSeedJob.stop;
+export const startTimesheetSeedJob = (): void => {
+  if (task) return;
+  task = cron.schedule(
+    '5 0 * * *',
+    () => {
+      void seedTimesheets();
+    },
+    { timezone: 'America/Regina' },
+  );
+};
+
+export const stopTimesheetSeedJob = (): void => {
+  if (task) {
+    task.stop();
+    task = undefined;
+  }
+};
 


### PR DESCRIPTION
## Summary
- schedule daily timesheet seeding at 00:05 Regina time
- allow stopping the scheduled timesheet seeding job

## Testing
- `npm test tests/timesheetSeedJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5fca7db14832d9ebc07719841a187