### PR TITLE
Fix Add Client navigation path

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/UserHistory.test.tsx
@@ -31,7 +31,7 @@ describe('UserHistory search add shortcut', () => {
 
   it('shows add button and navigates with id prefilled', async () => {
     renderWithProviders(
-      <MemoryRouter initialEntries={['/staff/client-management']}>
+      <MemoryRouter initialEntries={['/pantry/client-management']}>
         <ClientManagement />
       </MemoryRouter>,
     );

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -105,7 +105,7 @@ export default function UserHistory({
         <ConfirmDialog
           message={`Add client ${pendingId}?`}
           onConfirm={() => {
-            navigate(`/staff/client-management?tab=add&clientId=${pendingId}`);
+            navigate(`/pantry/client-management?tab=add&clientId=${pendingId}`);
             setPendingId(null);
           }}
           onCancel={() => setPendingId(null)}


### PR DESCRIPTION
## Summary
- fix the staff client history "Add Client" shortcut to navigate to the pantry client-management route so the create form opens with the client ID prefilled
- update the corresponding UserHistory test to initialize the router at the pantry client-management URL

## Testing
- npm test (fails: VolunteerBooking and AgencyAccess tests already failing in main)
- npm test -- src/pages/staff/__tests__/UserHistory.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c879e29f4c832dbcbd9f9a06fede13