### PR TITLE
test: ensure config logs and throws on invalid env vars

### DIFF
--- a/MJ_FB_Backend/tests/configInvalidEnvLogging.test.ts
+++ b/MJ_FB_Backend/tests/configInvalidEnvLogging.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+// Ensure logger mock is used, and environment variables are reset after each test.
+describe('config invalid environment variables', () => {
+  const originalPgUser = process.env.PG_USER;
+  const originalPgPort = process.env.PG_PORT;
+
+  afterEach(() => {
+    if (originalPgUser === undefined) {
+      delete process.env.PG_USER;
+    } else {
+      process.env.PG_USER = originalPgUser;
+    }
+    if (originalPgPort === undefined) {
+      delete process.env.PG_PORT;
+    } else {
+      process.env.PG_PORT = originalPgPort;
+    }
+    jest.resetModules();
+  });
+
+  it('logs an error and throws when env vars are missing or malformed', () => {
+    delete process.env.PG_USER;
+    process.env.PG_PORT = 'not-a-number';
+
+    const logger = require('../src/utils/logger').default;
+    (logger.error as jest.Mock).mockReset();
+
+    expect(() => require('../src/config')).toThrow();
+    expect(logger.error).toHaveBeenCalledWith(
+      '❌ Invalid or missing environment variables:',
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test stubbing invalid or missing environment variables to confirm config throws and logs an error

## Testing
- `npm test tests/configInvalidEnvLogging.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c70825ebf4832db27a4b00a943fb70