### PR TITLE
test: await profile data loads

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Profile.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Profile.test.tsx
@@ -38,6 +38,10 @@ describe('Profile password reset', () => {
           </Routes>
         </MemoryRouter>
       );
+      await waitFor(() => expect(getUserProfile).toHaveBeenCalled());
+      if (role !== 'staff' && role !== 'agency') {
+        await waitFor(() => expect(getUserPreferences).toHaveBeenCalled());
+      }
       const btn = await screen.findByRole('button', { name: /Reset Password/i });
       await waitFor(() => expect(btn).toBeEnabled());
       fireEvent.click(btn);
@@ -59,6 +63,8 @@ describe('Profile password reset', () => {
           </Routes>
         </MemoryRouter>
       );
+      await waitFor(() => expect(getVolunteerProfile).toHaveBeenCalled());
+      await waitFor(() => expect(getUserPreferences).toHaveBeenCalled());
       const btn = await screen.findByRole('button', { name: /Reset Password/i });
       await waitFor(() => expect(btn).toBeEnabled());
       fireEvent.click(btn);

--- a/MJ_FB_Frontend/src/__tests__/ProfileNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ProfileNav.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Profile from '../pages/booking/Profile';
+import { getUserProfile, getUserPreferences } from '../api/users';
+import { getVolunteerProfile } from '../api/volunteers';
 
 jest.mock('../api/users', () => ({
   getUserProfile: jest.fn().mockResolvedValue({
@@ -46,15 +48,19 @@ describe('Profile bottom nav', () => {
         <Profile role="volunteer" />
       </MemoryRouter>,
     );
+    await waitFor(() => expect(getVolunteerProfile).toHaveBeenCalled());
+    await waitFor(() => expect(getUserPreferences).toHaveBeenCalled());
     expect(await screen.findByRole('button', { name: /shifts/i })).toBeInTheDocument();
   });
 
-  it('does not show schedule option for shoppers', () => {
+  it('does not show schedule option for shoppers', async () => {
     render(
       <MemoryRouter initialEntries={['/profile']}>
         <Profile role="shopper" />
       </MemoryRouter>,
     );
+    await waitFor(() => expect(getUserProfile).toHaveBeenCalled());
+    await waitFor(() => expect(getUserPreferences).toHaveBeenCalled());
     expect(screen.queryByRole('button', { name: /shifts/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- ensure tests wait for profile and preference API calls
- cover profile bottom-nav tests with API waits

## Testing
- `npm test` *(fails: UpdateClientData, VolunteerBottomNav, EventForm, AgencyAccess, AuthProvider, PantrySchedule, VolunteerShopperAccess, Exports, PantrySettingsTab, DeleteVolunteer, DeleteClient, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68c706b8cfb0832d978dd9b48fd0c6e6