### PR TITLE
Add delivery dashboard events section

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -261,6 +261,7 @@ export default function App() {
         { label: 'Dashboard', to: '/' },
         { label: 'Book Delivery', to: '/delivery/book' },
         { label: 'Delivery History', to: '/delivery/history' },
+        { label: 'News & Events', to: '/events' },
       ],
     });
   } else if (role === 'shopper') {

--- a/MJ_FB_Frontend/src/pages/delivery/DeliveryDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/DeliveryDashboard.tsx
@@ -1,17 +1,47 @@
+import { useEffect, useMemo, useState } from 'react';
 import { Button, Grid, Stack, Typography } from '@mui/material';
 import LocalShipping from '@mui/icons-material/LocalShipping';
 import History from '@mui/icons-material/History';
 import Info from '@mui/icons-material/Info';
+import Announcement from '@mui/icons-material/Announcement';
 import { useNavigate } from 'react-router-dom';
 import SectionCard from '../../components/dashboard/SectionCard';
 import Page from '../../components/Page';
 import ClientBottomNav from '../../components/ClientBottomNav';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import EventList from '../../components/EventList';
+import { getEvents, type EventGroups } from '../../api/events';
 
 export default function DeliveryDashboard() {
   const navigate = useNavigate();
+  const [events, setEvents] = useState<EventGroups>({ today: [], upcoming: [], past: [] });
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    getEvents()
+      .then(data => {
+        setEvents(data ?? { today: [], upcoming: [], past: [] });
+        setError('');
+      })
+      .catch(() => {
+        setEvents({ today: [], upcoming: [], past: [] });
+        setError('Failed to load events');
+      });
+  }, []);
+
+  const visibleEvents = useMemo(
+    () => [...events.today, ...events.upcoming],
+    [events],
+  );
 
   return (
     <Page title="Delivery Dashboard">
+      <FeedbackSnackbar
+        open={!!error}
+        onClose={() => setError('')}
+        message={error}
+        severity="error"
+      />
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <Stack spacing={2}>
@@ -72,6 +102,12 @@ export default function DeliveryDashboard() {
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <Stack spacing={2}>
+            <SectionCard
+              title="News & Events"
+              icon={<Announcement color="primary" />}
+            >
+              <EventList events={visibleEvents} limit={5} />
+            </SectionCard>
             <SectionCard
               title="Helpful reminders"
               icon={<Info color="primary" />}

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/DeliveryDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/DeliveryDashboard.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DeliveryDashboard from '../DeliveryDashboard';
+import { getEvents, type EventGroups } from '../../../api/events';
+
+jest.mock('../../../api/events', () => ({
+  getEvents: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    role: 'delivery',
+    isAuthenticated: true,
+    name: 'Test User',
+    userRole: '',
+    access: [],
+    id: 123,
+    login: jest.fn(),
+    logout: jest.fn(),
+    cardUrl: '',
+    ready: true,
+  }),
+}));
+
+const mockedGetEvents = getEvents as jest.MockedFunction<typeof getEvents>;
+
+describe('DeliveryDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetEvents.mockReset();
+  });
+
+  it('shows events from the API', async () => {
+    const events: EventGroups = {
+      today: [
+        {
+          id: 1,
+          title: 'Community BBQ',
+          startDate: '2024-08-01',
+          endDate: '2024-08-01',
+          details: 'Join us for lunch',
+          createdBy: 12,
+          createdByName: 'Alex',
+          priority: 0,
+          visibleToClients: true,
+        },
+      ],
+      upcoming: [],
+      past: [],
+    };
+    mockedGetEvents.mockResolvedValue(events);
+
+    render(
+      <MemoryRouter>
+        <DeliveryDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Community BBQ/i)).toBeInTheDocument();
+  });
+
+  it('surfaces errors in the feedback snackbar when the request fails', async () => {
+    mockedGetEvents.mockRejectedValue(new Error('Network error'));
+
+    render(
+      <MemoryRouter>
+        <DeliveryDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Failed to load events/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- fetch delivery events when the dashboard loads and surface failures through the shared snackbar
- show a News & Events section with the shared EventList and expose the existing events route to delivery navigation
- cover the dashboard with unit tests that verify event rendering and error handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8c936f7c0832d807223552afb9895