### PR TITLE
Adjust delivery submit helper text layout

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -579,17 +579,27 @@ export default function BookDelivery() {
             </Box>
           )}
 
-          <Box display="flex" justifyContent="flex-end">
+          <Box
+            display="flex"
+            justifyContent="flex-end"
+            flexDirection="column"
+            alignItems={{ xs: 'stretch', sm: 'flex-end' }}
+          >
             <Button
               type="submit"
               variant="contained"
               size="medium"
               disabled={submitting || !allConfirmed}
+              sx={{ width: { xs: '100%', sm: 'auto' } }}
             >
               {submitting ? 'Submitting…' : 'Submit Delivery Request'}
             </Button>
             {!allConfirmed && (
-              <Typography variant="body2" color="text.secondary">
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mt: 1, textAlign: { xs: 'left', sm: 'right' } }}
+              >
                 Confirm your address, phone, and email above to submit.
               </Typography>
             )}


### PR DESCRIPTION
## Summary
- stack the delivery helper message beneath the submit button
- ensure the submit button remains full-width on small screens and align helper text responsively

## Testing
- npm test -- --passWithNoTests *(fails: existing frontend tests currently failing in main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68c8df236bdc832db9aaa78a9d8ee5fa