### PR TITLE
Handle volunteer username drop column safely

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000006_remove_username_add_unique_email_to_volunteers.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000006_remove_username_add_unique_email_to_volunteers.ts
@@ -1,7 +1,7 @@
 import type { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.dropColumn('volunteers', 'username');
+  pgm.dropColumn('volunteers', 'username', { ifExists: true });
   pgm.addConstraint('volunteers', 'volunteers_email_unique', { unique: ['email'] });
 }
 


### PR DESCRIPTION
## Summary
- guard the volunteers.username drop operation in the migration with ifExists

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c873e2a0cc832dbdbede021adf5ff4