### PR TITLE
Hide delivery items in client history

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/DeliveryHistory.tsx
@@ -8,10 +8,6 @@ import {
   Chip,
   CircularProgress,
   Container,
-  Divider,
-  List,
-  ListItem,
-  ListItemText,
   Stack,
   Typography,
 } from '@mui/material';
@@ -165,122 +161,104 @@ export default function DeliveryHistory() {
   return (
     <>
       <Container maxWidth="md" sx={{ pt: 4, pb: 12 }}>
-      <FeedbackSnackbar
-        open={snackbar.open}
-        onClose={handleSnackbarClose}
-        message={snackbar.message}
-        severity={snackbar.severity}
-      />
+        <FeedbackSnackbar
+          open={snackbar.open}
+          onClose={handleSnackbarClose}
+          message={snackbar.message}
+          severity={snackbar.severity}
+        />
 
-      <Typography variant="h4" component="h1" gutterBottom>
-        Delivery History
-      </Typography>
-      <Typography variant="body1" color="text.secondary" gutterBottom>
-        Review your previous delivery requests and track their status.
-      </Typography>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Delivery History
+        </Typography>
+        <Typography variant="body1" color="text.secondary" gutterBottom>
+          Review your previous delivery requests and track their status.
+        </Typography>
 
-      {error && (
-        <Box mb={3}>
-          <Typography color="error">{error}</Typography>
-        </Box>
-      )}
+        {error && (
+          <Box mb={3}>
+            <Typography color="error">{error}</Typography>
+          </Box>
+        )}
 
-      {loading ? (
-        <Box display="flex" justifyContent="center" py={6}>
-          <CircularProgress />
-        </Box>
-      ) : orders.length === 0 ? (
-        <Box textAlign="center" py={6}>
-          <Typography variant="h6" gutterBottom>
-            No deliveries yet
-          </Typography>
-          <Typography color="text.secondary" sx={{ mb: 3 }}>
-            Your delivery history will appear here once you submit a request.
-          </Typography>
-          <Button
-            component={RouterLink}
-            to="/delivery/book"
-            variant="contained"
-            size="medium"
-          >
-            Book a Delivery
-          </Button>
-        </Box>
-      ) : (
-        <Stack spacing={3}>
-          {orders.map(order => {
-            const submittedOn = formatDate(order.createdAt, true);
-            const scheduledFor = formatDate(order.scheduledFor ?? undefined, false);
-            return (
-              <Card key={order.id}>
-                <CardHeader
-                  title={`Order #${order.id}`}
-                  subheader={submittedOn ? `Submitted ${submittedOn}` : undefined}
-                  action={
-                    <Chip
-                      label={formatStatusLabel(order.status)}
-                      color={getStatusColor(order.status)}
-                    />
-                  }
-                />
-                <CardContent>
-                  <Stack spacing={1.5}>
-                    {scheduledFor && (
-                      <Typography variant="body2" color="text.secondary">
-                        Scheduled for {scheduledFor}
-                      </Typography>
-                    )}
-                    <Typography variant="body2">
-                      <strong>Address:</strong> {order.address}
-                    </Typography>
-                    <Typography variant="body2">
-                      <strong>Phone:</strong> {order.phone}
-                    </Typography>
-                    {order.email && (
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={6}>
+            <CircularProgress />
+          </Box>
+        ) : orders.length === 0 ? (
+          <Box textAlign="center" py={6}>
+            <Typography variant="h6" gutterBottom>
+              No deliveries yet
+            </Typography>
+            <Typography color="text.secondary" sx={{ mb: 3 }}>
+              Your delivery history will appear here once you submit a request.
+            </Typography>
+            <Button
+              component={RouterLink}
+              to="/delivery/book"
+              variant="contained"
+              size="medium"
+            >
+              Book a Delivery
+            </Button>
+          </Box>
+        ) : (
+          <Stack spacing={3}>
+            {orders.map(order => {
+              const submittedOn = formatDate(order.createdAt, true);
+              const scheduledFor = formatDate(order.scheduledFor ?? undefined, false);
+              return (
+                <Card key={order.id}>
+                  <CardHeader
+                    title={`Order #${order.id}`}
+                    subheader={submittedOn ? `Submitted ${submittedOn}` : undefined}
+                    action={
+                      <Chip
+                        label={formatStatusLabel(order.status)}
+                        color={getStatusColor(order.status)}
+                      />
+                    }
+                  />
+                  <CardContent>
+                    <Stack spacing={1.5}>
+                      {scheduledFor && (
+                        <Typography variant="body2" color="text.secondary">
+                          Scheduled for {scheduledFor}
+                        </Typography>
+                      )}
                       <Typography variant="body2">
-                        <strong>Email:</strong> {order.email}
+                        <strong>Address:</strong> {order.address}
                       </Typography>
-                    )}
-                    {order.notes && (
-                      <Typography variant="body2" color="text.secondary">
-                        {order.notes}
+                      <Typography variant="body2">
+                        <strong>Phone:</strong> {order.phone}
                       </Typography>
-                    )}
-                    <Divider sx={{ my: 1.5 }} />
-                    <Typography variant="subtitle1">Items</Typography>
-                    <List dense disablePadding>
-                      {order.items.map(item => (
-                        <ListItem
-                          key={`${order.id}-${item.itemId}`}
-                          disableGutters
-                          sx={{ py: 0.5 }}
+                      {order.email && (
+                        <Typography variant="body2">
+                          <strong>Email:</strong> {order.email}
+                        </Typography>
+                      )}
+                      {order.notes && (
+                        <Typography variant="body2" color="text.secondary">
+                          {order.notes}
+                        </Typography>
+                      )}
+                      {isCancellable(order.status) && (
+                        <LoadingButton
+                          variant="outlined"
+                          onClick={() => void handleCancel(order.id)}
+                          loading={cancellingId === order.id}
+                          fullWidth
                         >
-                          <ListItemText
-                            primary={item.name}
-                            secondary={`Quantity: ${item.quantity}${
-                              item.categoryName ? ` · ${item.categoryName}` : ''
-                            }`}
-                          />
-                        </ListItem>
-                      ))}
-                    </List>
-                    {isCancellable(order.status) && (
-                      <LoadingButton
-                        variant="outlined"
-                        onClick={() => void handleCancel(order.id)}
-                        loading={cancellingId === order.id}
-                        fullWidth
-                      >
-                        Cancel request
-                      </LoadingButton>
-                    )}
-                  </Stack>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </Stack>
-      )}
+                          Cancel request
+                        </LoadingButton>
+                      )}
+                    </Stack>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </Stack>
+        )}
       </Container>
       <ClientBottomNav />
     </>

--- a/MJ_FB_Frontend/src/pages/delivery/__tests__/DeliveryHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/__tests__/DeliveryHistory.test.tsx
@@ -149,4 +149,36 @@ describe('DeliveryHistory', () => {
     expect(await screen.findByLabelText('delivery')).toBeInTheDocument();
     expect(screen.getByLabelText('profile')).toBeInTheDocument();
   });
+
+  it('does not render item details in the delivery history', async () => {
+    const orderWithItems: DeliveryOrder = {
+      id: 205,
+      status: 'completed',
+      createdAt: '2024-07-15T10:00:00Z',
+      scheduledFor: null,
+      address: '101 Maple Road',
+      phone: '555-1234',
+      email: null,
+      notes: null,
+      items: [
+        {
+          itemId: 301,
+          name: 'Peanut Butter',
+          quantity: 1,
+          categoryId: 12,
+          categoryName: 'Pantry Staples',
+        },
+      ],
+    };
+
+    mockedApiFetch.mockResolvedValue({} as Response);
+    mockedHandleResponse.mockResolvedValue([orderWithItems]);
+
+    renderComponent();
+
+    expect(await screen.findByText('Order #205')).toBeInTheDocument();
+    expect(screen.queryByText('Items')).not.toBeInTheDocument();
+    expect(screen.queryByText('Peanut Butter')).not.toBeInTheDocument();
+    expect(screen.queryByText(/quantity/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- stop rendering the per-item list on delivery history cards so requests only show status and contact details
- add a unit test covering the absence of item names and quantities in the history view

## Testing
- npm test -- --watch=false src/pages/delivery/__tests__/DeliveryHistory.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c907bb8ed8832da0fc0ea15bee3ea4