### PR TITLE
Prevent React Query cache timers from hanging tests

### DIFF
--- a/MJ_FB_Frontend/testUtils/renderWithProviders.tsx
+++ b/MJ_FB_Frontend/testUtils/renderWithProviders.tsx
@@ -17,7 +17,12 @@ export function renderWithProviders(
   options?: Omit<RenderOptions, 'wrapper'>,
 ) {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
   });
 
   function Wrapper({ children }: ProvidersProps): ReactElement {


### PR DESCRIPTION
## Summary
- disable the react-query query cache timer in the testing QueryClient so Jest can finish DonorProfile specs

## Testing
- npm test -- DonorProfile.test.tsx --detectOpenHandles

------
https://chatgpt.com/codex/tasks/task_e_68c99cab3854832dbe00c33336fa2428