### PR TITLE
Add tests for delivery settings env validation

### DIFF
--- a/MJ_FB_Backend/.env.example
+++ b/MJ_FB_Backend/.env.example
@@ -69,6 +69,8 @@ CLIENT_RESCHEDULE_TEMPLATE_ID=6
 VOLUNTEER_RESCHEDULE_TEMPLATE_ID=7
 # Brevo template ID used for delivery request notifications
 DELIVERY_REQUEST_TEMPLATE_ID=16
+# Maximum delivery orders per client each month (optional, default 2, max 5)
+DELIVERY_MONTHLY_ORDER_LIMIT=2
 
 # Brevo template ID used for $1-$100 donor emails
 DONOR_TEMPLATE_ID_1_100=11

--- a/MJ_FB_Backend/src/utils/deliverySettings.ts
+++ b/MJ_FB_Backend/src/utils/deliverySettings.ts
@@ -1,12 +1,41 @@
+import { z } from 'zod';
 import pool from '../db';
 
 export interface DeliverySettings {
   requestEmail: string;
+  monthlyOrderLimit: number;
 }
 
 const DEFAULT_DELIVERY_SETTINGS: DeliverySettings = {
   requestEmail: 'amrutha.laxman@mjfoodbank.org',
+  monthlyOrderLimit: 2,
 };
+
+const MIN_MONTHLY_ORDER_LIMIT = 1;
+const MAX_MONTHLY_ORDER_LIMIT = 5;
+
+const deliveryEnvSchema = z
+  .object({
+    DELIVERY_MONTHLY_ORDER_LIMIT: z
+      .coerce.number({
+        invalid_type_error: 'DELIVERY_MONTHLY_ORDER_LIMIT must be a number',
+      })
+      .int('DELIVERY_MONTHLY_ORDER_LIMIT must be a whole number')
+      .min(
+        MIN_MONTHLY_ORDER_LIMIT,
+        `DELIVERY_MONTHLY_ORDER_LIMIT must be between ${MIN_MONTHLY_ORDER_LIMIT} and ${MAX_MONTHLY_ORDER_LIMIT}`,
+      )
+      .max(
+        MAX_MONTHLY_ORDER_LIMIT,
+        `DELIVERY_MONTHLY_ORDER_LIMIT must be between ${MIN_MONTHLY_ORDER_LIMIT} and ${MAX_MONTHLY_ORDER_LIMIT}`,
+      )
+      .default(DEFAULT_DELIVERY_SETTINGS.monthlyOrderLimit),
+  })
+  .transform(({ DELIVERY_MONTHLY_ORDER_LIMIT }) => ({
+    monthlyOrderLimit: DELIVERY_MONTHLY_ORDER_LIMIT,
+  }));
+
+const envSettings = deliveryEnvSchema.parse(process.env);
 
 let cache: DeliverySettings | null = null;
 
@@ -23,6 +52,7 @@ export async function getDeliverySettings(): Promise<DeliverySettings> {
 
   cache = {
     requestEmail: email || DEFAULT_DELIVERY_SETTINGS.requestEmail,
+    monthlyOrderLimit: envSettings.monthlyOrderLimit,
   };
 
   return cache;

--- a/MJ_FB_Backend/tests/utils/deliverySettings.test.ts
+++ b/MJ_FB_Backend/tests/utils/deliverySettings.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+const mockQuery = jest.fn();
+
+jest.mock('../../src/db', () => ({
+  __esModule: true,
+  default: { query: mockQuery },
+}));
+
+const DEFAULT_EMAIL = 'amrutha.laxman@mjfoodbank.org';
+
+describe('deliverySettings', () => {
+  const originalMonthlyLimit = process.env.DELIVERY_MONTHLY_ORDER_LIMIT;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockQuery.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalMonthlyLimit === undefined) {
+      delete process.env.DELIVERY_MONTHLY_ORDER_LIMIT;
+    } else {
+      process.env.DELIVERY_MONTHLY_ORDER_LIMIT = originalMonthlyLimit;
+    }
+  });
+
+  it('returns defaults when env vars are missing', async () => {
+    delete process.env.DELIVERY_MONTHLY_ORDER_LIMIT;
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { getDeliverySettings } = await import('../../src/utils/deliverySettings');
+    const settings = await getDeliverySettings();
+
+    expect(settings).toEqual({
+      requestEmail: DEFAULT_EMAIL,
+      monthlyOrderLimit: 2,
+    });
+    expect(mockQuery).toHaveBeenCalledWith(
+      "SELECT value FROM app_config WHERE key = 'delivery_request_email'",
+    );
+  });
+
+  it('reads the monthly order limit from environment variables', async () => {
+    process.env.DELIVERY_MONTHLY_ORDER_LIMIT = '3';
+    mockQuery.mockResolvedValueOnce({ rows: [{ value: 'ops@example.com ' }] });
+
+    const { getDeliverySettings } = await import('../../src/utils/deliverySettings');
+    const settings = await getDeliverySettings();
+
+    expect(settings.requestEmail).toBe('ops@example.com');
+    expect(settings.monthlyOrderLimit).toBe(3);
+  });
+
+  it('throws when the monthly limit exceeds the allowed range', async () => {
+    process.env.DELIVERY_MONTHLY_ORDER_LIMIT = '10';
+
+    await expect(import('../../src/utils/deliverySettings')).rejects.toThrow(
+      'DELIVERY_MONTHLY_ORDER_LIMIT must be between 1 and 5',
+    );
+  });
+});

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ Create a `.env` file in `MJ_FB_Backend` with the following variables. The server
 | `EMAIL_QUEUE_BACKOFF_MS`   | Initial backoff delay in ms for email retries (default 1000)                                                                              |
 | `EMAIL_QUEUE_MAX_AGE_DAYS` | Remove pending email jobs older than this many days (default 30)                                                                          |
 | `EMAIL_QUEUE_WARNING_SIZE` | Log a warning if the email queue exceeds this size (default 100)                                                                          |
+| `DELIVERY_MONTHLY_ORDER_LIMIT` | Maximum delivery orders allowed per client each month (default 2, max 5) |
+                                          |
 | `TELEGRAM_BOT_TOKEN`       | Telegram bot token used for ops alerts (optional) |
 | `TELEGRAM_ALERT_CHAT_ID`   | Telegram chat ID that receives ops alerts (optional) |
 


### PR DESCRIPTION
## Summary
- validate delivery monthly order limit via `zod` and expose the value with delivery settings
- cover delivery settings with unit tests for default, valid, and invalid environment inputs
- document the new `DELIVERY_MONTHLY_ORDER_LIMIT` variable in the backend env example and README

## Testing
- npm --prefix MJ_FB_Backend test

------
https://chatgpt.com/codex/tasks/task_e_68c8ed236524832dbc9a5d238ffe4a52