### PR TITLE
Allow email queue cleanup job to schedule during tests

### DIFF
--- a/MJ_FB_Backend/src/utils/emailQueueCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/emailQueueCleanupJob.ts
@@ -29,7 +29,7 @@ const emailQueueCleanupJob = scheduleDailyJob(
   cleanupEmailQueue,
   '0 3 * * *',
   true,
-  true,
+  false,
 );
 
 export const startEmailQueueCleanupJob = emailQueueCleanupJob.start;

--- a/MJ_FB_Backend/tests/emailQueueCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/emailQueueCleanupJob.test.ts
@@ -3,7 +3,8 @@ jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
   return {
     __esModule: true,
-    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
+    default: (cb: any, schedule: string, _runOnStart?: boolean, skipInTest?: boolean) =>
+      actual.default(cb, schedule, false, skipInTest),
   };
 });
 jest.mock('../src/utils/opsAlert');


### PR DESCRIPTION
## Summary
- Ensure email queue cleanup job schedules in test environment by disabling skipInTest flag
- Forward skipInTest parameter in tests so cron scheduling is asserted

## Testing
- `npm test tests/emailQueueCleanupJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c647b165e0832dacf5d2ed12d2cbeb