### PR TITLE
fix: avoid nested buttons in VolunteerSettingsTab

### DIFF
--- a/MJ_FB_Frontend/src/pages/admin/settings/VolunteerSettingsTab.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/settings/VolunteerSettingsTab.tsx
@@ -396,6 +396,7 @@ export default function VolunteerSettingsTab() {
                 <Typography sx={{ flexGrow: 1 }}>{master.name}</Typography>
                 <Stack direction="row" spacing={1}>
                   <IconButton
+                    component="span"
                     aria-label="edit"
                     onClick={e => {
                       e.stopPropagation();
@@ -405,6 +406,7 @@ export default function VolunteerSettingsTab() {
                     <EditIcon />
                   </IconButton>
                   <IconButton
+                    component="span"
                     aria-label="delete"
                     onClick={e => {
                       e.stopPropagation();


### PR DESCRIPTION
## Summary
- render action icons in VolunteerSettingsTab's accordion summary as spans to avoid nested button DOM errors

## Testing
- `npm test src/pages/admin/__tests__/VolunteerSettingsTab.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c63ede6450832da4d7ef13c9580c27