### PR TITLE
Show delivery orders in client history for staff

### DIFF
--- a/MJ_FB_Frontend/src/api/deliveryOrders.ts
+++ b/MJ_FB_Frontend/src/api/deliveryOrders.ts
@@ -1,5 +1,5 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
-import type { DeliveryOutstandingOrder } from '../types';
+import type { DeliveryOrder, DeliveryOutstandingOrder } from '../types';
 
 export async function getOutstandingDeliveryOrders(): Promise<DeliveryOutstandingOrder[]> {
   const res = await apiFetch(`${API_BASE}/delivery/orders/outstanding`);
@@ -11,4 +11,14 @@ export async function markDeliveryOrderCompleted(orderId: number): Promise<void>
     method: 'POST',
   });
   await handleResponse(res);
+}
+
+export async function getDeliveryOrdersForClient(
+  clientId: number,
+): Promise<DeliveryOrder[]> {
+  const params = new URLSearchParams({
+    clientId: String(clientId),
+  });
+  const res = await apiFetch(`${API_BASE}/delivery/orders?${params.toString()}`);
+  return handleResponse<DeliveryOrder[]>(res);
 }

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -7,16 +7,124 @@ import {
   rescheduleBookingByToken,
 } from '../../../api/bookings';
 import { deleteClientVisit } from '../../../api/clientVisits';
+import { getDeliveryOrdersForClient } from '../../../api/deliveryOrders';
 import EntitySearch from '../../../components/EntitySearch';
 import BookingManagementBase from '../../../components/BookingManagementBase';
 import EditClientDialog from './EditClientDialog';
 import ConfirmDialog from '../../../components/ConfirmDialog';
 import { useAuth } from '../../../hooks/useAuth';
