### PR TITLE
Allow multiple refresh tokens with expiry

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000060_update_refresh_tokens.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000060_update_refresh_tokens.ts
@@ -1,0 +1,19 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('refresh_tokens', 'refresh_tokens_subject_key', { ifExists: true });
+  pgm.addColumn('refresh_tokens', {
+    expires_at: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func("CURRENT_TIMESTAMP + INTERVAL '7 days'"),
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('refresh_tokens', 'expires_at');
+  pgm.addConstraint('refresh_tokens', 'refresh_tokens_subject_key', {
+    unique: ['subject'],
+  });
+}

--- a/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/expiredTokenCleanupJob.ts
@@ -13,6 +13,7 @@ export async function cleanupExpiredTokens(): Promise<void> {
     await pool.query(
       "DELETE FROM client_email_verifications WHERE expires_at < (CURRENT_DATE - INTERVAL '10 days')",
     );
+    await pool.query('DELETE FROM refresh_tokens WHERE expires_at < CURRENT_TIMESTAMP');
   } catch (err) {
     logger.error('Failed to clean up expired tokens', err);
   }

--- a/MJ_FB_Backend/tests/expiredTokenCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/expiredTokenCleanupJob.test.ts
@@ -27,6 +27,7 @@ describe('cleanupExpiredTokens', () => {
   it('removes expired password setup and email verification tokens', async () => {
     (pool.query as jest.Mock)
       .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rowCount: 1 });
     await cleanupExpiredTokens();
     expect(pool.query).toHaveBeenNthCalledWith(
@@ -36,6 +37,10 @@ describe('cleanupExpiredTokens', () => {
     expect(pool.query).toHaveBeenNthCalledWith(
       2,
       "DELETE FROM client_email_verifications WHERE expires_at < (CURRENT_DATE - INTERVAL '10 days')",
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      3,
+      'DELETE FROM refresh_tokens WHERE expires_at < CURRENT_TIMESTAMP',
     );
   });
 

--- a/MJ_FB_Backend/tests/logout.test.ts
+++ b/MJ_FB_Backend/tests/logout.test.ts
@@ -2,12 +2,16 @@ import request from 'supertest';
 import express from 'express';
 import authRouter from '../src/routes/auth';
 import pool from '../src/db';
-
+import jwt from 'jsonwebtoken';
 
 const app = express();
 app.use('/auth', authRouter);
 
 describe('POST /auth/logout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('clears auth cookies', async () => {
     const res = await request(app).post('/auth/logout');
     expect(res.status).toBe(204);
@@ -15,5 +19,24 @@ describe('POST /auth/logout', () => {
     expect(cookies).toBeDefined();
     expect(cookies.some(c => c.startsWith('token=;'))).toBe(true);
     expect(cookies.some(c => c.startsWith('refreshToken=;'))).toBe(true);
+  });
+
+  it('removes the stored refresh token when provided', async () => {
+    const refreshToken = jwt.sign(
+      { id: 1, type: 'user', jti: 'logout-jti' },
+      process.env.JWT_REFRESH_SECRET!,
+      { algorithm: 'HS256' },
+    );
+    (pool.query as jest.Mock).mockResolvedValue({ rowCount: 1 });
+
+    const res = await request(app)
+      .post('/auth/logout')
+      .set('Cookie', `refreshToken=${refreshToken}`);
+
+    expect(res.status).toBe(204);
+    expect(pool.query).toHaveBeenCalledWith(
+      'DELETE FROM refresh_tokens WHERE token_id=$1',
+      ['logout-jti'],
+    );
   });
 });

--- a/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
+++ b/MJ_FB_Backend/tests/refreshTokenVolunteer.test.ts
@@ -4,12 +4,15 @@ import authRouter from '../src/routes/auth';
 import pool from '../src/db';
 import jwt from 'jsonwebtoken';
 
-
 const app = express();
 app.use('/auth', authRouter);
 
 describe('POST /auth/refresh', () => {
-    it('preserves volunteer user fields when refreshing token', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves volunteer user fields when refreshing token', async () => {
     const payload = {
       id: 1,
       role: 'volunteer',
@@ -20,29 +23,66 @@ describe('POST /auth/refresh', () => {
     };
     const refreshToken = jwt.sign(payload, process.env.JWT_REFRESH_SECRET!, {
       algorithm: 'HS256',
+      expiresIn: '7d',
     });
+    const future = new Date(Date.now() + 60_000).toISOString();
     (pool.query as jest.Mock)
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ token_id: 'oldjti' }] })
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ subject: 'volunteer:1', expires_at: future }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1 });
 
-      const res = await request(app)
-        .post('/auth/refresh')
-        .set('Cookie', `refreshToken=${refreshToken}`);
+    const res = await request(app)
+      .post('/auth/refresh')
+      .set('Cookie', `refreshToken=${refreshToken}`);
 
-      expect(res.status).toBe(204);
-      const cookies = res.headers['set-cookie'] as unknown as string[];
-      expect(cookies).toBeDefined();
-      const accessCookie = cookies.find(c => c.startsWith('token='));
-      const refreshCookie = cookies.find(c => c.startsWith('refreshToken='));
-      expect(accessCookie).toBeDefined();
-      expect(refreshCookie).toBeDefined();
-      const accessToken = accessCookie!.split('token=')[1].split(';')[0];
-      const newRefreshToken = refreshCookie!.split('refreshToken=')[1].split(';')[0];
-      const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
-      expect(decoded.userId).toBe(9);
-      expect(decoded.userRole).toBe('shopper');
-      const decodedRefresh = jwt.verify(newRefreshToken, process.env.JWT_REFRESH_SECRET!) as any;
-      expect(decodedRefresh.userId).toBe(9);
-      expect(decodedRefresh.userRole).toBe('shopper');
-    });
+    expect(res.status).toBe(204);
+    const cookies = res.headers['set-cookie'] as unknown as string[];
+    expect(cookies).toBeDefined();
+    const accessCookie = cookies.find(c => c.startsWith('token='));
+    const refreshCookie = cookies.find(c => c.startsWith('refreshToken='));
+    expect(accessCookie).toBeDefined();
+    expect(refreshCookie).toBeDefined();
+    const accessToken = accessCookie!.split('token=')[1].split(';')[0];
+    const newRefreshToken = refreshCookie!.split('refreshToken=')[1].split(';')[0];
+    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
+    expect(decoded.userId).toBe(9);
+    expect(decoded.userRole).toBe('shopper');
+    const decodedRefresh = jwt.verify(newRefreshToken, process.env.JWT_REFRESH_SECRET!) as any;
+    expect(decodedRefresh.userId).toBe(9);
+    expect(decodedRefresh.userRole).toBe('shopper');
+
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toContain('WHERE token_id=$1');
+    expect((pool.query as jest.Mock).mock.calls[0][1]).toEqual(['oldjti']);
+    expect((pool.query as jest.Mock).mock.calls[1][0]).toContain(
+      'UPDATE refresh_tokens SET token_id=$1, expires_at=$2 WHERE token_id=$3',
+    );
+    expect((pool.query as jest.Mock).mock.calls[1][1][2]).toBe('oldjti');
   });
