### PR TITLE
Validate booking slot IDs early

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -60,20 +60,24 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
   const { slotId, date, isStaffBooking, note, type } = req.body;
   const emailType = type || 'Shopping Appointment';
   if (slotId === undefined || slotId === null) {
-    return res.status(400).json({ message: 'Please select a time slot' });
-  }
-
-  if (!isValidDateString(date)) {
-    return res.status(400).json({ message: 'Please choose a valid date' });
+    return res
+      .status(400)
+      .json({ message: 'Please select a valid time slot' });
   }
 
   const slotIdNum = Number(slotId);
   if (!Number.isInteger(slotIdNum)) {
-    return res.status(400).json({ message: 'Please select a valid time slot' });
+    return res
+      .status(400)
+      .json({ message: 'Please select a valid time slot' });
   }
 
   if (!date) {
     return res.status(400).json({ message: 'Please select a date' });
+  }
+
+  if (!isValidDateString(date)) {
+    return res.status(400).json({ message: 'Please choose a valid date' });
   }
 
   try {
@@ -926,19 +930,24 @@ export async function createBookingForUser(
   const { userId, slotId, date, note, type } = req.body;
   const emailType = type || 'Shopping Appointment';
   const staffBookingFlag = req.user.role === 'agency' ? true : !!req.body.isStaffBooking;
-  if (!userId || !slotId || !date) {
+  if (slotId === undefined || slotId === null) {
+    return res
+      .status(400)
+      .json({ message: 'Please select a valid time slot' });
+  }
+  if (!userId || !date) {
     return res
       .status(400)
       .json({ message: 'Please provide a user, time slot, and date' });
   }
-
-  if (!isValidDateString(date)) {
-    return res.status(400).json({ message: 'Please choose a valid date' });
-  }
-
   const slotIdNum = Number(slotId);
   if (!Number.isInteger(slotIdNum)) {
-    return res.status(400).json({ message: 'Please select a valid time slot' });
+    return res
+      .status(400)
+      .json({ message: 'Please select a valid time slot' });
+  }
+  if (!isValidDateString(date)) {
+    return res.status(400).json({ message: 'Please choose a valid date' });
   }
 
   try {

--- a/MJ_FB_Backend/tests/bookingSlotIdValidation.test.ts
+++ b/MJ_FB_Backend/tests/bookingSlotIdValidation.test.ts
@@ -40,7 +40,7 @@ describe('POST /bookings slotId validation', () => {
     const today = formatReginaDate(new Date());
     const res = await request(app).post('/bookings').send({ date: today });
     expect(res.status).toBe(400);
-    expect(res.body.message).toBe('Please select a time slot');
+    expect(res.body.message).toBe('Please select a valid time slot');
     expect(pool.query).not.toHaveBeenCalled();
     expect(pool.connect).not.toHaveBeenCalled();
   });

--- a/MJ_FB_Backend/tests/bookingSlotIdValidationStaff.test.ts
+++ b/MJ_FB_Backend/tests/bookingSlotIdValidationStaff.test.ts
@@ -33,6 +33,17 @@ beforeEach(() => {
 });
 
 describe('POST /bookings/staff slotId validation', () => {
+  it('returns 400 for missing slotId without querying the DB', async () => {
+    const today = formatReginaDate(new Date());
+    const res = await request(app)
+      .post('/bookings/staff')
+      .send({ userId: 1, date: today });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Please select a valid time slot');
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for non-integer slotId without querying the DB', async () => {
     const today = formatReginaDate(new Date());
     const res = await request(app)


### PR DESCRIPTION
## Summary
- enforce integer `slotId` and consistent 400 error for missing/invalid slots
- return before any DB calls when slotId is invalid
- add unit tests for client and staff slot validation

## Testing
- `npm test tests/bookingSlotIdValidation.test.ts`
- `npm test tests/bookingSlotIdValidationStaff.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6023a81cc832dbdcf7f59a228a010