### PR TITLE
Handle missing delivery order status

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
@@ -24,7 +24,7 @@ import {
   getApiErrorMessage,
   handleResponse,
 } from '../../api/client';
-import type { DeliveryOrder } from '../../types';
+import type { DeliveryOrder, DeliveryOrderStatus } from '../../types';
 
 type SnackbarState = {
   open: boolean;
@@ -33,7 +33,7 @@ type SnackbarState = {
 };
 
 const STATUS_COLOR_MAP: Partial<
-  Record<DeliveryOrder['status'], ChipProps['color']>
+  Record<DeliveryOrderStatus, ChipProps['color']>
 > = {
   pending: 'warning',
   approved: 'info',
@@ -56,15 +56,26 @@ function formatDate(value?: string | null, useTime = false): string | null {
   return useTime ? dateTimeFormatter.format(date) : dateFormatter.format(date);
 }
 
-function formatStatusLabel(status: string): string {
+function formatStatusLabel(status?: string | null): string {
+  if (!status) {
+    return 'Status Unknown';
+  }
+
   return status
-    .split(/[_\s]+/)
+    .split(/[\s_-]+/)
     .filter(Boolean)
-    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .map(part => {
+      const normalized = part.toLowerCase();
+      return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+    })
     .join(' ');
 }
 
-function getStatusColor(status: DeliveryOrder['status']): ChipProps['color'] {
+function getStatusColor(status?: DeliveryOrder['status'] | null): ChipProps['color'] {
+  if (!status) {
+    return 'default';
+  }
+
   return STATUS_COLOR_MAP[status] ?? 'default';
 }
 

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/DeliveryHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/DeliveryHistory.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import DeliveryHistory from '../DeliveryHistory';
 import { theme } from '../../../theme';
+import type { DeliveryOrder } from '../../../types';
 import {
   apiFetch,
   handleResponse,
@@ -87,6 +88,36 @@ describe('DeliveryHistory', () => {
 
     expect(await screen.findByText(/no deliveries yet/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /book a delivery/i })).toBeInTheDocument();
+  });
+
+  it('shows a fallback label when a delivery status is missing', async () => {
+    (apiFetch as jest.Mock).mockResolvedValueOnce({});
+    (handleResponse as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 101,
+        status: undefined,
+        createdAt: '2024-06-01T12:00:00Z',
+        scheduledFor: null,
+        address: '456 Oak Ave',
+        phone: '306-555-0199',
+        email: null,
+        notes: null,
+        items: [
+          {
+            itemId: 11,
+            name: 'Milk',
+            quantity: 1,
+            categoryId: 5,
+            categoryName: null,
+          },
+        ],
+      } as unknown as DeliveryOrder,
+    ]);
+
+    renderComponent();
+
+    expect(await screen.findByText('Order #101')).toBeInTheDocument();
+    expect(screen.getByText('Status Unknown')).toBeInTheDocument();
   });
 
   it('displays an error message when loading orders fails', async () => {

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -49,7 +49,7 @@ export interface DeliveryOrderItem {
 
 export interface DeliveryOrder {
   id: number;
-  status: DeliveryOrderStatus;
+  status?: DeliveryOrderStatus | null;
   createdAt: string;
   scheduledFor?: string | null;
   address: string;


### PR DESCRIPTION
## Summary
- prevent the delivery history status chip from crashing when an order is missing a status
- normalize status labels and colors while allowing the API to return null/undefined
- cover the missing-status scenario with a focused DeliveryHistory test

## Testing
- npm test *(fails in this environment with an out-of-memory error while running the full suite)*
- NODE_OPTIONS=--max-old-space-size=4096 npm test -- DeliveryHistory

------
https://chatgpt.com/codex/tasks/task_e_68c8ca145eac832db5de20bd4c3ed3bf