### PR TITLE
test: add warehouse controllers tests

### DIFF
--- a/MJ_FB_Backend/tests/outgoingDonationController.test.ts
+++ b/MJ_FB_Backend/tests/outgoingDonationController.test.ts
@@ -1,0 +1,200 @@
+import mockDb from './utils/mockDb';
+import {
+  listOutgoingDonations,
+  addOutgoingDonation,
+  updateOutgoingDonation,
+  deleteOutgoingDonation,
+} from '../src/controllers/warehouse/outgoingDonationController';
+import { refreshWarehouseOverall } from '../src/controllers/warehouse/warehouseOverallController';
+
+jest.mock('../src/controllers/warehouse/warehouseOverallController', () => ({
+  refreshWarehouseOverall: jest.fn(),
+}));
+
+const flushPromises = () => new Promise(process.nextTick);
+
+describe('outgoingDonationController', () => {
+  beforeEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (refreshWarehouseOverall as jest.Mock).mockReset();
+  });
+
+  it('lists outgoing donations for a date', async () => {
+    (mockDb.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          date: '2024-05-20',
+          weight: 10,
+          receiverId: 2,
+          receiver: 'Org',
+          note: null,
+        },
+      ],
+    });
+    const req = { query: { date: '2024-05-20' } } as any;
+    const res = { json: jest.fn() } as any;
+    await listOutgoingDonations(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenCalledWith(expect.any(String), ['2024-05-20']);
+    expect(res.json).toHaveBeenCalledWith([
+      {
+        id: 1,
+        date: '2024-05-20',
+        weight: 10,
+        receiverId: 2,
+        receiver: 'Org',
+        note: null,
+      },
+    ]);
+  });
+
+  it('requires date for listing', async () => {
+    const req = { query: {} } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    await listOutgoingDonations(req, res, jest.fn());
+    await flushPromises();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Date required' });
+  });
+
+  it('handles database error on list', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = { query: { date: '2024-05-20' } } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await listOutgoingDonations(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('adds outgoing donation', async () => {
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            date: '2024-05-20',
+            receiverId: 2,
+            weight: 5,
+            note: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ name: 'Org' }] });
+    const req = {
+      body: { date: '2024-05-20', receiverId: 2, weight: 5 },
+    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    await addOutgoingDonation(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), [
+      '2024-05-20',
+      2,
+      5,
+      null,
+    ]);
+    expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), [2]);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      id: 1,
+      date: '2024-05-20',
+      receiverId: 2,
+      weight: 5,
+      note: null,
+      receiver: 'Org',
+    });
+  });
+
+  it('handles database error on add', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = {
+      body: { date: '2024-05-20', receiverId: 2, weight: 5 },
+    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    const next = jest.fn();
+    await addOutgoingDonation(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('updates outgoing donation', async () => {
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ date: '2024-05-20' }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            date: '2024-05-21',
+            receiverId: 2,
+            weight: 5,
+            note: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ name: 'Org' }] });
+    const req = {
+      params: { id: '1' },
+      body: { date: '2024-05-21', receiverId: 2, weight: 5 },
+    } as any;
+    const res = { json: jest.fn() } as any;
+    await updateOutgoingDonation(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
+    expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), [
+      '2024-05-21',
+      2,
+      5,
+      null,
+      '1',
+    ]);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.json).toHaveBeenCalledWith({
+      id: 1,
+      date: '2024-05-21',
+      receiverId: 2,
+      weight: 5,
+      note: null,
+      receiver: 'Org',
+    });
+  });
+
+  it('handles database error on update', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = {
+      params: { id: '1' },
+      body: { date: '2024-05-21', receiverId: 2, weight: 5 },
+    } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await updateOutgoingDonation(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('deletes outgoing donation', async () => {
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ date: '2024-05-20' }] })
+      .mockResolvedValueOnce({});
+    const req = { params: { id: '1' } } as any;
+    const res = { json: jest.fn() } as any;
+    await deleteOutgoingDonation(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
+    expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), ['1']);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Deleted' });
+  });
+
+  it('handles database error on delete', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = { params: { id: '1' } } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await deleteOutgoingDonation(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+

--- a/MJ_FB_Backend/tests/pigPoundController.test.ts
+++ b/MJ_FB_Backend/tests/pigPoundController.test.ts
@@ -1,0 +1,138 @@
+import mockDb from './utils/mockDb';
+import {
+  listPigPounds,
+  addPigPound,
+  updatePigPound,
+  deletePigPound,
+} from '../src/controllers/warehouse/pigPoundController';
+import { refreshWarehouseOverall } from '../src/controllers/warehouse/warehouseOverallController';
+
+jest.mock('../src/controllers/warehouse/warehouseOverallController', () => ({
+  refreshWarehouseOverall: jest.fn(),
+}));
+
+const flushPromises = () => new Promise(process.nextTick);
+
+describe('pigPoundController', () => {
+  beforeEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (refreshWarehouseOverall as jest.Mock).mockReset();
+  });
+
+  it('lists pig pounds for a date', async () => {
+    (mockDb.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        { id: 1, date: '2024-05-20', weight: 10 },
+      ],
+    });
+    const req = { query: { date: '2024-05-20' } } as any;
+    const res = { json: jest.fn() } as any;
+    await listPigPounds(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenCalledWith(expect.any(String), ['2024-05-20']);
+    expect(res.json).toHaveBeenCalledWith([
+      { id: 1, date: '2024-05-20', weight: 10 },
+    ]);
+  });
+
+  it('requires date for listing', async () => {
+    const req = { query: {} } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    await listPigPounds(req, res, jest.fn());
+    await flushPromises();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Date required' });
+  });
+
+  it('handles database error on list', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = { query: { date: '2024-05-20' } } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await listPigPounds(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('adds pig pound entry', async () => {
+    (mockDb.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ id: 1, date: '2024-05-20', weight: 10 }],
+    });
+    const req = { body: { date: '2024-05-20', weight: 10 } } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    await addPigPound(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenCalledWith(expect.any(String), [
+      '2024-05-20',
+      10,
+    ]);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ id: 1, date: '2024-05-20', weight: 10 });
+  });
+
+  it('handles database error on add', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = { body: { date: '2024-05-20', weight: 10 } } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    const next = jest.fn();
+    await addPigPound(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('updates pig pound entry', async () => {
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ date: '2024-05-20' }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, date: '2024-05-21', weight: 12 }],
+      });
+    const req = { params: { id: '1' }, body: { date: '2024-05-21', weight: 12 } } as any;
+    const res = { json: jest.fn() } as any;
+    await updatePigPound(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
+    expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), [
+      '2024-05-21',
+      12,
+      '1',
+    ]);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.json).toHaveBeenCalledWith({ id: 1, date: '2024-05-21', weight: 12 });
+  });
+
+  it('handles database error on update', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = { params: { id: '1' }, body: { date: '2024-05-21', weight: 12 } } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await updatePigPound(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('deletes pig pound entry', async () => {
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ date: '2024-05-20' }] })
+      .mockResolvedValueOnce({});
+    const req = { params: { id: '1' } } as any;
+    const res = { json: jest.fn() } as any;
+    await deletePigPound(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
+    expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), ['1']);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Deleted' });
+  });
+
+  it('handles database error on delete', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = { params: { id: '1' } } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await deletePigPound(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+

--- a/MJ_FB_Backend/tests/surplusController.test.ts
+++ b/MJ_FB_Backend/tests/surplusController.test.ts
@@ -1,0 +1,169 @@
+import mockDb from './utils/mockDb';
+import {
+  listSurplus,
+  addSurplus,
+  updateSurplus,
+  deleteSurplus,
+} from '../src/controllers/warehouse/surplusController';
+import { refreshWarehouseOverall } from '../src/controllers/warehouse/warehouseOverallController';
+import { getWarehouseSettings } from '../src/utils/warehouseSettings';
+
+jest.mock('../src/controllers/warehouse/warehouseOverallController', () => ({
+  refreshWarehouseOverall: jest.fn(),
+}));
+
+jest.mock('../src/utils/warehouseSettings', () => ({
+  getWarehouseSettings: jest.fn(),
+}));
+
+const flushPromises = () => new Promise(process.nextTick);
+
+describe('surplusController', () => {
+  beforeEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (refreshWarehouseOverall as jest.Mock).mockReset();
+    (getWarehouseSettings as jest.Mock).mockReset();
+  });
+
+  it('lists surplus entries', async () => {
+    (mockDb.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        { id: 1, date: '2024-05-20', type: 'BREAD', count: 2, weight: 1 },
+      ],
+    });
+    const req = {} as any;
+    const res = { json: jest.fn() } as any;
+    await listSurplus(req, res, jest.fn());
+    await flushPromises();
+    expect(res.json).toHaveBeenCalledWith([
+      { id: 1, date: '2024-05-20', type: 'BREAD', count: 2, weight: 1 },
+    ]);
+  });
+
+  it('handles database error on list', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = {} as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await listSurplus(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('adds surplus entry', async () => {
+    (getWarehouseSettings as jest.Mock).mockResolvedValue({
+      breadWeightMultiplier: 0.5,
+      cansWeightMultiplier: 1,
+    });
+    (mockDb.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ id: 1, date: '2024-05-20', type: 'BREAD', count: 2, weight: 1 }],
+    });
+    const req = { body: { date: '2024-05-20', type: 'BREAD', count: 2 } } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    await addSurplus(req, res, jest.fn());
+    await flushPromises();
+    expect(getWarehouseSettings).toHaveBeenCalled();
+    expect(mockDb.query).toHaveBeenCalledWith(expect.any(String), [
+      '2024-05-20',
+      'BREAD',
+      2,
+      1,
+    ]);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      id: 1,
+      date: '2024-05-20',
+      type: 'BREAD',
+      count: 2,
+      weight: 1,
+    });
+  });
+
+  it('handles database error on add', async () => {
+    (getWarehouseSettings as jest.Mock).mockResolvedValue({
+      breadWeightMultiplier: 0.5,
+      cansWeightMultiplier: 1,
+    });
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = { body: { date: '2024-05-20', type: 'BREAD', count: 2 } } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    const next = jest.fn();
+    await addSurplus(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('updates surplus entry', async () => {
+    (getWarehouseSettings as jest.Mock).mockResolvedValue({
+      breadWeightMultiplier: 0.5,
+      cansWeightMultiplier: 1,
+    });
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ date: '2024-05-20' }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, date: '2024-05-21', type: 'BREAD', count: 2, weight: 1 }],
+      });
+    const req = {
+      params: { id: '1' },
+      body: { date: '2024-05-21', type: 'BREAD', count: 2 },
+    } as any;
+    const res = { json: jest.fn() } as any;
+    await updateSurplus(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
+    expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), [
+      '2024-05-21',
+      'BREAD',
+      2,
+      1,
+      '1',
+    ]);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.json).toHaveBeenCalledWith({
+      id: 1,
+      date: '2024-05-21',
+      type: 'BREAD',
+      count: 2,
+      weight: 1,
+    });
+  });
+
+  it('handles database error on update', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = {
+      params: { id: '1' },
+      body: { date: '2024-05-21', type: 'BREAD', count: 2 },
+    } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await updateSurplus(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('deletes surplus entry', async () => {
+    (mockDb.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ date: '2024-05-20' }] })
+      .mockResolvedValueOnce({});
+    const req = { params: { id: '1' } } as any;
+    const res = { json: jest.fn() } as any;
+    await deleteSurplus(req, res, jest.fn());
+    await flushPromises();
+    expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
+    expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), ['1']);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Deleted' });
+  });
+
+  it('handles database error on delete', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const req = { params: { id: '1' } } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+    await deleteSurplus(req, res, next);
+    await flushPromises();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+


### PR DESCRIPTION
## Summary
- add CRUD and error-path unit tests for outgoing donations controller
- cover pig pound controller with success and failure cases
- exercise surplus controller including weight calculations and db errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c76c44581c832da2736ac7e4f756c3