### PR TITLE
feat: add dialog online access switch

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
@@ -1,7 +1,14 @@
 import { screen, fireEvent } from '@testing-library/react';
+import { setTimeout as nodeSetTimeout, clearTimeout as nodeClearTimeout } from 'timers';
 import EditClientDialog from '../client-management/EditClientDialog';
 import { getUserByClientId } from '../../../api/users';
 import { renderWithProviders } from '../../../../testUtils/renderWithProviders';
+
+beforeAll(() => {
+  // Ensure undici timers receive Node timeout objects with a refresh method
+  global.setTimeout = nodeSetTimeout as any;
+  global.clearTimeout = nodeClearTimeout as any;
+});
 
 jest.mock('../../../api/users', () => ({
   ...jest.requireActual('../../../api/users'),
@@ -59,7 +66,9 @@ describe('EditClientDialog', () => {
       />,
     );
 
-    const toggle = await screen.findByRole('checkbox', { name: /online access/i });
+    const toggle = (
+      await screen.findAllByRole('switch', { name: /online access/i })
+    )[0];
     expect(toggle).not.toBeChecked();
     fireEvent.click(toggle);
     expect(toggle).toBeChecked();

--- a/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from 'react';
-import { Dialog, DialogTitle } from '@mui/material';
+import {
+  Dialog,
+  DialogTitle,
+  FormControlLabel,
+  Switch,
+  Stack,
+  FormHelperText,
+  FormControl,
+} from '@mui/material';
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from '../../../components/DialogCloseButton';
 import { getUserByClientId, updateUserInfo, requestPasswordReset } from '../../../api/users';
@@ -102,6 +110,26 @@ export default function EditClientDialog({
     <Dialog open={open} onClose={onClose}>
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>Edit Client</DialogTitle>
+      <Stack spacing={2} sx={{ px: 3, pt: 1 }}>
+        <FormControl>
+          <FormControlLabel
+            control={
+              <Switch
+                name="online access"
+                checked={form.onlineAccess}
+                onChange={e =>
+                  setForm(prev => ({
+                    ...prev,
+                    onlineAccess: e.target.checked,
+                  }))
+                }
+              />
+            }
+            label="Online Access"
+          />
+          <FormHelperText>Allow the client to sign in online.</FormHelperText>
+        </FormControl>
+      </Stack>
       <EditClientForm
         open={open}
         initialData={form}


### PR DESCRIPTION
## Summary
- add labeled Online Access switch to EditClientDialog
- test dialog Online Access switch using role label and ensure timers use Node implementation

## Testing
- `CI=true npm test src/pages/staff/__tests__/EditClientDialog.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c5fc906cd8832db3f73ef3a0090d4e