### PR TITLE
Validate volunteer roles date query

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerRoleController.ts
@@ -322,6 +322,9 @@ export async function listVolunteerRolesForVolunteer(
   if (!date) {
     return res.status(400).json({ message: 'date query parameter is required' });
   }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return res.status(400).json({ message: 'Invalid date' });
+  }
   try {
     const volunteerRes = await pool.query(
       'SELECT role_id FROM volunteer_trained_roles WHERE volunteer_id=$1',

--- a/MJ_FB_Backend/tests/volunteerRolesMine.test.ts
+++ b/MJ_FB_Backend/tests/volunteerRolesMine.test.ts
@@ -129,4 +129,14 @@ describe('GET /volunteer-roles/mine', () => {
     expect(pool.query).toHaveBeenCalledTimes(2);
     expect(res.body).toEqual([]);
   });
+
+  it('returns 400 for malformed date', async () => {
+    const res = await request(app)
+      .get('/volunteer-roles/mine')
+      .query({ date: '20250101' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('message', 'Invalid date');
+    expect(pool.query).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Validate `date` query against `YYYY-MM-DD` before formatting in volunteer role listing endpoint
- Return HTTP 400 with `Invalid date` message when malformed
- Add test ensuring malformed dates are rejected

## Testing
- `npm test tests/volunteerRolesMine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c63ec7c0c0832d88c78dc9c51c7718