### PR TITLE
Add delivery order management and notifications

### DIFF
--- a/MJ_FB_Backend/src/app.ts
+++ b/MJ_FB_Backend/src/app.ts
@@ -47,6 +47,8 @@ import leaveRequestsRoutes from './routes/leaveRequests';
 import sunshineBagsRoutes from './routes/sunshineBags';
 import webauthnRoutes from './routes/webauthn';
 import pantryAggregationsRoutes from './routes/pantry/aggregations';
+import deliveryCategoriesRoutes from './routes/delivery/categories';
+import deliveryOrdersRoutes from './routes/delivery/orders';
 import maintenanceRoutes from './routes/maintenance';
 import { optionalAuthMiddleware } from './middleware/authMiddleware';
 import maintenanceGuard from './middleware/maintenanceGuard';
@@ -130,6 +132,8 @@ api.use('/timesheets', timesheetsRoutes);
 api.use('/leave/requests', leaveRequestsRoutes);
 api.use('/sunshine-bags', sunshineBagsRoutes);
 api.use('/pantry-aggregations', pantryAggregationsRoutes);
+api.use('/delivery/categories', deliveryCategoriesRoutes);
+api.use('/delivery/orders', deliveryOrdersRoutes);
 api.use('/maintenance', maintenanceRoutes);
 
 // Redirect legacy /api requests to /api/v1

