### PR TITLE
test: flush timers in volunteer management

### DIFF
--- a/MJ_FB_Backend/tests/expiredTokenCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/expiredTokenCleanupJob.test.ts
@@ -8,6 +8,7 @@ jest.mock('../src/utils/scheduleDailyJob', () => {
 });
 import pool from '../src/db';
 import logger from '../src/utils/logger';
+const { cleanupExpiredTokens } = require('../src/utils/expiredTokenCleanupJob');
 
 describe('cleanupExpiredTokens', () => {
   beforeEach(() => {
@@ -15,8 +16,9 @@ describe('cleanupExpiredTokens', () => {
   });
 
   it('removes expired password setup and email verification tokens', async () => {
-    const { cleanupExpiredTokens } = require('../src/utils/expiredTokenCleanupJob');
-    (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 1 }).mockResolvedValueOnce({ rowCount: 1 });
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rowCount: 1 });
     await cleanupExpiredTokens();
     expect(pool.query).toHaveBeenNthCalledWith(
       1,
@@ -52,6 +54,7 @@ describe('startExpiredTokenCleanupJob/stopExpiredTokenCleanupJob', () => {
   });
 
   afterEach(() => {
+    jest.runOnlyPendingTimers();
     jest.useRealTimers();
     scheduleMock.mockReset();
   });

--- a/MJ_FB_Frontend/src/pages/volunteer-management/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/__tests__/VolunteerManagement.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import VolunteerManagement from '../VolunteerManagement';
@@ -19,7 +19,11 @@ jest.mock('../../../api/volunteers', () => ({
 }));
 
 describe('VolunteerManagement force booking', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
   beforeEach(() => {
+    jest.useFakeTimers();
+    user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     (getVolunteerRoles as jest.Mock).mockResolvedValue([
       {
         id: 1,
@@ -51,6 +55,12 @@ describe('VolunteerManagement force booking', () => {
       .mockResolvedValueOnce(undefined);
   });
 
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    cleanup();
+  });
+
   it('confirms increasing capacity before forcing booking', async () => {
     render(
       <MemoryRouter initialEntries={['/volunteers/schedule']}>
@@ -70,7 +80,7 @@ describe('VolunteerManagement force booking', () => {
 
     fireEvent.click(await screen.findByText('Available'));
 
-    await userEvent.type(await screen.findByLabelText('Search'), 'Test');
+    await user.type(await screen.findByLabelText('Search'), 'Test');
     fireEvent.click(await screen.findByRole('button', { name: 'Assign' }));
 
     expect(


### PR DESCRIPTION
## Summary
- ensure expired token cleanup tests import helper and clear pending timers
- run volunteer management tests with fake timers and cleanup to avoid lingering handles

## Testing
- `npm --prefix MJ_FB_Backend test tests/expiredTokenCleanupJob.test.ts`
- `npm --prefix MJ_FB_Frontend test src/pages/volunteer-management/__tests__/VolunteerManagement.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c73fd7e974832d95447ece5437f87b