### PR TITLE
Memoize staff management tabs

### DIFF
--- a/MJ_FB_Frontend/src/components/StyledTabs.tsx
+++ b/MJ_FB_Frontend/src/components/StyledTabs.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import type { ReactElement } from 'react';
 import { Paper, Tabs, Tab, Box, type SxProps, type Theme } from '@mui/material';
 
@@ -24,6 +24,47 @@ export default function StyledTabs({ tabs, value: valueProp, onChange, sx }: Sty
     if (valueProp === undefined) setInternal(newValue);
   };
 
+  const tabItems = useMemo(
+    () =>
+      tabs.map((tab, index) => ({
+        ...tab,
+        tabId: `tab-${index}`,
+        panelId: `tabpanel-${index}`,
+      })),
+    [tabs],
+  );
+
+  const tabHeaders = useMemo(
+    () =>
+      tabItems.map((tab) => (
+        <Tab
+          key={tab.tabId}
+          label={tab.label}
+          icon={tab.icon}
+          iconPosition={tab.icon ? 'start' : undefined}
+          id={tab.tabId}
+          aria-controls={tab.panelId}
+        />
+      )),
+    [tabItems],
+  );
+
+  const tabPanels = useMemo(
+    () =>
+      tabItems.map((tab, index) => (
+        <div
+          key={tab.panelId}
+          role="tabpanel"
+          hidden={value !== index}
+          id={tab.panelId}
+          aria-labelledby={tab.tabId}
+        >
+          <Box sx={{ pt: 2, display: value === index ? 'block' : 'none' }}>{tab.content}</Box>
+        </div>
+      )),
+    [tabItems, value],
+  );
+
   return (
     <Paper sx={{ p: 2, ...(sx as object) }}>
       <Tabs
@@ -33,28 +74,9 @@ export default function StyledTabs({ tabs, value: valueProp, onChange, sx }: Sty
         scrollButtons="auto"
         aria-label="styled tabs"
       >
-        {tabs.map((t, i) => (
-          <Tab
-            key={i}
-            label={t.label}
-            icon={t.icon}
-            iconPosition={t.icon ? 'start' : undefined}
-            id={`tab-${i}`}
-            aria-controls={`tabpanel-${i}`}
-          />
-        ))}
+        {tabHeaders}
       </Tabs>
-      {tabs.map((t, i) => (
-        <div
-          key={i}
-          role="tabpanel"
-          hidden={value !== i}
-          id={`tabpanel-${i}`}
-          aria-labelledby={`tab-${i}`}
-        >
-          <Box sx={{ pt: 2, display: value === i ? 'block' : 'none' }}>{t.content}</Box>
-        </div>
-      ))}
+      {tabPanels}
     </Paper>
   );
 }

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import StyledTabs from '../../components/StyledTabs';
 import Page from '../../components/Page';
 import PantryQuickLinks from '../../components/PantryQuickLinks';
@@ -25,14 +25,17 @@ export default function ClientManagement() {
     const idx = tabNames.indexOf(t);
     setTab(idx === -1 ? 0 : idx);
   }, [searchParams]);
-  const tabs = [
-    { label: 'Search Client', content: <UserHistory /> },
-    { label: 'Add', content: <AddClient /> },
-    { label: 'Update', content: <UpdateClientData /> },
-    { label: 'New Clients', content: <NewClients /> },
-    { label: 'No Shows', content: <NoShowWeek /> },
-    { label: 'Delete', content: <DeleteClient /> },
-  ];
+  const tabs = useMemo(
+    () => [
+      { label: 'Search Client', content: <UserHistory /> },
+      { label: 'Add', content: <AddClient /> },
+      { label: 'Update', content: <UpdateClientData /> },
+      { label: 'New Clients', content: <NewClients /> },
+      { label: 'No Shows', content: <NoShowWeek /> },
+      { label: 'Delete', content: <DeleteClient /> },
+    ],
+    [],
+  );
 
   return (
     <Page title="Client Management" header={<PantryQuickLinks />}>

--- a/MJ_FB_Frontend/src/pages/staff/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/VolunteerManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import StyledTabs from '../../components/StyledTabs';
 import Page from '../../components/Page';
@@ -32,12 +32,15 @@ export default function VolunteerManagement() {
     else setTab(0);
   }, [searchParams]);
 
-  const tabs = [
-    { label: 'Search Volunteer', content: <EditVolunteer /> },
-    { label: 'Add', content: <AddVolunteer /> },
-    { label: 'Delete', content: <DeleteVolunteer /> },
-    { label: 'Ranking', content: <VolunteerRanking /> },
-  ];
+  const tabs = useMemo(
+    () => [
+      { label: 'Search Volunteer', content: <EditVolunteer /> },
+      { label: 'Add', content: <AddVolunteer /> },
+      { label: 'Delete', content: <DeleteVolunteer /> },
+      { label: 'Ranking', content: <VolunteerRanking /> },
+    ],
+    [],
+  );
 
   return (
     <Page title="Volunteer Management" header={<VolunteerQuickLinks />}>


### PR DESCRIPTION
## Summary
- memoize the client management tab array so each panel is created once
- memoize the volunteer management tabs for the same reuse behaviour
- cache derived tab headers and panels inside `StyledTabs` to avoid remapping unchanged tabs

## Testing
- `npm test` *(fails: VolunteerBooking.test.tsx cannot find slot text and triggers undici setImmediate ReferenceError; AgencyAccess.test.tsx cannot find email label)*

------
https://chatgpt.com/codex/tasks/task_e_68c9981fd698832d8002c89403228c35