### PR TITLE
Fix duplicate admin timesheet fixtures in timesheet tests

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/timesheets.test.tsx
@@ -75,31 +75,6 @@ const defaultTimesheetsResponse = {
   error: null,
 } as const;
 
-const adminTimesheets = {
-  timesheets: [
-    {
-      id: 1,
-      staff_id: 2,
-      start_date: '2024-01-01',
-      end_date: '2024-01-07',
-      submitted_at: '2024-01-08',
-      approved_at: null,
-      total_hours: 40,
-      expected_hours: 40,
-      balance_hours: 0,
-      ot_hours: 0,
-    },
-  ],
-  isLoading: false,
-  error: null,
-} as const;
-
-const emptyAdminTimesheets = {
-  timesheets: [],
-  isLoading: false,
-  error: null,
-} as const;
-
 const mockUseAllTimesheets = jest.fn();
 const mockSearchStaff = jest.fn();
 const mockAdminSearchStaff = jest.fn();
@@ -111,10 +86,10 @@ const adminTimesheets = {
       staff_id: 2,
       start_date: '2024-01-01',
       end_date: '2024-01-07',
-      submitted_at: '2024-01-08T00:00:00Z',
+      submitted_at: '2024-01-08',
       approved_at: null,
-      total_hours: 0,
-      expected_hours: 0,
+      total_hours: 40,
+      expected_hours: 40,
       balance_hours: 0,
       ot_hours: 0,
     },


### PR DESCRIPTION
## Summary
- remove the duplicate admin fixtures in the timesheets test
- keep a single admin fixture with the values needed for admin scenarios

## Testing
- npm test -- timesheets.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9c6546104832da40bad24144e9609