### PR TITLE
test: silence VolunteerDashboard console error

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -119,6 +119,9 @@ describe('VolunteerDashboard', () => {
   });
 
   it('shows an error message if events cannot be fetched', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
     (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockRejectedValue(new Error('fail'));
@@ -127,6 +130,8 @@ describe('VolunteerDashboard', () => {
 
     await waitFor(() => expect(getEvents).toHaveBeenCalled());
     expect(await screen.findByText('Failed to load events')).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
   });
 
   it('hides slots already booked by volunteer', async () => {


### PR DESCRIPTION
## Summary
- mock `console.error` in VolunteerDashboard error test to avoid noisy console output

## Testing
- `CI=1 npm test -- src/__tests__/VolunteerDashboard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c64bbbe31c832da6364d556efaa5c3