### PR TITLE
Fix desktop slot layout width

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -496,7 +496,7 @@ export default function BookingUI<T = Slot>({
         {`Available slots for ${date.format('ddd, MMM D, YYYY')}`}
       </Typography>
       <Grid container spacing={2}>
-        <Grid size={{ xs: 12, md: 'auto' }}>
+        <Grid size={{ xs: 12, md: 5, lg: 4 }}>
           <Paper sx={{ p: 2, borderRadius: 2 }}>
             {!holidaysReady ? (
               <Skeleton variant="rectangular" height={296} />
@@ -533,7 +533,7 @@ export default function BookingUI<T = Slot>({
           </Paper>
         </Grid>
         <Grid
-          size={{ xs: 12, md: 'auto' }}
+          size={{ xs: 12, md: 7, lg: 8 }}
           sx={{ flexGrow: 1, flexBasis: { md: 0 }, minWidth: { md: 0 } }}
         >
           <Paper


### PR DESCRIPTION
## Summary
- adjust the booking layout grid ratios so the slot list keeps a usable width on desktop screens

## Testing
- npm test *(fails: process ran out of memory in jest worker after ~120 suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eec13bcc832d82dfd47313a2e66a