### PR TITLE
Show delivery request confirmation modal

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -8,6 +8,11 @@ import {
   Checkbox,
   CircularProgress,
   Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Divider,
   FormControl,
   FormControlLabel,
@@ -31,6 +36,7 @@ import {
 import type { DeliveryCategory, DeliveryItem } from '../../types';
 import { useAuth } from '../../hooks/useAuth';
 import { getUserProfile } from '../../api/users';
+import { useNavigate } from 'react-router-dom';
 
 type SelectionState = Record<number, boolean>;
 
@@ -83,6 +89,8 @@ export default function BookDelivery() {
   });
   const { id: clientId } = useAuth();
   const [contactEditForced, setContactEditForced] = useState(false);
+  const [successDialogOpen, setSuccessDialogOpen] = useState(false);
+  const navigate = useNavigate();
 
   const allConfirmed = addressConfirmed && phoneConfirmed && emailConfirmed;
 
@@ -220,6 +228,15 @@ export default function BookDelivery() {
     setSnackbar(prev => ({ ...prev, open: false }));
   };
 
+  const handleSuccessDialogClose = () => {
+    setSuccessDialogOpen(false);
+  };
+
+  const handleViewHistory = () => {
+    setSuccessDialogOpen(false);
+    navigate('/delivery/history');
+  };
+
   const validate = (): boolean => {
     const nextErrors: FormErrors = {};
     const trimmedAddress = address.trim();
@@ -289,11 +306,8 @@ export default function BookDelivery() {
         body: JSON.stringify(payload),
       });
       await handleResponse(res);
-      setSnackbar({
-        open: true,
-        message: 'Delivery request submitted',
-        severity: 'success',
-      });
+      setSuccessDialogOpen(true);
+      setSnackbar({ open: false, message: '', severity: 'success' });
       setAddress(trimmedAddress);
       setPhone(trimmedPhone);
       setEmail(trimmedEmail);
@@ -317,6 +331,37 @@ export default function BookDelivery() {
 
   return (
     <>
+      <Dialog
+        open={successDialogOpen}
+        onClose={handleSuccessDialogClose}
+        aria-labelledby="delivery-request-submitted-title"
+      >
+        <DialogTitle id="delivery-request-submitted-title">
+          Delivery request submitted
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            We received your request and will contact you with delivery details
+            soon. You can review past submissions in your delivery history.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button
+            onClick={handleSuccessDialogClose}
+            variant="text"
+            size="medium"
+          >
+            Close
+          </Button>
+          <Button
+            onClick={handleViewHistory}
+            variant="contained"
+            size="medium"
+          >
+            View Delivery History
+          </Button>
+        </DialogActions>
+      </Dialog>
       <Container
         component="form"
         onSubmit={handleSubmit}

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/BookDelivery.test.tsx
@@ -5,8 +5,17 @@ import type { DeliveryCategory } from '../../../types';
 import { apiFetch, handleResponse } from '../../../api/client';
 import { getUserProfile } from '../../../api/users';
 
+const mockNavigate = jest.fn();
 const mockUseAuth = jest.fn();
 const mockGetUserProfile = getUserProfile as jest.Mock;
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 jest.mock('../../../hooks/useAuth', () => ({
   useAuth: () => mockUseAuth(),
@@ -81,6 +90,7 @@ describe('BookDelivery', () => {
       cardUrl: '',
       ready: true,
     });
+    mockNavigate.mockReset();
   });
 
   test('disables unchecked items when category limit reached', async () => {
@@ -257,6 +267,12 @@ describe('BookDelivery', () => {
     });
 
     expect(await screen.findByText(/delivery request submitted/i)).toBeInTheDocument();
+
+    const viewHistoryButton = await screen.findByRole('button', {
+      name: /view delivery history/i,
+    });
+    fireEvent.click(viewHistoryButton);
+    expect(mockNavigate).toHaveBeenCalledWith('/delivery/history');
   });
 
   test('shows an error when the client id is unavailable', async () => {


### PR DESCRIPTION
## Summary
- add a submission confirmation dialog to the delivery booking page with an action to open delivery history
- reset success notifications and keep contact information handling unchanged after a submission
- update delivery booking tests to mock navigation and verify the modal flow

## Testing
- npm test *(fails: existing AgencyAccess/AuthProvider and other suite issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e3c55964832da4ab7fe5e3fa34e0