### PR TITLE
Align email link tests with config and allow maintenance env override

### DIFF
--- a/MJ_FB_Backend/src/middleware/maintenanceGuard.ts
+++ b/MJ_FB_Backend/src/middleware/maintenanceGuard.ts
@@ -8,7 +8,8 @@ export default async function maintenanceGuard(
 ) {
   if (req.method === 'OPTIONS') return next();
   // Tests run without an authenticated user; skip DB calls
-  if (process.env.NODE_ENV === 'test') return next();
+  // Use bracket notation so tests can override NODE_ENV at runtime
+  if (process.env['NODE_ENV'] === 'test') return next();
   const role = req.user?.role;
   // Staff and admin users bypass maintenance checks without a DB hit
   if (role === 'staff' || role === 'admin') return next();

--- a/MJ_FB_Backend/tests/emailLinks.test.ts
+++ b/MJ_FB_Backend/tests/emailLinks.test.ts
@@ -13,9 +13,10 @@ describe('buildCancelRescheduleLinks', () => {
   it('returns cancel and reschedule links', () => {
     const token = 'tok';
     const links = buildCancelRescheduleLinks(token);
+    const base = config.frontendOrigins[0];
     expect(links).toEqual({
-      cancelLink: `http://localhost:5173/cancel/${token}`,
-      rescheduleLink: `http://localhost:5173/reschedule/${token}`,
+      cancelLink: `${base}/cancel/${token}`,
+      rescheduleLink: `${base}/reschedule/${token}`,
     });
   });
 


### PR DESCRIPTION
## Summary
- adjust email link test to respect configured frontend origin
- allow maintenance guard to respect runtime NODE_ENV overrides

## Testing
- `npm test tests/emailLinks.test.ts tests/maintenanceGuard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6fff86f4c832d9ebea30d3ab31873