### PR TITLE
test: await volunteer ranking rendering

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerRankings.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerRankings.test.tsx
@@ -36,13 +36,13 @@ describe('VolunteerRankings', () => {
 
     await waitFor(() => expect(getVolunteerRoles).toHaveBeenCalled());
     await waitFor(() => expect(getVolunteerRankings).toHaveBeenCalledWith(undefined));
-    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(await screen.findByText(/Alice/)).toBeInTheDocument();
 
     fireEvent.mouseDown(screen.getByLabelText('Ranking'));
     fireEvent.click(screen.getByText('No Shows'));
 
     await waitFor(() => expect(getVolunteerNoShowRanking).toHaveBeenCalled());
-    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(await screen.findByText(/Bob/)).toBeInTheDocument();
 
     fireEvent.mouseDown(screen.getByLabelText('Ranking'));
     fireEvent.click(screen.getByText('Sorter (Warehouse)'));


### PR DESCRIPTION
## Summary
- await async volunteer ranking content to ensure render
- wait for no-show ranking update before assertions

## Testing
- `npx jest src/__tests__/VolunteerRankings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6440dec6c832db93b0c073031d8ed