### PR TITLE
Use CA$ currency formatting in donor pages

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/DonorDonationLog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DonorDonationLog.test.tsx
@@ -48,8 +48,8 @@ describe('Donor Donation Log', () => {
     );
 
     expect(await screen.findByText('john@example.com')).toBeInTheDocument();
-    expect(await screen.findByText('$50.00')).toBeInTheDocument();
-    expect(screen.queryByText('$75.00')).not.toBeInTheDocument();
+    expect(await screen.findByText('CA$50.00')).toBeInTheDocument();
+    expect(screen.queryByText('CA$75.00')).not.toBeInTheDocument();
   });
 
   it('edits and deletes a donation', async () => {
@@ -69,7 +69,7 @@ describe('Donor Donation Log', () => {
     );
 
     await screen.findByText('john@example.com');
-    expect(await screen.findByText('$50.00')).toBeInTheDocument();
+    expect(await screen.findByText('CA$50.00')).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText('Edit donation'));
     const amountField = screen.getByLabelText('Amount');

--- a/MJ_FB_Frontend/src/pages/donor-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonationLog.tsx
@@ -95,7 +95,7 @@ export default function DonationLog() {
   }
 
   const currency = useMemo(
-    () => new Intl.NumberFormat('en-CA', { style: 'currency', currency: 'CAD' }),
+    () => new Intl.NumberFormat('en', { style: 'currency', currency: 'CAD' }),
     [],
   );
 

--- a/MJ_FB_Frontend/src/pages/donor-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonorProfile.tsx
@@ -58,7 +58,7 @@ export default function DonorProfile() {
     enabled: !Number.isNaN(donorId),
   });
 
-  const currency = new Intl.NumberFormat('en-CA', {
+  const currency = new Intl.NumberFormat('en', {
     style: 'currency',
     currency: 'CAD',
   });


### PR DESCRIPTION
## Summary
- switch donor management currency formatting to a locale that renders the CA$ prefix
- update donation log tests to expect CA$-prefixed amounts

## Testing
- npm test -- --runTestsByPath src/__tests__/DonorDonationLog.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9a47417fc832db58092ea6f14979c