### PR TITLE
Run volunteer shift reminder cron during tests

### DIFF
--- a/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/volunteerShiftReminderJob.ts
@@ -53,7 +53,7 @@ const volunteerShiftReminderJob = scheduleDailyJob(
   sendNextDayVolunteerShiftReminders,
   '0 19 * * *',
   false,
-  true,
+  false,
 );
 
 export const startVolunteerShiftReminderJob = volunteerShiftReminderJob.start;


### PR DESCRIPTION
## Summary
- Run volunteer shift reminder cron job during tests by disabling `skipInTest`

## Testing
- `npm test tests/volunteerShiftReminderJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c656c59b14832d87cdb916e0804d27