### PR TITLE
feat: inject cron scheduler in volunteer no-show job

### DIFF
--- a/MJ_FB_Backend/src/jobs/volunteerNoShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/jobs/volunteerNoShowCleanupJob.ts
@@ -37,9 +37,13 @@ let job: cron.ScheduledTask | undefined;
 
 /**
  * Schedule the volunteer no-show cleanup job to run nightly at 7:00 PM Regina time.
+ *
+ * @param cronFn Optional scheduling function for tests; defaults to `cron.schedule`.
  */
-export function startVolunteerNoShowCleanupJob(): void {
-  job = cron.schedule(
+export function startVolunteerNoShowCleanupJob(
+  cronFn: typeof cron.schedule = cron.schedule,
+): void {
+  job = cronFn(
     '0 19 * * *',
     () => {
       void cleanupVolunteerNoShows();

--- a/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerNoShowCleanupJob.test.ts
@@ -1,4 +1,3 @@
-jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 jest.mock('../src/utils/opsAlert');
 const job = require('../src/jobs/volunteerNoShowCleanupJob');
 const {
@@ -41,24 +40,24 @@ describe('cleanupVolunteerNoShows', () => {
 });
 
 describe('startVolunteerNoShowCleanupJob/stopVolunteerNoShowCleanupJob', () => {
-  let scheduleMock: jest.Mock;
+  let cronMock: jest.Mock;
   let stopMock: jest.Mock;
   beforeEach(() => {
     jest.useFakeTimers();
-    scheduleMock = require('node-cron').schedule as jest.Mock;
+    cronMock = jest.fn();
     stopMock = jest.fn();
-    scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
+    cronMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
   });
 
   afterEach(() => {
     stopVolunteerNoShowCleanupJob();
     jest.useRealTimers();
-    scheduleMock.mockReset();
+    jest.clearAllMocks();
   });
 
   it('schedules and stops the cron job', () => {
-    startVolunteerNoShowCleanupJob();
-    expect(scheduleMock).toHaveBeenCalledWith(
+    startVolunteerNoShowCleanupJob(cronMock);
+    expect(cronMock).toHaveBeenCalledWith(
       '0 19 * * *',
       expect.any(Function),
       { timezone: 'America/Regina' },


### PR DESCRIPTION
## Summary
- allow startVolunteerNoShowCleanupJob to accept an optional scheduler function (defaults to cron.schedule)
- adjust volunteerNoShowCleanupJob tests to pass a mock scheduler and assert it runs

## Testing
- `npm test tests/volunteerNoShowCleanupJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c64dfde648832db284e671e448b777