### PR TITLE
Fix volunteer schedule schedule test timing

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -469,9 +469,11 @@ describe('VolunteerManagement schedule statuses', () => {
     fireEvent.mouseDown(screen.getByLabelText('Role'));
     fireEvent.click(await screen.findByRole('option', { name: 'Greeter' }));
 
-    expect(await screen.findByText('Alice')).toBeInTheDocument();
-    expect(await screen.findByText('Bob')).toBeInTheDocument();
-    expect(screen.queryByText('Carol')).toBeNull();
+    await waitFor(() => {
+      expect(screen.getByText(/Alice/i)).toBeInTheDocument();
+      expect(screen.getByText(/Bob/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Carol/i)).not.toBeInTheDocument();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- wait for the volunteer schedule test to render role bookings before asserting

## Testing
- npm test src/__tests__/VolunteerManagement.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c8d90cbc68832da1a4cd781488c81b