### PR TITLE
Wrap token cleanup job start and update tests

### DIFF
--- a/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
@@ -28,6 +28,9 @@ const expiredTokenCleanupJob = scheduleDailyJob(
   false,
 );
 
-export const startExpiredTokenCleanupJob = expiredTokenCleanupJob.start;
+export function startExpiredTokenCleanupJob(): void {
+  expiredTokenCleanupJob.start();
+}
+
 export const stopExpiredTokenCleanupJob = expiredTokenCleanupJob.stop;
 


### PR DESCRIPTION
## Summary
- wrap expired token cleanup job start method in a function to preserve closure
- load start function after mocking cron, assert scheduled with `0 3 * * *` and stop is called

## Testing
- `npm test tests/expiredTokenCleanupJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c70aac5414832dbc7615d1983ed5c0