### PR TITLE
Remove agency references from shared tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/App.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/App.test.tsx
@@ -63,11 +63,6 @@ jest.mock('../hooks/useAuth', () => {
     return ctx;
   };
 
-  const AgencyGuard = ({ children }) => {
-    const { role } = useAuth();
-    return role === 'agency' ? <>{children}</> : <Navigate to="/" replace />;
-  };
-
   const DonorManagementGuard = ({ children }) => {
     const { access } = useAuth();
     const allowed = access.includes('donor_management') || access.includes('admin');
@@ -78,7 +73,6 @@ jest.mock('../hooks/useAuth', () => {
     __esModule: true,
     AuthProvider,
     useAuth,
-    AgencyGuard,
     DonorManagementGuard,
   };
 });

--- a/MJ_FB_Frontend/src/__tests__/DashboardLink.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DashboardLink.test.tsx
@@ -21,8 +21,8 @@ describe('Dashboard link', () => {
     expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument();
   });
 
-  it('appears for agencies', () => {
-    renderNavbar([{ label: 'Agency', links: [{ label: 'Dashboard', to: '/' }] }]);
+  it('appears for delivery users', () => {
+    renderNavbar([{ label: 'Delivery', links: [{ label: 'Dashboard', to: '/' }] }]);
     expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/Profile.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Profile.test.tsx
@@ -26,10 +26,9 @@ describe('Profile password reset', () => {
 
   it.each([
     ['staff', { firstName: 'S', lastName: 'Taff', email: 's@example.com', phone: null, role: 'staff' } as UserProfile, { email: 's@example.com' }],
-    ['agency', { firstName: 'A', lastName: 'Gency', email: 'a@example.com', phone: null, role: 'agency' } as UserProfile, { email: 'a@example.com' }],
     ['shopper', { firstName: 'C', lastName: 'Lient', email: null, phone: null, role: 'shopper', clientId: 42 } as UserProfile, { clientId: '42' }],
     ['delivery', { firstName: 'D', lastName: 'Livery', email: null, phone: null, role: 'delivery', clientId: 84 } as UserProfile, { clientId: '84' }],
-    ])('sends reset link for %s', async (role, profile, payload) => {
+  ])('sends reset link for %s', async (role, profile, payload) => {
       (getUserProfile as jest.Mock).mockResolvedValue(profile);
       render(
         <MemoryRouter initialEntries={["/"]}>
@@ -39,7 +38,7 @@ describe('Profile password reset', () => {
         </MemoryRouter>
       );
       await waitFor(() => expect(getUserProfile).toHaveBeenCalled());
-      if (role !== 'staff' && role !== 'agency') {
+      if (role !== 'staff') {
         await waitFor(() => expect(getUserPreferences).toHaveBeenCalled());
       }
       const btn = await screen.findByRole('button', { name: /Reset Password/i });


### PR DESCRIPTION
## Summary
- drop the mocked AgencyGuard from App authentication tests
- update dashboard link test to cover delivery navigation instead of agency
- remove agency role case from profile password reset test while keeping other roles

## Testing
- npm test -- --watchAll=false --forceExit *(fails: existing PantryAggregations.test.tsx could not locate responsive table markup)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c1f91218832dbfee23b157c77050