### PR TITLE
Add client address field to client profiles

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -220,6 +220,15 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
 
   const order = orderResult.rows[0];
 
+  try {
+    await pool.query('UPDATE clients SET address = $1 WHERE client_id = $2', [
+      address,
+      clientId,
+    ]);
+  } catch (error) {
+    logger.error('Failed to update client address from delivery order', error);
+  }
+
   if (normalizedSelections.length > 0) {
     const values = normalizedSelections
       .map((_selection, index) => `($1, $${index * 2 + 2}, $${index * 2 + 3})`)

--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -274,6 +274,7 @@ export async function createUser(req: Request, res: Response, next: NextFunction
     lastName,
     email,
     phone,
+    address,
     clientId,
     role,
     onlineAccess,
@@ -284,6 +285,7 @@ export async function createUser(req: Request, res: Response, next: NextFunction
     lastName?: string;
     email?: string;
     phone?: string;
+    address?: string;
     clientId: number;
     role: UserRole;
     onlineAccess: boolean;
@@ -325,13 +327,14 @@ export async function createUser(req: Request, res: Response, next: NextFunction
     const profileLink = `https://portal.link2feed.ca/org/1605/intake/${clientId}`;
     const hashedPassword = password ? await bcrypt.hash(password, 10) : null;
     await pool.query(
-      `INSERT INTO clients (first_name, last_name, email, phone, client_id, role, password, online_access, profile_link, consent)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, true)`,
+      `INSERT INTO clients (first_name, last_name, email, phone, address, client_id, role, password, online_access, profile_link, consent)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true)`,
       [
         firstName || null,
         lastName || null,
         email || null,
         phone || null,
+        address || null,
         clientId,
         role,
         hashedPassword,
@@ -399,7 +402,7 @@ export async function getUserByClientId(req: Request, res: Response, next: NextF
   try {
     const { clientId } = req.params;
     const result = await pool.query(
-      `SELECT client_id, first_name, last_name, email, phone, online_access, password, consent
+      `SELECT client_id, first_name, last_name, email, phone, address, online_access, password, consent
        FROM clients WHERE client_id = $1`,
       [clientId]
     );
@@ -412,6 +415,7 @@ export async function getUserByClientId(req: Request, res: Response, next: NextF
       lastName: row.last_name,
       email: row.email,
       phone: row.phone,
+      address: row.address,
       clientId: row.client_id,
       onlineAccess: row.online_access,
       hasPassword: row.password != null,
@@ -442,6 +446,7 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
         lastName: row.last_name,
         email: row.email,
         phone: null,
+        address: null,
         role: 'staff',
         roles: row.access || [],
         consent: row.consent,
@@ -470,6 +475,7 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
         lastName: row.last_name,
         email: row.email,
         phone: row.phone,
+        address: null,
         role: 'volunteer',
         trainedAreas: trainedRes.rows.map(r => r.name),
         consent: row.consent,
@@ -491,13 +497,14 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
         lastName: '',
         email: row.email,
         phone: row.contact_info,
+        address: null,
         role: 'agency',
         consent: row.consent,
       });
     }
 
     const result = await pool.query(
-      `SELECT client_id, first_name, last_name, email, phone, role, consent
+      `SELECT client_id, first_name, last_name, email, phone, address, role, consent
        FROM clients WHERE client_id = $1`,
       [user.id],
     );
@@ -511,6 +518,7 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
       lastName: row.last_name,
       email: row.email,
       phone: row.phone,
+      address: row.address,
       clientId: row.client_id,
       role: row.role,
       bookingsThisMonth,
@@ -525,7 +533,11 @@ export async function getUserProfile(req: Request, res: Response, next: NextFunc
 export async function updateMyProfile(req: Request, res: Response, next: NextFunction) {
   const user = req.user;
   if (!user) return res.status(401).json({ message: 'Unauthorized' });
-  const { email, phone } = req.body as { email?: string; phone?: string };
+  const { email, phone, address } = req.body as {
+    email?: string;
+    phone?: string;
+    address?: string;
+  };
   try {
     if (user.type === 'staff') {
       const result = await pool.query(
@@ -544,6 +556,7 @@ export async function updateMyProfile(req: Request, res: Response, next: NextFun
         lastName: row.last_name,
         email: row.email,
         phone: null,
+        address: null,
         role: 'staff',
         roles: row.access || [],
         consent: row.consent,
@@ -576,6 +589,7 @@ export async function updateMyProfile(req: Request, res: Response, next: NextFun
         lastName: row.last_name,
         email: row.email,
         phone: row.phone,
+        address: null,
         role: 'volunteer',
         trainedAreas: trainedRes.rows.map(r => r.name),
         consent: row.consent,
@@ -601,6 +615,7 @@ export async function updateMyProfile(req: Request, res: Response, next: NextFun
         lastName: '',
         email: row.email,
         phone: row.contact_info,
+        address: null,
         role: 'agency',
         consent: row.consent,
       });
@@ -609,10 +624,11 @@ export async function updateMyProfile(req: Request, res: Response, next: NextFun
     const result = await pool.query(
       `UPDATE clients
        SET email = COALESCE($1, email),
-           phone = COALESCE($2, phone)
-       WHERE client_id = $3
-       RETURNING client_id, first_name, last_name, email, phone, role, consent`,
-      [email, phone, user.id],
+           phone = COALESCE($2, phone),
+           address = COALESCE($3, address)
+       WHERE client_id = $4
+       RETURNING client_id, first_name, last_name, email, phone, address, role, consent`,
+      [email, phone, address, user.id],
     );
     if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'User not found' });
@@ -624,6 +640,7 @@ export async function updateMyProfile(req: Request, res: Response, next: NextFun
       lastName: row.last_name,
       email: row.email,
       phone: row.phone,
+      address: row.address,
       clientId: row.client_id,
       role: row.role,
       bookingsThisMonth,
@@ -671,12 +688,13 @@ export async function updateUserByClientId(
     return res.status(403).json({ message: 'Forbidden' });
   }
   const { clientId } = req.params;
-  const { firstName, lastName, email, phone, onlineAccess, password } =
+  const { firstName, lastName, email, phone, address, onlineAccess, password } =
     req.body as {
       firstName: string;
       lastName: string;
       email?: string;
       phone?: string;
+      address?: string;
       onlineAccess?: boolean;
       password?: string;
     };
@@ -702,14 +720,15 @@ export async function updateUserByClientId(
       const result = await pool.query(
         `UPDATE clients
          SET first_name = $1, last_name = $2, email = $3, phone = $4,
-             online_access = true, password = COALESCE($5, password)
-         WHERE client_id = $6
-         RETURNING client_id, first_name, last_name, email, phone, profile_link, consent`,
+             address = $5, online_access = true, password = COALESCE($6, password)
+         WHERE client_id = $7
+         RETURNING client_id, first_name, last_name, email, phone, address, profile_link, consent`,
         [
           firstName,
           lastName,
           email || null,
           phone || null,
+          address || null,
           hashedPassword,
           clientId,
         ],
@@ -724,6 +743,7 @@ export async function updateUserByClientId(
         lastName: row.last_name,
         email: row.email,
         phone: row.phone,
+        address: row.address,
         profileLink: row.profile_link,
         consent: row.consent,
       });
@@ -731,10 +751,10 @@ export async function updateUserByClientId(
 
     const result = await pool.query(
       `UPDATE clients
-       SET first_name = $1, last_name = $2, email = $3, phone = $4
-       WHERE client_id = $5
-       RETURNING client_id, first_name, last_name, email, phone, profile_link, consent`,
-      [firstName, lastName, email || null, phone || null, clientId],
+       SET first_name = $1, last_name = $2, email = $3, phone = $4, address = $5
+       WHERE client_id = $6
+       RETURNING client_id, first_name, last_name, email, phone, address, profile_link, consent`,
+      [firstName, lastName, email || null, phone || null, address || null, clientId],
     );
     if ((result.rowCount ?? 0) === 0) {
       return res.status(404).json({ message: 'User not found' });
@@ -746,6 +766,7 @@ export async function updateUserByClientId(
       lastName: row.last_name,
       email: row.email,
       phone: row.phone,
+      address: row.address,
       profileLink: row.profile_link,
       consent: row.consent,
     });

--- a/MJ_FB_Backend/src/migrations/1700000000061_add_address_to_clients.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000061_add_address_to_clients.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('clients', {
+    address: { type: 'text' },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('clients', 'address');
+}

--- a/MJ_FB_Backend/src/models/user.ts
+++ b/MJ_FB_Backend/src/models/user.ts
@@ -6,6 +6,7 @@ export interface User {
   lastName?: string;
   email?: string | null;
   phone?: string | null;
+  address?: string | null;
   clientId: number;
   role: UserRole;
   bookingsThisMonth: number;

--- a/MJ_FB_Backend/src/schemas/userSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/userSchemas.ts
@@ -26,6 +26,7 @@ export const createUserSchema = z
     lastName: z.string().optional(),
     email: z.string().email().optional(),
     phone: z.string().optional(),
+    address: z.string().optional(),
     clientId: z.coerce.number().int().min(1).max(9_999_999),
     role: z.enum(['shopper', 'delivery']),
     onlineAccess: z.boolean(),
@@ -49,20 +50,28 @@ export const updateUserSchema = z.object({
   lastName: z.string().min(1),
   email: z.string().email().optional(),
   phone: z.string().optional(),
+  address: z.string().optional(),
   onlineAccess: z.boolean().optional(),
   password: passwordSchema.optional(),
 });
 
-// Schema for users updating their own contact information. Either
-// email or phone must be provided, but both are optional.
+// Schema for users updating their own contact information. At least one of
+// email, phone, or address must be provided, but all fields remain optional
+// individually.
 export const updateMyProfileSchema = z
   .object({
     email: z.string().email().optional(),
     phone: z.string().optional(),
+    address: z.string().optional(),
   })
-  .refine(data => data.email !== undefined || data.phone !== undefined, {
-    message: 'email or phone required',
-    path: ['email'],
+  .refine(
+    data =>
+      data.email !== undefined ||
+      data.phone !== undefined ||
+      data.address !== undefined,
+    {
+      message: 'email, phone, or address required',
+      path: ['email'],
   });
 
 

--- a/MJ_FB_Backend/tests/agencyProfile.test.ts
+++ b/MJ_FB_Backend/tests/agencyProfile.test.ts
@@ -39,6 +39,7 @@ describe('Agency profile routes', () => {
       lastName: '',
       email: 'agency@example.com',
       phone: '123-4567',
+      address: null,
       role: 'agency',
     });
   });
@@ -64,6 +65,7 @@ describe('Agency profile routes', () => {
       lastName: '',
       email: 'new@example.com',
       phone: 'info',
+      address: null,
       role: 'agency',
     });
   });

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -215,6 +215,11 @@ describe('deliveryOrderController', () => {
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         4,
+        'UPDATE clients SET address = $1 WHERE client_id = $2',
+        ['456 Elm St', 456],
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        5,
         expect.stringContaining('INSERT INTO delivery_order_items'),
         [77, 21, 2],
       );
@@ -335,6 +340,11 @@ describe('deliveryOrderController', () => {
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         4,
+        'UPDATE clients SET address = $1 WHERE client_id = $2',
+        ['789 Pine Ave', 555],
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        5,
         expect.stringContaining('INSERT INTO delivery_order_items'),
         [88, 52, 1],
       );

--- a/MJ_FB_Backend/tests/getUserByClientId.test.ts
+++ b/MJ_FB_Backend/tests/getUserByClientId.test.ts
@@ -28,6 +28,7 @@ describe('GET /users/id/:clientId', () => {
           last_name: 'Doe',
           email: 'jane@example.com',
           phone: '123',
+          address: '123 Main',
           online_access: true,
           password: 'hash',
         },
@@ -41,12 +42,13 @@ describe('GET /users/id/:clientId', () => {
       lastName: 'Doe',
       email: 'jane@example.com',
       phone: '123',
+      address: '123 Main',
       clientId: 5,
       onlineAccess: true,
       hasPassword: true,
     });
     expect(pool.query).toHaveBeenCalledWith(
-      `SELECT client_id, first_name, last_name, email, phone, online_access, password, consent\n       FROM clients WHERE client_id = $1`,
+      `SELECT client_id, first_name, last_name, email, phone, address, online_access, password, consent\n       FROM clients WHERE client_id = $1`,
       ['5'],
     );
   });

--- a/MJ_FB_Backend/tests/passwordResetFlow.test.ts
+++ b/MJ_FB_Backend/tests/passwordResetFlow.test.ts
@@ -263,7 +263,7 @@ describe('createUser password flow', () => {
     expect(bcrypt.hash).toHaveBeenCalledWith('Secret123!', 10);
     expect(generatePasswordSetupToken).not.toHaveBeenCalled();
     expect(sendTemplatedEmail).not.toHaveBeenCalled();
-    expect((pool.query as jest.Mock).mock.calls[2][1][6]).toBe('hashed');
+    expect((pool.query as jest.Mock).mock.calls[2][1][7]).toBe('hashed');
   });
 
   it('sends setup email when sendPasswordLink is true', async () => {

--- a/MJ_FB_Backend/tests/updateUserByClientId.test.ts
+++ b/MJ_FB_Backend/tests/updateUserByClientId.test.ts
@@ -54,7 +54,7 @@ describe('PATCH /users/id/:clientId', () => {
     expect(res.status).toBe(200);
     expect(bcrypt.hash).not.toHaveBeenCalled();
     const params = (pool.query as jest.Mock).mock.calls[0][1];
-    expect(params).toEqual(['Jane', 'Doe', null, null, null, '5']);
+    expect(params).toEqual(['Jane', 'Doe', null, null, null, null, '5']);
   });
 
   it('enables online access with password', async () => {
@@ -82,6 +82,6 @@ describe('PATCH /users/id/:clientId', () => {
     expect(res.status).toBe(200);
     expect(bcrypt.hash).toHaveBeenCalledWith('Secret1!', 10);
     const params = (pool.query as jest.Mock).mock.calls[0][1];
-    expect(params[4]).toBe('hashed');
+    expect(params[5]).toBe('hashed');
   });
 });


### PR DESCRIPTION
## Summary
- add a migration and model/schema updates so clients can store an address
- extend user controller profile and update flows plus delivery order creation to persist the address field
- update unit tests to cover address handling in user and delivery order controllers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8d1df7cf0832d874e095b815f0b0c