### PR TITLE
Use async query in pantry schedule test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PantrySchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PantrySchedule.test.tsx
@@ -43,7 +43,7 @@ describe('PantrySchedule Today button', () => {
     renderWithProviders(<PantrySchedule />);
 
     await waitFor(() => expect(getSlots).toHaveBeenCalledTimes(1));
-    expect(screen.getByText('9:00 AM - 9:30 AM')).toBeInTheDocument();
+    expect(await screen.findByText('9:00 AM - 9:30 AM')).toBeInTheDocument();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Next' }));
 


### PR DESCRIPTION
## Summary
- use async `screen.findByText` for pantry slot checks in Today button test

## Testing
- `CI=1 npm test src/__tests__/PantrySchedule.test.tsx` *(fails: Unable to find an element with the text: 9:00 AM - 9:30 AM)*

------
https://chatgpt.com/codex/tasks/task_e_68c73fd63bd4832d86aec7a45c92a05c