--- a/MJ_FB_Backend/src/controllers/deliveryCategoryController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryCategoryController.ts
@@ -1,0 +1,168 @@
+import { Request, Response } from 'express';
+import pool from '../db';
+import asyncHandler from '../middleware/asyncHandler';
+import parseIdParam from '../utils/parseIdParam';
+import type {
+  CreateDeliveryCategoryInput,
+  CreateDeliveryItemInput,
+  UpdateDeliveryCategoryInput,
+  UpdateDeliveryItemInput,
+} from '../schemas/delivery/categorySchemas';
+
+interface CategoryRow {
+  id: number;
+  name: string;
+  max_items: number;
+}
+
+interface ItemRow {
+  id: number;
+  category_id: number;
+  name: string;
+  is_active: boolean | null;
+}
+
+const mapCategory = (row: CategoryRow) => ({
+  id: row.id,
+  name: row.name,
+  maxItems: Number(row.max_items),
+});
+
+const mapItem = (row: ItemRow) => ({
+  id: row.id,
+  categoryId: row.category_id,
+  name: row.name,
+  isActive: row.is_active !== false,
+});
+
+export const listDeliveryCategories = asyncHandler(async (_req: Request, res: Response) => {
+  const [categoriesResult, itemsResult] = await Promise.all([
+    pool.query<CategoryRow>('SELECT id, name, max_items FROM delivery_categories ORDER BY name, id'),
+    pool.query<ItemRow>('SELECT id, category_id, name, is_active FROM delivery_items ORDER BY name, id'),
+  ]);
+
+  const itemsByCategory = new Map<number, ReturnType<typeof mapItem>[]>();
+  for (const row of itemsResult.rows) {
+    const formatted = mapItem(row);
+    if (!itemsByCategory.has(formatted.categoryId)) {
+      itemsByCategory.set(formatted.categoryId, []);
+    }
+    itemsByCategory.get(formatted.categoryId)!.push(formatted);
+  }
+
+  const categories = categoriesResult.rows.map(row => ({
+    ...mapCategory(row),
+    items: itemsByCategory.get(row.id) ?? [],
+  }));
+
+  res.json(categories);
+});
+
+export const createDeliveryCategory = asyncHandler(async (req: Request, res: Response) => {
+  const { name, maxItems } = req.body as CreateDeliveryCategoryInput;
+  const result = await pool.query<CategoryRow>(
+    'INSERT INTO delivery_categories (name, max_items) VALUES ($1, $2) RETURNING id, name, max_items',
+    [name, maxItems],
+  );
+  res.status(201).json({ ...mapCategory(result.rows[0]), items: [] });
+});
+
+export const updateDeliveryCategory = asyncHandler(async (req: Request, res: Response) => {
+  const id = parseIdParam(req.params.id);
+  if (!id) {
+    return res.status(400).json({ message: 'Invalid category id' });
+  }
+  const { name, maxItems } = req.body as UpdateDeliveryCategoryInput;
+  const result = await pool.query<CategoryRow>(
+    'UPDATE delivery_categories SET name = $1, max_items = $2 WHERE id = $3 RETURNING id, name, max_items',
+    [name, maxItems, id],
+  );
+  if (result.rowCount === 0) {
+    return res.status(404).json({ message: 'Category not found' });
+  }
+  res.json(mapCategory(result.rows[0]));
+});
+
+export const deleteDeliveryCategory = asyncHandler(async (req: Request, res: Response) => {
+  const id = parseIdParam(req.params.id);
+  if (!id) {
+    return res.status(400).json({ message: 'Invalid category id' });
+  }
+  const result = await pool.query('DELETE FROM delivery_categories WHERE id = $1', [id]);
+  if (result.rowCount === 0) {
+    return res.status(404).json({ message: 'Category not found' });
+  }
+  res.status(204).send();
+});
+
+export const createDeliveryItem = asyncHandler(async (req: Request, res: Response) => {
+  const categoryId = parseIdParam(req.params.categoryId);
+  if (!categoryId) {
+    return res.status(400).json({ message: 'Invalid category id' });
+  }
+  const { name, isActive } = req.body as CreateDeliveryItemInput;
+  try {
+    const result = await pool.query<ItemRow>(
+      'INSERT INTO delivery_items (category_id, name, is_active) VALUES ($1, $2, $3) RETURNING id, category_id, name, is_active',
+      [categoryId, name, isActive],
+    );
+    res.status(201).json(mapItem(result.rows[0]));
+  } catch (error: any) {
+    if (error?.code === '23503') {
+      return res.status(404).json({ message: 'Category not found' });
+    }
+    throw error;
+  }
+});
+
+export const updateDeliveryItem = asyncHandler(async (req: Request, res: Response) => {
+  const categoryId = parseIdParam(req.params.categoryId);
+  const itemId = parseIdParam(req.params.itemId);
+  if (!categoryId || !itemId) {
+    return res.status(400).json({ message: 'Invalid category or item id' });
+  }
+  const { name, isActive } = req.body as UpdateDeliveryItemInput;
+  const updates: string[] = [];
+  const params: Array<string | number | boolean> = [];
+  let index = 1;
+
+  if (name !== undefined) {
+    updates.push(`name = $${index++}`);
+    params.push(name);
+  }
+  if (isActive !== undefined) {
+    updates.push(`is_active = $${index++}`);
+    params.push(isActive);
+  }
+
+  if (!updates.length) {
+    return res.status(400).json({ message: 'No changes provided' });
+  }
+
+  params.push(itemId, categoryId);
+
+  const result = await pool.query<ItemRow>(
+    `UPDATE delivery_items SET ${updates.join(', ')} WHERE id = $${index++} AND category_id = $${index} RETURNING id, category_id, name, is_active`,
+    params,
+  );
+  if (result.rowCount === 0) {
+    return res.status(404).json({ message: 'Item not found' });
+  }
+  res.json(mapItem(result.rows[0]));
+});
+
+export const deleteDeliveryItem = asyncHandler(async (req: Request, res: Response) => {
+  const categoryId = parseIdParam(req.params.categoryId);
+  const itemId = parseIdParam(req.params.itemId);
+  if (!categoryId || !itemId) {
+    return res.status(400).json({ message: 'Invalid category or item id' });
+  }
+  const result = await pool.query('DELETE FROM delivery_items WHERE id = $1 AND category_id = $2', [
+    itemId,
+    categoryId,
+  ]);
+  if (result.rowCount === 0) {
+    return res.status(404).json({ message: 'Item not found' });
+  }
+  res.status(204).send();
+});

