### PR TITLE
Group delivery request items by category

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -81,6 +81,52 @@ function sortItems(items: DeliveryOrderItemDetail[]): DeliveryOrderItemDetail[] 
   });
 }
 
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, char => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
+}
+
+function buildItemListHtml(items: DeliveryOrderItemDetail[]): string {
+  if (items.length === 0) {
+    return 'No items selected';
+  }
+
+  const grouped = new Map<
+    number,
+    { categoryName: string; selections: DeliveryOrderItemDetail[] }
+  >();
+
+  for (const item of items) {
+    if (!grouped.has(item.categoryId)) {
+      grouped.set(item.categoryId, { categoryName: item.categoryName, selections: [] });
+    }
+    grouped.get(item.categoryId)!.selections.push(item);
+  }
+
+  return Array.from(grouped.values())
+    .map(({ categoryName, selections }) => {
+      const itemsText = selections
+        .map(selection => `${escapeHtml(selection.itemName)} x${selection.quantity}`)
+        .join(', ');
+      return `<strong>${escapeHtml(categoryName)}</strong> - ${itemsText}<br>`;
+    })
+    .join('');
+}
+
 function toIsoString(value: Date | string | null | undefined): string {
   if (!value) return new Date().toISOString();
   if (value instanceof Date) return value.toISOString();
@@ -269,12 +315,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
   }
 
   const createdAt = toIsoString(order.createdAt);
-  const itemList =
-    itemDetails.length > 0
-      ? itemDetails
-          .map(item => `${item.categoryName}: ${item.itemName} x${item.quantity}`)
-          .join('\n')
-      : 'No items selected';
+  const itemList = buildItemListHtml(itemDetails);
 
   try {
     const { requestEmail } = await getDeliverySettings();

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -255,7 +255,7 @@ describe('deliveryOrderController', () => {
           address: '456 Elm St',
           phone: '555-2222',
           email: 'shopper@example.com',
-          itemList: 'Bakery: Whole Wheat Bread x2',
+          itemList: '<strong>Bakery</strong> - Whole Wheat Bread x2<br>',
           createdAt: submittedAt.toISOString(),
         },
       });
@@ -386,7 +386,7 @@ describe('deliveryOrderController', () => {
           address: '789 Pine Ave',
           phone: '555-3333',
           email: 'client@example.com',
-          itemList: 'Produce: Fresh Produce Box x1',
+          itemList: '<strong>Produce</strong> - Fresh Produce Box x1<br>',
           createdAt: submittedAt.toISOString(),
         },
       });

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -19,7 +19,7 @@
 ## Handling new requests
 
 - Every submission to `/api/v1/delivery/orders` sends a Brevo email using `DELIVERY_REQUEST_TEMPLATE_ID`. Update the template when wording changes so the notification still matches the operation team’s process.
-- The notification includes the order ID, client ID, contact details, timestamp, and a newline-delimited list of requested items. Use that email to coordinate fulfillment and scheduling.
+- The notification includes the order ID, client ID, contact details, timestamp, and an HTML item summary that groups selections by category. Each category renders as `<strong>Category</strong> - Item xQuantity` with `<br>` line breaks, and the summary falls back to “No items selected” when a shopper doesn’t add items. Use that email to coordinate fulfillment and scheduling.
 - When the delivery date is confirmed, reply to the client with the plan (email or phone) and document the outcome in internal logs as needed. The app does not yet track delivery status, so rely on your operations checklist.
 
 ## Supporting clients


### PR DESCRIPTION
## Summary
- group delivery order selections by category when building the notification item list and escape HTML
- update delivery order controller tests for the new grouped HTML format
- document the grouped, bolded delivery item summary in the delivery operations guide

## Testing
- `npm test` *(fails: existing failure in tests/scheduleDailyJob.test.ts expecting cron.schedule to be called)*

------
https://chatgpt.com/codex/tasks/task_e_68c8dc5359ec832db01db6cb6927440f