### PR TITLE
Add scheduleDailyJob tests

### DIFF
--- a/MJ_FB_Backend/tests/scheduleDailyJob.test.ts
+++ b/MJ_FB_Backend/tests/scheduleDailyJob.test.ts
@@ -1,0 +1,35 @@
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+
+import cron from 'node-cron';
+import scheduleDailyJob from '../src/utils/scheduleDailyJob';
+
+describe('scheduleDailyJob', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it('executes callback immediately when runOnStart is true', () => {
+    const cb = jest.fn();
+    const job = scheduleDailyJob(cb, '* * * * *', true, false);
+    job.start();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cron.schedule).toHaveBeenCalledWith(
+      '* * * * *',
+      expect.any(Function),
+      { timezone: 'America/Regina' },
+    );
+  });
+
+  it('skips scheduling in test environment when skipInTest is true', () => {
+    const cb = jest.fn();
+    process.env.NODE_ENV = 'test';
+    const job = scheduleDailyJob(cb, '* * * * *', true, true);
+    job.start();
+    expect(cb).not.toHaveBeenCalled();
+    expect(cron.schedule).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- test that scheduleDailyJob executes callback immediately when run on start
- ensure node-cron not scheduled in test environment when skipInTest is true

## Testing
- `nvm use`
- `npm test tests/scheduleDailyJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c70ab1f6ac832d8b04bfdf91a74bc2