### PR TITLE
Move delivery history cancel button to full-width row

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
@@ -215,22 +215,10 @@ export default function DeliveryHistory() {
                   title={`Order #${order.id}`}
                   subheader={submittedOn ? `Submitted ${submittedOn}` : undefined}
                   action={
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      {isCancellable(order.status) && (
-                        <LoadingButton
-                          variant="outlined"
-                          size="small"
-                          onClick={() => void handleCancel(order.id)}
-                          loading={cancellingId === order.id}
-                        >
-                          Cancel request
-                        </LoadingButton>
-                      )}
-                      <Chip
-                        label={formatStatusLabel(order.status)}
-                        color={getStatusColor(order.status)}
-                      />
-                    </Stack>
+                    <Chip
+                      label={formatStatusLabel(order.status)}
+                      color={getStatusColor(order.status)}
+                    />
                   }
                 />
                 <CardContent>
@@ -274,6 +262,16 @@ export default function DeliveryHistory() {
                         </ListItem>
                       ))}
                     </List>
+                    {isCancellable(order.status) && (
+                      <LoadingButton
+                        variant="outlined"
+                        onClick={() => void handleCancel(order.id)}
+                        loading={cancellingId === order.id}
+                        fullWidth
+                      >
+                        Cancel request
+                      </LoadingButton>
+                    )}
                   </Stack>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary
- move the delivery history cancel action out of the card header and show it as a full-width button beneath each order’s details
- keep the status chip in the header so the current order state remains visible

## Testing
- CI=1 npm test *(fails: existing DeliveryHistory.test.tsx syntax error and other flaky suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cf4faaec832da5288d9180a4a9b0