### PR TITLE
test: ensure password token cleanup job schedules cron

### DIFF
--- a/MJ_FB_Backend/src/utils/passwordTokenCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/passwordTokenCleanupJob.ts
@@ -22,7 +22,7 @@ const passwordTokenCleanupJob = scheduleDailyJob(
   cleanupPasswordTokens,
   '0 1 * * *',
   true,
-  true,
+  false,
 );
 
 export const startPasswordTokenCleanupJob = passwordTokenCleanupJob.start;

--- a/MJ_FB_Backend/tests/passwordTokenCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/passwordTokenCleanupJob.test.ts
@@ -46,6 +46,7 @@ describe('startPasswordTokenCleanupJob/stopPasswordTokenCleanupJob', () => {
 
   it('schedules and stops the cron job', () => {
     startPasswordTokenCleanupJob();
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
     expect(scheduleMock).toHaveBeenCalledWith(
       '0 1 * * *',
       expect.any(Function),


### PR DESCRIPTION
## Summary
- allow password token cleanup job to run in test environment
- verify job schedules cron only once

## Testing
- `nvm use`
- `npm test tests/passwordTokenCleanupJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c64e001624832d9f96d39e67938b38