### PR TITLE
Grant donation entry access to trained volunteers

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -53,7 +53,11 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
           [volunteer.id],
         );
         const access: string[] = [];
-        if (rolesRes.rows.some(r => r.name === 'Donation Entry')) {
+        if (
+          rolesRes.rows.some(
+            r => r.name && r.name.toLowerCase() === 'donation entry',
+          )
+        ) {
           access.push('donation_entry');
         }
         const payload: AuthPayload = {
@@ -212,7 +216,11 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
           [volunteer.id],
         );
         const access: string[] = [];
-        if (rolesRes.rows.some(r => r.name === 'Donation Entry')) {
+        if (
+          rolesRes.rows.some(
+            r => r.name && r.name.toLowerCase() === 'donation entry',
+          )
+        ) {
           access.push('donation_entry');
         }
         const payload: AuthPayload = {

--- a/MJ_FB_Backend/src/controllers/webauthnController.ts
+++ b/MJ_FB_Backend/src/controllers/webauthnController.ts
@@ -79,7 +79,11 @@ async function loginByIdentifier(identifier: string, res: Response) {
         [volunteer.id],
       );
       const access: string[] = [];
-      if (rolesRes.rows.some(r => r.name === 'Donation Entry')) {
+      if (
+        rolesRes.rows.some(
+          r => r.name && r.name.toLowerCase() === 'donation entry',
+        )
+      ) {
         access.push('donation_entry');
       }
       const payload: AuthPayload = {
@@ -165,7 +169,11 @@ async function loginByIdentifier(identifier: string, res: Response) {
       [volunteer.id],
     );
     const access: string[] = [];
-    if (rolesRes.rows.some(r => r.name === 'Donation Entry')) {
+    if (
+      rolesRes.rows.some(
+        r => r.name && r.name.toLowerCase() === 'donation entry',
+      )
+    ) {
       access.push('donation_entry');
     }
     const payload: AuthPayload = {


### PR DESCRIPTION
## Summary
- Recognize Donation Entry training during volunteer authentication.
- Test volunteer login for Donation Entry role with seeded data.

## Testing
- `npm test tests/volunteerDonationEntry.test.ts tests/webauthnController.test.ts --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c5fca77ca4832da652af25cb74c2ab