### PR TITLE
Update delivery limit message to include usage count

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -141,7 +141,9 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
 
   const monthlyOrderCount = Number(monthlyOrderCountResult.rows[0]?.count ?? 0);
   if (monthlyOrderCount >= 2) {
-    return res.status(400).json({ message: "You've reached the monthly delivery limit" });
+    return res.status(400).json({
+      message: `You have already used the food bank ${monthlyOrderCount} times this month, please request again next month`,
+    });
   }
 
   let itemDetails: DeliveryOrderItemDetail[] = [];

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -281,7 +281,8 @@ describe('deliveryOrderController', () => {
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
-        message: "You've reached the monthly delivery limit",
+        message:
+          'You have already used the food bank 2 times this month, please request again next month',
       });
       expect(mockDb.query).toHaveBeenCalledTimes(1);
       expect(mockDb.query).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- include the monthly usage count in the delivery limit error response
- update the delivery order controller test to reflect the new message

## Testing
- npm test tests/deliveryOrderController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c8cfc22710832d93e589908ceaaf61