### PR TITLE
Fix zod number coercion errors in delivery schemas

### DIFF
--- a/MJ_FB_Backend/src/schemas/delivery/categorySchemas.ts
+++ b/MJ_FB_Backend/src/schemas/delivery/categorySchemas.ts
@@ -5,7 +5,8 @@ const nameSchema = z.string().trim().min(1, 'Name is required');
 export const createDeliveryCategorySchema = z.object({
   name: nameSchema,
   maxItems: z.coerce
-    .number({ invalid_type_error: 'maxItems must be a number' })
+    .number()
+    .finite('maxItems must be a number')
     .int('maxItems must be an integer')
     .min(0, 'maxItems must be 0 or greater'),
 });

--- a/MJ_FB_Backend/src/schemas/delivery/orderSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/delivery/orderSchemas.ts
@@ -2,11 +2,13 @@ import { z } from 'zod';
 
 export const deliveryOrderSelectionSchema = z.object({
   itemId: z.coerce
-    .number({ invalid_type_error: 'itemId must be a number' })
+    .number()
+    .finite('itemId must be a number')
     .int('itemId must be an integer')
     .positive('itemId must be positive'),
   quantity: z.coerce
-    .number({ invalid_type_error: 'quantity must be a number' })
+    .number()
+    .finite('quantity must be a number')
     .int('quantity must be an integer')
     .min(1, 'quantity must be at least 1'),
 });
@@ -15,7 +17,8 @@ const nonEmptyString = (field: string) => z.string().trim().min(1, `${field} is 
 
 export const createDeliveryOrderSchema = z.object({
   clientId: z.coerce
-    .number({ invalid_type_error: 'clientId must be a number' })
+    .number()
+    .finite('clientId must be a number')
     .int('clientId must be an integer')
     .positive('clientId must be positive'),
   address: nonEmptyString('Address'),


### PR DESCRIPTION
## Summary
- require coerced numeric fields in delivery schemas to be finite so they surface a clear error when input cannot be parsed as a number
- update delivery category and order validation to keep integer and range checks without using unsupported Zod options

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c87b0f5c6c832d9f4b8390b7a03a34