### PR TITLE
Use userEvent for Exports dropdown and assert aria-disabled

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Exports.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Exports.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Exports from '../pages/warehouse-management/Exports';
 import { getWarehouseOverallYears } from '../api/warehouseOverall';
@@ -27,7 +28,7 @@ describe('Exports page', () => {
 
     await waitFor(() => expect(getWarehouseOverallYears).toHaveBeenCalled());
 
-    fireEvent.mouseDown(screen.getByLabelText(/Year/i));
+    await userEvent.click(screen.getByRole('combobox'));
     const options = await screen.findAllByRole('option');
     expect(options).toHaveLength(2);
     expect(options[0]).toHaveTextContent('2022');
@@ -44,7 +45,7 @@ describe('Exports page', () => {
 
     await waitFor(() => expect(getWarehouseOverallYears).toHaveBeenCalled());
 
-    expect(screen.getByLabelText(/Year/i)).toBeDisabled();
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-disabled', 'true');
     expect(screen.getByRole('button', { name: /Export Donor Aggregations/i })).toBeDisabled();
     expect(
       screen.getByRole('button', { name: /Export Warehouse Overall Stats/i })


### PR DESCRIPTION
## Summary
- Replace fireEvent with userEvent for opening the year dropdown
- Assert combobox aria-disabled and keep option retrieval via role queries

## Testing
- `npm test src/__tests__/Exports.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c706b7210c832da2659c9b3841b69e