### PR TITLE
test: stabilize cookie domain tests

### DIFF
--- a/MJ_FB_Backend/tests/cookieDomain.test.ts
+++ b/MJ_FB_Backend/tests/cookieDomain.test.ts
@@ -1,5 +1,15 @@
 import request from 'supertest';
 
+jest.setTimeout(15000);
+
+afterEach(() => {
+  const cron = require('node-cron');
+  for (const task of cron.getTasks().values()) {
+    task.stop();
+  }
+  jest.resetModules();
+});
+
 // Ensure cookie domain isn't applied in non-production environments
 // even if COOKIE_DOMAIN is set.
 describe('auth cookies in non-production', () => {


### PR DESCRIPTION
## Summary
- allow extra time for module isolation in cookie domain test
- clean up cron tasks after each test to avoid open handles

## Testing
- `npm test tests/cookieDomain.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c76c416ffc832d9c8a6f56f3f85ccf