### PR TITLE
Improve service worker update handling

### DIFF
--- a/MJ_FB_Frontend/src/main.tsx
+++ b/MJ_FB_Frontend/src/main.tsx
@@ -33,7 +33,9 @@ function Main() {
 const container = document.getElementById('root')!;
 const root = ReactDOM.createRoot(container);
 
-registerSW({ immediate: true });
+const updateServiceWorker = registerSW({ immediate: true });
+
+void updateServiceWorker(true);
 
 root.render(
   <React.StrictMode>

--- a/MJ_FB_Frontend/src/service-worker.ts
+++ b/MJ_FB_Frontend/src/service-worker.ts
@@ -11,6 +11,7 @@ import {
 } from 'workbox-strategies'
 import { ExpirationPlugin } from 'workbox-expiration'
 import { BackgroundSyncPlugin } from 'workbox-background-sync'
+import { clientsClaim } from 'workbox-core'
 
 declare let self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: ManifestEntry[]
@@ -18,6 +19,24 @@ declare let self: ServiceWorkerGlobalScope & {
 
 // self.__WB_MANIFEST is injected at build time
 precacheAndRoute(self.__WB_MANIFEST)
+
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheKeys = await caches.keys()
+      await Promise.all(
+        cacheKeys
+          .filter((cacheName) => cacheName === 'static-assets')
+          .map((cacheName) => caches.delete(cacheName)),
+      )
+      clientsClaim()
+    })(),
+  )
+})
 
 // Cache static assets
 registerRoute(


### PR DESCRIPTION
## Summary
- ensure the service worker skips waiting, claims clients on activation, and clears stale static asset caches
- trigger the service worker updater after registration so open tabs refresh with the latest bundle

## Testing
- npm test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9d75becbc832dbf572c9cc9c2778c