### PR TITLE
Fix donor lookup queries for email-based schema

### DIFF
--- a/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
+++ b/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
@@ -34,7 +34,7 @@ export async function refreshWarehouseOverall(year: number, month: number) {
     pool.query(
       `SELECT o.email AS "donorEmail", COALESCE(SUM(d.weight)::int, 0) AS total
          FROM donations d
-         JOIN donors o ON d.donor_id = o.id
+         JOIN donors o ON d.donor_email = o.email
          WHERE EXTRACT(YEAR FROM d.date) = $1 AND EXTRACT(MONTH FROM d.date) = $2
          GROUP BY o.email`,
       [year, month],

--- a/MJ_FB_Backend/tests/donationController.test.ts
+++ b/MJ_FB_Backend/tests/donationController.test.ts
@@ -125,31 +125,35 @@ describe('donationController', () => {
       (mockDb.query as jest.Mock)
         .mockResolvedValueOnce({
           rows: [
-            { id: 1, date: '2024-05-20', donorId: 2, weight: 10 },
+            { id: 2, firstName: 'Alice', lastName: 'Smith', email: 'a@example.com' },
           ],
         })
         .mockResolvedValueOnce({
           rows: [
-            { firstName: 'Alice', lastName: 'Smith', email: 'a@example.com' },
+            { id: 1, date: '2024-05-20', weight: 10 },
           ],
         });
       const req = { body: { date: '2024-05-20', donorId: 2, weight: 10 } } as any;
       const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
       await addDonation(req, res, jest.fn());
       await flushPromises();
-      expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), [
-        '2024-05-20',
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        1,
+        'SELECT id, first_name AS "firstName", last_name AS "lastName", email FROM donors WHERE id = $1',
+        [2],
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
-        10,
-      ]);
-      expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), [2]);
+        'INSERT INTO donations (date, donor_email, weight) VALUES ($1, $2, $3) RETURNING id, date, weight',
+        ['2024-05-20', 'a@example.com', 10],
+      );
       expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith({
         id: 1,
         date: '2024-05-20',
-        donorId: 2,
         weight: 10,
+        donorId: 2,
         firstName: 'Alice',
         lastName: 'Smith',
         email: 'a@example.com',
@@ -172,12 +176,12 @@ describe('donationController', () => {
       (mockDb.query as jest.Mock)
         .mockResolvedValueOnce({ rows: [{ date: '2024-04-30' }] })
         .mockResolvedValueOnce({
-          rows: [{ id: 1, date: '2024-05-02', donorId: 2, weight: 15 }],
+          rows: [
+            { id: 2, firstName: 'Alice', lastName: 'Smith', email: 'a@example.com' },
+          ],
         })
         .mockResolvedValueOnce({
-          rows: [
-            { firstName: 'Alice', lastName: 'Smith', email: 'a@example.com' },
-          ],
+          rows: [{ id: 1, date: '2024-05-02', weight: 15 }],
         });
       const req = {
         params: { id: '1' },
@@ -191,8 +195,8 @@ describe('donationController', () => {
       expect(res.json).toHaveBeenCalledWith({
         id: 1,
         date: '2024-05-02',
-        donorId: 2,
         weight: 15,
+        donorId: 2,
         firstName: 'Alice',
         lastName: 'Smith',
         email: 'a@example.com',

--- a/MJ_FB_Backend/tests/donationsMonth.test.ts
+++ b/MJ_FB_Backend/tests/donationsMonth.test.ts
@@ -74,9 +74,9 @@ describe('GET /donations?month=', () => {
     );
     expect(pool.query).toHaveBeenNthCalledWith(
       2,
-      `SELECT d.id, d.date, d.weight, d.donor_id as "donorId",
+      `SELECT d.id, d.date, d.weight, o.id as "donorId",
               o.first_name as "firstName", o.last_name as "lastName", o.email
-         FROM donations d JOIN donors o ON d.donor_id = o.id
+         FROM donations d JOIN donors o ON d.donor_email = o.email
          WHERE d.date >= $1 AND d.date < $2 ORDER BY d.date, d.id`,
       [`${year}-${month}-01`, `${year}-${nextMonth}-01`],
     );

--- a/MJ_FB_Backend/tests/donorDonations.test.ts
+++ b/MJ_FB_Backend/tests/donorDonations.test.ts
@@ -50,7 +50,11 @@ describe('GET /donors/:id/donations', () => {
     );
     expect(pool.query).toHaveBeenNthCalledWith(
       2,
-      'SELECT id, date, weight FROM donations WHERE donor_id = $1 ORDER BY date DESC, id DESC',
+      `SELECT n.id, n.date, n.weight
+       FROM donations n
+       JOIN donors d ON n.donor_email = d.email
+       WHERE d.id = $1
+       ORDER BY n.date DESC, n.id DESC`,
       ['5'],
     );
     expect(res.body).toEqual([


### PR DESCRIPTION
## Summary
- join donations to donors by email in donor and warehouse controllers to match the latest schema
- update donation CRUD logic to resolve donor emails before persisting and handle missing donors
- refresh related tests to cover the new SQL and data flow

## Testing
- npx jest --runTestsByPath tests/topLists.test.ts tests/donorDonations.test.ts tests/donationsMonth.test.ts tests/donationController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c850f044a0832dbb22ecea0c4117ae