### PR TITLE
Validate start date in slot range endpoint

### DIFF
--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -331,14 +331,17 @@ export async function listSlotsRange(
       .status(400)
       .json({ message: 'days must be an integer between 1 and 120' });
   }
-  const startParam = req.query.start as string | undefined;
-  if (startParam !== undefined && !DATE_REGEX.test(startParam)) {
-    return res.status(400).json({ message: 'Invalid date' });
+  const startParam = req.query.start;
+  if (startParam !== undefined) {
+    if (typeof startParam !== 'string' || !DATE_REGEX.test(startParam)) {
+      return res.status(400).json({ message: 'Invalid date' });
+    }
   }
   const includePast = req.query.includePast === 'true';
 
   try {
-    const start = startParam ?? formatReginaDate(new Date());
+    const start =
+      typeof startParam === 'string' ? startParam : formatReginaDate(new Date());
     const reginaStart = formatReginaDate(start);
     const startDate = new Date(reginaStartOfDayISO(reginaStart));
     if (isNaN(startDate.getTime())) {


### PR DESCRIPTION
## Summary
- Validate `start` query parameter in `/slots/range` with a YYYY-MM-DD regex and proper type check
- Ensure invalid `start` values return a 400 error

## Testing
- `npm test tests/slots.test.ts -t 'start date validation'`


------
https://chatgpt.com/codex/tasks/task_e_68c64a579558832db4a292672e87d60b