### PR TITLE
Ensure staff deletion only occurs after confirmation

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
@@ -111,7 +111,7 @@ export default function AdminStaffList() {
           {toDelete && (
             <ConfirmDialog
               message={`Delete ${toDelete.firstName} ${toDelete.lastName}?`}
-              onConfirm={() => handleDelete()}
+              onConfirm={handleDelete}
               onCancel={() => setToDelete(null)}
             />
           )}

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/AdminStaffList.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/AdminStaffList.test.tsx
@@ -70,11 +70,6 @@ describe('AdminStaffList', () => {
   });
 
   it('does not delete staff when dialog is dismissed', async () => {
-    ConfirmDialogMock.mockImplementationOnce(({ onCancel }) => {
-      onCancel();
-      return null;
-    });
-
     renderWithProviders(
       <MemoryRouter>
         <AdminStaffList />
@@ -84,6 +79,8 @@ describe('AdminStaffList', () => {
     expect(await screen.findByText('John Doe')).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText('delete'));
+    expect(await screen.findByText('Delete John Doe?')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('close'));
 
     await waitFor(() => {
       expect(deleteStaff).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Avoid triggering deletion until confirm button is pressed on AdminStaffList
- Add test covering dialog dismissal to ensure deleteStaff isn't called

## Testing
- `CI=true npm test src/pages/admin/__tests__/AdminStaffList.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6021d4ce0832d881da67c950adc5d