--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -1,0 +1,316 @@
+import { Request, Response } from 'express';
+import pool from '../db';
+import asyncHandler from '../middleware/asyncHandler';
+import parseIdParam from '../utils/parseIdParam';
+import { sendTemplatedEmail } from '../utils/emailUtils';
+import logger from '../utils/logger';
+import {
+  createDeliveryOrderSchema,
+  type DeliveryOrderSelectionInput,
+} from '../schemas/delivery/orderSchemas';
+
+interface ItemInfoRow {
+  itemId: number;
+  categoryId: number;
+  itemName: string;
+  categoryName: string;
+  maxItems: number;
+}
+
+interface DeliveryOrderRow {
+  id: number;
+  clientId: number;
+  address: string;
+  phone: string;
+  email: string | null;
+  createdAt: Date | string;
+}
+
+interface DeliveryOrderItemRow {
+  orderId: number;
+  itemId: number;
+  quantity: number;
+  itemName: string;
+  categoryId: number;
+  categoryName: string;
+}
+
+interface DeliveryOrderItemDetail {
+  itemId: number;
+  quantity: number;
+  itemName: string;
+  categoryId: number;
+  categoryName: string;
+}
+
+type NormalizedSelection = { itemId: number; quantity: number };
+
+function normalizeSelections(selections: DeliveryOrderSelectionInput[]): NormalizedSelection[] {
+  const orderMap = new Map<number, { quantity: number; index: number }>();
+  let order = 0;
+  for (const selection of selections) {
+    const existing = orderMap.get(selection.itemId);
+    if (existing) {
+      existing.quantity += selection.quantity;
+    } else {
+      orderMap.set(selection.itemId, { quantity: selection.quantity, index: order++ });
+    }
+  }
+  return Array.from(orderMap.entries())
+    .sort((a, b) => a[1].index - b[1].index)
+    .map(([itemId, value]) => ({ itemId, quantity: value.quantity }));
+}
+
+function sortItems(items: DeliveryOrderItemDetail[]): DeliveryOrderItemDetail[] {
+  return [...items].sort((a, b) => {
+    const categoryCompare = a.categoryName.localeCompare(b.categoryName);
+    if (categoryCompare !== 0) return categoryCompare;
+    const itemCompare = a.itemName.localeCompare(b.itemName);
+    if (itemCompare !== 0) return itemCompare;
+    return a.itemId - b.itemId;
+  });
+}
+
+function toIsoString(value: Date | string | null | undefined): string {
+  if (!value) return new Date().toISOString();
+  if (value instanceof Date) return value.toISOString();
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString();
+  }
+  return new Date().toISOString();
+}
+
+export const createDeliveryOrder = asyncHandler(async (req: Request, res: Response) => {
+  const parsed = createDeliveryOrderSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ errors: parsed.error.issues });
+  }
+
+  if (!req.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const { clientId, address, phone, email, selections } = parsed.data;
+  const normalizedSelections = normalizeSelections(selections);
+
+  const isClient = req.user.role === 'delivery';
+  const isStaff = req.user.role === 'staff' || req.user.role === 'admin';
+
+  if (!isClient && !isStaff) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  if (isClient) {
+    const requesterId = parseIdParam(req.user.id);
+    if (!requesterId || requesterId !== clientId) {
+      return res.status(403).json({ message: 'Cannot create orders for other clients' });
+    }
+  }
+
+  let itemDetails: DeliveryOrderItemDetail[] = [];
+
+  if (normalizedSelections.length > 0) {
+    const itemIds = normalizedSelections.map(item => item.itemId);
+    const itemsResult = await pool.query<ItemInfoRow>(
+      `SELECT i.id AS "itemId",
+              i.category_id AS "categoryId",
+              i.name AS "itemName",
+              c.name AS "categoryName",
+              c.max_items AS "maxItems"
+         FROM delivery_items i
+         JOIN delivery_categories c ON c.id = i.category_id
+        WHERE i.id = ANY($1::int[])`,
+      [itemIds],
+    );
+
+    if ((itemsResult.rowCount ?? 0) !== itemIds.length) {
+      return res.status(400).json({ message: 'Invalid item selection' });
+    }
+
+    const itemById = new Map<number, ItemInfoRow>();
+    for (const row of itemsResult.rows) {
+      itemById.set(row.itemId, row);
+    }
+
+    const counts = new Map<number, { total: number; maxItems: number; categoryName: string }>();
+    for (const selection of normalizedSelections) {
+      const info = itemById.get(selection.itemId);
+      if (!info) {
+        return res.status(400).json({ message: 'Invalid item selection' });
+      }
+      const current = counts.get(info.categoryId) ?? {
+        total: 0,
+        maxItems: Number(info.maxItems),
+        categoryName: info.categoryName,
+      };
+      current.total += selection.quantity;
+      counts.set(info.categoryId, current);
+      if (current.total > current.maxItems) {
+        return res.status(400).json({
+          message: `Too many items selected for ${info.categoryName}. Limit is ${current.maxItems}.`,
+        });
+      }
+    }
+
+    itemDetails = sortItems(
+      normalizedSelections.map(selection => {
+        const info = itemById.get(selection.itemId)!;
+        return {
+          itemId: selection.itemId,
+          quantity: selection.quantity,
+          itemName: info.itemName,
+          categoryId: info.categoryId,
+          categoryName: info.categoryName,
+        };
+      }),
+    );
+  }
+
+  const orderResult = await pool.query<DeliveryOrderRow>(
+    `INSERT INTO delivery_orders (client_id, address, phone, email)
+         VALUES ($1, $2, $3, $4)
+      RETURNING id, client_id AS "clientId", address, phone, email, created_at AS "createdAt"`,
+    [clientId, address, phone, email],
+  );
+
+  const order = orderResult.rows[0];
+
+  if (normalizedSelections.length > 0) {
+    const values = normalizedSelections
+      .map((_selection, index) => `($1, $${index * 2 + 2}, $${index * 2 + 3})`)
+      .join(', ');
+    const params: number[] = [order.id];
+    for (const selection of normalizedSelections) {
+      params.push(selection.itemId, selection.quantity);
+    }
+    await pool.query(
+      `INSERT INTO delivery_order_items (order_id, item_id, quantity) VALUES ${values}`,
+      params,
+    );
+  }
+
+  const createdAt = toIsoString(order.createdAt);
+  const itemList =
+    itemDetails.length > 0
+      ? itemDetails
+          .map(item => `${item.categoryName}: ${item.itemName} x${item.quantity}`)
+          .join('\n')
+      : 'No items selected';
+
+  try {
+    await sendTemplatedEmail({
+      to: 'amrutha.laxman@mjfoodbank.org',
+      templateId: 16,
+      params: {
+        orderId: order.id,
+        clientId,
+        address,
+        phone,
+        email,
+        itemList,
+        createdAt,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to send delivery order notification email', error);
+  }
+
+  res.status(201).json({
+    id: order.id,
+    clientId: order.clientId,
+    address: order.address,
+    phone: order.phone,
+    email: order.email,
+    createdAt,
+    items: itemDetails,
+  });
+});
+
+export const getDeliveryOrderHistory = asyncHandler(async (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const isClient = req.user.role === 'delivery';
+  const isStaff = req.user.role === 'staff' || req.user.role === 'admin';
+
+  if (!isClient && !isStaff) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  let clientId: number | null = null;
+
+  if (isClient) {
+    clientId = parseIdParam(req.user.id);
+  } else {
+    const requested = req.query.clientId;
+    clientId = parseIdParam(requested);
+    if (!clientId) {
+      return res.status(400).json({ message: 'clientId is required' });
+    }
+  }
+
+  if (!clientId) {
+    return res.status(400).json({ message: 'clientId is required' });
+  }
+
+  const ordersResult = await pool.query<DeliveryOrderRow>(
+    `SELECT id, client_id AS "clientId", address, phone, email, created_at AS "createdAt"
+       FROM delivery_orders
+      WHERE client_id = $1
+      ORDER BY created_at DESC`,
+    [clientId],
+  );
+
+  const orders = ordersResult.rows;
+  const orderIds = orders.map(order => order.id);
+
+  const itemsByOrder = new Map<number, DeliveryOrderItemDetail[]>();
+
+  if (orderIds.length > 0) {
+    const itemsResult = await pool.query<DeliveryOrderItemRow>(
+      `SELECT oi.order_id AS "orderId",
+              oi.item_id AS "itemId",
+              oi.quantity,
+              i.name AS "itemName",
+              i.category_id AS "categoryId",
+              c.name AS "categoryName"
+         FROM delivery_order_items oi
+         JOIN delivery_items i ON i.id = oi.item_id
+         JOIN delivery_categories c ON c.id = i.category_id
+        WHERE oi.order_id = ANY($1::int[])
+     ORDER BY c.name, i.name`,
+      [orderIds],
+    );
+
+    for (const row of itemsResult.rows) {
+      if (!itemsByOrder.has(row.orderId)) {
+        itemsByOrder.set(row.orderId, []);
+      }
+      itemsByOrder.get(row.orderId)!.push({
+        itemId: row.itemId,
+        quantity: row.quantity,
+        itemName: row.itemName,
+        categoryId: row.categoryId,
+        categoryName: row.categoryName,
+      });
+    }
+
+    for (const [orderId, items] of itemsByOrder.entries()) {
+      itemsByOrder.set(orderId, sortItems(items));
+    }
+  }
+
+  const response = orders.map(order => ({
+    id: order.id,
+    clientId: order.clientId,
+    address: order.address,
+    phone: order.phone,
+    email: order.email,
+    createdAt: toIsoString(order.createdAt),
+    items: itemsByOrder.get(order.id) ?? [],
+  }));
+
+  res.json(response);
+});

--- a/MJ_FB_Backend/src/routes/delivery/categories.ts
+++ b/MJ_FB_Backend/src/routes/delivery/categories.ts
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+import {
+  listDeliveryCategories,
+  createDeliveryCategory,
+  updateDeliveryCategory,
+  deleteDeliveryCategory,
+  createDeliveryItem,
+  updateDeliveryItem,
+  deleteDeliveryItem,
+} from '../../controllers/deliveryCategoryController';
+import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
+import { validate } from '../../middleware/validate';
+import {
+  createDeliveryCategorySchema,
+  updateDeliveryCategorySchema,
+  createDeliveryItemSchema,
+  updateDeliveryItemSchema,
+} from '../../schemas/delivery/categorySchemas';
+
+const router = Router();
+
+router.use(authMiddleware);
+router.use(authorizeRoles('staff'));
+
+router.get('/', listDeliveryCategories);
+router.post('/', validate(createDeliveryCategorySchema), createDeliveryCategory);
+router.put('/:id', validate(updateDeliveryCategorySchema), updateDeliveryCategory);
+router.delete('/:id', deleteDeliveryCategory);
+router.post(
+  '/:categoryId/items',
+  validate(createDeliveryItemSchema),
+  createDeliveryItem,
+);
+router.put(
+  '/:categoryId/items/:itemId',
+  validate(updateDeliveryItemSchema),
+  updateDeliveryItem,
+);
+router.delete('/:categoryId/items/:itemId', deleteDeliveryItem);
+
+export default router;

--- a/MJ_FB_Backend/src/routes/delivery/orders.ts
+++ b/MJ_FB_Backend/src/routes/delivery/orders.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import {
+  createDeliveryOrder,
+  getDeliveryOrderHistory,
+} from '../../controllers/deliveryOrderController';
+import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
+import { validate } from '../../middleware/validate';
+import { createDeliveryOrderSchema } from '../../schemas/delivery/orderSchemas';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.post(
+  '/',
+  authorizeRoles('delivery', 'staff'),
+  validate(createDeliveryOrderSchema),
+  createDeliveryOrder,
+);
+
+router.get('/history', authorizeRoles('delivery', 'staff'), getDeliveryOrderHistory);
+
+export default router;

--- a/MJ_FB_Backend/src/schemas/delivery/categorySchemas.ts
+++ b/MJ_FB_Backend/src/schemas/delivery/categorySchemas.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+const nameSchema = z.string().trim().min(1, 'Name is required');
+
+export const createDeliveryCategorySchema = z.object({
+  name: nameSchema,
+  maxItems: z.coerce
+    .number({ invalid_type_error: 'maxItems must be a number' })
+    .int('maxItems must be an integer')
+    .min(0, 'maxItems must be 0 or greater'),
+});
+
+export const updateDeliveryCategorySchema = createDeliveryCategorySchema;
+
+export const createDeliveryItemSchema = z.object({
+  name: nameSchema,
+  isActive: z.coerce.boolean().optional().default(true),
+});
+
+export const updateDeliveryItemSchema = z
+  .object({
+    name: nameSchema.optional(),
+    isActive: z.coerce.boolean().optional(),
+  })
+  .refine(data => data.name !== undefined || data.isActive !== undefined, {
+    message: 'At least one field must be provided',
+    path: [],
+  });
+
+export type CreateDeliveryCategoryInput = z.infer<typeof createDeliveryCategorySchema>;
+export type UpdateDeliveryCategoryInput = z.infer<typeof updateDeliveryCategorySchema>;
+export type CreateDeliveryItemInput = z.infer<typeof createDeliveryItemSchema>;
+export type UpdateDeliveryItemInput = z.infer<typeof updateDeliveryItemSchema>;

--- a/MJ_FB_Backend/src/schemas/delivery/orderSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/delivery/orderSchemas.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const deliveryOrderSelectionSchema = z.object({
+  itemId: z.coerce
+    .number({ invalid_type_error: 'itemId must be a number' })
+    .int('itemId must be an integer')
+    .positive('itemId must be positive'),
+  quantity: z.coerce
+    .number({ invalid_type_error: 'quantity must be a number' })
+    .int('quantity must be an integer')
+    .min(1, 'quantity must be at least 1'),
+});
+
+const nonEmptyString = (field: string) => z.string().trim().min(1, `${field} is required`);
+
+export const createDeliveryOrderSchema = z.object({
+  clientId: z.coerce
+    .number({ invalid_type_error: 'clientId must be a number' })
+    .int('clientId must be an integer')
+    .positive('clientId must be positive'),
+  address: nonEmptyString('Address'),
+  phone: nonEmptyString('Phone'),
+  email: z.string().trim().email('A valid email address is required'),
+  selections: z.array(deliveryOrderSelectionSchema).default([]),
+});
+
+export type DeliveryOrderSelectionInput = z.infer<typeof deliveryOrderSelectionSchema>;
+export type CreateDeliveryOrderInput = z.infer<typeof createDeliveryOrderSchema>;

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -1,0 +1,160 @@
+import mockDb from './utils/mockDb';
+import { createDeliveryOrder } from '../src/controllers/deliveryOrderController';
+import { sendTemplatedEmail } from '../src/utils/emailUtils';
+
+jest.mock('../src/utils/emailUtils', () => ({
+  sendTemplatedEmail: jest.fn(),
+}));
+
+const flushPromises = () => new Promise(process.nextTick);
+
+describe('deliveryOrderController', () => {
+  beforeEach(() => {
+    (mockDb.query as jest.Mock).mockReset();
+    (sendTemplatedEmail as jest.Mock).mockReset();
+  });
+
+  describe('createDeliveryOrder', () => {
+    it('rejects selections exceeding category limits', async () => {
+      (mockDb.query as jest.Mock).mockResolvedValueOnce({
+        rows: [
+          {
+            itemId: 11,
+            categoryId: 5,
+            itemName: 'Canned Soup',
+            categoryName: 'Pantry',
+            maxItems: 1,
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const req = {
+        user: { role: 'delivery', id: '123', type: 'user' },
+        body: {
+          clientId: 123,
+          address: '123 Main St',
+          phone: '555-1111',
+          email: 'client@example.com',
+          selections: [
+            { itemId: 11, quantity: 2 },
+          ],
+        },
+      } as any;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      await createDeliveryOrder(req, res, jest.fn());
+      await flushPromises();
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Too many items selected for Pantry. Limit is 1.',
+      });
+      expect(mockDb.query).toHaveBeenCalledTimes(1);
+      expect(sendTemplatedEmail).not.toHaveBeenCalled();
+    });
+
+    it('creates an order and notifies staff via email', async () => {
+      const submittedAt = new Date('2024-06-01T15:30:00Z');
+      (mockDb.query as jest.Mock)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              itemId: 21,
+              categoryId: 8,
+              itemName: 'Whole Wheat Bread',
+              categoryName: 'Bakery',
+              maxItems: 3,
+            },
+          ],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 77,
+              clientId: 456,
+              address: '456 Elm St',
+              phone: '555-2222',
+              email: 'shopper@example.com',
+              createdAt: submittedAt,
+            },
+          ],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const req = {
+        user: { role: 'staff', id: '99', type: 'staff' },
+        body: {
+          clientId: 456,
+          address: '456 Elm St',
+          phone: '555-2222',
+          email: 'shopper@example.com',
+          selections: [
+            { itemId: 21, quantity: 2 },
+          ],
+        },
+      } as any;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      await createDeliveryOrder(req, res, jest.fn());
+      await flushPromises();
+
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('FROM delivery_items'),
+        [[21]],
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('INSERT INTO delivery_orders'),
+        [456, '456 Elm St', '555-2222', 'shopper@example.com'],
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('INSERT INTO delivery_order_items'),
+        [77, 21, 2],
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 77,
+        clientId: 456,
+        address: '456 Elm St',
+        phone: '555-2222',
+        email: 'shopper@example.com',
+        createdAt: submittedAt.toISOString(),
+        items: [
+          {
+            itemId: 21,
+            quantity: 2,
+            itemName: 'Whole Wheat Bread',
+            categoryId: 8,
+            categoryName: 'Bakery',
+          },
+        ],
+      });
+
+      expect(sendTemplatedEmail).toHaveBeenCalledWith({
+        to: 'amrutha.laxman@mjfoodbank.org',
+        templateId: 16,
+        params: {
+          orderId: 77,
+          clientId: 456,
+          address: '456 Elm St',
+          phone: '555-2222',
+          email: 'shopper@example.com',
+          itemList: 'Bakery: Whole Wheat Bread x2',
+          createdAt: submittedAt.toISOString(),
+        },
+      });
+    });
+  });
+});

