### PR TITLE
Validate sunshine bag date parameter

### DIFF
--- a/MJ_FB_Backend/src/controllers/sunshineBagController.ts
+++ b/MJ_FB_Backend/src/controllers/sunshineBagController.ts
@@ -32,6 +32,8 @@ export async function getSunshineBag(req: Request, res: Response, next: NextFunc
   try {
     const date = req.query.date as string;
     if (!date) return res.status(400).json({ message: 'Date required' });
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date))
+      return res.status(400).json({ message: 'Invalid date' });
     const result = await pool.query(
       'SELECT date, weight, client_count as "clientCount" FROM sunshine_bag_log WHERE date = $1',
       [date],


### PR DESCRIPTION
## Summary
- validate `date` query parameter in `getSunshineBag`

## Testing
- `npm test tests/sunshineBagController.test.ts`
- `npm test` *(fails: maintenanceGuard.test.ts: Expected 503, Received 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c63ec3c2a8832db336ebb23719d2ad