### PR TITLE
Adjust delivery email item list formatting

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -125,7 +125,10 @@ function buildItemListHtml(items: DeliveryOrderItemDetail[]): string {
   return Array.from(grouped.values())
     .map(({ categoryName, selections }) => {
       const itemsText = selections
-        .map(selection => `${escapeHtml(selection.itemName)} x${selection.quantity}`)
+        .map(selection => {
+          const quantityText = selection.quantity > 1 ? ` x${selection.quantity}` : '';
+          return `${escapeHtml(selection.itemName)}${quantityText}`;
+        })
         .join(', ');
       return `<strong>${escapeHtml(categoryName)}</strong> - ${itemsText}<br>`;
     })

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -403,7 +403,7 @@ describe('deliveryOrderController', () => {
           address: '789 Pine Ave',
           phone: '555-3333',
           email: 'client@example.com',
-          itemList: '<strong>Produce</strong> - Fresh Produce Box x1<br>',
+          itemList: '<strong>Produce</strong> - Fresh Produce Box<br>',
           createdAt: submittedAt.toISOString(),
         },
       });

--- a/docs/emailTemplates.md
+++ b/docs/emailTemplates.md
@@ -39,10 +39,10 @@ Cancellation, no-show, volunteer notification, and agency client update emails h
     ```
     Bakery
     - Whole Wheat Bread x2
-    - White Bread x1
+    - White Bread
 
     Produce
-    - Carrot Bundle x1
+    - Carrot Bundle
     ```
   - `createdAt` (ISO 8601 string) – submission timestamp for the request.
 


### PR DESCRIPTION
## Summary
- stop appending `x1` to delivery order items when only one unit is requested so Brevo emails read naturally
- update the delivery order controller test to match the new formatting
- refresh the delivery email template documentation example to remove single-item quantities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c908448c1c832d828f210263bfbf19