### PR TITLE
Seed delivery categories in development

### DIFF
--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -24,6 +24,7 @@ import { initEmailQueue, shutdownQueue } from './utils/emailQueue';
 import { startEmailQueueCleanupJob, stopEmailQueueCleanupJob } from './utils/emailQueueCleanupJob';
 import seedPayPeriods from './utils/payPeriodSeeder';
 import seedTimesheets from './utils/timesheetSeeder';
+import seedDeliveryData from './utils/deliverySeeder';
 import {
   startTimesheetSeedJob,
   stopTimesheetSeedJob,
@@ -72,6 +73,7 @@ async function init() {
       const end = `${now.getFullYear() + 1}-12-31`;
       await seedPayPeriods(start, end);
       await seedTimesheets();
+      await seedDeliveryData();
     }
     startTimesheetSeedJob();
     startRetentionJob();

--- a/MJ_FB_Backend/src/utils/deliverySeeder.ts
+++ b/MJ_FB_Backend/src/utils/deliverySeeder.ts
@@ -1,0 +1,112 @@
+import pool from '../db';
+import logger from './logger';
+
+interface DeliveryCategorySeed {
+  name: string;
+  maxItems: number;
+  items: string[];
+}
+
+const DELIVERY_SEED_DATA: DeliveryCategorySeed[] = [
+  {
+    name: 'Pantry Staples',
+    maxItems: 6,
+    items: ['Pasta', 'Rice', 'Canned Soup', 'Cereal', 'Canned Tomatoes', 'Peanut Butter'],
+  },
+  {
+    name: 'Proteins',
+    maxItems: 4,
+    items: ['Canned Tuna', 'Canned Chicken', 'Beans', 'Lentils'],
+  },
+  {
+    name: 'Fresh Produce',
+    maxItems: 5,
+    items: ['Apples', 'Bananas', 'Carrots', 'Onions', 'Potatoes'],
+  },
+  {
+    name: 'Dairy & Eggs',
+    maxItems: 3,
+    items: ['Milk', 'Cheese', 'Eggs', 'Yogurt'],
+  },
+  {
+    name: 'Frozen Meals',
+    maxItems: 3,
+    items: ['Frozen Vegetables', 'Frozen Meat', 'Frozen Entrées'],
+  },
+  {
+    name: 'Household & Hygiene',
+    maxItems: 3,
+    items: ['Toilet Paper', 'Laundry Detergent', 'Soap', 'Shampoo'],
+  },
+  {
+    name: 'Baby & Toddler',
+    maxItems: 2,
+    items: ['Diapers', 'Baby Formula', 'Baby Wipes'],
+  },
+  {
+    name: 'Snacks & Extras',
+    maxItems: 2,
+    items: ['Granola Bars', 'Crackers', 'Juice Boxes'],
+  },
+];
+
+export async function seedDeliveryData(): Promise<void> {
+  const client = await pool.connect();
+
+  try {
+    const tableCheck = await client.query<{ categories: string | null; items: string | null }>(
+      `SELECT
+         to_regclass('public.delivery_categories') AS categories,
+         to_regclass('public.delivery_items') AS items`,
+    );
+
+    const tables = tableCheck.rows[0];
+    if (!tables?.categories || !tables?.items) {
+      logger.warn('Skipping delivery seed: delivery tables not found');
+      return;
+    }
+
+    for (const category of DELIVERY_SEED_DATA) {
+      const insertCategory = await client.query<{ id: number }>(
+        `INSERT INTO delivery_categories (name, max_items)
+         SELECT $1, $2
+          WHERE NOT EXISTS (
+            SELECT 1 FROM delivery_categories WHERE name = $1
+          )
+         RETURNING id`,
+        [category.name, category.maxItems],
+      );
+
+      let categoryId = insertCategory.rows[0]?.id;
+      if (!categoryId) {
+        const existingCategory = await client.query<{ id: number }>(
+          'SELECT id FROM delivery_categories WHERE name = $1 LIMIT 1',
+          [category.name],
+        );
+        categoryId = existingCategory.rows[0]?.id;
+      }
+
+      if (!categoryId) {
+        logger.warn(`Skipping delivery items for category "${category.name}" – id lookup failed`);
+        continue;
+      }
+
+      for (const item of category.items) {
+        await client.query(
+          `INSERT INTO delivery_items (category_id, name)
+           VALUES ($1, $2)
+           ON CONFLICT (category_id, name) DO NOTHING`,
+          [categoryId, item],
+        );
+      }
+    }
+
+    logger.info('Delivery categories and items seeded');
+  } catch (err) {
+    logger.error('Error seeding delivery data:', err);
+  } finally {
+    client.release();
+  }
+}
+
+export default seedDeliveryData;

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -14,6 +14,14 @@
 3. Within each category, add the individual items that should be available on the delivery request form.
 4. Edit or delete categories and items as offerings change; the Book Delivery page reloads the latest definitions each time it opens.
 
+### Development defaults
+
+- Running the backend with `NODE_ENV=development` automatically seeds sample delivery categories and items via
+  [`seedDeliveryData`](../MJ_FB_Backend/src/utils/deliverySeeder.ts). The script checks for existing rows before inserting so it
+  can run repeatedly without creating duplicates.
+- The sample data covers pantry staples, proteins, produce, dairy, frozen meals, household and hygiene supplies, baby and
+  toddler needs, plus snack options to mirror a typical delivery request.
+
 ## Handling new requests
 
 - Every submission to `/api/v1/delivery/orders` sends a Brevo email using `DELIVERY_REQUEST_TEMPLATE_ID`. Update the template when wording changes so the notification still matches the operation team’s process.


### PR DESCRIPTION
## Summary
- add a delivery data seeder that loads sample categories and items for development
- invoke the new seeder during backend startup when running in development mode
- document that delivery categories auto-seed in development and outline the sample data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c860bae598832d8ec7c47c4a173919