### PR TITLE
Restore booking slots grid width

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -550,10 +550,7 @@ export default function BookingUI<T = Slot>({
             )}
           </Paper>
         </Grid>
-        <Grid
-          size={{ xs: 12, md: 7, lg: 8, xl: 9 }}
-          sx={{ flexGrow: 1, flexBasis: { md: 0 }, minWidth: { md: 0 } }}
-        >
+        <Grid size={{ xs: 12, md: 6 }}>
           <Paper
             ref={slotsRef}
             sx={{


### PR DESCRIPTION
## Summary
- restore the booking slots grid to the original 6-column layout so the slot box renders correctly again

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68c90286c900832db98cd43aba54d532