### PR TITLE
Make delivery request email configurable

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -3,6 +3,7 @@ import pool from '../db';
 import asyncHandler from '../middleware/asyncHandler';
 import parseIdParam from '../utils/parseIdParam';
 import { sendTemplatedEmail } from '../utils/emailUtils';
+import { getDeliverySettings } from '../utils/deliverySettings';
 import logger from '../utils/logger';
 import {
   createDeliveryOrderSchema,
@@ -216,8 +217,9 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
       : 'No items selected';
 
   try {
+    const { requestEmail } = await getDeliverySettings();
     await sendTemplatedEmail({
-      to: 'amrutha.laxman@mjfoodbank.org',
+      to: requestEmail,
       templateId: 16,
       params: {
         orderId: order.id,

--- a/MJ_FB_Backend/src/utils/deliverySettings.ts
+++ b/MJ_FB_Backend/src/utils/deliverySettings.ts
@@ -1,0 +1,34 @@
+import pool from '../db';
+
+export interface DeliverySettings {
+  requestEmail: string;
+}
+
+const DEFAULT_DELIVERY_SETTINGS: DeliverySettings = {
+  requestEmail: 'amrutha.laxman@mjfoodbank.org',
+};
+
+let cache: DeliverySettings | null = null;
+
+export async function getDeliverySettings(): Promise<DeliverySettings> {
+  if (cache) {
+    return cache;
+  }
+
+  const result = await pool.query(
+    "SELECT value FROM app_config WHERE key = 'delivery_request_email'",
+  );
+
+  const email = result.rows[0]?.value?.trim();
+
+  cache = {
+    requestEmail: email || DEFAULT_DELIVERY_SETTINGS.requestEmail,
+  };
+
+  return cache;
+}
+
+export async function refreshDeliverySettings(): Promise<DeliverySettings> {
+  cache = null;
+  return getDeliverySettings();
+}

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -1,17 +1,30 @@
 import mockDb from './utils/mockDb';
 import { createDeliveryOrder } from '../src/controllers/deliveryOrderController';
 import { sendTemplatedEmail } from '../src/utils/emailUtils';
+import { getDeliverySettings } from '../src/utils/deliverySettings';
 
 jest.mock('../src/utils/emailUtils', () => ({
   sendTemplatedEmail: jest.fn(),
 }));
 
+jest.mock('../src/utils/deliverySettings', () => ({
+  getDeliverySettings: jest.fn(),
+}));
+
 const flushPromises = () => new Promise(process.nextTick);
+
+const mockGetDeliverySettings = getDeliverySettings as jest.MockedFunction<
+  typeof getDeliverySettings
+>;
 
 describe('deliveryOrderController', () => {
   beforeEach(() => {
     (mockDb.query as jest.Mock).mockReset();
     (sendTemplatedEmail as jest.Mock).mockReset();
+    mockGetDeliverySettings.mockReset();
+    mockGetDeliverySettings.mockResolvedValue({
+      requestEmail: 'ops@example.com',
+    });
   });
 
   describe('createDeliveryOrder', () => {
@@ -214,7 +227,7 @@ describe('deliveryOrderController', () => {
       });
 
       expect(sendTemplatedEmail).toHaveBeenCalledWith({
-        to: 'amrutha.laxman@mjfoodbank.org',
+        to: 'ops@example.com',
         templateId: 16,
         params: {
           orderId: 77,


### PR DESCRIPTION
## Summary
- add a delivery settings helper that reads the request notification email from app_config with a default
- update the delivery order controller to pull the Brevo recipient from the configurable delivery settings
- update delivery order controller tests to mock the configurable email recipient

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8c9e9696c832d805d091e2ac20263