### PR TITLE
Fix ManageAvailability removal tests resolving confirm promise

### DIFF
--- a/MJ_FB_Frontend/src/components/ConfirmDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ConfirmDialog.tsx
@@ -4,7 +4,7 @@ import DialogCloseButton from './DialogCloseButton';
 
 interface ConfirmDialogProps {
   message: string;
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
   onCancel: () => void;
   children?: ReactNode;
 }

--- a/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ManageAvailability.tsx
@@ -611,8 +611,8 @@ export default function ManageAvailability() {
           {confirm && (
             <ConfirmDialog
               message={confirm.message}
-              onConfirm={() => {
-                void confirm.onConfirm();
+              onConfirm={async () => {
+                await confirm.onConfirm();
               }}
               onCancel={() => setConfirm(null)}
             />

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailability.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailability.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ManageAvailability from '../ManageAvailability';
 import {
   removeHoliday,
@@ -38,13 +39,15 @@ beforeEach(() => {
 describe('ManageAvailability', () => {
   it('confirms before removing a holiday', async () => {
     (getHolidays as jest.Mock).mockResolvedValue([{ date: '2024-01-01', reason: 'Holiday' }]);
+    const user = userEvent.setup();
     render(<ManageAvailability />);
 
-    const removeBtn = await screen.findByLabelText('remove');
-    fireEvent.click(removeBtn);
+    const holidayPanel = screen.getByRole('tabpanel', { name: /holidays/i });
+    const [removeBtn] = await within(holidayPanel).findAllByLabelText('remove');
+    await user.click(removeBtn);
 
     expect(await screen.findByText('Remove holiday?')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Confirm'));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
 
     await waitFor(() => {
       expect(removeHoliday).toHaveBeenCalledWith('2024-01-01');
@@ -55,14 +58,16 @@ describe('ManageAvailability', () => {
     (getBlockedSlots as jest.Mock).mockResolvedValue([
       { date: '2024-02-01', slotId: 1, reason: '' },
     ]);
+    const user = userEvent.setup();
     render(<ManageAvailability />);
 
-    fireEvent.click(screen.getByRole('tab', { name: /blocked slots/i }));
-    const removeBtn = await screen.findByLabelText('remove');
-    fireEvent.click(removeBtn);
+    await user.click(screen.getByRole('tab', { name: /blocked slots/i }));
+    const blockedPanel = screen.getByRole('tabpanel', { name: /blocked slots/i });
+    const [removeBtn] = await within(blockedPanel).findAllByLabelText('remove');
+    await user.click(removeBtn);
 
     expect(await screen.findByText('Remove blocked slot?')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Confirm'));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
 
     await waitFor(() => {
       expect(removeBlockedSlot).toHaveBeenCalledWith('2024-02-01', 1);
@@ -73,14 +78,16 @@ describe('ManageAvailability', () => {
     (getBreaks as jest.Mock).mockResolvedValue([
       { dayOfWeek: 0, slotId: 1, reason: '' },
     ]);
+    const user = userEvent.setup();
     render(<ManageAvailability />);
 
-    fireEvent.click(screen.getByRole('tab', { name: /staff breaks/i }));
-    const removeBtn = await screen.findByLabelText('remove');
-    fireEvent.click(removeBtn);
+    await user.click(screen.getByRole('tab', { name: /staff breaks/i }));
+    const breaksPanel = screen.getByRole('tabpanel', { name: /staff breaks/i });
+    const [removeBtn] = await within(breaksPanel).findAllByLabelText('remove');
+    await user.click(removeBtn);
 
     expect(await screen.findByText('Remove break?')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Confirm'));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
 
     await waitFor(() => {
       expect(removeBreak).toHaveBeenCalledWith(0, 1);


### PR DESCRIPTION
## Summary
- replace fireEvent usage in ManageAvailability tests with userEvent and scope remove button lookups to the active tab
- allow ConfirmDialog callbacks to return promises and await the confirm handler so delete flows resolve during tests

## Testing
- npm test -- ManageAvailability.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9732dea9c832da240669b6e8e6ac5