### PR TITLE
Log password setup links in non-production environments

### DIFF
--- a/MJ_FB_Backend/src/utils/passwordSetupUtils.ts
+++ b/MJ_FB_Backend/src/utils/passwordSetupUtils.ts
@@ -77,7 +77,7 @@ export function buildPasswordSetupEmailParams(
   if (userType === 'clients' && clientId !== undefined) {
     params.clientId = clientId;
   }
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV !== 'production') {
     const context =
       userType === 'clients' && clientId !== undefined
         ? `clients:${clientId}`


### PR DESCRIPTION
## Summary
- ensure password setup emails log their link whenever the backend is not running in production so developers can grab tokens in dev

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c88398e168832d90acff4bdc550cef