### PR TITLE
Allow cron mock in no-show cleanup job

### DIFF
--- a/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/noShowCleanupJob.ts
@@ -22,9 +22,13 @@ let job: cron.ScheduledTask | undefined;
 
 /**
  * Schedule the cleanup job to run nightly at 7:00 PM Regina time.
+ *
+ * @param cronFn Optional scheduling function, defaults to `cron.schedule`.
  */
-export function startNoShowCleanupJob(): void {
-  job = cron.schedule(
+export function startNoShowCleanupJob(
+  cronFn: typeof cron.schedule = cron.schedule,
+): void {
+  job = cronFn(
     '0 19 * * *',
     () => {
       void cleanupNoShows();

--- a/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/noShowCleanupJob.test.ts
@@ -1,4 +1,3 @@
-jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
   return {
@@ -41,20 +40,18 @@ describe('startNoShowCleanupJob/stopNoShowCleanupJob', () => {
   let scheduleMock: jest.Mock;
   let stopMock: jest.Mock;
   beforeEach(() => {
-    jest.useFakeTimers();
-    scheduleMock = require('node-cron').schedule as jest.Mock;
+    scheduleMock = jest.fn();
     stopMock = jest.fn();
     scheduleMock.mockReturnValue({ stop: stopMock, start: jest.fn() });
   });
 
   afterEach(() => {
     stopNoShowCleanupJob();
-    jest.useRealTimers();
     scheduleMock.mockReset();
   });
 
   it('schedules and stops the cron job', () => {
-    startNoShowCleanupJob();
+    startNoShowCleanupJob(scheduleMock);
     expect(scheduleMock).toHaveBeenCalledWith(
       '0 19 * * *',
       expect.any(Function),


### PR DESCRIPTION
## Summary
- make `startNoShowCleanupJob` accept an optional scheduling function
- use injected scheduler in tests to verify cron setup and teardown

## Testing
- `npm test tests/noShowCleanupJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c64dfa30f4832dae3e9636ed98a519