### PR TITLE
Pin VolunteerBooking test clock to morning

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerBooking.test.tsx
@@ -30,6 +30,22 @@ jest.mock('../hooks/useAuth', () => ({
 }));
 
 describe('VolunteerBooking', () => {
+  const fixedNow = new Date('2025-09-16T08:00:00Z');
+  let dateSpy: jest.SpyInstance<number, []> | undefined;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(fixedNow);
+    dateSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(fixedNow.valueOf());
+  });
+
+  afterEach(() => {
+    dateSpy?.mockRestore();
+    jest.useRealTimers();
+  });
+
   it('requests a slot and shows confirmation', async () => {
     (getHolidays as jest.Mock).mockResolvedValue([]);
     (getUserProfile as jest.Mock).mockResolvedValue({ bookingsThisMonth: 0 });


### PR DESCRIPTION
## Summary
- freeze `Date.now` to a fixed early-morning timestamp before rendering the VolunteerBooking test
- use Jest fake timers so dayjs treats the slot as upcoming and restore the spy/timers after each test

## Testing
- npm test -- src/__tests__/VolunteerBooking.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9c17fb2b4832d8e511fadcda5190c