### PR TITLE
Alert ops when blocked slot cleanup fails

### DIFF
--- a/MJ_FB_Backend/src/jobs/blockedSlotCleanupJob.ts
+++ b/MJ_FB_Backend/src/jobs/blockedSlotCleanupJob.ts
@@ -1,6 +1,7 @@
 import { schedule, ScheduledTask } from 'node-cron';
 import pool from '../db';
 import logger from '../utils/logger';
+import { alertOps } from '../utils/opsAlert';
 
 /**
  * Remove non-recurring blocked slots from past dates.
@@ -10,6 +11,7 @@ export async function cleanupPastBlockedSlots(): Promise<void> {
     await pool.query('DELETE FROM blocked_slots WHERE date < CURRENT_DATE');
   } catch (err) {
     logger.error('Failed to clean up blocked slots', err);
+    await alertOps('cleanupPastBlockedSlots', err);
   }
 }
 


### PR DESCRIPTION
## Summary
- notify operations via `alertOps` when blocked slot cleanup encounters errors
- test blocked slot cleanup job ops alerting

## Testing
- `npm test tests/blockedSlotCleanupJob.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c82872438c832d94c87ff2482000aa