-import { Box, Button, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  CircularProgress,
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+} from '@mui/material';
+import getApiErrorMessage from '../../../utils/getApiErrorMessage';
+import { formatLocaleDate } from '../../../utils/date';
+import type { DeliveryOrder, DeliveryOrderStatus } from '../../../types';
 
 interface User {
   name: string;
   client_id: number;
+}
+
+function getStatusColor(
+  status?: DeliveryOrderStatus | null,
+): 'default' | 'info' | 'success' | 'warning' | 'error' {
+  switch (status) {
+    case 'approved':
+      return 'info';
+    case 'scheduled':
+      return 'warning';
+    case 'completed':
+      return 'success';
+    case 'cancelled':
+      return 'error';
+    default:
+      return 'default';
+  }
+}
+
+function formatStatusLabel(status?: DeliveryOrderStatus | null) {
+  if (!status) return 'Pending';
+  return `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
+}
+
+function DeliveryOrderSummary({ order }: { order: DeliveryOrder }) {
+  const scheduledLabel = order.scheduledFor
+    ? formatLocaleDate(order.scheduledFor, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : 'Not scheduled';
+
+  return (
+    <Box>
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Typography variant="subtitle1">{`Order #${order.id}`}</Typography>
+        <Chip
+          size="small"
+          label={formatStatusLabel(order.status)}
+          color={getStatusColor(order.status)}
+        />
+      </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        {`Scheduled: ${scheduledLabel}`}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        {`Address: ${order.address}`}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        {`Phone: ${order.phone}`}
+      </Typography>
+      {order.email && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {`Email: ${order.email}`}
+        </Typography>
+      )}
+      {order.notes && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {`Notes: ${order.notes}`}
+        </Typography>
+      )}
+      <Typography variant="subtitle2" sx={{ mt: 1 }}>
+        Items
+      </Typography>
+      {order.items.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No items recorded
+        </Typography>
+      ) : (
+        <List dense disablePadding>
+          {order.items.map((item, index) => (
+            <ListItem key={`${order.id}-${item.itemId ?? index}`} disableGutters sx={{ py: 0 }}>
+              <ListItemText
+                primary={`${item.itemName || item.name || 'Item'} × ${item.quantity}`}
+                secondary={item.categoryName ?? undefined}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
 }
 
 export default function UserHistory({
@@ -28,6 +136,9 @@ export default function UserHistory({
   const navigate = useNavigate();
   const [selected, setSelected] = useState<User | null>(initialUser || null);
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [deliveryOrders, setDeliveryOrders] = useState<DeliveryOrder[]>([]);
+  const [deliveryLoading, setDeliveryLoading] = useState(false);
+  const [deliveryError, setDeliveryError] = useState<string | null>(null);
   const { role } = useAuth();
   const showNotes = role === 'staff' || role === 'agency';
 
@@ -40,13 +151,46 @@ export default function UserHistory({
     }
   }, [searchParams, initialUser]);
 
+  useEffect(() => {
+    if (!selected || role !== 'staff') {
+      setDeliveryOrders([]);
+      setDeliveryLoading(false);
+      setDeliveryError(null);
+      return;
+    }
+
+    let active = true;
+    setDeliveryLoading(true);
+    setDeliveryError(null);
+
+    getDeliveryOrdersForClient(selected.client_id)
+      .then(orders => {
+        if (!active) return;
+        setDeliveryOrders(orders);
+      })
+      .catch(err => {
+        if (!active) return;
+        setDeliveryOrders([]);
+        setDeliveryError(
+          getApiErrorMessage(err, 'Unable to load delivery orders'),
+        );
+      })
+      .finally(() => {
+        if (active) setDeliveryLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [selected?.client_id, role]);
+
   return (
     <Box>
       <Typography variant="h5" gutterBottom>
         {initialUser ? 'Client booking history' : 'Client history'}
       </Typography>
       <Box display="flex" justifyContent="center" alignItems="flex-start" minHeight="100vh">
-        <Box width="100%" maxWidth={800} mt={4}>
+        <Box width="100%" maxWidth={1200} mt={4}>
           {!initialUser && (
             <EntitySearch
               type="user"
@@ -59,45 +203,80 @@ export default function UserHistory({
             />
           )}
           {selected && (
-            <BookingManagementBase
-              user={selected}
-              getBookingHistory={getBookingHistory}
-              cancelBooking={cancelBooking}
-              rescheduleBookingByToken={rescheduleBookingByToken}
-              getSlots={getSlots}
-              onDeleteVisit={deleteClientVisit}
-              showNotes={showNotes}
-              showFilter={!initialUser}
-              showUserHeading={!initialUser}
-              renderEditDialog={
-                role === 'staff'
-                  ? ({ open, onClose, onUpdated }) => (
-                      <EditClientDialog
-                        open={open}
-                        clientId={selected.client_id}
-                        onClose={onClose}
-                        onUpdated={onUpdated}
-                        onClientUpdated={name =>
-                          setSelected({ ...selected, name })
-                        }
-                      />
-                    )
-                  : undefined
-              }
-              renderDeleteVisitButton={(b, isSmall, open) =>
-                role === 'staff' && b.status === 'visited' && !b.slot_id ? (
-                  <Button
-                    key="deleteVisit"
-                    onClick={open}
-                    variant="outlined"
-                    color="error"
-                    fullWidth={isSmall}
-                  >
-                    Delete visit
-                  </Button>
-                ) : null
-              }
-            />
+            <Grid
+              container
+              spacing={3}
+              alignItems="flex-start"
+              sx={{ mt: initialUser ? 0 : 2 }}
+            >
+              <Grid item xs={12} md={role === 'staff' ? 7 : 12}>
+                <BookingManagementBase
+                  user={selected}
+                  getBookingHistory={getBookingHistory}
+                  cancelBooking={cancelBooking}
+                  rescheduleBookingByToken={rescheduleBookingByToken}
+                  getSlots={getSlots}
+                  onDeleteVisit={deleteClientVisit}
+                  showNotes={showNotes}
+                  showFilter={!initialUser}
+                  showUserHeading={!initialUser}
+                  renderEditDialog={
+                    role === 'staff'
+                      ? ({ open, onClose, onUpdated }) => (
+                          <EditClientDialog
+                            open={open}
+                            clientId={selected.client_id}
+                            onClose={onClose}
+                            onUpdated={onUpdated}
+                            onClientUpdated={name =>
+                              setSelected({ ...selected, name })
+                            }
+                          />
+                        )
+                      : undefined
+                  }
+                  renderDeleteVisitButton={(b, isSmall, open) =>
+                    role === 'staff' && b.status === 'visited' && !b.slot_id ? (
+                      <Button
+                        key="deleteVisit"
+                        onClick={open}
+                        variant="outlined"
+                        color="error"
+                        fullWidth={isSmall}
+                      >
+                        Delete visit
+                      </Button>
+                    ) : null
+                  }
+                />
+              </Grid>
+              {role === 'staff' && (
+                <Grid item xs={12} md={5}>
+                  <Card>
+                    <CardHeader title="Delivery orders" subheader="Review hamper requests" />
+                    <CardContent>
+                      {deliveryLoading ? (
+                        <Box display="flex" justifyContent="center" py={2}>
+                          <CircularProgress size={24} />
+                        </Box>
+                      ) : deliveryError ? (
+                        <Typography color="error">{deliveryError}</Typography>
+                      ) : deliveryOrders.length === 0 ? (
+                        <Typography color="text.secondary">
+                          No delivery orders
+                        </Typography>
+                      ) : (
+                        <Stack spacing={2} divider={<Divider flexItem />}>
+                          {deliveryOrders.map(order => (
+                            <DeliveryOrderSummary key={order.id} order={order} />
+                          ))}
+                        </Stack>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Grid>
+              )}
+            </Grid>
           )}
         </Box>
       </Box>

--- a/MJ_FB_Frontend/src/pages/staff/client-management/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/__tests__/UserHistory.test.tsx
@@ -1,0 +1,138 @@
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from '../../../../../testUtils/renderWithProviders';
+import { MemoryRouter } from 'react-router-dom';
+import UserHistory from '../UserHistory';
+import { getDeliveryOrdersForClient } from '../../../../api/deliveryOrders';
+
+type MockedGetOrders = jest.MockedFunction<typeof getDeliveryOrdersForClient>;
+
+jest.mock('../../../../components/EntitySearch', () => ({
+  __esModule: true,
+  default: ({ onSelect }: { onSelect: (value: unknown) => void }) => (
+    <button onClick={() => onSelect({ name: 'Search Result', client_id: 456 })}>
+      Select client
+    </button>
+  ),
+}));
+
+jest.mock('../../../../components/BookingManagementBase', () => ({
+  __esModule: true,
+  default: ({ user }: { user: { client_id: number } }) => (
+    <div data-testid="booking-management-base">History for {user.client_id}</div>
+  ),
+}));
+
+jest.mock('../../../../api/deliveryOrders', () => ({
+  __esModule: true,
+  getDeliveryOrdersForClient: jest.fn(),
+}));
+
+const mockGetDeliveryOrdersForClient = getDeliveryOrdersForClient as MockedGetOrders;
+
+const originalFetch = globalThis.fetch;
+
+beforeAll(() => {
+  (globalThis as any).fetch = jest.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.includes('/auth/csrf-token')) {
+      return new Response(JSON.stringify({ csrfToken: 'test-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/auth/refresh')) {
+      return new Response(null, { status: 200 });
+    }
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem('role', 'staff');
+  localStorage.setItem('name', 'Test Staff');
+  localStorage.setItem('access', '[]');
+});
+
+describe('UserHistory delivery orders', () => {
+  it('fetches delivery orders when a client is selected from search', async () => {
+    mockGetDeliveryOrdersForClient.mockResolvedValueOnce([]);
+
+    renderWithProviders(
+      <MemoryRouter>
+        <UserHistory />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /select client/i }));
+
+    await waitFor(() => {
+      expect(mockGetDeliveryOrdersForClient).toHaveBeenCalledWith(456);
+    });
+  });
+
+  it('displays delivery order details for the selected client', async () => {
+    mockGetDeliveryOrdersForClient.mockResolvedValueOnce([
+      {
+        id: 10,
+        clientId: 123,
+        status: 'scheduled',
+        createdAt: '2024-05-01T17:00:00.000Z',
+        scheduledFor: '2024-05-14T15:30:00.000Z',
+        address: '123 Main St',
+        phone: '306-555-1234',
+        email: 'client@example.com',
+        notes: 'Leave at the back door',
+        items: [
+          {
+            itemId: 1,
+            quantity: 2,
+            categoryId: 7,
+            itemName: 'Milk',
+            categoryName: 'Dairy',
+          },
+          {
+            itemId: 2,
+            quantity: 1,
+            categoryId: 9,
+            itemName: 'Bread',
+            categoryName: 'Bakery',
+          },
+        ],
+      },
+    ]);
+
+    renderWithProviders(
+      <MemoryRouter>
+        <UserHistory initialUser={{ name: 'Client Example', client_id: 123 }} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mockGetDeliveryOrdersForClient).toHaveBeenCalledWith(123);
+    });
+
+    expect(await screen.findByText('Order #10')).toBeInTheDocument();
+    expect(screen.getByText('Scheduled: Tue, May 14, 2024')).toBeInTheDocument();
+    expect(screen.getByText('Address: 123 Main St')).toBeInTheDocument();
+    expect(screen.getByText('Phone: 306-555-1234')).toBeInTheDocument();
+    expect(screen.getByText('Email: client@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Notes: Leave at the back door')).toBeInTheDocument();
+    expect(screen.getByText('Milk × 2')).toBeInTheDocument();
+    expect(screen.getByText('Bread × 1')).toBeInTheDocument();
+    expect(screen.getByText('Dairy')).toBeInTheDocument();
+    expect(screen.getByText('Bakery')).toBeInTheDocument();
+  });
+});

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -44,4 +44,5 @@ Staff see a **Deliveries** page in the staff navigation. The view lists the newe
 - Create new delivery accounts from **Staff → Client Management → Add Client** by choosing the **Delivery** role. Existing pantry clients can also be converted from the same form.
 - Remind delivery clients to keep their contact information current—the form will reject blank address, phone, or email fields.
 - Staff can review a client’s delivery history by calling `GET /api/v1/delivery/orders/history?clientId=<id>` with a staff token. This endpoint returns the same payload the client sees in the app.
+- Staff → Client Management → History now loads `/api/v1/delivery/orders?clientId=<id>` whenever you select a client. The panel beside the booking timeline summarizes each hamper’s status, scheduled date, contact details, and requested items so the pantry and delivery teams share the same context during follow-up calls.
 - Staff may submit a request on a client’s behalf by sending the same payload to `POST /api/v1/delivery/orders`; include the `clientId` in the body so the order is recorded correctly.


### PR DESCRIPTION
## Summary
- add a delivery orders API helper so staff tools can request a client's submitted hampers
- extend the client history view to load delivery orders, presenting status, schedule, contact details, and items beside booking history
- cover the new staff workflow with a focused Jest test suite and document the addition in the delivery operations guide

## Testing
- npm test *(fails: existing suites such as VolunteerManagement emit act warnings and do not finish; see diagnostic output)*

------
https://chatgpt.com/codex/tasks/task_e_68c99ab0e28c832dbea11fa3359add47