### PR TITLE
Add is_active flag to delivery items

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000058_add_is_active_to_delivery_items.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000058_add_is_active_to_delivery_items.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('delivery_items', {
+    is_active: { type: 'boolean', notNull: true, default: true },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('delivery_items', 'is_active');
+}

--- a/MJ_FB_Backend/src/models/delivery.ts
+++ b/MJ_FB_Backend/src/models/delivery.ts
@@ -11,6 +11,7 @@ export interface DeliveryItem {
   id: number;
   categoryId: number;
   name: string;
+  isActive: boolean;
 }
 
 export interface DeliveryOrder {
@@ -61,7 +62,7 @@ export async function createDeliveryItem(
   const res = await client.query<DeliveryItem>(
     `INSERT INTO delivery_items (category_id, name)
      VALUES ($1, $2)
-     RETURNING id, category_id AS "categoryId", name`,
+     RETURNING id, category_id AS "categoryId", name, is_active AS "isActive"`,
     [categoryId, name],
   );
   return res.rows[0];
@@ -71,7 +72,7 @@ export async function listDeliveryItems(
   client: Queryable = pool,
 ): Promise<DeliveryItem[]> {
   const res = await client.query<DeliveryItem>(
-    `SELECT id, category_id AS "categoryId", name
+    `SELECT id, category_id AS "categoryId", name, is_active AS "isActive"
        FROM delivery_items
       ORDER BY name`,
   );
@@ -83,7 +84,7 @@ export async function listDeliveryItemsByCategory(
   client: Queryable = pool,
 ): Promise<DeliveryItem[]> {
   const res = await client.query<DeliveryItem>(
-    `SELECT id, category_id AS "categoryId", name
+    `SELECT id, category_id AS "categoryId", name, is_active AS "isActive"
        FROM delivery_items
       WHERE category_id = $1
       ORDER BY name`,

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -30,20 +30,58 @@ describe('deliveryOrderController', () => {
           ],
           rowCount: 1,
         });
-    it('rejects selections exceeding category limits after normalizing duplicates', async () => {
-      (mockDb.query as jest.Mock).mockResolvedValueOnce({
-        rows: [
-          {
-            itemId: 11,
-            categoryId: 5,
-            itemName: 'Canned Soup',
-            categoryName: 'Pantry',
-            maxItems: 3,
-          },
-        ],
-        rowCount: 1,
-      });
 
+      const req = {
+        user: { role: 'delivery', id: '123', type: 'user' },
+        body: {
+          clientId: 123,
+          address: '123 Main St',
+          phone: '555-1111',
+          email: 'client@example.com',
+          selections: [{ itemId: 11, quantity: 2 }],
+        },
+      } as any;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      await createDeliveryOrder(req, res, jest.fn());
+      await flushPromises();
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Too many items selected for Pantry. Limit is 1.',
+      });
+      expect(mockDb.query).toHaveBeenCalledTimes(2);
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('FROM delivery_orders'),
+        [123],
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('FROM delivery_items'),
+        [[11]],
+      );
+      expect(sendTemplatedEmail).not.toHaveBeenCalled();
+    });
+
+    it('rejects selections exceeding category limits after normalizing duplicates', async () => {
+      (mockDb.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              itemId: 11,
+              categoryId: 5,
+              itemName: 'Canned Soup',
+              categoryName: 'Pantry',
+              maxItems: 3,
+            },
+          ],
+          rowCount: 1,
+        });
 
       const req = {
         user: { role: 'delivery', id: '123', type: 'user' },
@@ -75,8 +113,9 @@ describe('deliveryOrderController', () => {
         1,
         expect.stringContaining('FROM delivery_orders'),
         [123],
-      expect(mockDb.query).toHaveBeenCalledTimes(1);
-      expect(mockDb.query).toHaveBeenCalledWith(
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        2,
         expect.stringContaining('FROM delivery_items'),
         [[11]],
       );


### PR DESCRIPTION
## Summary
- add a migration to introduce an `is_active` boolean column on `delivery_items`
- update delivery models to surface the new flag when creating and listing items
- adjust delivery order controller tests to cover the updated query expectations

## Testing
- `npm test -- tests/deliveryCategoryController.test.ts tests/deliveryOrderController.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c8525ffa28832d90f43a81bc8a0b49