### PR TITLE
Make blocked slot cleanup job schedulable

### DIFF
--- a/MJ_FB_Backend/src/jobs/blockedSlotCleanupJob.ts
+++ b/MJ_FB_Backend/src/jobs/blockedSlotCleanupJob.ts
@@ -1,4 +1,4 @@
-import { schedule, ScheduledTask } from 'node-cron';
+import { schedule as cronSchedule, ScheduledTask } from 'node-cron';
 import pool from '../db';
 import logger from '../utils/logger';
 
@@ -13,13 +13,17 @@ export async function cleanupPastBlockedSlots(): Promise<void> {
   }
 }
 
+export const schedule = cronSchedule;
+
 let task: ScheduledTask | undefined;
 
 /**
  * Schedule the cleanup job to run nightly at 2:00 AM Regina time.
  */
-export function startBlockedSlotCleanupJob(): void {
-  task = schedule(
+export function startBlockedSlotCleanupJob(
+  cronFn: typeof schedule = schedule,
+): void {
+  task = cronFn(
     '0 2 * * *',
     () => {
       void cleanupPastBlockedSlots();

--- a/MJ_FB_Backend/tests/blockedSlotCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/blockedSlotCleanupJob.test.ts
@@ -1,10 +1,5 @@
-jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 const job = require('../src/jobs/blockedSlotCleanupJob');
-const {
-  cleanupPastBlockedSlots,
-  startBlockedSlotCleanupJob,
-  stopBlockedSlotCleanupJob,
-} = job;
+const { cleanupPastBlockedSlots, startBlockedSlotCleanupJob, stopBlockedSlotCleanupJob } = job;
 import pool from '../src/db';
 
 describe('cleanupPastBlockedSlots', () => {
@@ -22,23 +17,12 @@ describe('cleanupPastBlockedSlots', () => {
 });
 
 describe('startBlockedSlotCleanupJob/stopBlockedSlotCleanupJob', () => {
-  let scheduleMock: jest.Mock;
-  let stopMock: jest.Mock;
-  beforeEach(() => {
-    jest.useFakeTimers();
-    scheduleMock = require('node-cron').schedule as jest.Mock;
-    stopMock = jest.fn();
-    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
-  });
-
-  afterEach(() => {
-    stopBlockedSlotCleanupJob();
-    jest.useRealTimers();
-    scheduleMock.mockReset();
-  });
-
   it('schedules and stops the cron job', () => {
-    startBlockedSlotCleanupJob();
+    jest.useFakeTimers();
+    const stopMock = jest.fn();
+    const scheduleMock = jest.fn().mockReturnValue({ stop: stopMock, start: jest.fn() });
+
+    startBlockedSlotCleanupJob(scheduleMock);
     expect(scheduleMock).toHaveBeenCalledWith(
       '0 2 * * *',
       expect.any(Function),
@@ -46,5 +30,6 @@ describe('startBlockedSlotCleanupJob/stopBlockedSlotCleanupJob', () => {
     );
     stopBlockedSlotCleanupJob();
     expect(stopMock).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- expose node-cron schedule in the blocked slot cleanup job and allow injection
- simplify test by injecting a mock scheduler

## Testing
- `npm test tests/blockedSlotCleanupJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c638e5740c832dbb32d4b93d4ef975