### PR TITLE
Use "to" when formatting event date ranges

### DIFF
--- a/MJ_FB_Frontend/src/components/EventList.tsx
+++ b/MJ_FB_Frontend/src/components/EventList.tsx
@@ -23,7 +23,7 @@ export default function EventList({ events, limit, onDelete, onChange, onEdit }:
   function formatDateRange(start: string, end: string) {
     const startText = formatLocaleDate(start);
     const endText = formatLocaleDate(end);
-    return startText === endText ? startText : `${startText} - ${endText}`;
+    return startText === endText ? startText : `${startText} to ${endText}`;
   }
 
   async function changePriority(ev: Event, delta: number) {


### PR DESCRIPTION
## Summary
- show event date ranges with "to" instead of a hyphen so the separator is clearer alongside ISO-formatted dates

## Testing
- npm test *(fails: AgencyAccess and UserHistory suites that are already failing in the test run)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f2aa029c832d8509641d3ef1997b