### PR TITLE
Make new clients migration idempotent

### DIFF
--- a/MJ_FB_Backend/src/migrations/1699999999998_create_new_clients.ts
+++ b/MJ_FB_Backend/src/migrations/1699999999998_create_new_clients.ts
@@ -7,7 +7,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     email: { type: 'text' },
     phone: { type: 'text' },
     created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
-  });
+  }, { ifNotExists: true });
 
   pgm.addColumn('bookings', {
     new_client_id: {
@@ -15,7 +15,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       references: 'new_clients',
       onDelete: 'set null',
     },
-  });
+  }, { ifNotExists: true });
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {


### PR DESCRIPTION
## Summary
- make the `new_clients` migration tolerate reruns by using `ifNotExists` on the table and column definitions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c840f98954832db3a7cab4f845129d