### PR TITLE
Allow delivery clients to read delivery categories

### DIFF
--- a/MJ_FB_Backend/src/routes/delivery/categories.ts
+++ b/MJ_FB_Backend/src/routes/delivery/categories.ts
@@ -20,9 +20,10 @@ import {
 const router = Router();
 
 router.use(authMiddleware);
-router.use(authorizeRoles('staff'));
 
-router.get('/', listDeliveryCategories);
+router.get('/', authorizeRoles('delivery', 'staff'), listDeliveryCategories);
+
+router.use(authorizeRoles('staff'));
 router.post('/', validate(createDeliveryCategorySchema), createDeliveryCategory);
 router.put('/:id', validate(updateDeliveryCategorySchema), updateDeliveryCategory);
 router.delete('/:id', deleteDeliveryCategory);


### PR DESCRIPTION
## Summary
- allow delivery-role users to access the delivery categories list endpoint
- keep category and item management routes limited to staff

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c85c3a120c832d9182795341af5ef7