### PR TITLE
Add WebAuthn controller error handling tests

### DIFF
--- a/MJ_FB_Backend/tests/controllers/webauthnController.test.ts
+++ b/MJ_FB_Backend/tests/controllers/webauthnController.test.ts
@@ -1,0 +1,70 @@
+jest.mock('../../src/models/webauthn', () => ({
+  getCredential: jest.fn(),
+  saveCredential: jest.fn(),
+  getCredentialById: jest.fn(),
+}));
+
+jest.mock('../../src/utils/authUtils', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../src/models/agency', () => ({
+  getAgencyByEmail: jest.fn(),
+}));
+
+import { generateChallenge, registerCredential, verifyCredential } from '../../src/controllers/webauthnController';
+import { getCredential, saveCredential, getCredentialById } from '../../src/models/webauthn';
+import UnauthorizedError from '../../src/utils/UnauthorizedError';
+
+describe('webauthnController error handling', () => {
+  const mockedGetCredential = getCredential as jest.MockedFunction<typeof getCredential>;
+  const mockedSaveCredential = saveCredential as jest.MockedFunction<typeof saveCredential>;
+  const mockedGetCredentialById = getCredentialById as jest.MockedFunction<typeof getCredentialById>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('forwards an error when registration is missing the credential ID', async () => {
+    const error = new Error('Missing credential ID');
+    mockedSaveCredential.mockRejectedValueOnce(error);
+    const req = {
+      body: { identifier: 'user@example.com' },
+    } as any;
+    const res = { json: jest.fn() } as any;
+    const next = jest.fn();
+
+    await registerCredential(req, res, next);
+
+    expect(mockedSaveCredential).toHaveBeenCalledWith('user@example.com', undefined);
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when verification results are invalid', async () => {
+    mockedGetCredentialById.mockResolvedValueOnce(null);
+
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const res = { status, json } as any;
+    const req = { body: { credentialId: 'invalid-credential' } } as any;
+    const next = jest.fn();
+
+    await verifyCredential(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ message: 'Invalid credentials' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects listing credentials when the user is unauthorized', async () => {
+    mockedGetCredential.mockRejectedValueOnce(new UnauthorizedError('Forbidden'));
+
+    const res = { json: jest.fn() } as any;
+    const req = { body: { identifier: 'forbidden@example.com' } } as any;
+
+    await expect(generateChallenge(req, res)).rejects.toBeInstanceOf(UnauthorizedError);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add focused controller tests covering WebAuthn registration failures when the credential ID is missing
- ensure verification rejects invalid passkey lookups and propagates unauthorized listing errors

## Testing
- npm test -- tests/controllers/webauthnController.test.ts
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8ecf55ecc832dbbd8ed8abaea607d