### PR TITLE
Run expired token cleanup job during tests

### DIFF
--- a/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
@@ -25,7 +25,7 @@ const expiredTokenCleanupJob = scheduleDailyJob(
   cleanupExpiredTokens,
   '0 3 * * *',
   true,
-  true,
+  false,
 );
 
 export const startExpiredTokenCleanupJob = expiredTokenCleanupJob.start;


### PR DESCRIPTION
## Summary
- Ensure expired token cleanup job isn't skipped in test environment

## Testing
- `npm test tests/expiredTokenCleanupJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c647b3b040832d9290956ad645ab4a