### PR TITLE
Add tests for UnauthorizedError name and status

### DIFF
--- a/MJ_FB_Backend/src/utils/UnauthorizedError.ts
+++ b/MJ_FB_Backend/src/utils/UnauthorizedError.ts
@@ -2,6 +2,7 @@ export default class UnauthorizedError extends Error {
   status: number;
   constructor(message = 'Invalid credentials') {
     super(message);
+    this.name = 'UnauthorizedError';
     this.status = 401;
   }
 }

--- a/MJ_FB_Backend/tests/utils/UnauthorizedError.test.ts
+++ b/MJ_FB_Backend/tests/utils/UnauthorizedError.test.ts
@@ -1,15 +1,19 @@
-import UnauthorizedError from '../src/utils/UnauthorizedError';
+import UnauthorizedError from '../../src/utils/UnauthorizedError';
 
 describe('UnauthorizedError', () => {
-  it('defaults message and status', () => {
+  it('sets default message along with name and status', () => {
     const err = new UnauthorizedError();
+
     expect(err.message).toBe('Invalid credentials');
+    expect(err.name).toBe('UnauthorizedError');
     expect(err.status).toBe(401);
   });
 
-  it('allows overriding message', () => {
+  it('preserves name and status when overriding the message', () => {
     const err = new UnauthorizedError('Custom message');
+
     expect(err.message).toBe('Custom message');
+    expect(err.name).toBe('UnauthorizedError');
     expect(err.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary
- assign the UnauthorizedError class a name for clarity
- move the UnauthorizedError test under tests/utils and verify name, message, and status

## Testing
- npm test -- tests/utils/UnauthorizedError.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c8ed2061c8832dbc09011abc778a49