### PR TITLE
Fix volunteer booking time formatting and test interaction

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/VolunteerDailyBookings.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/VolunteerDailyBookings.tsx
@@ -116,7 +116,7 @@ export default function VolunteerDailyBookings() {
         .filter(r => r.available > 0)
         .map(r => ({
           id: r.id.toString(),
-          label: `${r.name} ${formatTime(r.start_time)}–${formatTime(
+          label: `${r.name} ${formatTime(r.start_time)} – ${formatTime(
             r.end_time,
           )}`,
         }));

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerDailyBookings.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/VolunteerDailyBookings.test.tsx
@@ -97,10 +97,10 @@ describe('VolunteerDailyBookings', () => {
     );
 
     const user = userEvent.setup();
-    const select = await screen.findByLabelText('Status');
-    await user.click(select);
-    const option = await screen.findByRole('option', { name: 'Completed' });
-    await user.click(option);
+    await user.click(await screen.findByLabelText('Status'));
+    await user.click(
+      await screen.findByRole('option', { name: 'Completed' }),
+    );
 
     await waitFor(() =>
       expect(updateVolunteerBookingStatus).toHaveBeenCalledWith(1, 'completed'),


### PR DESCRIPTION
## Summary
- Display volunteer role times with spaced en dash (e.g., `9:00 AM – 10:00 AM`)
- Exercise status selector with `userEvent` in VolunteerDailyBookings test

## Testing
- `CI=true npm test src/pages/staff/__tests__/VolunteerDailyBookings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c602214064832da0a9ca22a477ac4f