### PR TITLE
Add delivery booking workflow

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -131,6 +131,10 @@ const DonorDonationLog = React.lazy(() =>
 const PrivacyPolicy = React.lazy(() =>
   import('./pages/privacy/PrivacyPolicy')
 );
+const BookDelivery = React.lazy(() => import('./pages/delivery/BookDelivery'));
+const DeliveryHistory = React.lazy(
+  () => import('./pages/delivery/DeliveryHistory')
+);
 
 const Spinner = () => <CircularProgress />;
 
@@ -245,6 +249,15 @@ export default function App() {
         { label: 'Dashboard', to: '/' },
         { label: 'Book Appointment', to: '/agency/book' },
         { label: 'Booking History', to: '/agency/history' },
+      ],
+    });
+  } else if (role === 'delivery') {
+    navGroups.push({
+      label: 'Delivery',
+      links: [
+        { label: 'Dashboard', to: '/' },
+        { label: 'Book Delivery', to: '/delivery/book' },
+        { label: 'Delivery History', to: '/delivery/history' },
       ],
     });
   } else if (role === 'shopper') {
@@ -565,6 +578,19 @@ export default function App() {
                       <Route
                         path="/volunteer/history"
                         element={<VolunteerBookingHistory />}
+                      />
+                    </>
+                  )}
+
+                  {role === 'delivery' && (
+                    <>
+                      <Route
+                        path="/delivery/book"
+                        element={<BookDelivery />}
+                      />
+                      <Route
+                        path="/delivery/history"
+                        element={<DeliveryHistory />}
                       />
                     </>
                   )}

