### PR TITLE
Prefill delivery booking contact details with confirmation

### DIFF
--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -248,6 +248,7 @@ export interface UserProfile {
   lastName: string;
   email: string | null;
   phone: string | null;
+  address?: string | null;
   role: Role;
   clientId?: number;
   bookingsThisMonth?: number;


### PR DESCRIPTION
## Summary
- load the signed-in profile when the delivery form mounts and show the address, phone, and email read-only until confirmed
- add confirmation checkboxes and edit toggles for each contact field, and disable submission until all are confirmed
- send trimmed contact updates with the order payload and update tests to cover the new workflow

## Testing
- npm test -- BookDelivery

------
https://chatgpt.com/codex/tasks/task_e_68c8d1e4cbcc832d98d90a1a650983a7