### PR TITLE
Enable maintenance guard check during tests

### DIFF
--- a/MJ_FB_Backend/src/middleware/maintenanceGuard.ts
+++ b/MJ_FB_Backend/src/middleware/maintenanceGuard.ts
@@ -6,7 +6,6 @@ export default async function maintenanceGuard(
   res: Response,
   next: NextFunction,
 ) {
-  if (process.env.NODE_ENV === 'test') return next();
   if (req.method === 'OPTIONS') return next();
   try {
     const result = await pool.query(


### PR DESCRIPTION
## Summary
- ensure maintenance guard runs during tests by removing test env bypass

## Testing
- `nvm use`
- `npm test tests/maintenanceGuard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c644275f74832db5e9c1ba026f84e1