### PR TITLE
Ensure booking reminders schedule in tests

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -93,7 +93,7 @@ const bookingReminderJob = scheduleDailyJob(
   sendNextDayBookingReminders,
   '0 19 * * *',
   false,
-  true,
+  false,
 );
 
 export const startBookingReminderJob = bookingReminderJob.start;


### PR DESCRIPTION
## Summary
- Always schedule booking reminder cron job by disabling test skip

## Testing
- `npm test tests/bookingReminderJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c656c32520832d948f7fdac4bb8709