### PR TITLE
Adjust button defaults to medium sizing

### DIFF
--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -129,7 +129,7 @@ let theme = createTheme({
     MuiAppBar: { styleOverrides: { root: { backgroundColor: BRAND_PRIMARY } } },
 
     MuiButton: {
-      defaultProps: { size: 'small', disableElevation: true },
+      defaultProps: { size: 'medium', disableElevation: true },
       styleOverrides: {
         root: {
           borderRadius: 5,
@@ -142,6 +142,7 @@ let theme = createTheme({
           transition: 'border-color 0.25s, background-color 0.25s',
           '&:focus-visible': { boxShadow: `0 0 0 3px ${alpha(BRAND_PRIMARY, 0.25)}` },
           lineHeight: 1.2,
+          minHeight: '48px',
         },
         containedPrimary: {
           '&:hover': { backgroundColor: darken(BRAND_PRIMARY, 0.08) },


### PR DESCRIPTION
## Summary
- set the Material UI button default size to medium so buttons meet tap target guidance
- enforce a 48px minimum button height in the shared theme for consistent touch areas

## Testing
- npm test *(fails: existing VolunteerCoverageCard ordering expectation and VolunteerBooking suite syntax error caused by duplicate historyPath declaration in BookingUI.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cc20c2a290832dbd33bab5235da883