+
+  it('rejects expired refresh tokens', async () => {
+    const payload = {
+      id: 1,
+      role: 'volunteer',
+      type: 'volunteer',
+      jti: 'expired',
+    };
+    const refreshToken = jwt.sign(payload, process.env.JWT_REFRESH_SECRET!, {
+      algorithm: 'HS256',
+      expiresIn: '7d',
+    });
+    const past = new Date(Date.now() - 60_000).toISOString();
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ subject: 'volunteer:1', expires_at: past }],
+    });
+
+    const res = await request(app)
+      .post('/auth/refresh')
+      .set('Cookie', `refreshToken=${refreshToken}`);
+
+    expect(res.status).toBe(401);
+    expect((pool.query as jest.Mock).mock.calls).toHaveLength(1);
+  });
+});

--- a/MJ_FB_Backend/tests/userController.test.ts
+++ b/MJ_FB_Backend/tests/userController.test.ts
@@ -150,9 +150,13 @@ describe('userController', () => {
       const token = jwt.sign(payload, process.env.JWT_REFRESH_SECRET!, {
         algorithm: 'HS256',
       });
+      const future = new Date(Date.now() + 60_000).toISOString();
       (pool.query as jest.Mock)
-        .mockResolvedValueOnce({ rowCount: 1, rows: [{ token_id: 'old' }] })
-        .mockResolvedValueOnce({});
+        .mockResolvedValueOnce({
+          rowCount: 1,
+          rows: [{ subject: 'staff:1', expires_at: future }],
+        })
+        .mockResolvedValueOnce({ rowCount: 1 });
 
       const req: any = { headers: { cookie: `refreshToken=${token}` } };
       const res: any = {


### PR DESCRIPTION
## Summary
- add a migration that drops the refresh_tokens subject uniqueness and adds an expires_at column
- update token issuing and refresh/logout flows to use per-token IDs, store expirations, and trim expired rows
- extend backend tests for multi-session refresh handling, expired tokens, and logout cleanup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8c72a14a4832db94fc112fddc5006