### PR TITLE
test: mock sequential apiFetch responses in AuthProvider tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/AuthProvider.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AuthProvider.test.tsx
@@ -37,6 +37,7 @@ describe('AuthProvider cardUrl cleanup', () => {
   it('clears cardUrl on logout', async () => {
     (apiFetch as jest.Mock)
       .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cardUrl: '/card.pdf' }) });
     (apiLogout as jest.Mock).mockResolvedValue(undefined);
 
@@ -56,6 +57,7 @@ describe('AuthProvider cardUrl cleanup', () => {
   it('clears cardUrl when session ends in another tab', async () => {
     (apiFetch as jest.Mock)
       .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ cardUrl: '/card.pdf' }) });
     (apiLogout as jest.Mock).mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary
- mock initial refresh, login refresh, and stats apiFetch calls for AuthProvider tests

## Testing
- `npm test -- src/__tests__/AuthProvider.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c73fd5c8c0832db3a3f68d0b685f6a