### PR TITLE
chore: enable backend coverage reports

### DIFF
--- a/MJ_FB_Backend/jest.config.js
+++ b/MJ_FB_Backend/jest.config.js
@@ -12,4 +12,8 @@ module.exports = {
       },
     ],
   },
+  collectCoverage: true,
+  coverageProvider: 'v8',
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
 };


### PR DESCRIPTION
## Summary
- collect coverage data when running backend tests

## Testing
- `nvm use`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c7015ff9cc832d9664c51e32634fc0