### PR TITLE
Normalize user email handling

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000063_normalize_user_emails.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000063_normalize_user_emails.ts
@@ -1,0 +1,9 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql("UPDATE staff SET email = NULLIF(LOWER(TRIM(email)), '') WHERE email IS NOT NULL;");
+  pgm.sql("UPDATE volunteers SET email = NULLIF(LOWER(TRIM(email)), '') WHERE email IS NOT NULL;");
+  pgm.sql("UPDATE clients SET email = NULLIF(LOWER(TRIM(email)), '') WHERE email IS NOT NULL;");
+}
+
+export async function down(): Promise<void> {}

--- a/MJ_FB_Backend/tests/userController.test.ts
+++ b/MJ_FB_Backend/tests/userController.test.ts
@@ -952,7 +952,7 @@ describe('userController', () => {
 
       expect(pool.query).toHaveBeenCalledWith(
         expect.stringContaining('address = COALESCE($3, address)'),
-        [undefined, undefined, '456 Oak Ave', 7],
+        [null, undefined, '456 Oak Ave', 7],
       );
       expect(mockGetClientBookingsThisMonth).toHaveBeenCalledWith(7);
       expect(res.json).toHaveBeenCalledWith({

--- a/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
+++ b/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
@@ -53,6 +53,6 @@ describe('donation entry volunteer login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.access).toEqual(['donation_entry']);
-    expect((pool.query as jest.Mock).mock.calls[1][0]).toMatch(/WHERE v.email = \$1/);
+    expect((pool.query as jest.Mock).mock.calls[1][0]).toMatch(/WHERE LOWER\(v.email\) = \$1/);
   });
 });


### PR DESCRIPTION
## Summary
- normalize email input via a shared helper in the user controller and update all client, staff, and volunteer create/update code paths to store trimmed lowercase addresses
- compare lowercase email values during login checks and extend tests to cover case-insensitive authentication and updated queries
- add a migration to backfill existing client, staff, and volunteer email records to the normalized format

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc207245f0832d96980b1077060c2a