### PR TITLE
Fix delivery monthly limit to respect Regina timezone

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -112,11 +112,15 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
     }
   }
 
+  // created_at is stored in UTC, so convert to Regina time before truncating to the month
   const monthlyOrderCountResult = await pool.query<CountRow>(
     `SELECT COUNT(*)::int AS count
        FROM delivery_orders
       WHERE client_id = $1
-        AND date_trunc('month', created_at) = date_trunc('month', CURRENT_DATE)`,
+        AND date_trunc(
+              'month',
+              (created_at AT TIME ZONE 'UTC') AT TIME ZONE 'America/Regina'
+            ) = date_trunc('month', timezone('America/Regina', now()))`,
     [clientId],
   );
 

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -56,9 +56,11 @@ describe('deliveryOrderController', () => {
       expect(mockDb.query).toHaveBeenCalledTimes(2);
       expect(mockDb.query).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('FROM delivery_orders'),
+        expect.stringContaining('America/Regina'),
         [123],
       );
+      const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
+      expect(firstQuery).toContain('FROM delivery_orders');
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM delivery_items'),
@@ -111,9 +113,11 @@ describe('deliveryOrderController', () => {
       expect(mockDb.query).toHaveBeenCalledTimes(2);
       expect(mockDb.query).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('FROM delivery_orders'),
+        expect.stringContaining('America/Regina'),
         [123],
       );
+      const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
+      expect(firstQuery).toContain('FROM delivery_orders');
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM delivery_items'),
@@ -175,9 +179,11 @@ describe('deliveryOrderController', () => {
 
       expect(mockDb.query).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('FROM delivery_orders'),
+        expect.stringContaining('America/Regina'),
         [456],
       );
+      const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
+      expect(firstQuery).toContain('FROM delivery_orders');
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM delivery_items'),
@@ -260,9 +266,11 @@ describe('deliveryOrderController', () => {
       });
       expect(mockDb.query).toHaveBeenCalledTimes(1);
       expect(mockDb.query).toHaveBeenCalledWith(
-        expect.stringContaining('FROM delivery_orders'),
+        expect.stringContaining('America/Regina'),
         [321],
       );
+      const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
+      expect(firstQuery).toContain('FROM delivery_orders');
       expect(sendTemplatedEmail).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary
- convert the delivery order monthly limit query to truncate `created_at` in the Regina timezone before enforcing the limit
- extend delivery order controller tests to assert the monthly count query includes the Regina timezone conversion

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8c7c4c8f8832da5757c16884667d3