### PR TITLE
Avoid running expired token cleanup on startup

### DIFF
--- a/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
@@ -24,7 +24,7 @@ export async function cleanupExpiredTokens(): Promise<void> {
 const expiredTokenCleanupJob = scheduleDailyJob(
   cleanupExpiredTokens,
   '0 3 * * *',
-  true,
+  false,
   false,
 );
 


### PR DESCRIPTION
## Summary
- prevent expired token cleanup job from running immediately on server start
- leave scheduling to nightly cron to allow test verification

## Testing
- `npm test tests/expiredTokenCleanupJob.test.ts --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68c701f2686c832d9b7f154801a917dc