### PR TITLE
Load maintenance settings on mount

### DIFF
--- a/MJ_FB_Frontend/src/api/maintenance.ts
+++ b/MJ_FB_Frontend/src/api/maintenance.ts
@@ -5,8 +5,18 @@ export interface Maintenance {
   notice?: string;
 }
 
+export interface MaintenanceSettings {
+  maintenanceMode: boolean;
+  upcomingNotice?: string;
+}
+
 export async function getMaintenance(): Promise<Maintenance> {
   const res = await apiFetch(`${API_BASE}/maintenance`);
+  return handleResponse(res);
+}
+
+export async function getMaintenanceSettings(): Promise<MaintenanceSettings> {
+  const res = await apiFetch(`${API_BASE}/maintenance/settings`);
   return handleResponse(res);
 }
 
@@ -19,7 +29,23 @@ export async function updateMaintenance(settings: Maintenance): Promise<Maintena
   return handleResponse(res);
 }
 
+export async function updateMaintenanceSettings(
+  settings: MaintenanceSettings,
+): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/maintenance/settings`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  });
+  await handleResponse(res);
+}
+
 export async function clearMaintenance(): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/maintenance/stats`, { method: 'DELETE' });
+  await handleResponse(res);
+}
+
+export async function clearMaintenanceStats(): Promise<void> {
   const res = await apiFetch(`${API_BASE}/maintenance/stats`, { method: 'DELETE' });
   await handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/pages/admin/Maintenance.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/Maintenance.tsx
@@ -5,10 +5,10 @@ import Page from '../../components/Page';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import {
-  getMaintenance,
-  updateMaintenance,
-  clearMaintenance,
-  type Maintenance,
+  getMaintenanceSettings,
+  updateMaintenanceSettings,
+  clearMaintenanceStats,
+  type MaintenanceSettings,
 } from '../../api/maintenance';
 
 export default function Maintenance() {
@@ -20,9 +20,9 @@ export default function Maintenance() {
   useEffect(() => {
     async function load() {
       try {
-        const data = await getMaintenance();
+        const data = await getMaintenanceSettings();
         setMaintenanceMode(data.maintenanceMode);
-        setUpcomingNotice(data.notice ?? '');
+        setUpcomingNotice(data.upcomingNotice ?? '');
       } catch (err: any) {
         setError(err.message || String(err));
       }
@@ -32,11 +32,11 @@ export default function Maintenance() {
 
   async function handleSave() {
     try {
-      const settings: Maintenance = {
+      const settings: MaintenanceSettings = {
         maintenanceMode,
-        notice: upcomingNotice,
+        upcomingNotice,
       };
-      await updateMaintenance(settings);
+      await updateMaintenanceSettings(settings);
       setMessage('Settings saved');
     } catch (err: any) {
       setError(err.message || String(err));
@@ -45,7 +45,7 @@ export default function Maintenance() {
 
   async function handleClearStats() {
     try {
-      await clearMaintenance();
+      await clearMaintenanceStats();
       setMessage('Maintenance stats cleared');
     } catch (err: any) {
       setError(err.message || String(err));

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/Maintenance.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/Maintenance.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from '../../../theme';
@@ -25,12 +25,17 @@ describe('Maintenance', () => {
     );
 
     const switchEl = await screen.findByRole('switch', { name: /maintenance mode/i });
-    expect(getMaintenanceSettings).toHaveBeenCalled();
+    await waitFor(() => expect(getMaintenanceSettings).toHaveBeenCalled());
     fireEvent.click(switchEl);
     fireEvent.change(screen.getByLabelText(/upcoming notice/i), { target: { value: 'Soon' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-    expect(updateMaintenanceSettings).toHaveBeenCalledWith({ maintenanceMode: true, upcomingNotice: 'Soon' });
+    await waitFor(() =>
+      expect(updateMaintenanceSettings).toHaveBeenCalledWith({
+        maintenanceMode: true,
+        upcomingNotice: 'Soon',
+      }),
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Clear Maintenance Stats' }));
-    expect(clearMaintenanceStats).toHaveBeenCalled();
+    await waitFor(() => expect(clearMaintenanceStats).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
## Summary
- Retrieve maintenance settings on component mount via `getMaintenanceSettings`
- Update admin maintenance actions to use new API helpers
- Wait for maintenance settings loading in tests

## Testing
- `CI=true npm test src/pages/admin/__tests__/Maintenance.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5fc8df4f0832da74de6f90cffd2e3