### PR TITLE
fix volunteer nav test label

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerBottomNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBottomNav.test.tsx
@@ -20,13 +20,13 @@ describe('VolunteerBottomNav', () => {
     mockUseAuth.mockReturnValue({ role: 'volunteer', userRole: '' });
   });
 
-  it('selects volunteer tab when on schedule route', () => {
+  it('selects shifts tab when on schedule route', () => {
     render(
       <MemoryRouter initialEntries={['/volunteer/schedule']}>
         <VolunteerBottomNav />
       </MemoryRouter>,
     );
-    const scheduleBtn = screen.getByRole('button', { name: /volunteer/i });
+    const scheduleBtn = screen.getByRole('button', { name: /shifts/i });
     expect(scheduleBtn).toHaveClass('Mui-selected');
   });
 


### PR DESCRIPTION
## Summary
- update VolunteerBottomNav test to look for "Shifts" button

## Testing
- `npm test` *(fails: A jest worker process (pid=4579) was terminated by another process: signal=SIGTERM)*

------
https://chatgpt.com/codex/tasks/task_e_68c7826ea200832d96b11f1b1bd057d0