### PR TITLE
Seed delivery categories during dev startup

### DIFF
--- a/MJ_FB_Backend/src/server.ts
+++ b/MJ_FB_Backend/src/server.ts
@@ -41,6 +41,7 @@ import {
 } from './jobs/blockedSlotCleanupJob';
 import { startDbBloatMonitorJob, stopDbBloatMonitorJob } from './utils/dbBloatMonitorJob';
 import { startVacuumJob, stopVacuumJob } from './utils/vacuumJob';
+import seedDeliveryData from './utils/deliverySeeder';
 
 
 const PORT = config.port;
@@ -72,6 +73,7 @@ async function init() {
       const end = `${now.getFullYear() + 1}-12-31`;
       await seedPayPeriods(start, end);
       await seedTimesheets();
+      await seedDeliveryData();
     }
     startTimesheetSeedJob();
     startRetentionJob();

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -9,6 +9,8 @@
 
 ## Configure categories and items
 
+> **Note:** When running the backend in development mode, the server automatically seeds baseline delivery categories and items on startup. Update `src/utils/deliverySeeder.ts` if you need to adjust the default definitions.
+
 1. Sign in as a staff admin and open **Admin → Settings → Pantry**.
 2. Use the **Delivery categories** card to create a category and set its **Max items per delivery** limit.
 3. Within each category, add the individual items that should be available on the delivery request form.


### PR DESCRIPTION
## Summary
- import the delivery data seeder into the server startup and invoke it in development
- document that development startup seeds default delivery categories and where to adjust them

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8641fb568832dadd3cde071650ab2