--- a/MJ_FB_Backend/tests/emailQueueCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/emailQueueCleanupJob.test.ts
@@ -1,4 +1,13 @@
-jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+const cronScheduleMock = jest.fn();
+jest.mock(
+  'node-cron',
+  () => ({
+    __esModule: true,
+    default: { schedule: cronScheduleMock },
+    schedule: cronScheduleMock,
+  }),
+  { virtual: true },
+);
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
   return {

--- a/MJ_FB_Backend/tests/expiredTokenCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/expiredTokenCleanupJob.test.ts
@@ -1,4 +1,13 @@
-jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+const cronScheduleMock = jest.fn();
+jest.mock(
+  'node-cron',
+  () => ({
+    __esModule: true,
+    default: { schedule: cronScheduleMock },
+    schedule: cronScheduleMock,
+  }),
+  { virtual: true },
+);
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
   return {

--- a/MJ_FB_Backend/tests/passwordTokenCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/passwordTokenCleanupJob.test.ts
@@ -1,4 +1,13 @@
-jest.mock('node-cron', () => ({ schedule: jest.fn() }), { virtual: true });
+const cronScheduleMock = jest.fn();
+jest.mock(
+  'node-cron',
+  () => ({
+    __esModule: true,
+    default: { schedule: cronScheduleMock },
+    schedule: cronScheduleMock,
+  }),
+  { virtual: true },
+);
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
   return {

--- a/MJ_FB_Backend/tests/userController.test.ts
+++ b/MJ_FB_Backend/tests/userController.test.ts
@@ -9,10 +9,14 @@ import issueAuthTokens from '../src/utils/authUtils';
 jest.mock('../src/db');
 jest.mock('bcrypt');
 // Targeted mock for issueAuthTokens to avoid overriding other exports
-jest.mock('../src/utils/authUtils', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
+jest.mock('../src/utils/authUtils', () => {
+  const actual = jest.requireActual('../src/utils/authUtils');
+  return {
+    __esModule: true,
+    ...actual,
+    default: jest.fn(),
+  };
+});
 
 describe('userController', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- add controllers, schemas, and routes to manage delivery categories and orders
- validate delivery order selections, enforce category limits, and trigger staff email notifications
- expand test coverage for delivery orders and adjust cron job mocks for node-cron compatibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c83d2b4e44832d99995171e0410499