### PR TITLE
Refine delivery contact editing flow

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -74,9 +74,7 @@ export default function BookDelivery() {
   const [addressConfirmed, setAddressConfirmed] = useState(false);
   const [phoneConfirmed, setPhoneConfirmed] = useState(false);
   const [emailConfirmed, setEmailConfirmed] = useState(false);
-  const [editingAddress, setEditingAddress] = useState(false);
-  const [editingPhone, setEditingPhone] = useState(false);
-  const [editingEmail, setEditingEmail] = useState(false);
+  const [editingContact, setEditingContact] = useState(false);
   const [snackbar, setSnackbar] = useState<SnackbarState>({
     open: false,
     message: '',
@@ -291,9 +289,7 @@ export default function BookDelivery() {
       setAddressConfirmed(false);
       setPhoneConfirmed(false);
       setEmailConfirmed(false);
-      setEditingAddress(false);
-      setEditingPhone(false);
-      setEditingEmail(false);
+      setEditingContact(false);
     } catch (err) {
       const message = getApiErrorMessage(
         err,
@@ -410,52 +406,52 @@ export default function BookDelivery() {
 
           <Divider sx={{ my: 4 }} />
 
-          <Typography variant="h5" component="h2" gutterBottom>
-            Contact information
-          </Typography>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={1}
+            alignItems={{ xs: 'stretch', sm: 'center' }}
+            justifyContent="space-between"
+            sx={{ mb: 2 }}
+          >
+            <Typography variant="h5" component="h2">
+              Contact information
+            </Typography>
+            <Button
+              type="button"
+              variant="outlined"
+              onClick={() => {
+                setEditingContact(true);
+                setAddressConfirmed(false);
+                setPhoneConfirmed(false);
+                setEmailConfirmed(false);
+              }}
+              sx={{ width: { xs: '100%', sm: 'auto' } }}
+              disabled={editingContact}
+            >
+              Edit contact info
+            </Button>
+          </Stack>
 
           <Grid container spacing={2} sx={{ mb: 3 }}>
             <Grid size={{ xs: 12 }}>
               <Stack spacing={1}>
-                <Stack
-                  direction={{ xs: 'column', sm: 'row' }}
-                  spacing={1}
-                  alignItems={{ sm: 'flex-end' }}
-                >
-                  <TextField
-                    fullWidth
-                    label="Delivery address"
-                    value={address}
-                    onChange={event => {
-                      setAddress(event.target.value);
-                      setAddressConfirmed(false);
-                      setFormErrors(prev => ({
-                        ...prev,
-                        address: undefined,
-                        addressConfirm: undefined,
-                      }));
-                    }}
-                    error={Boolean(formErrors.address)}
-                    helperText={formErrors.address}
-                    InputProps={{ readOnly: !editingAddress }}
-                    sx={{ flex: 1 }}
-                  />
-                  <Button
-                    type="button"
-                    variant="outlined"
-                    onClick={() => {
-                      setEditingAddress(prev => {
-                        const next = !prev;
-                        if (next) {
-                          setAddressConfirmed(false);
-                        }
-                        return next;
-                      });
-                    }}
-                  >
-                    {editingAddress ? 'Done editing' : 'Edit address'}
-                  </Button>
-                </Stack>
+                <TextField
+                  fullWidth
+                  label="Delivery address"
+                  value={address}
+                  onChange={event => {
+                    setAddress(event.target.value);
+                    setAddressConfirmed(false);
+                    setFormErrors(prev => ({
+                      ...prev,
+                      address: undefined,
+                      addressConfirm: undefined,
+                    }));
+                  }}
+                  error={Boolean(formErrors.address)}
+                  helperText={formErrors.address}
+                  InputProps={{ readOnly: !editingContact }}
+                />
                 <FormControl error={Boolean(formErrors.addressConfirm)}>
                   <FormControlLabel
                     control={
@@ -480,44 +476,23 @@ export default function BookDelivery() {
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
               <Stack spacing={1}>
-                <Stack
-                  direction={{ xs: 'column', sm: 'row' }}
-                  spacing={1}
-                  alignItems={{ sm: 'flex-end' }}
-                >
-                  <TextField
-                    fullWidth
-                    label="Phone number"
-                    value={phone}
-                    onChange={event => {
-                      setPhone(event.target.value);
-                      setPhoneConfirmed(false);
-                      setFormErrors(prev => ({
-                        ...prev,
-                        phone: undefined,
-                        phoneConfirm: undefined,
-                      }));
-                    }}
-                    error={Boolean(formErrors.phone)}
-                    helperText={formErrors.phone}
-                    InputProps={{ readOnly: !editingPhone }}
-                  />
-                  <Button
-                    type="button"
-                    variant="outlined"
-                    onClick={() => {
-                      setEditingPhone(prev => {
-                        const next = !prev;
-                        if (next) {
-                          setPhoneConfirmed(false);
-                        }
-                        return next;
-                      });
-                    }}
-                  >
-                    {editingPhone ? 'Done editing' : 'Edit phone'}
-                  </Button>
-                </Stack>
+                <TextField
+                  fullWidth
+                  label="Phone number"
+                  value={phone}
+                  onChange={event => {
+                    setPhone(event.target.value);
+                    setPhoneConfirmed(false);
+                    setFormErrors(prev => ({
+                      ...prev,
+                      phone: undefined,
+                      phoneConfirm: undefined,
+                    }));
+                  }}
+                  error={Boolean(formErrors.phone)}
+                  helperText={formErrors.phone}
+                  InputProps={{ readOnly: !editingContact }}
+                />
                 <FormControl error={Boolean(formErrors.phoneConfirm)}>
                   <FormControlLabel
                     control={
@@ -542,44 +517,23 @@ export default function BookDelivery() {
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
               <Stack spacing={1}>
-                <Stack
-                  direction={{ xs: 'column', sm: 'row' }}
-                  spacing={1}
-                  alignItems={{ sm: 'flex-end' }}
-                >
-                  <TextField
-                    fullWidth
-                    label="Email"
-                    value={email}
-                    onChange={event => {
-                      setEmail(event.target.value);
-                      setEmailConfirmed(false);
-                      setFormErrors(prev => ({
-                        ...prev,
-                        email: undefined,
-                        emailConfirm: undefined,
-                      }));
-                    }}
-                    error={Boolean(formErrors.email)}
-                    helperText={formErrors.email}
-                    InputProps={{ readOnly: !editingEmail }}
-                  />
-                  <Button
-                    type="button"
-                    variant="outlined"
-                    onClick={() => {
-                      setEditingEmail(prev => {
-                        const next = !prev;
-                        if (next) {
-                          setEmailConfirmed(false);
-                        }
-                        return next;
-                      });
-                    }}
-                  >
-                    {editingEmail ? 'Done editing' : 'Edit email'}
-                  </Button>
-                </Stack>
+                <TextField
+                  fullWidth
+                  label="Email"
+                  value={email}
+                  onChange={event => {
+                    setEmail(event.target.value);
+                    setEmailConfirmed(false);
+                    setFormErrors(prev => ({
+                      ...prev,
+                      email: undefined,
+                      emailConfirm: undefined,
+                    }));
+                  }}
+                  error={Boolean(formErrors.email)}
+                  helperText={formErrors.email}
+                  InputProps={{ readOnly: !editingContact }}
+                />
                 <FormControl error={Boolean(formErrors.emailConfirm)}>
                   <FormControlLabel
                     control={
@@ -603,6 +557,25 @@ export default function BookDelivery() {
               </Stack>
             </Grid>
           </Grid>
+
+          {editingContact && (
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: { xs: 'stretch', sm: 'flex-end' },
+                mb: 3,
+              }}
+            >
+              <Button
+                type="button"
+                variant="contained"
+                onClick={() => setEditingContact(false)}
+                sx={{ width: { xs: '100%', sm: 'auto' } }}
+              >
+                Save contact info
+              </Button>
+            </Box>
+          )}
 
           <Box display="flex" justifyContent="flex-end">
             <Button

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
@@ -150,17 +150,26 @@ describe('BookDelivery', () => {
     fireEvent.click(emailConfirm);
     expect(submitButton).not.toBeDisabled();
 
-    fireEvent.click(screen.getByRole('button', { name: /edit address/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit contact info/i }));
     const addressField = screen.getByLabelText(/delivery address/i) as HTMLInputElement;
+    const phoneField = screen.getByLabelText(/^phone number$/i) as HTMLInputElement;
+    const emailField = screen.getByLabelText(/^email$/i) as HTMLInputElement;
     expect(addressField).not.toHaveAttribute('readonly');
+    expect(phoneField).not.toHaveAttribute('readonly');
+    expect(emailField).not.toHaveAttribute('readonly');
     expect(addressConfirm).not.toBeChecked();
+    expect(phoneConfirm).not.toBeChecked();
+    expect(emailConfirm).not.toBeChecked();
     expect(submitButton).toBeDisabled();
 
     fireEvent.change(addressField, { target: { value: '456 New Street' } });
     expect(addressConfirm).not.toBeChecked();
 
-    fireEvent.click(screen.getByRole('button', { name: /done editing/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save contact info/i }));
     expect(addressField).toHaveAttribute('readonly');
+    expect(phoneField).toHaveAttribute('readonly');
+    expect(emailField).toHaveAttribute('readonly');
+    expect(screen.getByRole('button', { name: /edit contact info/i })).not.toBeDisabled();
   });
 
   test('submits updated contact information in delivery payload', async () => {
@@ -173,23 +182,17 @@ describe('BookDelivery', () => {
     const cereal = await screen.findByRole('checkbox', { name: /cereal/i });
     fireEvent.click(cereal);
 
-    fireEvent.click(screen.getByRole('button', { name: /edit address/i }));
+    fireEvent.click(screen.getByRole('button', { name: /edit contact info/i }));
     fireEvent.change(screen.getByLabelText(/delivery address/i), {
       target: { value: ' 456 New Street ' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /done editing/i }));
-
-    fireEvent.click(screen.getByRole('button', { name: /edit phone/i }));
     fireEvent.change(screen.getByLabelText(/^phone number$/i), {
       target: { value: ' 306-555-2222 ' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /done editing/i }));
-
-    fireEvent.click(screen.getByRole('button', { name: /edit email/i }));
     fireEvent.change(screen.getByLabelText(/^email$/i), {
       target: { value: ' new@example.com ' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /done editing/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save contact info/i }));
 
     fireEvent.click(screen.getByLabelText(/address is correct/i));
     fireEvent.click(screen.getByLabelText(/phone number is correct/i));


### PR DESCRIPTION
## Summary
- replace the per-field editing toggles with a single `editingContact` state and responsive edit/save controls
- update the contact text fields to respect the new editing mode and show a save action when active
- adjust the Book Delivery tests to cover the unified contact editing workflow

## Testing
- npm test -- --runTestsByPath src/pages/delivery/__tests__/BookDelivery.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c8da969174832d87b5321d4170a6b3