### PR TITLE
Make event titles bold in dashboard event list

### DIFF
--- a/MJ_FB_Frontend/src/components/EventList.tsx
+++ b/MJ_FB_Frontend/src/components/EventList.tsx
@@ -37,7 +37,15 @@ export default function EventList({ events, limit, onDelete, onChange, onEdit }:
         <ListItem key={ev.id} sx={{ pl: 0 }}>
           <ListItemText
             disableTypography
-            primary={<Typography>{`${formatDateRange(ev.startDate, ev.endDate)} - ${ev.title}`}</Typography>}
+            primary={
+              <Typography component="span" variant="body1">
+                {formatDateRange(ev.startDate, ev.endDate)}
+                {' - '}
+                <Box component="span" fontWeight="bold">
+                  {ev.title}
+                </Box>
+              </Typography>
+            }
             secondary={
               <>
                 {ev.details && (


### PR DESCRIPTION
## Summary
- make News & Events listings emphasize the event title with bold typography

## Testing
- `npm test` *(fails: existing test failures and process ran out of memory during run)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f20c81b0832daca412e2ca8094f4