### PR TITLE
Add leave request controller tests and validation

### DIFF
--- a/MJ_FB_Backend/src/controllers/leaveRequestController.ts
+++ b/MJ_FB_Backend/src/controllers/leaveRequestController.ts
@@ -6,6 +6,7 @@ import {
   updateLeaveRequestStatus,
   countApprovedPersonalDaysThisQuarter,
   LeaveType,
+  findLeaveRequestOverlaps,
 } from "../models/leaveRequest";
 import { ensureTimesheetDay } from "../models/timesheet";
 import { insertEvent } from "../models/event";
@@ -18,18 +19,34 @@ export async function createLeaveRequest(
 ): Promise<void> {
   try {
     const { startDate, endDate, type, reason } = req.body;
+    const staffId = Number(req.user!.id);
     if (type === LeaveType.Personal) {
-      const count = await countApprovedPersonalDaysThisQuarter(
-        Number(req.user!.id),
-      );
+      const count = await countApprovedPersonalDaysThisQuarter(staffId);
       if (count >= 1) {
         return void res
           .status(400)
           .json({ message: "Only one personal day per quarter is allowed" });
       }
     }
+    const overlaps = await findLeaveRequestOverlaps(
+      staffId,
+      startDate,
+      endDate,
+    );
+    if (overlaps.length > 0) {
+      return void res.status(400).json({
+        message: "Leave request overlaps an existing request",
+        overlap: overlaps.map(overlap => ({
+          id: overlap.id,
+          start_date: overlap.start_date,
+          end_date: overlap.end_date,
+          status: overlap.status,
+          type: overlap.type,
+        })),
+      });
+    }
     const record = await insertLeaveRequest(
-      Number(req.user!.id),
+      staffId,
       startDate,
       endDate,
       type,
@@ -82,6 +99,9 @@ export async function approveLeaveRequest(
       return void res.status(400).json({ message: "Invalid ID" });
     }
     const record = await updateLeaveRequestStatus(id, "approved");
+    if (!record) {
+      return void res.status(404).json({ message: "Leave request not found" });
+    }
     if (record.type !== LeaveType.Personal) {
       const start = new Date(record.start_date);
       const end = new Date(record.end_date);
@@ -122,6 +142,9 @@ export async function rejectLeaveRequest(
       return void res.status(400).json({ message: "Invalid ID" });
     }
     const record = await updateLeaveRequestStatus(id, "rejected");
+    if (!record) {
+      return void res.status(404).json({ message: "Leave request not found" });
+    }
     res.json(record);
   } catch (err) {
     next(err);

--- a/MJ_FB_Backend/src/routes/leaveRequests.ts
+++ b/MJ_FB_Backend/src/routes/leaveRequests.ts
@@ -1,16 +1,24 @@
 import express from "express";
 import { authMiddleware, authorizeRoles } from "../middleware/authMiddleware";
+import { validate } from "../middleware/validate";
 import {
   createLeaveRequest,
   listLeaveRequests,
   approveLeaveRequest,
   rejectLeaveRequest,
 } from "../controllers/leaveRequestController";
+import { createLeaveRequestSchema } from "../schemas/leaveRequestSchemas";
 
 const router = express.Router();
 
 router.get("/", authMiddleware, authorizeRoles("admin"), listLeaveRequests);
-router.post("/", authMiddleware, authorizeRoles("staff", "admin"), createLeaveRequest);
+router.post(
+  "/",
+  authMiddleware,
+  authorizeRoles("staff", "admin"),
+  validate(createLeaveRequestSchema),
+  createLeaveRequest,
+);
 router.post(
   "/:id/approve",
   authMiddleware,

--- a/MJ_FB_Backend/src/schemas/leaveRequestSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/leaveRequestSchemas.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { LeaveType } from "../models/leaveRequest";
+
+const isoDateString = z
+  .string()
+  .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/u, "Invalid date format");
+
+export const createLeaveRequestSchema = z
+  .object({
+    startDate: isoDateString,
+    endDate: isoDateString,
+    type: z.nativeEnum(LeaveType),
+    reason: z
+      .string()
+      .max(1000)
+      .optional()
+      .nullable(),
+  })
+  .refine(data => data.endDate >= data.startDate, {
+    message: "endDate must be on or after startDate",
+    path: ["endDate"],
+  });
+
+export type CreateLeaveRequestInput = z.infer<typeof createLeaveRequestSchema>;

--- a/MJ_FB_Backend/tests/controllers/leaveRequestController.test.ts
+++ b/MJ_FB_Backend/tests/controllers/leaveRequestController.test.ts
@@ -1,0 +1,269 @@
+import "../setupTests";
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+
+import leaveRequestsRoutes from "../../src/routes/leaveRequests";
+import mockPool from "../utils/mockDb";
+import {
+  insertLeaveRequest,
+  updateLeaveRequestStatus,
+  countApprovedPersonalDaysThisQuarter,
+  findLeaveRequestOverlaps,
+  LeaveType,
+} from "../../src/models/leaveRequest";
+import { ensureTimesheetDay } from "../../src/models/timesheet";
+import { insertEvent } from "../../src/models/event";
+
+jest.mock("jsonwebtoken");
+jest.mock("../../src/models/leaveRequest", () => {
+  const actual = jest.requireActual("../../src/models/leaveRequest");
+  return {
+    ...actual,
+    insertLeaveRequest: jest.fn(),
+    updateLeaveRequestStatus: jest.fn(),
+    countApprovedPersonalDaysThisQuarter: jest.fn(),
+    findLeaveRequestOverlaps: jest.fn(),
+  };
+});
+jest.mock("../../src/models/timesheet", () => ({
+  ensureTimesheetDay: jest.fn(),
+}));
+jest.mock("../../src/models/event", () => ({
+  insertEvent: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/leave/requests", leaveRequestsRoutes);
+
+const mockedJwtVerify = jwt.verify as jest.Mock;
+const mockedQuery = mockPool.query as jest.Mock;
+const mockedInsertLeaveRequest =
+  insertLeaveRequest as jest.MockedFunction<typeof insertLeaveRequest>;
+const mockedUpdateLeaveRequestStatus =
+  updateLeaveRequestStatus as jest.MockedFunction<typeof updateLeaveRequestStatus>;
+const mockedCountPersonalDays =
+  countApprovedPersonalDaysThisQuarter as jest.MockedFunction<
+    typeof countApprovedPersonalDaysThisQuarter
+  >;
+const mockedFindLeaveRequestOverlaps =
+  findLeaveRequestOverlaps as jest.MockedFunction<typeof findLeaveRequestOverlaps>;
+const mockedEnsureTimesheetDay =
+  ensureTimesheetDay as jest.MockedFunction<typeof ensureTimesheetDay>;
+const mockedInsertEvent = insertEvent as jest.MockedFunction<typeof insertEvent>;
+
+const baseLeaveRequest = {
+  id: 42,
+  staff_id: 7,
+  start_date: "2024-06-10",
+  end_date: "2024-06-11",
+  type: LeaveType.Vacation,
+  status: "pending",
+  reason: null,
+  requester_name: "Test Staff",
+  created_at: "now",
+  updated_at: "now",
+};
+
+const mockStaffAuth = (role: "staff" | "admin" = "staff") => {
+  mockedJwtVerify.mockReturnValue({ id: 7, role, type: "staff" });
+  mockedQuery.mockResolvedValueOnce({
+    rowCount: 1,
+    rows: [
+      {
+        id: 7,
+        first_name: "Test",
+        last_name: "Staff",
+        email: "staff@example.com",
+        role,
+      },
+    ],
+  });
+};
+
+const mockVolunteerAuth = () => {
+  mockedJwtVerify.mockReturnValue({ id: 99, role: "volunteer", type: "volunteer" });
+  mockedQuery.mockResolvedValueOnce({
+    rowCount: 1,
+    rows: [
+      {
+        id: 99,
+        first_name: "Vol",
+        last_name: "unteer",
+        email: "vol@example.com",
+      },
+    ],
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedCountPersonalDays.mockResolvedValue(0);
+  mockedFindLeaveRequestOverlaps.mockResolvedValue([]);
+  mockedInsertLeaveRequest.mockResolvedValue({ ...baseLeaveRequest });
+  mockedUpdateLeaveRequestStatus.mockResolvedValue({
+    ...baseLeaveRequest,
+    status: "approved",
+  });
+  mockedEnsureTimesheetDay.mockResolvedValue(undefined);
+  mockedInsertEvent.mockResolvedValue({} as any);
+});
+
+describe("leaveRequestController routes", () => {
+  it("rejects requests without authentication", async () => {
+    const res = await request(app)
+      .post("/api/v1/leave/requests")
+      .send({
+        startDate: "2024-06-10",
+        endDate: "2024-06-11",
+        type: LeaveType.Vacation,
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ message: "Missing token" });
+  });
+
+  it("returns 403 when a volunteer attempts to create a leave request", async () => {
+    mockVolunteerAuth();
+
+    const res = await request(app)
+      .post("/api/v1/leave/requests")
+      .set("Authorization", "Bearer token")
+      .send({
+        startDate: "2024-06-10",
+        endDate: "2024-06-11",
+        type: LeaveType.Vacation,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: "Forbidden" });
+    expect(mockedInsertLeaveRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid payloads with schema errors", async () => {
+    mockStaffAuth();
+
+    const res = await request(app)
+      .post("/api/v1/leave/requests")
+      .set("Authorization", "Bearer token")
+      .send({
+        startDate: "2024-06-11",
+        endDate: "2024-06-10",
+        type: LeaveType.Vacation,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors?.[0]?.message).toBe(
+      "endDate must be on or after startDate",
+    );
+    expect(mockedInsertLeaveRequest).not.toHaveBeenCalled();
+  });
+
+  it("returns an overlap error when dates conflict", async () => {
+    mockStaffAuth();
+    mockedFindLeaveRequestOverlaps.mockResolvedValueOnce([
+      {
+        id: 55,
+        start_date: "2024-06-10",
+        end_date: "2024-06-12",
+        status: "pending",
+        type: LeaveType.Vacation,
+      },
+    ]);
+
+    const res = await request(app)
+      .post("/api/v1/leave/requests")
+      .set("Authorization", "Bearer token")
+      .send({
+        startDate: "2024-06-11",
+        endDate: "2024-06-12",
+        type: LeaveType.Vacation,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      message: "Leave request overlaps an existing request",
+      overlap: [
+        {
+          id: 55,
+          start_date: "2024-06-10",
+          end_date: "2024-06-12",
+          status: "pending",
+          type: LeaveType.Vacation,
+        },
+      ],
+    });
+    expect(mockedInsertLeaveRequest).not.toHaveBeenCalled();
+  });
+
+  it("allows admins to approve leave requests", async () => {
+    mockStaffAuth("admin");
+    mockedUpdateLeaveRequestStatus.mockResolvedValueOnce({
+      ...baseLeaveRequest,
+      status: "approved",
+    });
+
+    const res = await request(app)
+      .post("/api/v1/leave/requests/9/approve")
+      .set("Authorization", "Bearer token");
+
+    expect(res.status).toBe(200);
+    expect(mockedUpdateLeaveRequestStatus).toHaveBeenCalledWith(9, "approved");
+    expect(mockedEnsureTimesheetDay).toHaveBeenCalledTimes(2);
+    expect(mockedEnsureTimesheetDay).toHaveBeenNthCalledWith(1, 7, "2024-06-10");
+    expect(mockedEnsureTimesheetDay).toHaveBeenNthCalledWith(2, 7, "2024-06-11");
+    expect(mockedInsertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "staff_leave",
+        startDate: "2024-06-10",
+        endDate: "2024-06-11",
+        createdBy: 7,
+      }),
+    );
+    expect(res.body).toMatchObject({ status: "approved" });
+  });
+
+  it("prevents staff from approving leave requests", async () => {
+    mockStaffAuth("staff");
+
+    const res = await request(app)
+      .post("/api/v1/leave/requests/9/approve")
+      .set("Authorization", "Bearer token");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: "Forbidden" });
+    expect(mockedUpdateLeaveRequestStatus).not.toHaveBeenCalled();
+  });
+
+  it("allows admins to reject leave requests", async () => {
+    mockStaffAuth("admin");
+    mockedUpdateLeaveRequestStatus.mockResolvedValueOnce({
+      ...baseLeaveRequest,
+      status: "rejected",
+    });
+
+    const res = await request(app)
+      .post("/api/v1/leave/requests/9/reject")
+      .set("Authorization", "Bearer token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("rejected");
+    expect(mockedEnsureTimesheetDay).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when attempting to update a missing leave request", async () => {
+    mockStaffAuth("admin");
+    mockedUpdateLeaveRequestStatus.mockResolvedValueOnce(null);
+
+    const res = await request(app)
+      .post("/api/v1/leave/requests/123/approve")
+      .set("Authorization", "Bearer token");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: "Leave request not found" });
+    expect(mockedEnsureTimesheetDay).not.toHaveBeenCalled();
+    expect(mockedInsertEvent).not.toHaveBeenCalled();
+  });
+});
+

--- a/MJ_FB_Backend/tests/leaveRequests.test.ts
+++ b/MJ_FB_Backend/tests/leaveRequests.test.ts
@@ -52,23 +52,25 @@ describe("leave requests controller", () => {
   });
 
   it("creates a leave request", async () => {
-    (mockPool.query as jest.Mock).mockResolvedValueOnce({
-      rows: [
-        {
-          id: 1,
-          staff_id: 1,
-          start_date: "2024-01-02",
-          end_date: "2024-01-03",
-          type: "vacation",
-          status: "pending",
-          reason: null,
-          requester_name: "Test User",
-          created_at: "now",
-          updated_at: "now",
-        },
-      ],
-      rowCount: 1,
-    });
+    (mockPool.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            staff_id: 1,
+            start_date: "2024-01-02",
+            end_date: "2024-01-03",
+            type: "vacation",
+            status: "pending",
+            reason: null,
+            requester_name: "Test User",
+            created_at: "now",
+            updated_at: "now",
+          },
+        ],
+        rowCount: 1,
+      });
     const req: any = {
       user: { id: "1", role: "staff", type: "staff" },
       body: {


### PR DESCRIPTION
## Summary
- enforce leave request payload validation with a dedicated schema and route middleware
- prevent overlapping leave requests and return 404s when approving or rejecting missing records
- cover controller flows with new integration tests and update existing specs for overlap handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8ecec2f90832db05349754ad6d060