--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -1,0 +1,434 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CircularProgress,
+  Container,
+  Divider,
+  Grid,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import {
+  API_BASE,
+  apiFetch,
+  getApiErrorMessage,
+  handleResponse,
+} from '../../api/client';
+import type { DeliveryCategory, DeliveryItem } from '../../types';
+
+type QuantityState = Record<number, number>;
+
+type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+};
+
+type FormErrors = {
+  address?: string;
+  phone?: string;
+  email?: string;
+  items?: string;
+};
+
+const PHONE_REGEX = /^\+?[0-9 ()-]{7,}$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function resolveCategoryLimit(category: DeliveryCategory): number {
+  const rawLimit =
+    category.limit ??
+    category.maxItems ??
+    category.maxSelections ??
+    category.limitPerOrder ??
+    0;
+  return rawLimit && rawLimit > 0 ? rawLimit : Number.POSITIVE_INFINITY;
+}
+
+function resolveItemLimit(item: DeliveryItem): number | null {
+  const rawLimit = item.maxQuantity ?? item.maxPerOrder ?? null;
+  return rawLimit && rawLimit > 0 ? rawLimit : null;
+}
+
+function sanitizeQuantity(value: string): number {
+  if (!value) return 0;
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return 0;
+  return Math.max(0, Math.floor(parsed));
+}
+
+export default function BookDelivery() {
+  const [categories, setCategories] = useState<DeliveryCategory[]>([]);
+  const [selectedQuantities, setSelectedQuantities] = useState<QuantityState>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [address, setAddress] = useState('');
+  const [phone, setPhone] = useState('');
+  const [email, setEmail] = useState('');
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  useEffect(() => {
+    let active = true;
+    async function loadCategories() {
+      setLoading(true);
+      try {
+        const res = await apiFetch(`${API_BASE}/delivery/categories`);
+        const data = await handleResponse<DeliveryCategory[]>(res);
+        if (active) {
+          setCategories(data);
+          setError('');
+        }
+      } catch (err) {
+        if (active) {
+          const message = getApiErrorMessage(err);
+          setError(message);
+          setSnackbar({ open: true, message, severity: 'error' });
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    void loadCategories();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const validIds = new Set<number>();
+    categories.forEach(category => {
+      category.items.forEach(item => validIds.add(item.id));
+    });
+    setSelectedQuantities(prev => {
+      const next: QuantityState = {};
+      Object.entries(prev).forEach(([id, quantity]) => {
+        const itemId = Number(id);
+        if (validIds.has(itemId) && quantity > 0) {
+          next[itemId] = quantity;
+        }
+      });
+      return next;
+    });
+  }, [categories]);
+
+  const categoryTotals = useMemo(() => {
+    const totals: Record<number, number> = {};
+    categories.forEach(category => {
+      totals[category.id] = category.items.reduce(
+        (sum, item) => sum + (selectedQuantities[item.id] ?? 0),
+        0,
+      );
+    });
+    return totals;
+  }, [categories, selectedQuantities]);
+
+  const hasSelections = useMemo(
+    () => Object.values(selectedQuantities).some(quantity => quantity > 0),
+    [selectedQuantities],
+  );
+
+  useEffect(() => {
+    if (hasSelections) {
+      setFormErrors(prev => ({ ...prev, items: undefined }));
+    }
+  }, [hasSelections]);
+
+  const handleQuantityChange = (
+    category: DeliveryCategory,
+    item: DeliveryItem,
+    value: string,
+  ) => {
+    const quantity = sanitizeQuantity(value);
+    const categoryLimit = resolveCategoryLimit(category);
+    const itemLimit = resolveItemLimit(item);
+
+    setSelectedQuantities(prev => {
+      const otherSelected = category.items.reduce((sum, categoryItem) => {
+        if (categoryItem.id === item.id) return sum;
+        return sum + (prev[categoryItem.id] ?? 0);
+      }, 0);
+
+      let allowed = quantity;
+      if (Number.isFinite(categoryLimit)) {
+        allowed = Math.min(allowed, Math.max(0, categoryLimit - otherSelected));
+      }
+      if (itemLimit !== null) {
+        allowed = Math.min(allowed, itemLimit);
+      }
+
+      const next = { ...prev };
+      if (allowed > 0) {
+        next[item.id] = allowed;
+      } else {
+        delete next[item.id];
+      }
+      return next;
+    });
+  };
+
+  const remainingSelections = (category: DeliveryCategory) => {
+    const limit = resolveCategoryLimit(category);
+    if (!Number.isFinite(limit)) return null;
+    const total = categoryTotals[category.id] ?? 0;
+    return Math.max(0, limit - total);
+  };
+
+  const handleSnackbarClose = () => {
+    setSnackbar(prev => ({ ...prev, open: false }));
+  };
+
+  const validate = (): boolean => {
+    const nextErrors: FormErrors = {};
+    const trimmedAddress = address.trim();
+    const trimmedPhone = phone.trim();
+    const trimmedEmail = email.trim();
+
+    if (!trimmedAddress) {
+      nextErrors.address = 'Address is required';
+    }
+    if (!trimmedPhone) {
+      nextErrors.phone = 'Phone number is required';
+    } else if (!PHONE_REGEX.test(trimmedPhone)) {
+      nextErrors.phone = 'Enter a valid phone number';
+    }
+    if (!trimmedEmail) {
+      nextErrors.email = 'Email is required';
+    } else if (!EMAIL_REGEX.test(trimmedEmail)) {
+      nextErrors.email = 'Enter a valid email address';
+    }
+    if (!hasSelections) {
+      nextErrors.items = 'Select at least one item to continue';
+    }
+
+    setFormErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validate()) return;
+
+    const payload = {
+      address: address.trim(),
+      phone: phone.trim(),
+      email: email.trim(),
+      items: Object.entries(selectedQuantities)
+        .filter(([, quantity]) => quantity > 0)
+        .map(([itemId, quantity]) => ({
+          itemId: Number(itemId),
+          quantity,
+        })),
+    };
+
+    setSubmitting(true);
+    try {
+      const res = await apiFetch(`${API_BASE}/delivery/orders`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      await handleResponse(res);
+      setSnackbar({
+        open: true,
+        message: 'Delivery request submitted',
+        severity: 'success',
+      });
+      setAddress('');
+      setPhone('');
+      setEmail('');
+      setSelectedQuantities({});
+      setFormErrors({});
+    } catch (err) {
+      const message = getApiErrorMessage(err);
+      setSnackbar({ open: true, message, severity: 'error' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Container
+      component="form"
+      onSubmit={handleSubmit}
+      maxWidth="md"
+      sx={{ py: 4 }}
+    >
+      <FeedbackSnackbar
+        open={snackbar.open}
+        onClose={handleSnackbarClose}
+        message={snackbar.message}
+        severity={snackbar.severity}
+      />
+      <Typography variant="h4" component="h1" gutterBottom>
+        Book Delivery
+      </Typography>
+      <Typography variant="body1" color="text.secondary" gutterBottom>
+        Choose the items you would like delivered and confirm your contact
+        information. We will follow up with your delivery details.
+      </Typography>
+
+      {error && (
+        <Box mb={3}>
+          <Typography color="error">{error}</Typography>
+        </Box>
+      )}
+
+      {loading ? (
+        <Box display="flex" justifyContent="center" py={6}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
+          <Stack spacing={3}>
+            {categories.map(category => {
+              const limit = resolveCategoryLimit(category);
+              const remaining = remainingSelections(category);
+              return (
+                <Card key={category.id}>
+                  <CardHeader
+                    title={category.name}
+                    subheader={
+                      Number.isFinite(limit)
+                        ? `Select up to ${limit} items`
+                        : 'No item limit'
+                    }
+                  />
+                  <CardContent>
+                    {category.description && (
+                      <Typography color="text.secondary" sx={{ mb: 2 }}>
+                        {category.description}
+                      </Typography>
+                    )}
+                    <Grid container spacing={2}>
+                      {category.items.map(item => {
+                        const quantity = selectedQuantities[item.id] ?? 0;
+                        const itemLimit = resolveItemLimit(item);
+                        return (
+                          <Grid key={item.id} size={{ xs: 12, sm: 6 }}>
+                            <TextField
+                              fullWidth
+                              type="number"
+                              label={`${item.name} quantity`}
+                              value={quantity}
+                              onChange={event =>
+                                handleQuantityChange(
+                                  category,
+                                  item,
+                                  event.target.value,
+                                )
+                              }
+                              inputProps={{
+                                min: 0,
+                                ...(itemLimit ? { max: itemLimit } : {}),
+                              }}
+                            />
+                            {item.description && (
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                                sx={{ mt: 1 }}
+                              >
+                                {item.description}
+                              </Typography>
+                            )}
+                            {itemLimit && (
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                                sx={{ mt: 1 }}
+                              >
+                                {`Maximum ${itemLimit} per order`}
+                              </Typography>
+                            )}
+                          </Grid>
+                        );
+                      })}
+                    </Grid>
+                    {Number.isFinite(limit) && (
+                      <Typography variant="body2" sx={{ mt: 2 }}>
+                        Remaining selections: {remaining ?? 0} of {limit}
+                      </Typography>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </Stack>
+
+          {categories.length === 0 && !error && (
+            <Typography color="text.secondary" sx={{ mt: 2 }}>
+              No delivery items are currently available.
+            </Typography>
+          )}
+
+          {formErrors.items && (
+            <Typography variant="body2" color="error" sx={{ mt: 2 }}>
+              {formErrors.items}
+            </Typography>
+          )}
+
+          <Divider sx={{ my: 4 }} />
+
+          <Typography variant="h5" component="h2" gutterBottom>
+            Contact information
+          </Typography>
+
+          <Grid container spacing={2} sx={{ mb: 3 }}>
+            <Grid size={{ xs: 12 }}>
+              <TextField
+                fullWidth
+                label="Delivery address"
+                value={address}
+                onChange={event => setAddress(event.target.value)}
+                error={Boolean(formErrors.address)}
+                helperText={formErrors.address}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <TextField
+                fullWidth
+                label="Phone number"
+                value={phone}
+                onChange={event => setPhone(event.target.value)}
+                error={Boolean(formErrors.phone)}
+                helperText={formErrors.phone}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <TextField
+                fullWidth
+                label="Email"
+                value={email}
+                onChange={event => setEmail(event.target.value)}
+                error={Boolean(formErrors.email)}
+                helperText={formErrors.email}
+              />
+            </Grid>
+          </Grid>
+
+          <Box display="flex" justifyContent="flex-end">
+            <Button
+              type="submit"
+              variant="contained"
+              size="medium"
+              disabled={submitting}
+            >
+              {submitting ? 'Submitting…' : 'Submit Delivery Request'}
+            </Button>
+          </Box>
+        </>
+      )}
+    </Container>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  CircularProgress,
+  Container,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+} from '@mui/material';
+import type { ChipProps } from '@mui/material/Chip';
+import { Link as RouterLink } from 'react-router-dom';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import {
+  API_BASE,
+  apiFetch,
+  getApiErrorMessage,
+  handleResponse,
+} from '../../api/client';
+import type { DeliveryOrder } from '../../types';
+
+type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+};
+
+const STATUS_COLOR_MAP: Partial<
+  Record<DeliveryOrder['status'], ChipProps['color']>
+> = {
+  pending: 'warning',
+  approved: 'info',
+  scheduled: 'info',
+  completed: 'success',
+  cancelled: 'default',
+};
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' });
+
+function formatDate(value?: string | null, useTime = false): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return useTime ? dateTimeFormatter.format(date) : dateFormatter.format(date);
+}
+
+function formatStatusLabel(status: string): string {
+  return status
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function getStatusColor(status: DeliveryOrder['status']): ChipProps['color'] {
+  return STATUS_COLOR_MAP[status] ?? 'default';
+}
+
+export default function DeliveryHistory() {
+  const [orders, setOrders] = useState<DeliveryOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'error',
+  });
+
+  useEffect(() => {
+    let active = true;
+    async function loadOrders() {
+      setLoading(true);
+      try {
+        const res = await apiFetch(`${API_BASE}/delivery/orders`);
+        const data = await handleResponse<DeliveryOrder[]>(res);
+        if (active) {
+          setOrders(data);
+          setError('');
+        }
+      } catch (err) {
+        if (active) {
+          const message = getApiErrorMessage(err);
+          setError(message);
+          setSnackbar({ open: true, message, severity: 'error' });
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    void loadOrders();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleSnackbarClose = () => {
+    setSnackbar(prev => ({ ...prev, open: false }));
+  };
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <FeedbackSnackbar
+        open={snackbar.open}
+        onClose={handleSnackbarClose}
+        message={snackbar.message}
+        severity={snackbar.severity}
+      />
+
+      <Typography variant="h4" component="h1" gutterBottom>
+        Delivery History
+      </Typography>
+      <Typography variant="body1" color="text.secondary" gutterBottom>
+        Review your previous delivery requests and track their status.
+      </Typography>
+
+      {error && (
+        <Box mb={3}>
+          <Typography color="error">{error}</Typography>
+        </Box>
+      )}
+
+      {loading ? (
+        <Box display="flex" justifyContent="center" py={6}>
+          <CircularProgress />
+        </Box>
+      ) : orders.length === 0 ? (
+        <Box textAlign="center" py={6}>
+          <Typography variant="h6" gutterBottom>
+            No deliveries yet
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 3 }}>
+            Your delivery history will appear here once you submit a request.
+          </Typography>
+          <Button
+            component={RouterLink}
+            to="/delivery/book"
+            variant="contained"
+            size="medium"
+          >
+            Book a Delivery
+          </Button>
+        </Box>
+      ) : (
+        <Stack spacing={3}>
+          {orders.map(order => {
+            const submittedOn = formatDate(order.createdAt, true);
+            const scheduledFor = formatDate(order.scheduledFor ?? undefined, false);
+            return (
+              <Card key={order.id}>
+                <CardHeader
+                  title={`Order #${order.id}`}
+                  subheader={submittedOn ? `Submitted ${submittedOn}` : undefined}
+                  action={
+                    <Chip
+                      label={formatStatusLabel(order.status)}
+                      color={getStatusColor(order.status)}
+                    />
+                  }
+                />
+                <CardContent>
+                  <Stack spacing={1.5}>
+                    {scheduledFor && (
+                      <Typography variant="body2" color="text.secondary">
+                        Scheduled for {scheduledFor}
+                      </Typography>
+                    )}
+                    <Typography variant="body2">
+                      <strong>Address:</strong> {order.address}
+                    </Typography>
+                    <Typography variant="body2">
+                      <strong>Phone:</strong> {order.phone}
+                    </Typography>
+                    {order.email && (
+                      <Typography variant="body2">
+                        <strong>Email:</strong> {order.email}
+                      </Typography>
+                    )}
+                    {order.notes && (
+                      <Typography variant="body2" color="text.secondary">
+                        {order.notes}
+                      </Typography>
+                    )}
+                    <Divider sx={{ my: 1.5 }} />
+                    <Typography variant="subtitle1">Items</Typography>
+                    <List dense disablePadding>
+                      {order.items.map(item => (
+                        <ListItem
+                          key={`${order.id}-${item.itemId}`}
+                          disableGutters
+                          sx={{ py: 0.5 }}
+                        >
+                          <ListItemText
+                            primary={item.name}
+                            secondary={`Quantity: ${item.quantity}${
+                              item.categoryName ? ` · ${item.categoryName}` : ''
+                            }`}
+                          />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Stack>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </Stack>
+      )}
+    </Container>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import BookDelivery from '../BookDelivery';
+import type { DeliveryCategory } from '../../../types';
+import { apiFetch, handleResponse } from '../../../api/client';
+
+jest.mock('../../../api/client', () => ({
+  API_BASE: '/api/v1',
+  apiFetch: jest.fn(),
+  handleResponse: jest.fn(),
+  getApiErrorMessage: jest.fn((error: unknown) =>
+    error instanceof Error ? error.message : 'Request failed',
+  ),
+}));
+
+const mockCategories: DeliveryCategory[] = [
+  {
+    id: 1,
+    name: 'Pantry Staples',
+    limit: 3,
+    items: [
+      { id: 10, categoryId: 1, name: 'Cereal', maxQuantity: 3 },
+      { id: 11, categoryId: 1, name: 'Pasta', maxQuantity: 3 },
+    ],
+  },
+];
+
+describe('BookDelivery', () => {
+  beforeEach(() => {
+    (apiFetch as jest.Mock).mockClear();
+    (handleResponse as jest.Mock).mockClear();
+    (apiFetch as jest.Mock).mockResolvedValue(
+      new Response(null, { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+  });
+
+  test('caps selection when category limit reached', async () => {
+    (handleResponse as jest.Mock).mockResolvedValueOnce(mockCategories);
+
+    render(
+      <MemoryRouter>
+        <BookDelivery />
+      </MemoryRouter>,
+    );
+
+    const cerealInput = await screen.findByLabelText(/cereal quantity/i);
+    fireEvent.change(cerealInput, { target: { value: '2' } });
+
+    const pastaInput = screen.getByLabelText(/pasta quantity/i);
+    fireEvent.change(pastaInput, { target: { value: '2' } });
+
+    await waitFor(() => expect(pastaInput).toHaveValue(1));
+    expect(screen.getByText(/remaining selections: 0 of 3/i)).toBeInTheDocument();
+  });
+
+  test('submits selections with contact information', async () => {
+    (handleResponse as jest.Mock)
+      .mockResolvedValueOnce(mockCategories)
+      .mockResolvedValueOnce({});
+
+    render(
+      <MemoryRouter>
+        <BookDelivery />
+      </MemoryRouter>,
+    );
+
+    const cerealInput = await screen.findByLabelText(/cereal quantity/i);
+    fireEvent.change(cerealInput, { target: { value: '1' } });
+
+    fireEvent.change(screen.getByLabelText(/delivery address/i), {
+      target: { value: '123 Main Street' },
+    });
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '306-555-0100' },
+    });
+    fireEvent.change(screen.getByLabelText(/^email$/i), {
+      target: { value: 'test@example.com' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /submit delivery request/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+
+    const postCall = (apiFetch as jest.Mock).mock.calls[1];
+    expect(postCall[0]).toBe('/api/v1/delivery/orders');
+    expect(postCall[1]).toMatchObject({ method: 'POST' });
+    const body = JSON.parse(postCall[1].body);
+    expect(body).toEqual({
+      address: '123 Main Street',
+      phone: '306-555-0100',
+      email: 'test@example.com',
+      items: [{ itemId: 10, quantity: 1 }],
+    });
+
+    expect(await screen.findByText(/delivery request submitted/i)).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -11,6 +11,54 @@ export type StaffAccess =
   | 'donation_entry'
   | 'aggregations';
 
+export interface DeliveryItem {
+  id: number;
+  categoryId: number;
+  name: string;
+  description?: string | null;
+  maxQuantity?: number | null;
+  maxPerOrder?: number | null;
+  unit?: string | null;
+}
+
+export interface DeliveryCategory {
+  id: number;
+  name: string;
+  description?: string | null;
+  limit?: number | null;
+  maxItems?: number | null;
+  maxSelections?: number | null;
+  limitPerOrder?: number | null;
+  items: DeliveryItem[];
+}
+
+export type DeliveryOrderStatus =
+  | 'pending'
+  | 'approved'
+  | 'scheduled'
+  | 'completed'
+  | 'cancelled';
+
+export interface DeliveryOrderItem {
+  itemId: number;
+  name: string;
+  quantity: number;
+  categoryId: number;
+  categoryName?: string | null;
+}
+
+export interface DeliveryOrder {
+  id: number;
+  status: DeliveryOrderStatus;
+  createdAt: string;
+  scheduledFor?: string | null;
+  address: string;
+  phone: string;
+  email?: string | null;
+  notes?: string | null;
+  items: DeliveryOrderItem[];
+}
+
 export interface Staff {
   id: number;
   firstName: string;


### PR DESCRIPTION
## Summary
- extend the dashboard navigation to surface delivery booking and history routes for delivery users
- implement delivery booking and delivery history pages with API integration, validation, and user feedback
- document delivery data shapes and cover booking form behaviour with targeted unit tests

## Testing
- npm test *(fails: process ran out of memory when running the full suite)*
- npm test -- BookDelivery

------
https://chatgpt.com/codex/tasks/task_e_68c83d5e14bc832dbb65a95ed6ffb4c9