### PR TITLE
Add safe area padding for client bottom navigation overlays

### DIFF
--- a/MJ_FB_Frontend/src/pages/CancelBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/CancelBooking.tsx
@@ -36,7 +36,10 @@ export default function CancelBooking() {
   }
 
   return (
-    <Page title="Cancel booking">
+    <Page
+      title="Cancel booking"
+      sx={{ pb: { xs: 'calc(72px + env(safe-area-inset-bottom))' } }}
+    >
       <Grid container spacing={2} justifyContent="center">
         <Grid size={{ xs: 12, sm: 8, md: 6 }}>
           <FormCard title="Cancel booking" onSubmit={handleSubmit} actions={

--- a/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
+++ b/MJ_FB_Frontend/src/pages/RescheduleBooking.tsx
@@ -84,7 +84,10 @@ export default function RescheduleBooking() {
   }
 
   return (
-    <Page title="Reschedule">
+    <Page
+      title="Reschedule"
+      sx={{ pb: { xs: 'calc(72px + env(safe-area-inset-bottom))' } }}
+    >
       <Grid container spacing={2} justifyContent="center">
         <Grid size={{ xs: 12, sm: 8, md: 6 }}>
           {tokenValid && (

--- a/MJ_FB_Frontend/src/pages/booking/Profile.tsx
+++ b/MJ_FB_Frontend/src/pages/booking/Profile.tsx
@@ -147,7 +147,10 @@ export default function Profile({ role }: { role: Role }) {
 
   return (
     <ErrorBoundary>
-      <PageContainer maxWidth="sm">
+      <PageContainer
+        maxWidth="sm"
+        sx={{ pb: { xs: 'calc(72px + env(safe-area-inset-bottom))' } }}
+      >
         <PageCard
           variant="elevation"
           elevation={0}

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -152,7 +152,10 @@ export default function ClientDashboard() {
   }
 
   return (
-    <Page title="Client Dashboard">
+    <Page
+      title="Client Dashboard"
+      sx={{ pb: { xs: 'calc(72px + env(safe-area-inset-bottom))' } }}
+    >
       <OnboardingModal
         storageKey="clientOnboarding"
         title="Welcome!"

--- a/MJ_FB_Frontend/src/pages/delivery/DeliveryDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/DeliveryDashboard.tsx
@@ -35,7 +35,10 @@ export default function DeliveryDashboard() {
   );
 
   return (
-    <Page title="Delivery Dashboard">
+    <Page
+      title="Delivery Dashboard"
+      sx={{ pb: { xs: 'calc(72px + env(safe-area-inset-bottom))' } }}
+    >
       <FeedbackSnackbar
         open={!!error}
         onClose={() => setError('')}

--- a/MJ_FB_Frontend/src/pages/privacy/PrivacyPolicy.tsx
+++ b/MJ_FB_Frontend/src/pages/privacy/PrivacyPolicy.tsx
@@ -7,7 +7,10 @@ import { useAuth } from '../../hooks/useAuth';
 export default function PrivacyPolicy() {
   const { role, isAuthenticated } = useAuth();
   return (
-    <Page title="Privacy Policy – Harvest Pantry Booking App">
+    <Page
+      title="Privacy Policy – Harvest Pantry Booking App"
+      sx={{ pb: { xs: 'calc(72px + env(safe-area-inset-bottom))' } }}
+    >
       <Stack spacing={2}>
         <Typography>Last updated: September 13, 2025</Typography>
 


### PR DESCRIPTION
## Summary
- add safe-area aware bottom padding to client and delivery dashboards, booking cancellation/reschedule, and privacy policy pages so content stays above the navigation on phones
- extend the booking profile container with matching mobile padding to keep action buttons visible above the bottom nav

## Testing
- npm test *(fails: BookingUI duplicate `historyPath` declaration and VolunteerCoverageCard ordering expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68cc20c9b2fc832db6c2b2d36f3d3409