### PR TITLE
Ensure DonorProfile test waits for refetch before assertions

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/DonorProfile.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DonorProfile.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../../testUtils/renderWithProviders';
 import DonorProfile from '../pages/donor-management/DonorProfile';
@@ -97,14 +97,17 @@ describe('DonorProfile', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
-    expect(updateMonetaryDonor).toHaveBeenCalledWith(1, {
-      firstName: 'Jane',
-      lastName: 'Smith',
-      email: 'jane@example.com',
+    await waitFor(() => {
+      expect(updateMonetaryDonor).toHaveBeenCalledWith(1, {
+        firstName: 'Jane',
+        lastName: 'Smith',
+        email: 'jane@example.com',
+      });
+      expect(getMonetaryDonor).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Donor updated')).toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+      expect(screen.getByText('jane@example.com')).toBeInTheDocument();
     });
-    expect(await screen.findByText('Donor updated')).toBeInTheDocument();
-    expect(await screen.findByText('Jane Smith')).toBeInTheDocument();
-    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- import waitFor and wrap DonorProfile save assertions so the React Query refetch can complete
- assert the donor refetch is called twice and keep snackbar/name checks in the same waitFor block

## Testing
- npm test -- src/__tests__/DonorProfile.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9c18084f0832d9540ba89290a31db