### PR TITLE
test: cover booking history header actions

### DIFF
--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -229,6 +229,13 @@ export default function BookingUI<T = Slot>({
       : role === 'volunteer'
         ? 'Book volunteer shift'
         : 'Book appointment';
+  const historyPath = location.pathname.startsWith('/volunteer/schedule')
+    ? '/volunteer/history'
+    : location.pathname.startsWith('/book-appointment')
+      ? '/booking-history'
+      : null;
+  const historyLabel =
+    historyPath === '/volunteer/history' ? 'View volunteer history' : 'View booking history';
   const displayName = shopperName ?? authName ?? 'John Shopper';
 
   const [date, setDate] = useState<Dayjs>(() => {
@@ -668,7 +675,22 @@ export default function BookingUI<T = Slot>({
 
   if (embedded) return content;
   return (
-    <Page title={pageTitle}>
+    <Page
+      title={pageTitle}
+      header={
+        historyPath ? (
+          <Button
+            component={RouterLink}
+            to={historyPath}
+            variant="outlined"
+            size="medium"
+            sx={{ minHeight: 48 }}
+          >
+            {historyLabel}
+          </Button>
+        ) : undefined
+      }
+    >
       {content}
       {role === 'volunteer' ? <VolunteerBottomNav /> : <ClientBottomNav />}
     </Page>


### PR DESCRIPTION
## Summary
- mock useAuth with jest.fn to configure shopper or volunteer contexts in BookingUI tests and reset supporting layout mocks per case
- assert breadcrumb header renders booking history and volunteer history links with correct text and href for shopper and volunteer routes
- expose booking history header button in BookingUI when navigating via book-appointment or volunteer schedule paths

## Testing
- npm test -- BookingUI

------
https://chatgpt.com/codex/tasks/task_e_68cc1d97b9e8832da0bd47224df321f4