### PR TITLE
test: cover pay period seeding scenarios

### DIFF
--- a/MJ_FB_Backend/tests/payPeriodSeeder.test.ts
+++ b/MJ_FB_Backend/tests/payPeriodSeeder.test.ts
@@ -1,4 +1,5 @@
-import pool from '../src/db';
+import mockDb from './utils/mockDb';
+import logger from '../src/utils/logger';
 import { seedPayPeriods } from '../src/utils/payPeriodSeeder';
 
 describe('seedPayPeriods', () => {
@@ -7,36 +8,27 @@ describe('seedPayPeriods', () => {
   });
 
   it('inserts 14-day pay periods between dates', async () => {
-    const calls: any[] = [];
-    (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
-      calls.push({ sql, params });
-      return { rowCount: 1 };
-    });
+    (mockDb.query as jest.Mock).mockResolvedValue({ rowCount: 1 });
 
     await seedPayPeriods('2024-08-03', '2024-09-13');
 
-    expect(calls).toHaveLength(3);
-    expect(calls[0].sql).toContain('ON CONFLICT DO NOTHING');
-    expect(calls[0].params).toEqual(['2024-08-03', '2024-08-16']);
-    expect(calls[1].params).toEqual(['2024-08-17', '2024-08-30']);
-    expect(calls[2].params).toEqual(['2024-08-31', '2024-09-13']);
-  });
-
-  it('continues when pay period already exists', async () => {
-    const calls: any[] = [];
-    const results = [{ rowCount: 1 }, { rowCount: 0 }, { rowCount: 1 }];
-    (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
-      calls.push({ sql, params });
-      return results.shift();
-    });
-
-    await seedPayPeriods('2024-08-03', '2024-09-13');
-
-    expect(calls).toHaveLength(3);
+    expect(mockDb.query).toHaveBeenCalledTimes(3);
+    expect((mockDb.query as jest.Mock).mock.calls[0][0]).toContain('ON CONFLICT DO NOTHING');
+    expect((mockDb.query as jest.Mock).mock.calls[0][1]).toEqual([
+      '2024-08-03',
+      '2024-08-16',
+    ]);
+    expect((mockDb.query as jest.Mock).mock.calls[1][1]).toEqual([
+      '2024-08-17',
+      '2024-08-30',
+    ]);
+    expect((mockDb.query as jest.Mock).mock.calls[2][1]).toEqual([
+      '2024-08-31',
+      '2024-09-13',
+    ]);
   });
 
   it('skips duplicates when seeding the same range twice', async () => {
-    const calls: any[] = [];
     const results = [
       { rowCount: 1 },
       { rowCount: 1 },
@@ -45,30 +37,38 @@ describe('seedPayPeriods', () => {
       { rowCount: 0 },
       { rowCount: 0 },
     ];
-    (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
-      calls.push({ sql, params });
-      return results.shift();
-    });
+    (mockDb.query as jest.Mock).mockImplementation(() => results.shift());
 
     await seedPayPeriods('2024-08-03', '2024-09-13');
     await seedPayPeriods('2024-08-03', '2024-09-13');
 
-    expect(calls).toHaveLength(6);
-    expect(calls[0].sql).toContain('ON CONFLICT DO NOTHING');
-    expect(calls[3].sql).toContain('ON CONFLICT DO NOTHING');
+    expect(mockDb.query).toHaveBeenCalledTimes(6);
+    expect((mockDb.query as jest.Mock).mock.calls[0][0]).toContain('ON CONFLICT DO NOTHING');
+    expect((mockDb.query as jest.Mock).mock.calls[3][0]).toContain('ON CONFLICT DO NOTHING');
+  });
+
+  it('logs errors when queries fail', async () => {
+    const error = new Error('db failure');
+    (mockDb.query as jest.Mock).mockRejectedValue(error);
+
+    await seedPayPeriods('2024-08-03', '2024-08-16');
+
+    expect(logger.error).toHaveBeenCalledWith('Error seeding pay periods:', error);
   });
 
   it('handles cross-year boundaries', async () => {
-    const calls: any[] = [];
-    (pool.query as jest.Mock).mockImplementation(async (sql: string, params?: any[]) => {
-      calls.push({ sql, params });
-      return { rowCount: 1 };
-    });
+    (mockDb.query as jest.Mock).mockResolvedValue({ rowCount: 1 });
 
     await seedPayPeriods('2024-12-28', '2025-01-24');
 
-    expect(calls).toHaveLength(2);
-    expect(calls[0].params).toEqual(['2024-12-28', '2025-01-10']);
-    expect(calls[1].params).toEqual(['2025-01-11', '2025-01-24']);
+    expect(mockDb.query).toHaveBeenCalledTimes(2);
+    expect((mockDb.query as jest.Mock).mock.calls[0][1]).toEqual([
+      '2024-12-28',
+      '2025-01-10',
+    ]);
+    expect((mockDb.query as jest.Mock).mock.calls[1][1]).toEqual([
+      '2025-01-11',
+      '2025-01-24',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- verify pay period seeding inserts expected periods
- check repeated seeding skips duplicates
- ensure errors during seeding are logged

## Testing
- `npm test tests/payPeriodSeeder.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c7082cc37c832dbf0cb1fff000a644