### PR TITLE
test: add stats controller tests

### DIFF
--- a/MJ_FB_Backend/tests/statsController.test.ts
+++ b/MJ_FB_Backend/tests/statsController.test.ts
@@ -1,0 +1,29 @@
+import { getStats } from '../src/controllers/statsController';
+import { getBadgeCardLink } from '../src/utils/badgeUtils';
+
+jest.mock('../src/utils/badgeUtils', () => ({
+  getBadgeCardLink: jest.fn(),
+}));
+
+describe('statsController.getStats', () => {
+  beforeEach(() => {
+    (getBadgeCardLink as jest.Mock).mockReset();
+  });
+
+  it('returns cardUrl when email is provided', () => {
+    (getBadgeCardLink as jest.Mock).mockReturnValue('/cards/thanks.pdf');
+    const req = { query: { email: 'user@example.com' } } as any;
+    const res = { json: jest.fn() } as any;
+    getStats(req, res, jest.fn());
+    expect(getBadgeCardLink).toHaveBeenCalledWith('user@example.com');
+    expect(res.json).toHaveBeenCalledWith({ cardUrl: '/cards/thanks.pdf' });
+  });
+
+  it('returns undefined cardUrl when email is missing', () => {
+    const req = { query: {} } as any;
+    const res = { json: jest.fn() } as any;
+    getStats(req, res, jest.fn());
+    expect(getBadgeCardLink).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ cardUrl: undefined });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for stats controller to ensure card URL returned when email is provided
- verify undefined card URL when email is omitted

## Testing
- `cd MJ_FB_Backend && nvm use && npm test tests/statsController.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c70ab60570832d90c12e5945052ed2