### PR TITLE
Add pantry deliveries page and tests

### DIFF
--- a/MJ_FB_Frontend/jest.config.cjs
+++ b/MJ_FB_Frontend/jest.config.cjs
@@ -7,6 +7,7 @@ module.exports = {
     '<rootDir>/src/__tests__/**/*.test.tsx',
     '<rootDir>/src/api/__tests__/**/*.test.ts',
     '<rootDir>/src/hooks/**/*.test.tsx',
+    '<rootDir>/tests/**/*.test.tsx',
   ],
   setupFiles: ['<rootDir>/loadEnv.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -138,6 +138,9 @@ const DeliveryHistory = React.lazy(
 const DeliveryDashboard = React.lazy(
   () => import('./pages/delivery/DeliveryDashboard')
 );
+const PantryDeliveries = React.lazy(
+  () => import('./pages/pantry/Deliveries')
+);
 
 const Spinner = () => <CircularProgress />;
 
@@ -183,6 +186,7 @@ export default function App() {
       { label: 'Pantry Visits', to: '/pantry/visits' },
       { label: 'Client Management', to: '/pantry/client-management' },
       { label: 'Agency Management', to: '/pantry/agency-management' },
+      { label: 'Deliveries', to: '/pantry/deliveries' },
     ];
     if (showStaff) navGroups.push({ label: 'Harvest Pantry', links: staffLinks });
     if (showVolunteerManagement)
@@ -376,6 +380,9 @@ export default function App() {
                   )}
                   {showStaff && (
                     <Route path="/pantry/schedule" element={<PantrySchedule />} />
+                  )}
+                  {showStaff && (
+                    <Route path="/pantry/deliveries" element={<PantryDeliveries />} />
                   )}
                   {showStaff && (
                     <Route path="/pantry/visits" element={<PantryVisits />} />

--- a/MJ_FB_Frontend/src/api/deliveryOrders.ts
+++ b/MJ_FB_Frontend/src/api/deliveryOrders.ts
@@ -1,0 +1,14 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+import type { DeliveryOutstandingOrder } from '../types';
+
+export async function getOutstandingDeliveryOrders(): Promise<DeliveryOutstandingOrder[]> {
+  const res = await apiFetch(`${API_BASE}/delivery/orders/outstanding`);
+  return handleResponse<DeliveryOutstandingOrder[]>(res);
+}
+
+export async function markDeliveryOrderCompleted(orderId: number): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/delivery/orders/${orderId}/complete`, {
+    method: 'POST',
+  });
+  await handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/pages/pantry/Deliveries.tsx
+++ b/MJ_FB_Frontend/src/pages/pantry/Deliveries.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CircularProgress,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { LoadingButton } from '@mui/lab';
+import { Link as RouterLink } from 'react-router-dom';
+import Page from '../../components/Page';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { getApiErrorMessage } from '../../api/client';
+import {
+  getOutstandingDeliveryOrders,
+  markDeliveryOrderCompleted,
+} from '../../api/deliveryOrders';
+import type { DeliveryOutstandingOrder } from '../../types';
+
+const submittedFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' });
+
+function formatDateTime(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return submittedFormatter.format(date);
+}
+
+function formatDate(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return dateFormatter.format(date);
+}
+
+type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+};
+
+export default function Deliveries() {
+  const [orders, setOrders] = useState<DeliveryOutstandingOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [completingId, setCompletingId] = useState<number | null>(null);
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    getOutstandingDeliveryOrders()
+      .then(data => {
+        if (!active) return;
+        setOrders(data);
+        setError('');
+      })
+      .catch(err => {
+        if (!active) return;
+        const message = getApiErrorMessage(
+          err,
+          'We could not load outstanding delivery orders. Please try again.',
+        );
+        setError(message);
+        setSnackbar({ open: true, message, severity: 'error' });
+        setOrders([]);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleSnackbarClose = () => {
+    setSnackbar(prev => ({ ...prev, open: false }));
+  };
+
+  const handleMarkCompleted = useCallback(async (orderId: number) => {
+    setCompletingId(orderId);
+    try {
+      await markDeliveryOrderCompleted(orderId);
+      setOrders(prev => prev.filter(order => order.id !== orderId));
+      setError('');
+      setSnackbar({
+        open: true,
+        message: 'Delivery marked completed.',
+        severity: 'success',
+      });
+    } catch (err) {
+      const message = getApiErrorMessage(
+        err,
+        'We could not mark this delivery as completed. Please try again.',
+      );
+      setSnackbar({ open: true, message, severity: 'error' });
+    } finally {
+      setCompletingId(null);
+    }
+  }, []);
+
+  return (
+    <Page title="Delivery Orders" header={<PantryQuickLinks />}> 
+      <FeedbackSnackbar
+        open={snackbar.open}
+        onClose={handleSnackbarClose}
+        message={snackbar.message}
+        severity={snackbar.severity}
+      />
+
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        justifyContent="space-between"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        sx={{ mb: 3 }}
+      >
+        <Typography variant="body1" color="text.secondary">
+          Review outstanding delivery requests and close them once a delivery is completed.
+        </Typography>
+        <Button
+          component={RouterLink}
+          to="/pantry/deliveries/record"
+          variant="contained"
+          size="medium"
+        >
+          Record Delivery
+        </Button>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box display="flex" justifyContent="center" py={6}>
+          <CircularProgress />
+        </Box>
+      ) : orders.length === 0 ? (
+        <Box textAlign="center" py={6}>
+          <Typography variant="h6" gutterBottom>
+            {error ? 'No deliveries to display' : 'No outstanding deliveries'}
+          </Typography>
+          <Typography color="text.secondary">
+            {error
+              ? 'Resolve the issue above and refresh to try again.'
+              : 'New delivery requests will appear here once they are submitted.'}
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={3}>
+          {orders.map(order => {
+            const submittedOn = formatDateTime(order.createdAt);
+            const scheduledFor = formatDate(order.scheduledFor);
+            const clientLabel = order.clientName
+              ? `Client ${order.clientId} · ${order.clientName}`
+              : `Client ${order.clientId}`;
+
+            return (
+              <Card key={order.id}>
+                <CardHeader
+                  title={clientLabel}
+                  subheader={submittedOn ? `Submitted ${submittedOn}` : undefined}
+                />
+                <CardContent>
+                  <Stack spacing={1.5}>
+                    <Typography variant="body2">
+                      <strong>Order #:</strong> {order.id}
+                    </Typography>
+                    {scheduledFor && (
+                      <Typography variant="body2">
+                        <strong>Scheduled for:</strong> {scheduledFor}
+                      </Typography>
+                    )}
+                    <Typography variant="body2">
+                      <strong>Address:</strong> {order.address}
+                    </Typography>
+                    <Typography variant="body2">
+                      <strong>Phone:</strong> {order.phone}
+                    </Typography>
+                    {order.email && (
+                      <Typography variant="body2">
+                        <strong>Email:</strong> {order.email}
+                      </Typography>
+                    )}
+                    {order.notes && (
+                      <Typography variant="body2" color="text.secondary">
+                        {order.notes}
+                      </Typography>
+                    )}
+
+                    <Divider sx={{ my: 1 }} />
+
+                    <Typography variant="subtitle1">Items</Typography>
+                    {order.items.length > 0 ? (
+                      <List dense sx={{ py: 0 }}>
+                        {order.items.map(item => {
+                          const itemName = item.name || item.itemName || 'Item';
+                          return (
+                            <ListItem
+                              key={`${order.id}-${item.itemId}-${itemName}`}
+                              disableGutters
+                              sx={{ py: 0.5 }}
+                            >
+                              <ListItemText
+                                primary={`${item.quantity} × ${itemName}`}
+                                secondary={item.categoryName ?? undefined}
+                              />
+                            </ListItem>
+                          );
+                        })}
+                      </List>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        No items listed.
+                      </Typography>
+                    )}
+
+                    <Box>
+                      <LoadingButton
+                        variant="contained"
+                        onClick={() => void handleMarkCompleted(order.id)}
+                        loading={completingId === order.id}
+                      >
+                        Mark Completed
+                      </LoadingButton>
+                    </Box>
+                  </Stack>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </Stack>
+      )}
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -41,14 +41,17 @@ export type DeliveryOrderStatus =
 
 export interface DeliveryOrderItem {
   itemId: number;
-  name: string;
   quantity: number;
   categoryId: number;
+  name?: string;
+  itemName?: string;
   categoryName?: string | null;
 }
 
 export interface DeliveryOrder {
   id: number;
+  clientId?: number;
+  clientName?: string | null;
   status?: DeliveryOrderStatus | null;
   createdAt: string;
   scheduledFor?: string | null;
@@ -57,6 +60,10 @@ export interface DeliveryOrder {
   email?: string | null;
   notes?: string | null;
   items: DeliveryOrderItem[];
+}
+
+export interface DeliveryOutstandingOrder extends DeliveryOrder {
+  clientId: number;
 }
 
 export interface Staff {

--- a/MJ_FB_Frontend/tests/DeliveriesPage.test.tsx
+++ b/MJ_FB_Frontend/tests/DeliveriesPage.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Deliveries from '../src/pages/pantry/Deliveries';
+import {
+  getOutstandingDeliveryOrders,
+  markDeliveryOrderCompleted,
+} from '../src/api/deliveryOrders';
+import type { DeliveryOutstandingOrder } from '../src/types';
+
+jest.mock('../src/api/deliveryOrders', () => ({
+  getOutstandingDeliveryOrders: jest.fn(),
+  markDeliveryOrderCompleted: jest.fn(),
+}));
+
+const mockOrders: DeliveryOutstandingOrder[] = [
+  {
+    id: 101,
+    clientId: 1234,
+    clientName: 'Jane Doe',
+    status: 'approved',
+    createdAt: '2024-08-10T15:00:00.000Z',
+    scheduledFor: '2024-08-15T18:30:00.000Z',
+    address: '123 Main St',
+    phone: '306-555-1234',
+    email: 'jane@example.com',
+    notes: 'Leave at the back door.',
+    items: [
+      { itemId: 1, quantity: 2, name: 'Canned Beans', categoryId: 10, categoryName: 'Pantry' },
+      { itemId: 2, quantity: 1, name: 'Whole Wheat Bread', categoryId: 11, categoryName: 'Bakery' },
+    ],
+  },
+  {
+    id: 102,
+    clientId: 5678,
+    status: 'pending',
+    createdAt: '2024-08-12T12:00:00.000Z',
+    scheduledFor: null,
+    address: '456 Elm St',
+    phone: '306-555-5678',
+    email: null,
+    notes: null,
+    items: [],
+  },
+];
+
+describe('Pantry Deliveries page', () => {
+  const mockedGetOutstanding = getOutstandingDeliveryOrders as jest.MockedFunction<
+    typeof getOutstandingDeliveryOrders
+  >;
+  const mockedMarkCompleted = markDeliveryOrderCompleted as jest.MockedFunction<
+    typeof markDeliveryOrderCompleted
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetOutstanding.mockResolvedValue(mockOrders);
+  });
+
+  it('renders outstanding delivery orders with contact details and items', async () => {
+    render(
+      <MemoryRouter>
+        <Deliveries />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Client 1234 · Jane Doe/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Order #:/i)).toHaveLength(2);
+    expect(screen.getByText('101')).toBeInTheDocument();
+    expect(screen.getByText(/123 Main St/)).toBeInTheDocument();
+    expect(screen.getByText(/306-555-1234/)).toBeInTheDocument();
+    expect(screen.getByText(/2 × Canned Beans/)).toBeInTheDocument();
+    expect(screen.getByText(/Bakery/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /record delivery/i })).toBeInTheDocument();
+    expect(screen.getByText(/No items listed\./)).toBeInTheDocument();
+  });
+
+  it('marks a delivery as completed and removes it from the list', async () => {
+    mockedMarkCompleted.mockResolvedValue();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Deliveries />
+      </MemoryRouter>,
+    );
+
+    const buttons = await screen.findAllByRole('button', { name: /mark completed/i });
+    await user.click(buttons[0]);
+
+    expect(mockedMarkCompleted).toHaveBeenCalledWith(101);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Client 1234/)).not.toBeInTheDocument();
+    });
+
+    expect(await screen.findByText('Delivery marked completed.')).toBeInTheDocument();
+    expect(screen.getByText(/Client 5678/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Harvest Pantry Deliveries nav link and route that lazy loads the new page
- implement a staff deliveries view that lists outstanding orders, shows details, and supports marking them complete with feedback
- add delivery order API helpers, extend types, and cover the new page with Jest tests while enabling the root tests directory in Jest config

## Testing
- npm test -- --runTestsByPath tests/DeliveriesPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9098104b4832d8c6301a28e66ad10