### PR TITLE
test: ensure initializeSlots is idempotent

### DIFF
--- a/MJ_FB_Backend/tests/initializeSlots.test.ts
+++ b/MJ_FB_Backend/tests/initializeSlots.test.ts
@@ -1,11 +1,13 @@
 import { initializeSlots, slots } from '../src/data';
 
 describe('initializeSlots', () => {
-  it('populates slots only once', () => {
+  it('does not modify slots on subsequent calls', () => {
     initializeSlots();
     const firstRun = slots.slice();
+    const initialLength = slots.length;
+    // Second call should hit the early return branch and leave slots untouched
     initializeSlots();
-    expect(slots).toHaveLength(10);
+    expect(slots).toHaveLength(initialLength);
     expect(slots).toEqual(firstRun);
   });
 });


### PR DESCRIPTION
## Summary
- verify initializeSlots leaves slot data untouched when invoked repeatedly

## Testing
- `npm test tests/initializeSlots.test.ts -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c708278e1c832d909af5946b731885