### PR TITLE
Fix volunteer management schedule test timezone

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -400,7 +400,9 @@ describe('VolunteerManagement search captions', () => {
 
 describe('VolunteerManagement schedule statuses', () => {
   beforeEach(() => {
-    jest.useFakeTimers().setSystemTime(new Date('2024-01-01'));
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2024-01-01T06:00:00Z'));
     (getVolunteerRoles as jest.Mock).mockResolvedValue([
       {
         id: 1,


### PR DESCRIPTION
## Summary
- ensure the VolunteerManagement schedule status tests freeze time at Regina midnight so snapshots align with expected day

## Testing
- npm test src/__tests__/VolunteerManagement.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c8f3bc4e3c832d90c910a45c20082a