### PR TITLE
Normalize email handling in login flows

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerController.ts
@@ -8,6 +8,14 @@ import { sendTemplatedEmail } from '../../utils/emailUtils';
 import { reginaStartOfDayISO } from '../../utils/dateUtils';
 import type { PoolClient } from 'pg';
 
+const normalizeOptionalEmail = (value?: string | null) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+};
+
 export async function updateTrainedArea(
   req: Request,
   res: Response,
@@ -109,6 +117,8 @@ export async function createVolunteer(
     sendPasswordLink?: boolean;
   };
 
+  const normalizedEmailInput = normalizeOptionalEmail(email);
+
   if (
     !firstName ||
     !lastName ||
@@ -121,17 +131,19 @@ export async function createVolunteer(
     });
   }
 
-  if (onlineAccess && !email) {
+  if (onlineAccess && !normalizedEmailInput) {
     return res
       .status(400)
       .json({ message: 'Email required for online account' });
   }
 
   try {
-    if (email) {
+    const normalizedEmail = normalizedEmailInput;
+
+    if (normalizedEmail) {
       const emailCheck = await pool.query(
         'SELECT id FROM volunteers WHERE LOWER(email) = LOWER($1)',
-        [email],
+        [normalizedEmail],
       );
       if ((emailCheck.rowCount ?? 0) > 0) {
         return res.status(400).json({ message: 'Email already exists' });
@@ -153,7 +165,7 @@ export async function createVolunteer(
       `INSERT INTO volunteers (first_name, last_name, email, phone, password, consent)
        VALUES ($1,$2,$3,$4,$5, true)
        RETURNING id`,
-      [firstName, lastName, email, phone, hashedPassword]
+      [firstName, lastName, normalizedEmail, phone, hashedPassword]
     );
     const volunteerId = result.rows[0].id;
     await pool.query(
@@ -161,11 +173,11 @@ export async function createVolunteer(
        SELECT $1, vr.id, vr.category_id FROM volunteer_roles vr WHERE vr.id = ANY($2::int[])`,
       [volunteerId, roleIds]
     );
-    if (sendPasswordLink && email) {
+    if (sendPasswordLink && normalizedEmail) {
       const token = await generatePasswordSetupToken('volunteers', volunteerId);
       const params = buildPasswordSetupEmailParams('volunteers', token);
       await sendTemplatedEmail({
-        to: email,
+        to: normalizedEmail,
         templateId: config.passwordSetupTemplateId,
         params,
       });
@@ -204,10 +216,11 @@ export async function updateVolunteer(
     sendPasswordLink?: boolean;
   };
   try {
-    if (email) {
+    const normalizedEmail = normalizeOptionalEmail(email);
+    if (normalizedEmail) {
       const emailCheck = await pool.query(
         'SELECT id FROM volunteers WHERE LOWER(email) = LOWER($1) AND id <> $2',
-        [email, id],
+        [normalizedEmail, id],
       );
       if ((emailCheck.rowCount ?? 0) > 0) {
         return res.status(400).json({ message: 'Email already exists' });
@@ -235,7 +248,7 @@ export async function updateVolunteer(
       [
         firstName,
         lastName,
-        email || null,
+        normalizedEmail,
         phone || null,
         onlineAccess,
         hashedPassword,
@@ -247,11 +260,11 @@ export async function updateVolunteer(
     }
     const row = result.rows[0];
 
-    if (sendPasswordLink && email && onlineAccess && !hadPassword) {
+    if (sendPasswordLink && normalizedEmail && onlineAccess && !hadPassword) {
       const token = await generatePasswordSetupToken('volunteers', Number(id));
       const params = buildPasswordSetupEmailParams('volunteers', token);
       await sendTemplatedEmail({
-        to: email,
+        to: normalizedEmail,
         templateId: config.passwordSetupTemplateId,
         params,
       });

--- a/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
+++ b/MJ_FB_Backend/tests/volunteerDonationEntry.test.ts
@@ -53,6 +53,8 @@ describe('donation entry volunteer login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.access).toEqual(['donation_entry']);
-    expect((pool.query as jest.Mock).mock.calls[1][0]).toMatch(/WHERE v.email = \$1/);
+    expect((pool.query as jest.Mock).mock.calls[1][0]).toContain(
+      'WHERE LOWER(v.email) = $1',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- normalize email comparisons in the login controller for staff, volunteers, and clients
- persist lowercase trimmed emails when creating or updating staff, volunteers, and client records
- add regression coverage for mixed-case email login across user roles

## Testing
- npx jest tests/login.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc20f8bce0832d96d9297a0f8321ff