### PR TITLE
Rename leave rejection button and refine test lookup

### DIFF
--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
 import { ReadableStream, WritableStream } from 'stream/web';
+import {
+  setTimeout as nodeSetTimeout,
+  clearTimeout as nodeClearTimeout,
+  setInterval as nodeSetInterval,
+  clearInterval as nodeClearInterval,
+} from 'timers';
 
 // Polyfill TextEncoder/Decoder for testing environment
 (global as any).TextEncoder = TextEncoder;
@@ -12,6 +18,12 @@ import { ReadableStream, WritableStream } from 'stream/web';
 (global as any).performance = (global as any).performance || ({} as any);
 (global as any).performance.markResourceTiming =
   (global as any).performance.markResourceTiming || (() => {});
+
+// Use Node's timer implementations so undici's fast timers have refresh()
+(global as any).setTimeout = nodeSetTimeout;
+(global as any).clearTimeout = nodeClearTimeout;
+(global as any).setInterval = nodeSetInterval;
+(global as any).clearInterval = nodeClearInterval;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { fetch, Headers, Request, Response, FormData, File } = require('undici');

--- a/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/LeaveRequests.tsx
@@ -74,7 +74,7 @@ export default function AdminLeaveRequests() {
               >
                 <Button
                   variant="contained"
-                  
+
                   sx={{ width: { xs: '100%', sm: 'auto' } }}
                   onClick={() =>
                     approve.mutate(
@@ -92,7 +92,7 @@ export default function AdminLeaveRequests() {
                   sx={{ width: { xs: '100%', sm: 'auto' } }}
                   onClick={() => setRejecting(r)}
                 >
-                  Reject Leave
+                  Reject
                 </Button>
               </Box>
             </CardContent>

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/LeaveRequests.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/LeaveRequests.test.tsx
@@ -35,7 +35,7 @@ describe('AdminLeaveRequests', () => {
     const user = userEvent.setup();
     renderWithProviders(<LeaveRequests />);
     expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
-    const rejectBtn = screen.getByRole('button', { name: 'Reject' });
+    const rejectBtn = screen.getByRole('button', { name: 'Reject', exact: true });
     await user.click(rejectBtn);
     expect(
       screen.getByText('Reject leave request for Jane Doe?'),
@@ -53,7 +53,7 @@ describe('AdminLeaveRequests', () => {
   it('closes dialog without rejecting when cancelled', async () => {
     const user = userEvent.setup();
     renderWithProviders(<LeaveRequests />);
-    await user.click(screen.getByRole('button', { name: 'Reject' }));
+    await user.click(screen.getByRole('button', { name: 'Reject', exact: true }));
     await user.click(screen.getByLabelText('close'));
     expect(mockReject).not.toHaveBeenCalled();
     expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Rename rejection button in admin leave requests to 'Reject'
- Query the reject button by its exact accessible name in tests
- Ensure Jest uses Node timers so undici's fast timer can refresh

## Testing
- `CI=true npm test src/pages/admin/__tests__/LeaveRequests.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5fc8f1108832d91cd6b565717778b