### PR TITLE
feat: add abortable agency client search

### DIFF
--- a/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencyBookAppointment.tsx
@@ -12,12 +12,7 @@ import BookingUI from '../BookingUI';
 import { searchAgencyClients } from '../../api/agencies';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import Page from '../../components/Page';
-
-interface AgencyClient {
-  id: number;
-  name: string;
-  email?: string;
-}
+import type { AgencyClient } from '../../types';
 
 export default function AgencyBookAppointment() {
   const [clients, setClients] = useState<AgencyClient[]>([]);
@@ -37,26 +32,7 @@ export default function AgencyBookAppointment() {
     searchAgencyClients(search)
       .then(data => {
         if (!active) return;
-        interface AgencyClientData {
-          id?: number;
-          client_id?: number;
-          name?: string;
-          client_name?: string;
-          first_name?: string;
-          last_name?: string;
-          email?: string;
-        }
-        const mapped = Array.isArray(data)
-          ? data.map((c: AgencyClientData) => ({
-              id: c.id ?? c.client_id!,
-              name:
-                c.name ??
-                c.client_name ??
-                `${c.first_name ?? ''} ${c.last_name ?? ''}`.trim(),
-              email: c.email,
-            }))
-          : [];
-        setClients(mapped);
+        setClients(data);
       })
       .catch(() => active && setSnackbar('Failed to load clients'))
       .finally(() => {

--- a/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/AgencySchedule.tsx
@@ -4,12 +4,7 @@ import Page from '../../components/Page';
 import { getMyAgencyClients } from '../../api/agencies';
 import { Stack, Typography } from '@mui/material';
 import type { UserSearchResult } from '../../api/users';
-
-interface AgencyClient {
-  id: number;
-  name: string;
-  email?: string;
-}
+import type { AgencyClient } from '../../types';
 
 export default function AgencySchedule() {
   const [clients, setClients] = useState<AgencyClient[]>([]);

--- a/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
+++ b/MJ_FB_Frontend/src/pages/agency/ClientList.tsx
@@ -21,12 +21,7 @@ import {
 import { useAuth } from '../../hooks/useAuth';
 import Page from '../../components/Page';
 import type { ApiError } from '../../api/client';
-
-interface AgencyClient {
-  id: number;
-  name: string;
-  email?: string;
-}
+import type { AgencyClient } from '../../types';
 
 export default function ClientList() {
   const [clients, setClients] = useState<AgencyClient[]>([]);

--- a/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/AgencyClientManager.tsx
@@ -27,12 +27,7 @@ import {
   getAgencyClients,
 } from '../../api/agencies';
 import BookingUI from '../BookingUI';
-
-interface AgencyClient {
-  clientId: number;
-  name: string;
-  email?: string;
-}
+import type { AgencyClient } from '../../types';
 
 export default function AgencyClientManager() {
   const [agency, setAgency] = useState<{ id: number; name: string } | null>(null);
@@ -54,7 +49,7 @@ export default function AgencyClientManager() {
         ? (data as any).clients
         : [];
       const mapped = list.map((c: any) => ({
-        clientId: typeof c === 'object' ? c.client_id : Number(c),
+        id: typeof c === 'object' ? c.client_id : Number(c),
         name:
           typeof c === 'object'
             ? c.name ??
@@ -106,7 +101,7 @@ export default function AgencyClientManager() {
   const confirmRemove = async () => {
     if (!agency || !removeClient) return;
     try {
-      await removeAgencyClient(agency.id, removeClient.clientId);
+      await removeAgencyClient(agency.id, removeClient.id);
       setSnackbar({ message: 'Client removed', severity: 'success' });
       load(agency.id);
     } catch (err: any) {
@@ -176,7 +171,7 @@ export default function AgencyClientManager() {
                 <List dense>
                   {clients.map(c => (
                     <ListItem
-                      key={c.clientId}
+                      key={c.id}
                       secondaryAction={
                         <Stack direction="row" spacing={1} alignItems="center">
                           <Button
@@ -196,7 +191,7 @@ export default function AgencyClientManager() {
                         </Stack>
                       }
                     >
-                      <ListItemText primary={c.name} secondary={`ID: ${c.clientId}`} />
+                      <ListItemText primary={c.name} secondary={`ID: ${c.id}`} />
                     </ListItem>
                   ))}
                   {clients.length === 0 && <Typography>No clients assigned.</Typography>}
@@ -259,7 +254,7 @@ export default function AgencyClientManager() {
             <Box sx={{ display: bookingLoading ? 'none' : 'block' }}>
               <BookingUI
                 shopperName={bookingClient.name}
-                userId={bookingClient.clientId}
+                userId={bookingClient.id}
                 embedded
                 onLoadingChange={setBookingLoading}
               />

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -19,6 +19,12 @@ export interface Staff {
   access: StaffAccess[];
 }
 
+export interface AgencyClient {
+  id: number;
+  name: string;
+  email?: string;
+}
+
 export interface LoginResponse {
   role: Role;
   name: string;


### PR DESCRIPTION
## Summary
- add shared `AgencyClient` interface
- switch agency client search to AbortController with typed results
- update agency pages to consume typed client data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c82862f760832d8df6fe7400bb4b95