### PR TITLE
Document delivery request email parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,10 +68,12 @@ See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` |
 | `CLIENT_RESCHEDULE_TEMPLATE_ID` | Booking reschedule notifications for clients | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `appleCalendarLink`, `type` |
 | `VOLUNTEER_RESCHEDULE_TEMPLATE_ID` | Volunteer shift reschedule emails | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `appleCalendarLink`, `type` |
-| `DELIVERY_REQUEST_TEMPLATE_ID` | Delivery request notifications for staff | `orderId`, `clientId`, `address`, `phone`, `email`, `itemList`, `createdAt` |
+| `DELIVERY_REQUEST_TEMPLATE_ID` | Delivery request notifications for staff | `orderId`, `clientId`, `clientName`, `address`, `phone`, `email`, `itemList`, `createdAt` |
 | `DONOR_TEMPLATE_ID_*` | Monetary donor emails for tiered amounts ($1–$100, $101–$500, $501–$1,000, $1,001–$10,000, $10,001–$30,000) | `firstName`, `amount`, `families`, `adults`, `children`, `pounds`, `month`, `year` |
 
-Client and volunteer reschedule emails currently use Brevo template ID **10**.
+Client and volunteer reschedule emails currently use Brevo template ID **10**. Delivery request notifications format the `itemList`
+with category headings so staff can scan grouped selections quickly (for example, `Bakery` followed by the requested loaves on
+their own lines).
 
 Cancellation, no-show, volunteer booking notification, and agency membership emails are no longer sent.
 

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -19,7 +19,7 @@
 ## Handling new requests
 
 - Every submission to `/api/v1/delivery/orders` sends a Brevo email using `DELIVERY_REQUEST_TEMPLATE_ID`. Update the template when wording changes so the notification still matches the operation team’s process.
-- The notification includes the order ID, client ID, contact details, timestamp, and a newline-delimited list of requested items. Use that email to coordinate fulfillment and scheduling.
+- The notification includes the order ID, client ID, client name, contact details, timestamp, and a grouped list of requested items. Items are organized by category with each category name on its own line followed by the requested products on separate bullet lines. Use that email to coordinate fulfillment and scheduling.
 - When the delivery date is confirmed, reply to the client with the plan (email or phone) and document the outcome in internal logs as needed. The app does not yet track delivery status, so rely on your operations checklist.
 
 ## Supporting clients

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -12,6 +12,7 @@ parameters supplied to each template.
 | `VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID` | Volunteer shift reminder emails | `body`, `cancelLink`, `rescheduleLink`, `type` | `volunteerShiftReminderJob.ts` |
 | `CLIENT_RESCHEDULE_TEMPLATE_ID` | Booking reschedule notifications for clients | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `appleCalendarLink`, `type` | `bookingController.ts` |
 | `VOLUNTEER_RESCHEDULE_TEMPLATE_ID` | Volunteer shift reschedule emails | `oldDate`, `oldTime`, `newDate`, `newTime`, `cancelLink`, `rescheduleLink`, `googleCalendarLink`, `appleCalendarLink`, `type` | `volunteerBookingController.ts` |
+| `DELIVERY_REQUEST_TEMPLATE_ID` | Delivery request notifications for staff | `orderId`, `clientId`, `clientName`, `address`, `phone`, `email`, `itemList`, `createdAt` | `deliveryOrderController.ts` |
 
 Client and volunteer reschedule notifications share Brevo template ID **10**.
 
@@ -23,6 +24,29 @@ If `ICS_BASE_URL` is configured, the `appleCalendarLink` points to the hosted `.
 file; otherwise it falls back to a base64 `data:` URI.
 
 Cancellation, no-show, volunteer notification, and agency client update emails have been discontinued.
+
+## Delivery request notifications
+
+- **Template ID variable:** `DELIVERY_REQUEST_TEMPLATE_ID`
+- **Params:**
+  - `orderId` (number) – database ID for the delivery order.
+  - `clientId` (number) – client identifier recorded with the order.
+  - `clientName` (string) – shopper name assembled from their client profile; blank when not available.
+  - `address` (string) – delivery address submitted on the form.
+  - `phone` (string) – phone number supplied by the client.
+  - `email` (string) – contact email for scheduling follow-up.
+  - `itemList` (string) – newline-delimited summary grouped by category, e.g.
+    ```
+    Bakery
+    - Whole Wheat Bread x2
+    - White Bread x1
+
+    Produce
+    - Carrot Bundle x1
+    ```
+  - `createdAt` (ISO 8601 string) – submission timestamp for the request.
+
+Operations staff receive the email at the address configured under **Admin → Settings → Pantry → Delivery**.
 
 ## Volunteer booking confirmation and reminder emails
 


### PR DESCRIPTION
## Summary
- add the client name parameter to delivery request email template references
- document the grouped delivery item list format for operations staff
- update delivery staff guide with the expanded notification details

## Testing
- nvm use
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8dc5e2bd0832d970399d3bf215c3f