### PR TITLE
Add online access toggle to client dialog and update tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
@@ -66,9 +66,7 @@ describe('EditClientDialog', () => {
       />,
     );
 
-    const toggle = (
-      await screen.findAllByRole('switch', { name: /online access/i })
-    )[0];
+    const toggle = await screen.findByLabelText(/online access/i);
     expect(toggle).not.toBeChecked();
     fireEvent.click(toggle);
     expect(toggle).toBeChecked();

--- a/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   FormHelperText,
   FormControl,
+  Tooltip,
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from '../../../components/DialogCloseButton';
@@ -111,30 +112,39 @@ export default function EditClientDialog({
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>Edit Client</DialogTitle>
       <Stack spacing={2} sx={{ px: 3, pt: 1 }}>
-        <FormControl>
-          <FormControlLabel
-            control={
-              <Switch
-                name="online access"
-                checked={form.onlineAccess}
-                onChange={e =>
-                  setForm(prev => ({
-                    ...prev,
-                    onlineAccess: e.target.checked,
-                  }))
+        <Tooltip
+          title="Client already has a password"
+          disableHoverListener={!form.hasPassword}
+        >
+          <span>
+            <FormControl>
+              <FormControlLabel
+                control={
+                  <Switch
+                    name="online access"
+                    checked={form.onlineAccess}
+                    onChange={e =>
+                      setForm(prev => ({
+                        ...prev,
+                        onlineAccess: e.target.checked,
+                      }))
+                    }
+                    disabled={form.hasPassword}
+                  />
                 }
+                label="Online Access"
               />
-            }
-            label="Online Access"
-          />
-          <FormHelperText>Allow the client to sign in online.</FormHelperText>
-        </FormControl>
+              <FormHelperText>Allow the client to sign in online.</FormHelperText>
+            </FormControl>
+          </span>
+        </Tooltip>
       </Stack>
       <EditClientForm
         open={open}
         initialData={form}
         onSave={data => handleSave(clientId, data, onClientUpdated, onUpdated, onClose)}
         onSendReset={data => handleSendReset(clientId, data, onClientUpdated, onUpdated, onClose)}
+        showOnlineAccessToggle={false}
       />
     </Dialog>
   );

--- a/MJ_FB_Frontend/src/pages/staff/client-management/EditClientForm.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/EditClientForm.tsx
@@ -31,6 +31,7 @@ interface Props {
   initialData: EditClientFormData;
   onSave: (data: EditClientFormData) => Promise<boolean> | boolean;
   onSendReset?: (data: EditClientFormData) => void | Promise<void>;
+  showOnlineAccessToggle?: boolean;
 }
 
 export default function EditClientForm({
@@ -38,6 +39,7 @@ export default function EditClientForm({
   initialData,
   onSave,
   onSendReset,
+  showOnlineAccessToggle = true,
 }: Props) {
   const [form, setForm] = useState<EditClientFormData>(initialData);
 
@@ -74,31 +76,33 @@ export default function EditClientForm({
 
           <Stack spacing={2}>
             <Typography variant="subtitle1">Account</Typography>
-            <Tooltip
-              title="Client already has a password"
-              disableHoverListener={!form.hasPassword}
-            >
-              <span>
-                <FormControl>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={form.onlineAccess}
-                        onChange={e =>
-                          updateForm('onlineAccess', e.target.checked)
-                        }
-                        disabled={form.hasPassword}
-                        data-testid="online-access-toggle"
-                      />
-                    }
-                    label="Online Access"
-                  />
-                  <FormHelperText>
-                    Allow the client to sign in online.
-                  </FormHelperText>
-                </FormControl>
-              </span>
-            </Tooltip>
+            {showOnlineAccessToggle && (
+              <Tooltip
+                title="Client already has a password"
+                disableHoverListener={!form.hasPassword}
+              >
+                <span>
+                  <FormControl>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={form.onlineAccess}
+                          onChange={e =>
+                            updateForm('onlineAccess', e.target.checked)
+                          }
+                          disabled={form.hasPassword}
+                          data-testid="online-access-toggle"
+                        />
+                      }
+                      label="Online Access"
+                    />
+                    <FormHelperText>
+                      Allow the client to sign in online.
+                    </FormHelperText>
+                  </FormControl>
+                </span>
+              </Tooltip>
+            )}
             {form.onlineAccess && !form.hasPassword && (
               <PasswordField
                 fullWidth


### PR DESCRIPTION
## Summary
- add labeled online access switch to EditClientDialog with tooltip and state handling
- allow EditClientForm to hide its own toggle when parent supplies one
- query switch by label in EditClientDialog test

## Testing
- `CI=true npm test src/pages/staff/__tests__/EditClientDialog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c60222691c832da325c51c8ac5a8dc