### PR TITLE
test: add UnauthorizedError tests

### DIFF
--- a/MJ_FB_Backend/tests/UnauthorizedError.test.ts
+++ b/MJ_FB_Backend/tests/UnauthorizedError.test.ts
@@ -1,0 +1,15 @@
+import UnauthorizedError from '../src/utils/UnauthorizedError';
+
+describe('UnauthorizedError', () => {
+  it('defaults message and status', () => {
+    const err = new UnauthorizedError();
+    expect(err.message).toBe('Invalid credentials');
+    expect(err.status).toBe(401);
+  });
+
+  it('allows overriding message', () => {
+    const err = new UnauthorizedError('Custom message');
+    expect(err.message).toBe('Custom message');
+    expect(err.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for UnauthorizedError default values
- ensure custom message still uses 401 status

## Testing
- `npm test tests/UnauthorizedError.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c70ab2ded8832db4ee30d3b330d008