### PR TITLE
Ensure pay period cron job runs in tests

### DIFF
--- a/MJ_FB_Backend/src/utils/payPeriodCronJob.ts
+++ b/MJ_FB_Backend/src/utils/payPeriodCronJob.ts
@@ -15,7 +15,7 @@ export async function seedNextYear(): Promise<void> {
 /**
  * Schedule the job to run annually on Nov 30.
  */
-const payPeriodCronJob = scheduleDailyJob(seedNextYear, '0 0 30 11 *', false);
+const payPeriodCronJob = scheduleDailyJob(seedNextYear, '0 0 30 11 *', false, false);
 
 export const startPayPeriodCronJob = payPeriodCronJob.start;
 export const stopPayPeriodCronJob = payPeriodCronJob.stop;


### PR DESCRIPTION
## Summary
- allow pay period cron job to schedule during tests by disabling `skipInTest`

## Testing
- `npm test tests/payPeriodCronJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c647b3e6fc832d8802b72a4d196347