### PR TITLE
Add fallback volunteer stats tests

### DIFF
--- a/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
+++ b/MJ_FB_Backend/tests/volunteerLeaderboard.test.ts
@@ -9,17 +9,25 @@ jest.mock('../src/middleware/authMiddleware', () => ({
   authorizeAccess: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
 }));
 
-const app = express();
-app.use(express.json());
-app.use((req, _res, next) => {
-  (req as any).user = { id: 1, role: 'volunteer' };
-  next();
-});
-app.use('/volunteer-stats', volunteerStatsRouter);
+const createApp = (user?: { id: number; role: string }) => {
+  const app = express();
+  app.use(express.json());
+  if (user) {
+    app.use((req, _res, next) => {
+      (req as any).user = user;
+      next();
+    });
+  }
+  app.use('/volunteer-stats', volunteerStatsRouter);
+  return app;
+};
 
 describe('Volunteer leaderboard', () => {
+  let app: express.Express;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    app = createApp({ id: 1, role: 'volunteer' });
   });
 
   it('returns rank and percentile', async () => {
@@ -31,5 +39,19 @@ describe('Volunteer leaderboard', () => {
     expect(query).toContain('volunteer_counts');
     expect(query).toContain('::numeric');
     expect(query).toContain("vb.status = 'completed'");
+  });
+
+  it('returns 401 when user context is missing', async () => {
+    const res = await request(createApp()).get('/volunteer-stats/leaderboard');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ message: 'Unauthorized' });
+    expect(pool.query as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('returns null values when the leaderboard query has no rows', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get('/volunteer-stats/leaderboard');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ rank: null, percentile: null });
   });
 });


### PR DESCRIPTION
## Summary
- refactor volunteer leaderboard and group stats tests to create isolated app instances per scenario
- add coverage for missing user context and empty leaderboard responses
- ensure volunteer group stats returns zeroed totals when no data is returned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99e809d34832d819f685fbec0dd24