### PR TITLE
Add confirmation reminder for delivery submission

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -84,6 +84,8 @@ export default function BookDelivery() {
   });
   const { id: clientId } = useAuth();
 
+  const allConfirmed = addressConfirmed && phoneConfirmed && emailConfirmed;
+
   useEffect(() => {
     let active = true;
     async function loadProfile() {
@@ -604,18 +606,21 @@ export default function BookDelivery() {
             </Grid>
           </Grid>
 
-          <Box display="flex" justifyContent="flex-end">
+          <Stack spacing={1} alignItems="flex-end">
             <Button
               type="submit"
               variant="contained"
               size="medium"
-              disabled={
-                submitting || !addressConfirmed || !phoneConfirmed || !emailConfirmed
-              }
+              disabled={submitting || !allConfirmed}
             >
               {submitting ? 'Submitting…' : 'Submit Delivery Request'}
             </Button>
-          </Box>
+            {!allConfirmed && (
+              <Typography variant="body2" color="text.secondary">
+                Confirm your address, phone, and email above to submit.
+              </Typography>
+            )}
+          </Stack>
         </>
       )}
     </Container>

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
@@ -48,6 +48,8 @@ const mockProfile = {
   clientId: 321,
 };
 
+const confirmationReminderText = /confirm your address, phone, and email above to submit/i;
+
 function renderPage() {
   render(
     <MemoryRouter>
@@ -121,6 +123,7 @@ describe('BookDelivery', () => {
     const emailConfirm = screen.getByLabelText(/email is correct/i);
 
     expect(submitButton).toBeDisabled();
+    expect(screen.getByText(confirmationReminderText)).toBeInTheDocument();
 
     fireEvent.click(addressConfirm);
     expect(submitButton).toBeDisabled();
@@ -130,9 +133,11 @@ describe('BookDelivery', () => {
 
     fireEvent.click(emailConfirm);
     expect(submitButton).not.toBeDisabled();
+    expect(screen.queryByText(confirmationReminderText)).not.toBeInTheDocument();
 
     fireEvent.click(phoneConfirm);
     expect(submitButton).toBeDisabled();
+    expect(screen.getByText(confirmationReminderText)).toBeInTheDocument();
   });
 
   test('allows editing contact fields and resets confirmation', async () => {
@@ -149,12 +154,14 @@ describe('BookDelivery', () => {
     fireEvent.click(phoneConfirm);
     fireEvent.click(emailConfirm);
     expect(submitButton).not.toBeDisabled();
+    expect(screen.queryByText(confirmationReminderText)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /edit address/i }));
     const addressField = screen.getByLabelText(/delivery address/i) as HTMLInputElement;
     expect(addressField).not.toHaveAttribute('readonly');
     expect(addressConfirm).not.toBeChecked();
     expect(submitButton).toBeDisabled();
+    expect(screen.getByText(confirmationReminderText)).toBeInTheDocument();
 
     fireEvent.change(addressField, { target: { value: '456 New Street' } });
     expect(addressConfirm).not.toBeChecked();


### PR DESCRIPTION
## Summary
- display a helper message explaining why the delivery submit button is disabled until contact details are confirmed
- keep the submit action grouped with the reminder so the disabled state is obvious
- update the BookDelivery tests to cover the reminder visibility when confirmations change

## Testing
- npm test -- BookDelivery

------
https://chatgpt.com/codex/tasks/task_e_68c8da9bb990832d95dd59944f233396