### PR TITLE
Expand slot list width

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -532,7 +532,10 @@ export default function BookingUI<T = Slot>({
             )}
           </Paper>
         </Grid>
-        <Grid size={{ xs: 12, md: 6 }}>
+        <Grid
+          size={{ xs: 12, md: 'auto' }}
+          sx={{ flexGrow: 1, flexBasis: { md: 0 }, minWidth: { md: 0 } }}
+        >
           <Paper
             ref={slotsRef}
             sx={{


### PR DESCRIPTION
## Summary
- let the booking slots grid item flex to fill the remaining container width beside the calendar
- zero out the grid item's flex basis on desktop so the slot list paper stretches across the layout

## Testing
- npm test *(fails: existing suites such as AgencyAccess/UserHistory and a Jest worker hit OOM in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e061284c832dbf35ac97cebe4174