### PR TITLE
Schedule booking retention job nightly

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingRetentionJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingRetentionJob.ts
@@ -56,7 +56,7 @@ export async function cleanupOldRecords(): Promise<void> {
   }
 }
 
-const retentionJob = scheduleDailyJob(cleanupOldRecords, '0 3 31 1 *', true, true);
+const retentionJob = scheduleDailyJob(cleanupOldRecords, '0 3 * * *', true, true);
 
 export const startRetentionJob = retentionJob.start;
 export const stopRetentionJob = retentionJob.stop;

--- a/MJ_FB_Backend/tests/bookingRetentionJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingRetentionJob.test.ts
@@ -1,0 +1,68 @@
+import mockPool from './utils/mockDb';
+
+jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+
+jest.mock('../src/utils/scheduleDailyJob', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() })),
+}));
+
+const scheduleDailyJob = require('../src/utils/scheduleDailyJob').default;
+const job = require('../src/utils/bookingRetentionJob');
+const { cleanupOldRecords } = job;
+
+describe('bookingRetentionJob scheduling', () => {
+  it('invokes scheduleDailyJob with nightly schedule', () => {
+    expect(scheduleDailyJob).toHaveBeenCalledWith(
+      cleanupOldRecords,
+      '0 3 * * *',
+      true,
+      true,
+    );
+  });
+});
+
+describe('cleanupOldRecords', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(new Date('2025-06-15T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('updates volunteers, deletes old records, and vacuums tables', async () => {
+    const mockClient = { query: jest.fn().mockResolvedValue({}), release: jest.fn() };
+    (mockPool.connect as jest.Mock).mockResolvedValueOnce(mockClient);
+
+    await cleanupOldRecords();
+
+    const cutoff = new Date('2025-06-15T00:00:00Z');
+    cutoff.setFullYear(cutoff.getFullYear() - 1);
+
+    expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(mockClient.query.mock.calls[1][0]).toContain('UPDATE volunteers v');
+    expect(mockClient.query.mock.calls[1][1]).toEqual([cutoff]);
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      3,
+      'DELETE FROM volunteer_bookings WHERE date < $1',
+      [cutoff],
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      4,
+      'DELETE FROM bookings WHERE date < $1',
+      [cutoff],
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(5, 'COMMIT');
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      6,
+      'VACUUM (ANALYZE) volunteer_bookings',
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      7,
+      'VACUUM (ANALYZE) bookings',
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- Run booking retention job every night at 3 AM
- Test retention job scheduling and record cleanup

## Testing
- `cd MJ_FB_Backend && nvm use && npm test tests/bookingRetentionJob.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c8287134c8832da53805d21b547d3d