### PR TITLE
Fix EntitySearch result typing

### DIFF
--- a/MJ_FB_Frontend/src/components/EntitySearch.tsx
+++ b/MJ_FB_Frontend/src/components/EntitySearch.tsx
@@ -48,9 +48,18 @@ export default function EntitySearch<T extends SearchResultBase>({
       return;
     }
     let active = true;
-    const fn = searchFn || (type === 'user' ? searchUsers : searchVolunteers);
+
+    const defaultSearch: (query: string) => Promise<T[]> =
+      type === 'user'
+        ? async (query: string) =>
+            (await searchUsers(query)) as unknown as T[]
+        : async (query: string) =>
+            (await searchVolunteers(query)) as unknown as T[];
+
+    const runSearch = searchFn ?? defaultSearch;
+
     setHasSearched(true);
-    fn(debouncedQuery)
+    runSearch(debouncedQuery)
       .then(data => {
         if (active) setResults(data);
       })


### PR DESCRIPTION
## Summary
- ensure EntitySearch uses a typed fallback search function so generics resolve to the expected result shape

## Testing
- npm test *(fails: existing syntax error in `src/__tests__/DashboardLink.test.tsx`)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c8565100832da6a29f5c9685fe78