### PR TITLE
test: await form load and allow saving online access

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import UpdateClientData from '../pages/staff/client-management/UpdateClientData';
 import {
   getIncompleteUsers,
@@ -41,17 +41,22 @@ describe('UpdateClientData', () => {
   it('shows server error message when update fails', async () => {
     (updateUserInfo as jest.Mock).mockRejectedValueOnce({
       message: 'Unable to update client',
-      details: { errors: [{ message: 'Email already exists' }] },
+      details: { errors: [{ message: 'Email already exists.' }] },
     });
     render(<UpdateClientData />);
 
-    await screen.findByRole('button', { name: 'Edit' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    const editBtn = await screen.findByRole('button', { name: 'Edit' });
+    await act(async () => {
+      fireEvent.click(editBtn);
+    });
+    await screen.findByRole('button', { name: 'Save' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    });
 
     await waitFor(() =>
       expect(
-        screen.getByText('Email already exists')
+        screen.getByText('Email already exists.')
       ).toBeInTheDocument()
     );
   });
@@ -59,16 +64,23 @@ describe('UpdateClientData', () => {
   it('enables online access without password and sends reset link', async () => {
     render(<UpdateClientData />);
 
-    await screen.findByRole('button', { name: 'Edit' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.click(screen.getByLabelText('Online Access'));
+    const editBtn = await screen.findByRole('button', { name: 'Edit' });
+    await act(async () => {
+      fireEvent.click(editBtn);
+    });
+    const toggle = await screen.findByLabelText('Online Access');
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
 
     const saveBtn = screen.getByRole('button', { name: /^save$/i });
     expect(saveBtn).not.toBeDisabled();
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /send password reset link/i }),
-    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /send password reset link/i }),
+      );
+    });
 
     await waitFor(() =>
       expect(updateUserInfo).toHaveBeenCalledWith(
@@ -91,8 +103,10 @@ describe('UpdateClientData', () => {
 
     render(<UpdateClientData />);
 
-    await screen.findByRole('button', { name: 'Edit' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const editBtn = await screen.findByRole('button', { name: 'Edit' });
+    await act(async () => {
+      fireEvent.click(editBtn);
+    });
 
     const checkbox = await screen.findByLabelText('Online Access');
     expect(checkbox).toBeDisabled();

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -61,27 +61,28 @@ export default function UpdateClientData() {
 
   async function handleEdit(client: IncompleteUser) {
     setSelected(client);
+    // Prefill form with basic info so validation passes while details load
+    setForm({
+      firstName: client.firstName || "",
+      lastName: client.lastName || "",
+      email: client.email || "",
+      phone: client.phone || "",
+      onlineAccess: false,
+      password: "",
+      hasPassword: false,
+    });
     try {
       const data = await getUserByClientId(String(client.clientId));
       setForm({
-        firstName: data.firstName || "",
-        lastName: data.lastName || "",
-        email: data.email || "",
-        phone: data.phone || "",
+        firstName: data.firstName || client.firstName || "",
+        lastName: data.lastName || client.lastName || "",
+        email: data.email || client.email || "",
+        phone: data.phone || client.phone || "",
         onlineAccess: Boolean(data.onlineAccess),
         password: "",
         hasPassword: data.hasPassword,
       });
     } catch (err: unknown) {
-      setForm({
-        firstName: client.firstName || "",
-        lastName: client.lastName || "",
-        email: client.email || "",
-        phone: client.phone || "",
-        onlineAccess: false,
-        password: "",
-        hasPassword: false,
-      });
       setSnackbar({
         open: true,
         message: getApiErrorMessage(err, 'Failed to load client details'),


### PR DESCRIPTION
## Summary
- prefill client edit form before fetching details so toggling Online Access validates without a password
- wait for form readiness and wrap interactions in tests with `act`
- adjust error assertion to match component message

## Testing
- `npm test src/__tests__/UpdateClientData.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c7826d5390832d88216f7a2bdd5b03