### PR TITLE
Add address support to profile editing

### DIFF
--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -101,6 +101,7 @@ export async function getUserProfile(): Promise<UserProfile> {
 export async function updateMyProfile(data: {
   email?: string;
   phone?: string;
+  address?: string | null;
 }): Promise<UserProfile> {
   const res = await apiFetch(`${API_BASE}/users/me`, {
     method: "PATCH",

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -35,6 +35,7 @@ export default function Profile({ role }: { role: Role }) {
   const [submitting, setSubmitting] = useState(false);
   const [editing, setEditing] = useState(false);
   const [email, setEmail] = useState("");
+  const [address, setAddress] = useState("");
   const [phone, setPhone] = useState("");
   const [phoneError, setPhoneError] = useState("");
   const [saving, setSaving] = useState(false);
@@ -55,6 +56,7 @@ export default function Profile({ role }: { role: Role }) {
       .then((p) => {
         setProfile(p);
         setEmail(p.email ?? "");
+        setAddress(p.address ?? "");
         setPhone(p.phone ?? "");
       })
       .catch((e) => setError(e instanceof Error ? e.message : String(e)));
@@ -105,9 +107,10 @@ export default function Profile({ role }: { role: Role }) {
       }
       setSaving(true);
       try {
-        const updated = await updateMyProfile({ email, phone });
+        const updated = await updateMyProfile({ email, phone, address });
         setProfile(updated);
         setEmail(updated.email ?? "");
+        setAddress(updated.address ?? "");
         setPhone(updated.phone ?? "");
         setToast({
           open: true,
@@ -202,6 +205,14 @@ export default function Profile({ role }: { role: Role }) {
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
+                  disabled={!editing}
+                  InputLabelProps={{ shrink: true }}
+                />
+                <TextField
+                  label="Address"
+                  type="text"
+                  value={address}
+                  onChange={(e) => setAddress(e.target.value)}
                   disabled={!editing}
                   InputLabelProps={{ shrink: true }}
                 />

--- a/MJ_FB_Frontend/src/pages/booking/__tests__/Profile.test.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/__tests__/Profile.test.tsx
@@ -1,0 +1,110 @@
+import Profile from '../Profile';
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+} from '../../../../testUtils/renderWithProviders';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import * as usersApi from '../../../api/users';
+
+const actualUsersApi =
+  jest.requireActual('../../../api/users') as typeof usersApi;
+
+jest.mock('../../../api/users', () => {
+  const actual = jest.requireActual('../../../api/users');
+  return {
+    ...actual,
+    getUserProfile: jest.fn(),
+    updateMyProfile: jest.fn(),
+    getUserPreferences: jest.fn(),
+  };
+});
+
+describe('Profile page', () => {
+  afterEach(() => {
+    (usersApi.getUserProfile as jest.Mock).mockReset();
+    (usersApi.getUserProfile as jest.Mock).mockImplementation(
+      actualUsersApi.getUserProfile,
+    );
+    (usersApi.updateMyProfile as jest.Mock).mockReset();
+    (usersApi.updateMyProfile as jest.Mock).mockImplementation(
+      actualUsersApi.updateMyProfile,
+    );
+    (usersApi.getUserPreferences as jest.Mock).mockReset();
+    (usersApi.getUserPreferences as jest.Mock).mockImplementation(
+      actualUsersApi.getUserPreferences,
+    );
+  });
+
+  it('allows editing the address and saves changes', async () => {
+    const mockGetUserProfile =
+      usersApi.getUserProfile as jest.MockedFunction<
+        typeof actualUsersApi.getUserProfile
+      >;
+    const mockUpdateMyProfile =
+      usersApi.updateMyProfile as jest.MockedFunction<
+        typeof actualUsersApi.updateMyProfile
+      >;
+    const mockGetUserPreferences =
+      usersApi.getUserPreferences as jest.MockedFunction<
+        typeof actualUsersApi.getUserPreferences
+      >;
+
+    mockGetUserProfile.mockResolvedValue({
+      id: 1,
+      firstName: 'Test',
+      lastName: 'User',
+      email: 'test@example.com',
+      phone: '123-456-7890',
+      address: '123 Main St',
+      role: 'shopper',
+      clientId: 42,
+    });
+    mockGetUserPreferences.mockResolvedValue({ emailReminders: true });
+    mockUpdateMyProfile.mockResolvedValue({
+      id: 1,
+      firstName: 'Test',
+      lastName: 'User',
+      email: 'test@example.com',
+      phone: '123-456-7890',
+      address: '456 New Rd',
+      role: 'shopper',
+      clientId: 42,
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MemoryRouter>
+        <Profile role="shopper" />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByDisplayValue('test@example.com'),
+    ).toBeInTheDocument();
+    const addressField = (await screen.findByLabelText('Address')) as HTMLInputElement;
+    expect(addressField).toHaveValue('123 Main St');
+    expect(addressField).toBeDisabled();
+
+    const editButton = screen.getByRole('button', { name: /edit profile/i });
+    await user.click(editButton);
+    expect(addressField).not.toBeDisabled();
+
+    await user.clear(addressField);
+    await user.type(addressField, '456 New Rd');
+
+    await user.click(editButton);
+
+    await waitFor(() =>
+      expect(mockUpdateMyProfile).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        phone: '123-456-7890',
+        address: '456 New Rd',
+      }),
+    );
+
+    await waitFor(() => expect(addressField).toBeDisabled());
+    expect(addressField).toHaveValue('456 New Rd');
+  });
+});

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -248,6 +248,7 @@ export interface UserProfile {
   lastName: string;
   email: string | null;
   phone: string | null;
+  address?: string | null;
   role: Role;
   clientId?: number;
   bookingsThisMonth?: number;


### PR DESCRIPTION
## Summary
- add an optional address field to the UserProfile type and include it in the updateMyProfile payload
- extend the booking profile page to show and persist the address alongside email and phone
- add a focused Jest test covering editing and saving the address value

## Testing
- npm test *(fails: DeliveryHistory, AgencyAccess, and UserHistory existing suites)*
- npx jest src/pages/booking/__tests__/Profile.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c8d1e1172c832d820e571685b67d86