### PR TITLE
Allow forcing volunteer bookings to grow slot capacity

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -420,11 +420,11 @@ export async function createVolunteerBookingForVolunteer(
       );
       if (Number(countRes.rows[0].count) >= maxVolunteers) {
         if (force) {
-          maxVolunteers = Number(countRes.rows[0].count) + 1;
           await client.query(
-            'UPDATE volunteer_slots SET max_volunteers = $1 WHERE slot_id = $2',
-            [maxVolunteers, roleId],
+            'UPDATE volunteer_slots SET max_volunteers = max_volunteers + 1 WHERE slot_id = $1',
+            [roleId],
           );
+          maxVolunteers += 1;
         } else {
           await client.query('ROLLBACK');
           return res.status(400).json({ message: 'Role is full' });

--- a/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
+++ b/MJ_FB_Backend/tests/volunteerBookingForce.test.ts
@@ -94,8 +94,8 @@ describe('createVolunteerBookingForVolunteer force', () => {
     expect(res.status).toBe(201);
     const updateCall = client.query.mock.calls[3];
     expect(updateCall[0]).toMatch(
-      /UPDATE volunteer_slots SET max_volunteers = \$1 WHERE slot_id = \$2/,
+      /UPDATE volunteer_slots SET max_volunteers = max_volunteers \+ 1 WHERE slot_id = \$1/,
     );
-    expect(updateCall[1]).toEqual([2, 1]);
+    expect(updateCall[1]).toEqual([1]);
   });
 });


### PR DESCRIPTION
## Summary
- increment volunteer slot capacity when staff force a booking
- test forced volunteer booking updates capacity before insert

## Testing
- `npm test tests/volunteerBookingForce.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c6023cbaa8832d9a30eb15f1b643c7