### PR TITLE
Fix delivery order history endpoint

### DIFF
--- a/MJ_FB_Backend/src/routes/delivery/orders.ts
+++ b/MJ_FB_Backend/src/routes/delivery/orders.ts
@@ -18,6 +18,7 @@ router.post(
   createDeliveryOrder,
 );
 
+router.get('/', authorizeRoles('delivery', 'staff'), getDeliveryOrderHistory);
 router.get('/history', authorizeRoles('delivery', 'staff'), getDeliveryOrderHistory);
 
 export default router;

--- a/MJ_FB_Backend/tests/deliveryOrdersRoute.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrdersRoute.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import express from 'express';
+import deliveryOrdersRouter from '../src/routes/delivery/orders';
+import pool from '../src/db';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  __esModule: true,
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.user = { id: '42', role: 'delivery', type: 'user' };
+    next();
+  },
+  authorizeRoles: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/delivery/orders', deliveryOrdersRouter);
+
+describe('delivery orders routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the authenticated client order history at /delivery/orders', async () => {
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 12,
+            clientId: 42,
+            address: '123 Main St',
+            phone: '555-0000',
+            email: 'client@example.com',
+            createdAt: '2024-07-10T15:00:00Z',
+          },
+        ],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            orderId: 12,
+            itemId: 7,
+            quantity: 3,
+            itemName: 'Canned Soup',
+            categoryId: 5,
+            categoryName: 'Pantry',
+          },
+        ],
+        rowCount: 1,
+      });
+
+    const res = await request(app).get('/delivery/orders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: 12,
+        clientId: 42,
+        address: '123 Main St',
+        phone: '555-0000',
+        email: 'client@example.com',
+        createdAt: '2024-07-10T15:00:00.000Z',
+        items: [
+          {
+            itemId: 7,
+            quantity: 3,
+            itemName: 'Canned Soup',
+            categoryId: 5,
+            categoryName: 'Pantry',
+          },
+        ],
+      },
+    ]);
+
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('FROM delivery_orders'),
+      [42],
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('FROM delivery_order_items'),
+      [[12]],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expose GET /delivery/orders so delivery and staff users can retrieve delivery order history without a /history suffix
- add a route-level test to ensure authenticated clients receive their delivery order history from the new endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8c74febac832d9be13e59dc79f343