### PR TITLE
Ensure fetchWithRetry timers clear and tighten tests

### DIFF
--- a/MJ_FB_Frontend/src/api/fetchWithRetry.ts
+++ b/MJ_FB_Frontend/src/api/fetchWithRetry.ts
@@ -1,3 +1,29 @@
+const MAX_BACKOFF_DELAY = 2_147_483_647; // match Node.js maximum timeout (~24.8 days)
+
+function computeBackoffDelay(base: number, attempt: number): number {
+  if (!Number.isFinite(base)) {
+    return 0;
+  }
+  const normalizedBase = Math.max(0, base);
+  const normalizedAttempt = Number.isFinite(attempt)
+    ? Math.max(0, Math.floor(attempt))
+    : 0;
+
+  let delay = normalizedBase;
+  for (let step = 0; step < normalizedAttempt; step += 1) {
+    if (delay >= MAX_BACKOFF_DELAY) {
+      return MAX_BACKOFF_DELAY;
+    }
+    delay *= 2;
+  }
+
+  if (!Number.isFinite(delay)) {
+    return MAX_BACKOFF_DELAY;
+  }
+
+  return Math.min(delay, MAX_BACKOFF_DELAY);
+}
+
 export async function fetchWithRetry(
   resource: RequestInfo | URL,
   options: RequestInit,
@@ -29,8 +55,15 @@ export async function fetchWithRetry(
       lastStatus = 0;
       if (i === retries) break;
     }
-    if (i < retries)
-      await new Promise(res => setTimeout(res, backoff * 2 ** i));
+    if (i < retries) {
+      const delay = computeBackoffDelay(backoff, i);
+      await new Promise<void>(resolve => {
+        const timeoutId = setTimeout(() => {
+          clearTimeout(timeoutId);
+          resolve();
+        }, delay);
+      });
+    }
   }
 
   const error: any = new Error(


### PR DESCRIPTION
## Summary
- bound retry backoff delays and clear scheduled timers in fetchWithRetry
- update fetchWithRetry tests to flush timers safely, verify no leaks, and cover 5xx retry behavior

## Testing
- CI=1 npm test -- --runTestsByPath src/api/__tests__/fetchWithRetry.test.ts --runInBand --watch=false --testNamePattern=retries
- CI=1 npm test -- --runTestsByPath src/api/__tests__/fetchWithRetry.test.ts --runInBand --watch=false --testNamePattern="returns immediately on success"
- CI=1 npm test -- --runTestsByPath src/api/__tests__/fetchWithRetry.test.ts --runInBand --watch=false --testNamePattern="retries on 5xx response"

------
https://chatgpt.com/codex/tasks/task_e_68c97336a460832d9d15822310601bf8