### PR TITLE
Show client bottom nav on delivery pages

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -21,6 +21,7 @@ import {
   Typography,
 } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import ClientBottomNav from '../../components/ClientBottomNav';
 import {
   API_BASE,
   apiFetch,
@@ -304,12 +305,13 @@ export default function BookDelivery() {
   };
 
   return (
-    <Container
-      component="form"
-      onSubmit={handleSubmit}
-      maxWidth="md"
-      sx={{ py: 4 }}
-    >
+    <>
+      <Container
+        component="form"
+        onSubmit={handleSubmit}
+        maxWidth="md"
+        sx={{ pt: 4, pb: 12 }}
+      >
       <FeedbackSnackbar
         open={snackbar.open}
         onClose={handleSnackbarClose}
@@ -606,6 +608,8 @@ export default function BookDelivery() {
           </Box>
         </>
       )}
-    </Container>
+      </Container>
+      <ClientBottomNav />
+    </>
   );
 }

--- a/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
@@ -19,6 +19,7 @@ import type { ChipProps } from '@mui/material/Chip';
 import { Link as RouterLink } from 'react-router-dom';
 import { LoadingButton } from '@mui/lab';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import ClientBottomNav from '../../components/ClientBottomNav';
 import {
   API_BASE,
   apiFetch,
@@ -162,7 +163,8 @@ export default function DeliveryHistory() {
   );
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <>
+      <Container maxWidth="md" sx={{ pt: 4, pb: 12 }}>
       <FeedbackSnackbar
         open={snackbar.open}
         onClose={handleSnackbarClose}
@@ -279,6 +281,8 @@ export default function DeliveryHistory() {
           })}
         </Stack>
       )}
-    </Container>
+      </Container>
+      <ClientBottomNav />
+    </>
   );
 }

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
@@ -252,4 +252,13 @@ describe('BookDelivery', () => {
     ).toBeInTheDocument();
     expect(apiFetch).toHaveBeenCalledTimes(1);
   });
+
+  test('displays client bottom navigation', async () => {
+    renderPage();
+
+    await screen.findByRole('button', { name: /submit delivery request/i });
+
+    expect(screen.getByLabelText('delivery')).toBeInTheDocument();
+    expect(screen.getByLabelText('profile')).toBeInTheDocument();
+  });
 });

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/DeliveryHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/DeliveryHistory.test.tsx
@@ -14,6 +14,10 @@ jest.mock('../../../api/client', () => {
   };
 });
 
+jest.mock('../../../hooks/useAuth', () => ({
+  useAuth: () => ({ role: 'delivery' }),
+}));
+
 import { theme } from '../../../theme';
 import type { DeliveryOrder } from '../../../types';
 import {
@@ -134,5 +138,15 @@ describe('DeliveryHistory', () => {
     expect(
       await screen.findByText('Network unavailable', { selector: 'p' }),
     ).toBeInTheDocument();
+  });
+
+  it('shows bottom navigation for delivery clients', async () => {
+    mockedApiFetch.mockResolvedValue({} as Response);
+    mockedHandleResponse.mockResolvedValue([]);
+
+    renderComponent();
+
+    expect(await screen.findByLabelText('delivery')).toBeInTheDocument();
+    expect(screen.getByLabelText('profile')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add the ClientBottomNav component to the delivery booking and history pages and adjust spacing so it stays visible
- extend the delivery booking and history page tests to cover the new navigation links

## Testing
- npm test -- BookDelivery
- npm test -- DeliveryHistory

------
https://chatgpt.com/codex/tasks/task_e_68c8e0f92e38832db20ec5ec9a8f892f