### PR TITLE
Fix UserHistory test to target specific search input

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/UserHistory.test.tsx
@@ -36,9 +36,12 @@ describe('UserHistory search add shortcut', () => {
       </MemoryRouter>,
     );
 
-    fireEvent.change(screen.getByTestId('entity-search-input'), {
-      target: { value: '123' },
-    });
+    fireEvent.change(
+      screen.getByLabelText('Search by name or client ID'),
+      {
+        target: { value: '123' },
+      },
+    );
 
     act(() => {
       jest.advanceTimersByTime(300);
@@ -49,6 +52,6 @@ describe('UserHistory search add shortcut', () => {
     fireEvent.click(await screen.findByRole('button', { name: /confirm/i }));
 
     expect(await screen.findByRole('button', { name: /add client/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/client id/i)).toHaveValue('123');
+    expect(screen.getByLabelText('Client ID')).toHaveValue('123');
   });
 });


### PR DESCRIPTION
## Summary
- update the UserHistory test to target the client search input by its descriptive label
- adjust the final assertion to grab the Client ID field explicitly after navigation

## Testing
- npm test -- UserHistory.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c973357ab8832da7b7cbbbddf5fee5