### PR TITLE
Validate client visit listing date format

### DIFF
--- a/MJ_FB_Backend/src/controllers/clientVisitController.ts
+++ b/MJ_FB_Backend/src/controllers/clientVisitController.ts
@@ -123,6 +123,9 @@ export async function listVisits(req: Request, res: Response, next: NextFunction
   try {
     const date = req.query.date as string;
     if (!date) return res.status(400).json({ message: 'Date required' });
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return res.status(400).json({ message: 'Invalid date' });
+    }
     const result = await pool.query(
       `SELECT v.id,
               to_char(v.date, 'YYYY-MM-DD') as date,

--- a/MJ_FB_Backend/tests/clientVisitController.test.ts
+++ b/MJ_FB_Backend/tests/clientVisitController.test.ts
@@ -11,6 +11,7 @@ import {
   deleteVisit,
   toggleVisitVerification,
   getVisitStats,
+  listVisits,
 } from '../src/controllers/clientVisitController';
 
 jest.mock('../src/controllers/pantry/pantryAggregationController', () => ({
@@ -36,6 +37,16 @@ describe('clientVisitController', () => {
     (refreshPantryWeekly as jest.Mock).mockReset();
     (refreshPantryMonthly as jest.Mock).mockReset();
     (refreshPantryYearly as jest.Mock).mockReset();
+  });
+
+  it('returns 400 for invalid date format', async () => {
+    const req = { query: { date: '2024/05/20' } } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    const next = jest.fn();
+    await listVisits(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid date' });
+    expect(mockDb.query).not.toHaveBeenCalled();
   });
 
   it('deleteVisit triggers pantry refresh', async () => {


### PR DESCRIPTION
## Summary
- validate `listVisits` date query against `YYYY-MM-DD`
- add test confirming 400 response on invalid date

## Testing
- `cd MJ_FB_Backend && npm test tests/clientVisitController.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c63ec27ed4832d87560a235018220b