### PR TITLE
Format volunteer shift times and improve status control

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/VolunteerDailyBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/VolunteerDailyBookings.tsx
@@ -150,7 +150,7 @@ export default function VolunteerDailyBookings() {
                     <Card key={shiftKey} sx={{ mt: 1 }}>
                       <CardContent>
                         <Typography gutterBottom>
-                          {formatTime(start)} - {formatTime(end)}
+                          {formatTime(start)} – {formatTime(end)}
                         </Typography>
                         <Stack spacing={1}>
                           {list.map(b => (
@@ -176,6 +176,9 @@ export default function VolunteerDailyBookings() {
                                     )
                                   }
                                 >
+                                  <MenuItem value="approved" disabled>
+                                    Approved
+                                  </MenuItem>
                                   <MenuItem value="completed">Completed</MenuItem>
                                   <MenuItem value="no_show">No Show</MenuItem>
                                   <MenuItem value="cancelled">Cancelled</MenuItem>


### PR DESCRIPTION
## Summary
- display volunteer shift times with an en dash (e.g. `9:00 AM – 10:00 AM`)
- ensure status selector is controlled and includes an Approved option
- update VolunteerDailyBookings test to use userEvent for status changes

## Testing
- `CI=true npm test src/pages/staff/__tests__/VolunteerDailyBookings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5fc8fb4a4832d8717e49fa77913f8