### PR TITLE
Adjust login form layout for mobile keyboards

### DIFF
--- a/MJ_FB_Frontend/src/components/FormCard.tsx
+++ b/MJ_FB_Frontend/src/components/FormCard.tsx
@@ -23,15 +23,24 @@ export default function FormCard({
   elevation = 1,
   ...paperProps
 }: FormCardProps) {
+  const { sx: boxSx, ...restBoxProps } = boxProps ?? {};
+
   return (
     <Box
       display="flex"
-      justifyContent="center"
-      alignItems={centered ? 'center' : 'flex-start'}
-      minHeight="80vh"
+      flexDirection="column"
+      justifyContent={
+        centered ? { xs: 'flex-start', sm: 'center' } : 'flex-start'
+      }
+      alignItems="center"
+      minHeight={{ xs: 'auto', sm: '80vh' }}
       px={2}
-      py={centered ? 0 : 4}
-      {...boxProps}
+      sx={{
+        pt: { xs: centered ? 6 : 4, sm: centered ? 0 : 4 },
+        pb: { xs: centered ? 6 : 4, sm: centered ? 0 : 4 },
+        ...(boxSx ?? {}),
+      }}
+      {...restBoxProps}
     >
       <Paper
         component="form"

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -133,9 +133,11 @@ export default function Login({
           display="flex"
           flexDirection="column"
           alignItems="center"
-          justifyContent="center"
-          minHeight="80vh"
+          justifyContent={{ xs: 'flex-start', sm: 'center' }}
+          minHeight={{ xs: 'auto', sm: '80vh' }}
           px={2}
+          pt={{ xs: 6, sm: 0 }}
+          pb={{ xs: 6, sm: 0 }}
         >
           <CircularProgress color="primary" />
         </Box>
@@ -144,9 +146,11 @@ export default function Login({
           display="flex"
           flexDirection="column"
           alignItems="center"
-          justifyContent="center"
-          minHeight="80vh"
+          justifyContent={{ xs: 'flex-start', sm: 'center' }}
+          minHeight={{ xs: 'auto', sm: '80vh' }}
           px={2}
+          pt={{ xs: 6, sm: 0 }}
+          pb={{ xs: 6, sm: 0 }}
         >
           <FormCard
             onSubmit={handleSubmit}
@@ -175,8 +179,6 @@ export default function Login({
                 </MuiLink>
               </Stack>
             }
-            centered={false}
-            boxProps={{ minHeight: 0, px: 0, py: 0 }}
           >
             <TextField
               value={identifier}


### PR DESCRIPTION
## Summary
- make FormCard use responsive flex settings so forms stay centered on desktop but start near the top on phones with extra breathing room
- rely on the new FormCard defaults from the login page and add matching responsive spacing for the surrounding containers so the inputs remain visible when the keyboard opens

## Testing
- TZ=America/Regina npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc1edfd230832dbbc5fefe9dc9786e