### PR TITLE
Update delivery client dashboard and navigation

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -135,6 +135,9 @@ const BookDelivery = React.lazy(() => import('./pages/delivery/BookDelivery'));
 const DeliveryHistory = React.lazy(
   () => import('./pages/delivery/DeliveryHistory')
 );
+const DeliveryDashboard = React.lazy(
+  () => import('./pages/delivery/DeliveryDashboard')
+);
 
 const Spinner = () => <CircularProgress />;
 
@@ -350,6 +353,8 @@ export default function App() {
                             <Dashboard role="staff" masterRoleFilter={['Pantry']} />
                           </Suspense>
                         )
+                      ) : role === 'delivery' ? (
+                        <DeliveryDashboard />
                       ) : (
                         <ClientDashboard />
                       )

--- a/MJ_FB_Frontend/src/__tests__/ClientBottomNav.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/ClientBottomNav.test.tsx
@@ -49,6 +49,28 @@ describe('ClientBottomNav', () => {
     expect(queryByLabelText('dashboard')).not.toBeInTheDocument();
   });
 
+  it('shows delivery navigation for delivery clients', () => {
+    mockUseAuth.mockReturnValue({ role: 'delivery' });
+    render(
+      <MemoryRouter initialEntries={['/delivery/history']}>
+        <ClientBottomNav />
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText('delivery')).toHaveClass('Mui-selected');
+    expect(screen.queryByLabelText('bookings')).not.toBeInTheDocument();
+  });
+
+  it('navigates delivery clients to the delivery booking page', () => {
+    mockUseAuth.mockReturnValue({ role: 'delivery' });
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ClientBottomNav />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByLabelText('delivery'));
+    expect(mockNavigate).toHaveBeenCalledWith('/delivery/book');
+  });
+
   it('uses a larger tap target', () => {
     const { container } = render(
       <MemoryRouter initialEntries={['/']}>

--- a/MJ_FB_Frontend/src/components/ClientBottomNav.tsx
+++ b/MJ_FB_Frontend/src/components/ClientBottomNav.tsx
@@ -16,9 +16,16 @@ export default function ClientBottomNav() {
     ({ role } = useAuth());
   } catch {}
   if (role === 'staff') return null;
-  let value: 'dashboard' | 'bookings' | 'profile' = 'dashboard';
-  if (pathname.startsWith('/book-appointment') || pathname.startsWith('/booking-history')) value = 'bookings';
-  else if (pathname.startsWith('/profile')) value = 'profile';
+  const isDelivery = role === 'delivery';
+  let value: 'dashboard' | 'bookings' | 'delivery' | 'profile' = 'dashboard';
+  if (pathname.startsWith('/profile')) value = 'profile';
+  else if (isDelivery) {
+    if (pathname.startsWith('/delivery')) value = 'delivery';
+  } else if (
+    pathname.startsWith('/book-appointment') ||
+    pathname.startsWith('/booking-history')
+  )
+    value = 'bookings';
 
   return (
     <Paper
@@ -39,11 +46,17 @@ export default function ClientBottomNav() {
         onChange={(_, newValue) => {
           if (newValue === 'dashboard') navigate('/');
           if (newValue === 'bookings') navigate('/book-appointment');
+          if (newValue === 'delivery') navigate('/delivery/book');
           if (newValue === 'profile') navigate('/profile');
         }}
       >
         <BottomNavigationAction label="Dashboard" value="dashboard" icon={<Dashboard />} aria-label="dashboard" />
-        <BottomNavigationAction label="Bookings" value="bookings" icon={<CalendarToday />} aria-label="bookings" />
+        <BottomNavigationAction
+          label={isDelivery ? 'Delivery' : 'Bookings'}
+          value={isDelivery ? 'delivery' : 'bookings'}
+          icon={<CalendarToday />}
+          aria-label={isDelivery ? 'delivery' : 'bookings'}
+        />
         <BottomNavigationAction label="Profile" value="profile" icon={<AccountCircle />} aria-label="profile" />
       </BottomNavigation>
     </Paper>

--- a/MJ_FB_Frontend/src/pages/delivery/DeliveryDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/DeliveryDashboard.tsx
@@ -1,0 +1,97 @@
+import { Button, Grid, Stack, Typography } from '@mui/material';
+import LocalShipping from '@mui/icons-material/LocalShipping';
+import History from '@mui/icons-material/History';
+import Info from '@mui/icons-material/Info';
+import { useNavigate } from 'react-router-dom';
+import SectionCard from '../../components/dashboard/SectionCard';
+import Page from '../../components/Page';
+import ClientBottomNav from '../../components/ClientBottomNav';
+
+export default function DeliveryDashboard() {
+  const navigate = useNavigate();
+
+  return (
+    <Page title="Delivery Dashboard">
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Stack spacing={2}>
+            <SectionCard
+              title="Request a delivery"
+              icon={<LocalShipping color="primary" />}
+            >
+              <Stack spacing={2}>
+                <Typography color="text.secondary">
+                  Tell us what you need and we will arrange a delivery with you.
+                </Typography>
+                <Stack
+                  direction={{ xs: 'column', sm: 'row' }}
+                  spacing={1}
+                  alignItems={{ xs: 'stretch', sm: 'center' }}
+                >
+                  <Button
+                    variant="contained"
+                    size="medium"
+                    sx={{ textTransform: 'none', width: { xs: '100%', sm: 'auto' } }}
+                    onClick={() => navigate('/delivery/book')}
+                  >
+                    Book a delivery
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    size="medium"
+                    sx={{ textTransform: 'none', width: { xs: '100%', sm: 'auto' } }}
+                    onClick={() => navigate('/delivery/history')}
+                  >
+                    View history
+                  </Button>
+                </Stack>
+              </Stack>
+            </SectionCard>
+            <SectionCard
+              title="Track your requests"
+              icon={<History color="primary" />}
+            >
+              <Stack spacing={1.5}>
+                <Typography color="text.secondary">
+                  Review every order, see scheduled dates, and double-check what you requested.
+                </Typography>
+                <Button
+                  variant="text"
+                  size="medium"
+                  sx={{
+                    textTransform: 'none',
+                    alignSelf: { xs: 'stretch', sm: 'flex-start' },
+                  }}
+                  onClick={() => navigate('/delivery/history')}
+                >
+                  Go to delivery history
+                </Button>
+              </Stack>
+            </SectionCard>
+          </Stack>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Stack spacing={2}>
+            <SectionCard
+              title="Helpful reminders"
+              icon={<Info color="primary" />}
+            >
+              <Stack component="ul" spacing={1.5} sx={{ pl: 2, m: 0 }}>
+                <Typography component="li" color="text.secondary">
+                  Keep your address, phone, and email up to date so we can reach you quickly.
+                </Typography>
+                <Typography component="li" color="text.secondary">
+                  Submit one request at a time—place a new order after we finish the current one.
+                </Typography>
+                <Typography component="li" color="text.secondary">
+                  Contact the food bank if you need to change or cancel a request after submitting it.
+                </Typography>
+              </Stack>
+            </SectionCard>
+          </Stack>
+        </Grid>
+      </Grid>
+      <ClientBottomNav />
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated DeliveryDashboard page with quick actions and reminders for delivery clients
- show the new delivery dashboard at the root route for delivery users instead of the shopper dashboard
- adjust the client bottom navigation and tests so delivery clients see a Delivery tab that links to their booking flow

## Testing
- CI=1 npm test -- --maxWorkers=2 *(fails: Jest worker terminated by SIGTERM in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85353b858832d85f5039a830cc89e