### PR TITLE
Polyfill setImmediate for Jest environment

### DIFF
--- a/MJ_FB_Frontend/jest.setup.ts
+++ b/MJ_FB_Frontend/jest.setup.ts
@@ -6,6 +6,8 @@ import {
   clearTimeout as nodeClearTimeout,
   setInterval as nodeSetInterval,
   clearInterval as nodeClearInterval,
+  setImmediate as nodeSetImmediate,
+  clearImmediate as nodeClearImmediate,
 } from 'timers';
 
 // Polyfill TextEncoder/Decoder for testing environment
@@ -13,8 +15,6 @@ import {
 (global as any).TextDecoder = TextDecoder as any;
 (global as any).ReadableStream = ReadableStream as any;
 (global as any).WritableStream = WritableStream as any;
-(global as any).clearImmediate =
-  (global as any).clearImmediate || ((id: number) => clearTimeout(id));
 (global as any).performance = (global as any).performance || ({} as any);
 (global as any).performance.markResourceTiming =
   (global as any).performance.markResourceTiming || (() => {});
@@ -24,6 +24,8 @@ import {
 (global as any).clearTimeout = nodeClearTimeout;
 (global as any).setInterval = nodeSetInterval;
 (global as any).clearInterval = nodeClearInterval;
+(global as any).setImmediate = nodeSetImmediate;
+(global as any).clearImmediate = nodeClearImmediate;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { fetch, Headers, Request, Response, FormData, File } = require('undici');


### PR DESCRIPTION
## Summary
- register Node's `setImmediate`/`clearImmediate` in the Jest setup so undici timers work in tests

## Testing
- npm test -- --runTestsByPath src/pages/admin/__tests__/LeaveRequests.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c99cd6303c832da663979ca6f93ab5