### PR TITLE
Update delivery categories API path

### DIFF
--- a/MJ_FB_Frontend/src/api/deliveryCategories.ts
+++ b/MJ_FB_Frontend/src/api/deliveryCategories.ts
@@ -22,14 +22,14 @@ interface DeliveryCategoryItemPayload {
 }
 
 export async function getDeliveryCategories(): Promise<DeliveryCategory[]> {
-  const res = await apiFetch(`${API_BASE}/delivery-categories`);
+  const res = await apiFetch(`${API_BASE}/delivery/categories`);
   return handleResponse(res);
 }
 
 export async function createDeliveryCategory(
   payload: DeliveryCategoryPayload,
 ): Promise<DeliveryCategory> {
-  const res = await apiFetch(`${API_BASE}/delivery-categories`, {
+  const res = await apiFetch(`${API_BASE}/delivery/categories`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -41,7 +41,7 @@ export async function updateDeliveryCategory(
   id: number,
   payload: DeliveryCategoryPayload,
 ): Promise<DeliveryCategory> {
-  const res = await apiFetch(`${API_BASE}/delivery-categories/${id}`, {
+  const res = await apiFetch(`${API_BASE}/delivery/categories/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -50,7 +50,7 @@ export async function updateDeliveryCategory(
 }
 
 export async function deleteDeliveryCategory(id: number): Promise<void> {
-  const res = await apiFetch(`${API_BASE}/delivery-categories/${id}`, {
+  const res = await apiFetch(`${API_BASE}/delivery/categories/${id}`, {
     method: 'DELETE',
   });
   await handleResponse(res);
@@ -60,7 +60,7 @@ export async function createDeliveryCategoryItem(
   categoryId: number,
   payload: DeliveryCategoryItemPayload,
 ): Promise<DeliveryCategoryItem> {
-  const res = await apiFetch(`${API_BASE}/delivery-categories/${categoryId}/items`, {
+  const res = await apiFetch(`${API_BASE}/delivery/categories/${categoryId}/items`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -73,7 +73,7 @@ export async function updateDeliveryCategoryItem(
   itemId: number,
   payload: DeliveryCategoryItemPayload,
 ): Promise<DeliveryCategoryItem> {
-  const res = await apiFetch(`${API_BASE}/delivery-categories/${categoryId}/items/${itemId}`, {
+  const res = await apiFetch(`${API_BASE}/delivery/categories/${categoryId}/items/${itemId}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -85,7 +85,7 @@ export async function deleteDeliveryCategoryItem(
   categoryId: number,
   itemId: number,
 ): Promise<void> {
-  const res = await apiFetch(`${API_BASE}/delivery-categories/${categoryId}/items/${itemId}`, {
+  const res = await apiFetch(`${API_BASE}/delivery/categories/${categoryId}/items/${itemId}`, {
     method: 'DELETE',
   });
   await handleResponse(res);


### PR DESCRIPTION
## Summary
- update the deliveryCategories API wrapper to call the /delivery/categories endpoints so it matches other usage

## Testing
- NODE_OPTIONS=--max-old-space-size=4096 CI=1 npm test -- --runTestsByPath src/__tests__/VolunteerBooking.test.tsx *(fails: VolunteerBooking › requests a slot and shows confirmation)*

------
https://chatgpt.com/codex/tasks/task_e_68c843a84630832db3ebc1684c3a88eb