### PR TITLE
Remove unnecessary microtask flush in volunteer shopper test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerShopperAccess.test.tsx
@@ -41,6 +41,5 @@ describe('Volunteer with shopper profile', () => {
     fireEvent.click(bookLink);
     await screen.findByText(/BookingUI Component/i);
     await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
-    await new Promise(resolve => setTimeout(resolve, 0));
   });
 });


### PR DESCRIPTION
## Summary
- remove the redundant microtask flush from the volunteer shopper access test since existing waitFor assertions already settle async work

## Testing
- CI=1 npm test -- --runInBand --detectOpenHandles VolunteerShopperAccess.test.tsx
  - Jest reports an existing @tanstack/query-core timeout handle after the run, matching prior behavior


------
https://chatgpt.com/codex/tasks/task_e_68c8cc051be0832da67619a57c23ec17