### PR TITLE
test: select slot by accessible label

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/RecurringBookings.test.tsx
@@ -144,9 +144,7 @@ test('submits one-time booking', async () => {
   const listbox = await screen.findByRole('listbox');
   fireEvent.click(within(listbox).getByText('Cat'));
   const table = await screen.findByRole('table');
-  const slot = within(table)
-    .getAllByRole('button')
-    .find((b) => !b.textContent?.trim())!;
+  const slot = within(table).getByRole('button', { name: /sign up/i });
   fireEvent.click(slot);
   await waitFor(() => expect(requestVolunteerBooking).toHaveBeenCalled());
   expect(createRecurringVolunteerBooking).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- use accessible `Sign up` button query in RecurringBookings test

## Testing
- `npx jest src/__tests__/RecurringBookings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c637f4e3a8832da395428087ee1272