### PR TITLE
test: update volunteer access login navigation

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
@@ -1,12 +1,18 @@
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
-import { loginVolunteer } from '../api/volunteers';
+import { login } from '../api/users';
 import { renderWithProviders } from '../../testUtils/renderWithProviders';
 
-jest.mock('../api/volunteers', () => ({
-  loginVolunteer: jest.fn(),
-  resolveVolunteerBookingConflict: jest.fn(),
+jest.mock('../api/client', () => ({
+  API_BASE: '',
+  apiFetch: jest.fn(),
 }));
+
+jest.mock('../api/users', () => ({
+  login: jest.fn(),
+}));
+
+const { apiFetch } = require('../api/client');
 
 jest.mock('../pages/volunteer-management/VolunteerDashboard', () => () => <div>VolunteerDashboard</div>);
 jest.mock('../pages/volunteer-management/VolunteerSchedule', () => () => <div>VolunteerSchedule</div>);
@@ -18,26 +24,35 @@ jest.mock('../pages/staff/client-management/UserHistory', () => () => <div>Booki
 describe('Volunteer with shopper profile', () => {
   it('shows booking links and allows access to booking routes', async () => {
     localStorage.clear();
-    (loginVolunteer as jest.Mock).mockResolvedValue({
+    (login as jest.Mock).mockResolvedValue({
       role: 'volunteer',
       name: 'Test',
       userRole: 'shopper',
     });
 
+    (apiFetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
     renderWithProviders(<App />);
 
-    fireEvent.click(await screen.findByText(/volunteer login/i));
+    fireEvent.click(await screen.findByText(/login/i));
 
-    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'vol@example.com' } });
-    fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), { target: { value: 'pass' } });
-    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    fireEvent.change(await screen.findByLabelText(/client id or email/i), {
+      target: { value: 'vol@example.com' },
+    });
+    fireEvent.change(
+      await screen.findByLabelText(/password/i, { selector: 'input' }),
+      { target: { value: 'pass' } },
+    );
+    fireEvent.click(await screen.findByRole('button', { name: /login/i }));
 
     await waitFor(() =>
       expect(
         screen.getByRole('link', { name: /Book Shopping Appointment/i }),
       ).toBeInTheDocument(),
     );
-    expect(loginVolunteer).toHaveBeenCalledWith('vol@example.com', 'pass');
+    expect(login).toHaveBeenCalledWith('vol@example.com', 'pass');
     expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument();
 
     fireEvent.click(


### PR DESCRIPTION
## Summary
- update volunteer shopper access test to use generic login link
- mock unified `login` API and client requests

## Testing
- `npm test src/__tests__/VolunteerShopperAccess.test.tsx` *(fails: Unable to find role="link" and name `/Book Shopping Appointment/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68c73fd6d50c832d9708e1cea8b9a5b6