### PR TITLE
Fix delivery seeder import path

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000059_seed_delivery_data.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000059_seed_delivery_data.ts
@@ -1,6 +1,6 @@
 import type { MigrationBuilder } from 'node-pg-migrate';
 import type { Queryable } from '../models/bookingRepository';
-import seedDeliveryData, { DELIVERY_CATEGORY_SEEDS } from '../utils/deliverySeeder.js';
+import seedDeliveryData, { DELIVERY_CATEGORY_SEEDS } from '../utils/deliverySeeder';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   await seedDeliveryData(undefined, pgm.db as unknown as Queryable);


### PR DESCRIPTION
## Summary
- fix the delivery data seeding migration to import the TypeScript seeder module without a .js extension so ts-node can resolve it

## Testing
- npm test -- --runTestsByPath tests/deliveryCategoryController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c8e6db4c7c832dbc5543f60f07e299