### PR TITLE
Expand booking slot list height for large displays

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -559,7 +559,10 @@ export default function BookingUI<T = Slot>({
             sx={{
               p: 2,
               borderRadius: 2,
-              maxHeight: { xs: 420, md: 560, xl: 640 },
+              maxHeight: {
+                xs: 420,
+                md: 'clamp(560px, calc(100vh - 240px), 960px)',
+              },
               overflow: 'auto',
               width: '100%',
             }}


### PR DESCRIPTION
## Summary
- allow the booking slot list container to grow taller on desktop breakpoints so more timeslots stay visible on large screens

## Testing
- npm test -- --watch=false *(fails: AgencyAccess.test.tsx and related suites already failing in the base branch)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fed4d438832db3cd19bd9bea9cd8