### PR TITLE
refactor: add volunteer booking types

### DIFF
--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -119,6 +119,25 @@ export type VolunteerBookingStatus =
   | 'no_show'
   | 'completed';
 
+export interface RawVolunteerBooking {
+  id: number;
+  status: VolunteerBookingStatus;
+  role_id: number;
+  date: string;
+  start_time?: string;
+  end_time?: string;
+  startTime?: string;
+  endTime?: string;
+  role_name: string;
+  category_name?: string;
+  volunteer_id?: number;
+  volunteer_name?: string;
+  status_color?: string;
+  reschedule_token?: string;
+  recurring_id?: number;
+  note?: string | null;
+}
+
 export interface VolunteerBooking {
   id: number;
   status: VolunteerBookingStatus;
@@ -126,6 +145,8 @@ export interface VolunteerBooking {
   date: string;
   start_time: string;
   end_time: string;
+  startTime?: string;
+  endTime?: string;
   role_name: string;
   category_name?: string;
   volunteer_id?: number;
@@ -265,6 +286,21 @@ export interface BookingActionResponse {
   rescheduleToken?: string;
   googleCalendarUrl?: string;
   icsUrl?: string;
+}
+
+export interface VolunteerBookingRequest {
+  roleId: number;
+  date: string;
+  type: 'volunteer shift';
+  note?: string;
+}
+
+export interface ResolveVolunteerBookingConflictRequest {
+  existingBookingId: number;
+  roleId?: number;
+  date?: string;
+  keep: 'existing' | 'new';
+  type: 'volunteer shift';
 }
 
 export interface VolunteerBookingInfo {


### PR DESCRIPTION
## Summary
- add RawVolunteerBooking and request body interfaces
- type volunteer booking API calls and normalization
- replace any mappings with typed versions

## Testing
- `npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c8286207f8832db6543ea6be3749b2