### PR TITLE
Add outstanding delivery order management routes

### DIFF
--- a/MJ_FB_Backend/src/routes/delivery/orders.ts
+++ b/MJ_FB_Backend/src/routes/delivery/orders.ts
@@ -3,6 +3,8 @@ import {
   createDeliveryOrder,
   cancelDeliveryOrder,
   getDeliveryOrderHistory,
+  listOutstandingDeliveryOrders,
+  completeDeliveryOrder,
 } from '../../controllers/deliveryOrderController';
 import { authMiddleware, authorizeRoles } from '../../middleware/authMiddleware';
 import { validate } from '../../middleware/validate';
@@ -21,6 +23,16 @@ router.post(
 
 router.get('/', authorizeRoles('delivery', 'staff'), getDeliveryOrderHistory);
 router.get('/history', authorizeRoles('delivery', 'staff'), getDeliveryOrderHistory);
+router.get(
+  '/outstanding',
+  authorizeRoles('staff'),
+  listOutstandingDeliveryOrders,
+);
+router.post(
+  '/:id/complete',
+  authorizeRoles('staff'),
+  completeDeliveryOrder,
+);
 router.post('/:id/cancel', authorizeRoles('delivery', 'staff'), cancelDeliveryOrder);
 
 export default router;

--- a/MJ_FB_Backend/tests/deliveryOrdersRoute.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrdersRoute.test.ts
@@ -3,13 +3,21 @@ import express from 'express';
 import deliveryOrdersRouter from '../src/routes/delivery/orders';
 import pool from '../src/db';
 
+let mockUser: any = { id: '42', role: 'delivery', type: 'user' };
+
 jest.mock('../src/middleware/authMiddleware', () => ({
   __esModule: true,
-  authMiddleware: (req: any, _res: any, next: any) => {
-    req.user = { id: '42', role: 'delivery', type: 'user' };
+  authMiddleware: jest.fn((req: any, _res: any, next: any) => {
+    req.user = mockUser;
     next();
-  },
-  authorizeRoles: () => (_req: any, _res: any, next: any) => next(),
+  }),
+  authorizeRoles: (...roles: string[]) =>
+    (req: any, res: any, next: any) => {
+      if (!req.user || !roles.includes(req.user.role)) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      return next();
+    },
 }));
 
 const app = express();
@@ -19,6 +27,7 @@ app.use('/delivery/orders', deliveryOrdersRouter);
 describe('delivery orders routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUser = { id: '42', role: 'delivery', type: 'user' };
   });
 
   it('returns the authenticated client order history at /delivery/orders', async () => {
@@ -88,6 +97,191 @@ describe('delivery orders routes', () => {
       2,
       expect.stringContaining('FROM delivery_order_items'),
       [[12]],
+    );
+  });
+
+  it('requires staff role to list outstanding delivery orders', async () => {
+    const res = await request(app).get('/delivery/orders/outstanding');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: 'Forbidden' });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('lists outstanding delivery orders for staff users', async () => {
+    mockUser = { id: '7', role: 'staff', type: 'staff' };
+
+    (pool.query as jest.Mock)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 101,
+            clientId: 88,
+            address: '10 River Ave',
+            phone: '555-1111',
+            email: null,
+            status: 'pending',
+            scheduledFor: null,
+            notes: 'Leave at back door',
+            createdAt: '2024-07-01T14:00:00Z',
+          },
+          {
+            id: 205,
+            clientId: 93,
+            address: '22 Pine St',
+            phone: '555-2222',
+            email: 'shopper@example.com',
+            status: 'scheduled',
+            scheduledFor: '2024-07-12T16:30:00Z',
+            notes: null,
+            createdAt: '2024-07-05T09:15:00Z',
+          },
+        ],
+        rowCount: 2,
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            orderId: 101,
+            itemId: 301,
+            quantity: 2,
+            itemName: 'Apples',
+            categoryId: 40,
+            categoryName: 'Produce',
+          },
+          {
+            orderId: 101,
+            itemId: 205,
+            quantity: 1,
+            itemName: 'Whole Wheat Bread',
+            categoryId: 12,
+            categoryName: 'Bakery',
+          },
+          {
+            orderId: 205,
+            itemId: 410,
+            quantity: 3,
+            itemName: 'Milk',
+            categoryId: 8,
+            categoryName: 'Dairy',
+          },
+        ],
+        rowCount: 3,
+      });
+
+    const res = await request(app).get('/delivery/orders/outstanding');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: 101,
+        clientId: 88,
+        address: '10 River Ave',
+        phone: '555-1111',
+        email: null,
+        status: 'pending',
+        scheduledFor: null,
+        notes: 'Leave at back door',
+        createdAt: '2024-07-01T14:00:00.000Z',
+        items: [
+          {
+            itemId: 205,
+            quantity: 1,
+            itemName: 'Whole Wheat Bread',
+            categoryId: 12,
+            categoryName: 'Bakery',
+          },
+          {
+            itemId: 301,
+            quantity: 2,
+            itemName: 'Apples',
+            categoryId: 40,
+            categoryName: 'Produce',
+          },
+        ],
+      },
+      {
+        id: 205,
+        clientId: 93,
+        address: '22 Pine St',
+        phone: '555-2222',
+        email: 'shopper@example.com',
+        status: 'scheduled',
+        scheduledFor: '2024-07-12T16:30:00.000Z',
+        notes: null,
+        createdAt: '2024-07-05T09:15:00.000Z',
+        items: [
+          {
+            itemId: 410,
+            quantity: 3,
+            itemName: 'Milk',
+            categoryId: 8,
+            categoryName: 'Dairy',
+          },
+        ],
+      },
+    ]);
+
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("status <> 'completed'"),
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("status <> 'cancelled'"),
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('FROM delivery_order_items'),
+      [[101, 205]],
+    );
+  });
+
+  it('requires staff role to complete a delivery order', async () => {
+    const res = await request(app).post('/delivery/orders/55/complete');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: 'Forbidden' });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('marks a delivery order as completed', async () => {
+    mockUser = { id: '99', role: 'staff', type: 'staff' };
+
+    (pool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 55,
+          clientId: 300,
+          address: '789 Pine St',
+          phone: '555-1234',
+          email: 'shopper@example.com',
+          status: 'completed',
+          scheduledFor: '2024-07-22T18:00:00Z',
+          notes: 'Leave at front desk',
+          createdAt: '2024-07-10T17:30:00Z',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const res = await request(app).post('/delivery/orders/55/complete');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: 55,
+      clientId: 300,
+      address: '789 Pine St',
+      phone: '555-1234',
+      email: 'shopper@example.com',
+      status: 'completed',
+      scheduledFor: '2024-07-22T18:00:00.000Z',
+      notes: 'Leave at front desk',
+      createdAt: '2024-07-10T17:30:00.000Z',
+    });
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("SET status = 'completed'"),
+      [55],
     );
   });
 });


### PR DESCRIPTION
## Summary
- add controller support for listing outstanding delivery orders and completing requests
- secure new delivery order routes for staff-only outstanding listings and completion actions
- extend delivery order route tests to cover authorization, listing results, and completion handling

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c9097fd6a0832dab3ec15680d12e6a