### PR TITLE
Configure Jest coverage instrumentation

### DIFF
--- a/MJ_FB_Frontend/jest.config.cjs
+++ b/MJ_FB_Frontend/jest.config.cjs
@@ -1,6 +1,9 @@
 module.exports = {
   testEnvironment: 'jsdom',
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  coverageProvider: 'v8',
+  coverageDirectory: '<rootDir>/coverage',
+  coverageReporters: ['text', 'lcov', 'clover'],
   testMatch: [
     '<rootDir>/src/pages/admin/__tests__/**/*.test.tsx',
     '<rootDir>/src/pages/**/__tests__/**/*.test.tsx',

--- a/MJ_FB_Frontend/src/__tests__/DashboardLink.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DashboardLink.test.tsx
@@ -23,10 +23,11 @@ describe('Dashboard link', () => {
 
   it('appears for staff groups', () => {
     renderNavbar([{ label: 'Staff', links: [{ label: 'Dashboard', to: '/' }] }]);
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument();
+  });
 
   it('appears for delivery users', () => {
     renderNavbar([{ label: 'Delivery', links: [{ label: 'Dashboard', to: '/' }] }]);
-
     expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- configure Jest to use the V8 coverage provider and save reports under `coverage/`
- fix the dashboard link test to assert the staff navigation renders the dashboard link

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9cb196288832dafde1915b205b973