### PR TITLE
test: use specific query in CancelBooking test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/CancelBooking.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/CancelBooking.test.tsx
@@ -15,7 +15,9 @@ describe('CancelBooking page', () => {
         </Routes>
       </MemoryRouter>,
     );
-    expect(await screen.findByText('Booking cancelled')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Booking cancelled', { selector: 'p' }),
+    ).toBeInTheDocument();
     expect(bookingsApi.cancelBookingByToken).toHaveBeenCalledWith('tok123');
   });
 });


### PR DESCRIPTION
## Summary
- use a more specific query to find the cancellation message in CancelBooking test

## Testing
- `npm test -- src/__tests__/CancelBooking.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c7019c98f8832db7968973b78c0cdc