### PR TITLE
Fix donor profile last donation display

### DIFF
--- a/MJ_FB_Frontend/src/pages/donor-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonorProfile.tsx
@@ -185,6 +185,12 @@ export default function DonorProfile() {
             <Typography>
               Total Donated: {currency.format(donor.amount)}
             </Typography>
+            <Typography>
+              Last Donation:{' '}
+              {donor.lastDonationISO
+                ? formatLocaleDate(donor.lastDonationISO)
+                : 'N/A'}
+            </Typography>
           </Stack>
         )}
 


### PR DESCRIPTION
## Summary
- Show last donation date or `N/A` on donor profile when no last donation recorded

## Testing
- `npx jest src/__tests__/DonorProfile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c643ff92e0832dbe492b1d27252c24