### PR TITLE
Fix Grid import for UserHistory layout

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UserHistory.tsx
@@ -22,13 +22,13 @@ import {
   Chip,
   CircularProgress,
   Divider,
-  Grid,
   List,
   ListItem,
   ListItemText,
   Stack,
   Typography,
 } from '@mui/material';
+import Grid from '@mui/material/GridLegacy';
 import getApiErrorMessage from '../../../utils/getApiErrorMessage';
 import { formatLocaleDate } from '../../../utils/date';
 import type { DeliveryOrder, DeliveryOrderStatus } from '../../../types';


### PR DESCRIPTION
## Summary
- switch UserHistory to import the legacy Grid component so container/item props continue to type-check under the latest MUI types

## Testing
- CI=1 npm run build
- CI=1 npm test *(fails: existing suites timesheets, VolunteerBooking, AgencyAccess, fetchWithRetry)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bad6cff8832db55984079559e93e