### PR TITLE
fix maintenance guard test env

### DIFF
--- a/MJ_FB_Backend/tests/maintenanceGuard.test.ts
+++ b/MJ_FB_Backend/tests/maintenanceGuard.test.ts
@@ -20,6 +20,16 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+const originalEnv = process.env.NODE_ENV;
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'production';
+});
+
+afterAll(() => {
+  process.env.NODE_ENV = originalEnv;
+});
+
 describe('maintenanceGuard', () => {
   it('blocks anonymous access during maintenance', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- ensure maintenanceGuard tests run under production environment

## Testing
- `npx jest tests/maintenanceGuard.test.ts --detectOpenHandles`
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68c65267c198832d9831934655b8b53e