### PR TITLE
Fix delivery migration import path

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000059_seed_delivery_data.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000059_seed_delivery_data.ts
@@ -1,6 +1,6 @@
 import type { MigrationBuilder } from 'node-pg-migrate';
 import type { Queryable } from '../models/bookingRepository';
-import seedDeliveryData, { DELIVERY_CATEGORY_SEEDS } from '../utils/deliverySeeder';
+import seedDeliveryData, { DELIVERY_CATEGORY_SEEDS } from '../utils/deliverySeeder.js';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   await seedDeliveryData(undefined, pgm.db as unknown as Queryable);


### PR DESCRIPTION
## Summary
- update the delivery seeding migration to import the shared seeder using the compiled `.js` path so node can resolve it at runtime

## Testing
- npm run build
- npm test *(fails: Node v22 is required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e54d463c832d80b7ebcda0845c22