### PR TITLE
Fix closing tag in BookDelivery submit actions

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -593,7 +593,7 @@ export default function BookDelivery() {
                 Confirm your address, phone, and email above to submit.
               </Typography>
             )}
-          </Stack>
+          </Box>
         </>
       )}
     </Container>


### PR DESCRIPTION
## Summary
- close the Book Delivery submit action container with the correct Box tag to fix JSX parsing

## Testing
- npm test *(fails: existing test suites such as AgencyAccess and UserHistory currently fail in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c8dd539310832db1f084555e8b1b26