### PR TITLE
Validate slot dates and skip maintenance DB check in tests

### DIFF
--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -335,10 +335,10 @@ export async function listSlotsRange(
   if (startParam !== undefined && !DATE_REGEX.test(startParam)) {
     return res.status(400).json({ message: 'Invalid date' });
   }
-  const start = startParam ?? formatReginaDate(new Date());
   const includePast = req.query.includePast === 'true';
 
   try {
+    const start = startParam ?? formatReginaDate(new Date());
     const reginaStart = formatReginaDate(start);
     const startDate = new Date(reginaStartOfDayISO(reginaStart));
     if (isNaN(startDate.getTime())) {


### PR DESCRIPTION
## Summary
- Ensure slot range handler computes default start date after validating query param
- Bypass maintenance-mode DB lookup in tests or for staff/admin users to prevent unnecessary queries

## Testing
- `npm test tests/slots.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c647ae9c18832dbf30b190b616bf62