### PR TITLE
fix donor list row structure

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Donors.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Donors.test.tsx
@@ -49,11 +49,11 @@ describe('Donors page', () => {
         expect(getMonetaryDonors).toHaveBeenLastCalledWith(term),
       );
 
-      const link = await screen.findByText('jane@example.com');
-      const anchor = link.closest('a');
-      expect(anchor).toHaveAttribute('href', '/donor-management/donors/1');
+      const emailCell = await screen.findByText('jane@example.com');
+      const row = emailCell.closest('tr');
+      expect(row).toBeInTheDocument();
 
-      fireEvent.click(anchor!);
+      fireEvent.click(row!);
       expect(await screen.findByText('Donor Profile')).toBeInTheDocument();
     },
   );

--- a/MJ_FB_Frontend/src/pages/donor-management/Donors.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/Donors.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   Stack,
   TextField,
@@ -19,6 +19,7 @@ export default function Donors() {
   const [term, setTerm] = useState('');
   const [debounced, setDebounced] = useState('');
   const [donors, setDonors] = useState<MonetaryDonor[]>([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const handle = setTimeout(() => setDebounced(term), 300);
@@ -62,10 +63,9 @@ export default function Donors() {
                 {donors.map(d => (
                   <TableRow
                     key={d.id}
-                    component={RouterLink}
-                    to={`/donor-management/donors/${d.id}`}
                     hover
-                    sx={{ textDecoration: 'none', color: 'inherit' }}
+                    sx={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
+                    onClick={() => navigate(`/donor-management/donors/${d.id}`)}
                   >
                     <TableCell>{d.firstName}</TableCell>
                     <TableCell>{d.lastName}</TableCell>


### PR DESCRIPTION
## Summary
- avoid nesting `<td>` inside `<a>` by navigating on row click
- adjust donors test to click table row

## Testing
- `npm test` *(fails: fetchWithRetry, UpdateClientData, EventForm, AgencyAccess, PantrySchedule, VolunteerShopperAccess, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c73fd91a78832db665ab40da756b85