### PR TITLE
Sync delivery profile contact info

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -497,7 +497,7 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
     }
 
     const result = await pool.query(
-      `SELECT client_id, first_name, last_name, email, phone, role, consent
+      `SELECT client_id, first_name, last_name, email, phone, address, role, consent
        FROM clients WHERE client_id = $1`,
       [user.id],
     );
@@ -511,6 +511,7 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
       lastName: row.last_name,
       email: row.email,
       phone: row.phone,
+      address: row.address,
       clientId: row.client_id,
       role: row.role,
       bookingsThisMonth,

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -70,7 +70,7 @@ async function authenticate(req: Request): Promise<AuthResult> {
 
       if (type === 'user') {
         const userRes = await pool.query(
-          'SELECT client_id, first_name, last_name, email, role, phone FROM clients WHERE client_id = $1',
+          'SELECT client_id, first_name, last_name, email, role, phone, address FROM clients WHERE client_id = $1',
           [id],
         );
         if ((userRes.rowCount ?? 0) > 0) {
@@ -80,6 +80,7 @@ async function authenticate(req: Request): Promise<AuthResult> {
             role,
             email: userRes.rows[0].email,
             phone: userRes.rows[0].phone,
+            address: userRes.rows[0].address,
             name: `${userRes.rows[0].first_name} ${userRes.rows[0].last_name}`,
           };
           return {

--- a/MJ_FB_Backend/src/types/RequestUser.ts
+++ b/MJ_FB_Backend/src/types/RequestUser.ts
@@ -4,6 +4,7 @@ export interface RequestUser extends AuthenticatedUser {
   type: 'user' | 'staff' | 'volunteer' | 'agency';
   email?: string;
   phone?: string;
+  address?: string;
   name?: string;
   userRole?: 'shopper' | 'delivery';
   access?: string[];

--- a/MJ_FB_Backend/tests/clientProfileVisitCount.test.ts
+++ b/MJ_FB_Backend/tests/clientProfileVisitCount.test.ts
@@ -35,6 +35,7 @@ describe('client profile visit count', () => {
           last_name: 'Doe',
           email: null,
           phone: null,
+          address: '123 Main St',
           role: 'shopper',
         }],
       })
@@ -52,6 +53,7 @@ describe('client profile visit count', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.bookingsThisMonth).toBe(0);
+    expect(res.body.address).toBe('123 Main St');
     expect((pool.query as jest.Mock).mock.calls[2][0]).toMatch(/UPDATE clients c/);
   });
 });

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -239,11 +239,11 @@ describe('deliveryOrderController', () => {
             categoryName: 'Bakery',
           },
         ],
-      });
+    });
 
-      expect(sendTemplatedEmail).toHaveBeenCalledWith({
-        to: 'ops@example.com',
-        templateId: 16,
+    expect(sendTemplatedEmail).toHaveBeenCalledWith({
+      to: 'ops@example.com',
+      templateId: 16,
         params: {
           orderId: 77,
           clientId: 456,
@@ -277,6 +277,7 @@ describe('deliveryOrderController', () => {
           ],
           rowCount: 1,
         })
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] })
         .mockResolvedValueOnce({
           rows: [
             {
@@ -330,11 +331,16 @@ describe('deliveryOrderController', () => {
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         3,
+        expect.stringContaining('UPDATE clients'),
+        ['789 Pine Ave', '555-3333', 'client@example.com', 555],
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        4,
         expect.stringContaining('INSERT INTO delivery_orders'),
         [555, '789 Pine Ave', '555-3333', 'client@example.com', 'pending', null, null],
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
-        4,
+        5,
         expect.stringContaining('INSERT INTO delivery_order_items'),
         [88, 52, 1],
       );
@@ -374,6 +380,81 @@ describe('deliveryOrderController', () => {
           createdAt: submittedAt.toISOString(),
         },
       });
+    });
+
+    it('updates the client profile when contact details change', async () => {
+      const submittedAt = new Date('2024-07-20T18:15:00Z');
+      (mockDb.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              itemId: 52,
+              categoryId: 9,
+              itemName: 'Fresh Produce Box',
+              categoryName: 'Produce',
+              maxItems: 2,
+            },
+          ],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 88,
+              clientId: 555,
+              address: '789 Pine Ave',
+              phone: '555-3333',
+              email: 'client@example.com',
+              status: 'pending',
+              scheduledFor: null,
+              notes: null,
+              createdAt: submittedAt,
+            },
+          ],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const req = {
+        user: {
+          role: 'delivery',
+          id: '555',
+          type: 'user',
+          address: '456 Old Ave',
+          phone: '555-0000',
+          email: 'old@example.com',
+        },
+        body: {
+          clientId: 555,
+          address: '789 Pine Ave',
+          phone: '555-3333',
+          email: 'client@example.com',
+          selections: [{ itemId: 52, quantity: 1 }],
+        },
+      } as any;
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      await createDeliveryOrder(req, res, jest.fn());
+      await flushPromises();
+
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('UPDATE clients'),
+        ['789 Pine Ave', '555-3333', 'client@example.com', 555],
+      );
+      expect(req.user).toMatchObject({
+        address: '789 Pine Ave',
+        phone: '555-3333',
+        email: 'client@example.com',
+      });
+
+      expect(res.status).toHaveBeenCalledWith(201);
     });
 
     it('rejects a third order in the same month', async () => {


### PR DESCRIPTION
## Summary
- update delivery order creation to refresh delivery clients' contact info when they submit new address, phone, or email
- expose the stored address through authentication and `/users/me` so subsequent requests see the updated profile data
- extend controller tests to cover the profile sync behaviour and ensure the user profile response includes the address field

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8d1e089d4832db07cfa1f92ff9e21