### PR TITLE
test: add volunteer shift reminder job tests

### DIFF
--- a/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
+++ b/MJ_FB_Backend/tests/volunteerShiftReminderJob.test.ts
@@ -17,6 +17,7 @@ jest.doMock('../src/utils/scheduleDailyJob', () => {
 jest.mock('../src/utils/opsAlert');
 
 const pool = require('../src/db').default;
+const { enqueueEmail } = require('../src/utils/emailQueue');
 const volunteerShiftReminder = require('../src/utils/volunteerShiftReminderJob');
 const {
   sendNextDayVolunteerShiftReminders,
@@ -24,6 +25,8 @@ const {
   stopVolunteerShiftReminderJob,
 } = volunteerShiftReminder;
 import { alertOps } from '../src/utils/opsAlert';
+import logger from '../src/utils/logger';
+import { formatReginaDateWithDay, formatTimeToAmPm } from '../src/utils/dateUtils';
 
 describe('sendNextDayVolunteerShiftReminders', () => {
   beforeEach(() => {
@@ -35,12 +38,70 @@ describe('sendNextDayVolunteerShiftReminders', () => {
     jest.clearAllMocks();
   });
 
-  it('alerts ops on failure', async () => {
-    (pool.query as jest.Mock).mockRejectedValue(new Error('boom'));
+  it('queues reminders for upcoming shifts', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          email: 'vol@example.com',
+          volunteer_id: 1,
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          reschedule_token: 'abc123',
+        },
+      ],
+      rowCount: 1,
+    });
+
     await sendNextDayVolunteerShiftReminders();
+
+    const formattedDate = formatReginaDateWithDay('2024-01-02');
+    const body = `Date: ${formattedDate} from ${formatTimeToAmPm('09:00:00')} to ${formatTimeToAmPm('10:00:00')}`;
+    const base = process.env.FRONTEND_ORIGIN!.split(',')[0];
+    expect(enqueueEmail).toHaveBeenCalledWith({
+      to: 'vol@example.com',
+      templateId: 0,
+      params: {
+        body,
+        cancelLink: `${base}/cancel/abc123`,
+        rescheduleLink: `${base}/reschedule/abc123`,
+        type: 'Volunteer Shift',
+      },
+    });
+  });
+
+  it('sends no reminders when there are no shifts', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0 });
+    await sendNextDayVolunteerShiftReminders();
+    expect(enqueueEmail).not.toHaveBeenCalled();
+  });
+
+  it('logs and alerts ops when queueing fails', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          email: 'vol@example.com',
+          volunteer_id: 1,
+          start_time: null,
+          end_time: null,
+          reschedule_token: 'oops',
+        },
+      ],
+      rowCount: 1,
+    });
+    const err = new Error('queue failed');
+    (enqueueEmail as jest.Mock).mockImplementation(() => {
+      throw err;
+    });
+
+    await sendNextDayVolunteerShiftReminders();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send volunteer shift reminders',
+      err,
+    );
     expect(alertOps).toHaveBeenCalledWith(
       'sendNextDayVolunteerShiftReminders',
-      expect.any(Error),
+      err,
     );
   });
 });


### PR DESCRIPTION
## Summary
- add coverage for volunteer shift reminder emails
- ensure no reminders are queued when no shifts exist
- verify logging and ops alerts on queue failures

## Testing
- `npm test tests/volunteerShiftReminderJob.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c7aee0fa98832dbb393a29875b8b5e