### PR TITLE
test: await agency booking async effects

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AgencyBookAppointment.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
 import AgencyBookAppointment from '../pages/agency/AgencyBookAppointment';
 
@@ -31,7 +31,9 @@ describe('AgencyBookAppointment', () => {
     await screen.findByText('Alice');
     fireEvent.click(screen.getByText('Alice'));
 
-    expect(await screen.findByText(/Loading availability/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText(/Loading availability/i)).toBeInTheDocument(),
+    );
   });
 
   it('renders BookingUI when a client is selected', async () => {
@@ -54,7 +56,11 @@ describe('AgencyBookAppointment', () => {
     await screen.findByText('Alice');
     fireEvent.click(screen.getByText('Alice'));
 
-    await screen.findByText(/BookingUI Alice 1/);
-    expect(screen.queryByText(/Loading availability/i)).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByText(/BookingUI Alice 1/)).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText(/Loading availability/i)).toBeNull(),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- ensure AgencyBookAppointment test waits for loading and BookingUI via waitFor

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npm test -- src/__tests__/AgencyBookAppointment.test.tsx`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c648a13508832da019868494cccad7