### PR TITLE
Validate start date in slot range endpoint

### DIFF
--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -45,6 +45,7 @@ interface SlotRangeData {
 }
 
 const REGINA_TZ = 'America/Regina';
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 function currentReginaTime(): string {
   const parts = new Intl.DateTimeFormat('en-CA', {
@@ -286,7 +287,15 @@ export async function listSlotsRange(
       .status(400)
       .json({ message: 'days must be an integer between 1 and 120' });
   }
-  const start = (req.query.start as string) || formatReginaDate(new Date());
+  const startProvided = Object.prototype.hasOwnProperty.call(
+    req.query,
+    'start',
+  );
+  const startParam = req.query.start as string | undefined;
+  if (startProvided && (!startParam || !DATE_REGEX.test(startParam))) {
+    return res.status(400).json({ message: 'Invalid date' });
+  }
+  const start = startParam || formatReginaDate(new Date());
   const includePast = req.query.includePast === 'true';
 
   try {


### PR DESCRIPTION
## Summary
- ensure `/slots/range` start query param matches `YYYY-MM-DD`
- return HTTP 400 with `{ message: 'Invalid date' }` when start date is invalid

## Testing
- `npm test tests/slots.test.ts -- -t 'start date validation'` *(fails: Expected 400 Received 500)*

------
https://chatgpt.com/codex/tasks/task_e_68c638df9a40832daa2c2d5ef03a79db