### PR TITLE
Include camelCase time fields on volunteer booking detail

### DIFF
--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -225,6 +225,8 @@ export interface VolunteerBookingDetail {
   date: string;
   start_time: string;
   end_time: string;
+  startTime?: string;
+  endTime?: string;
   status_color?: string;
   role_name?: string;
   can_book?: boolean;


### PR DESCRIPTION
## Summary
- allow `VolunteerBookingDetail` to expose optional camelCase time fields so components can gracefully handle either naming convention

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9058077e4832dad6dd058be197977