### PR TITLE
test: stabilize VolunteerCoverageCard test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerCoverageCard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerCoverageCard.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react';
 import VolunteerCoverageCard from '../components/dashboard/VolunteerCoverageCard';
 import { getVolunteerRoles, getVolunteerBookingsByRole } from '../api/volunteers';
 
@@ -52,20 +53,21 @@ describe('VolunteerCoverageCard', () => {
       { status: 'approved', date: '2024-01-15', volunteer_name: 'Bob' },
     ]);
 
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     render(<VolunteerCoverageCard />);
 
     await screen.findByText('Greeter 8:00 AM–12:00 PM (Front)');
 
-    await userEvent.click(
-      screen.getByText('Greeter 8:00 AM–12:00 PM (Front)'),
-    );
-
-    expect(
-      await screen.findByText('Volunteers – Greeter 8:00 AM–12:00 PM'),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Alice')).toBeInTheDocument();
-    expect(screen.getByText('Bob')).toBeInTheDocument();
-  });
+    await act(async () => {
+      await user.click(screen.getByText('Greeter 8:00 AM–12:00 PM (Front)'));
+      jest.runOnlyPendingTimers();
+      expect(
+        await screen.findByText('Volunteers – Greeter 8:00 AM–12:00 PM'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+    });
+  }, 10000);
 
   it('shows coverage per shift', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-01-15T12:00:00Z'));


### PR DESCRIPTION
## Summary
- wrap VolunteerCoverageCard click in `act` to satisfy React state updates and ensure expectations run
- extend test timeout and use user-event timers to keep mocked API calls quick

## Testing
- `npx jest src/__tests__/VolunteerCoverageCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c644004088832db60d934fb98293b9