### PR TITLE
Use FormData for leave request form submission

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
@@ -84,16 +84,12 @@ export default function LeaveManagement() {
               component="form"
               onSubmit={e => {
                 e.preventDefault();
-                const form = e.currentTarget as typeof e.currentTarget & {
-                  type: { value: string };
-                  start: { value: string };
-                  end: { value: string };
-                };
+                const data = new FormData(e.currentTarget);
                 leaveMutation.mutate(
                   {
-                    type: form.type.value,
-                    startDate: form.start.value,
-                    endDate: form.end.value,
+                    type: data.get('type')?.toString() ?? '',
+                    startDate: data.get('start')?.toString() ?? '',
+                    endDate: data.get('end')?.toString() ?? '',
                   },
                   { onSuccess: () => setOpen(false) },
                 );

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/LeaveManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/LeaveManagement.test.tsx
@@ -6,6 +6,30 @@ import LeaveManagement from '../LeaveManagement';
 
 const mockMutate = jest.fn();
 
+beforeEach(() => {
+  class TestFormData {
+    private data = new Map<string, string>();
+    constructor(form?: HTMLFormElement) {
+      if (form) {
+        Array.from(form.elements).forEach(el => {
+          const input = el as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+          if (input.name) {
+            this.data.set(input.name, input.value);
+          }
+        });
+      }
+    }
+    append(name: string, value: string) {
+      this.data.set(name, value);
+    }
+    get(name: string) {
+      return this.data.get(name) ?? null;
+    }
+  }
+  (global as any).FormData = TestFormData as any;
+  (window as any).FormData = TestFormData as any;
+});
+
 jest.mock('../../../api/timesheets', () => ({
   useTimesheets: () => ({
     timesheets: [


### PR DESCRIPTION
## Summary
- Use `FormData` to read leave request fields in staff leave management page
- Polyfill `FormData` in tests and adjust leave request test

## Testing
- `npm test -- src/pages/staff/__tests__/LeaveManagement.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c7019b1a50832d8fcbca3661fb1997