### PR TITLE
Fix booking UI build errors

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -81,9 +81,11 @@ export default function VolunteerCoverageCard({
               );
               const volunteers = todayBookings
                 .map((b: any) => b.volunteer_name)
-                .filter(Boolean);
+                .filter(Boolean) as string[];
               const startTime = s.start_time;
               const hour = Number.parseInt(startTime?.split(':')[0] ?? '', 10);
+              const period: CoverageItem['period'] =
+                Number.isFinite(hour) && hour < 12 ? 'morning' : 'afternoon';
               return {
                 roleName: `${r.name} ${formatTime(s.start_time)}–${formatTime(
                   s.end_time,
@@ -93,8 +95,8 @@ export default function VolunteerCoverageCard({
                 total: r.max_volunteers,
                 volunteers,
                 startTime,
-                period: Number.isFinite(hour) && hour < 12 ? 'morning' : 'afternoon',
-              };
+                period,
+              } satisfies CoverageItem;
             }),
           ),
         );

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -223,9 +223,6 @@ export default function BookingUI<T = Slot>({
 }: BookingUIProps<T>) {
   const location = useLocation();
   const { role, name: authName, userRole } = useAuth();
-  const isVolunteerSchedule = location.pathname.startsWith('/volunteer/schedule');
-  const historyPath = isVolunteerSchedule ? '/volunteer/history' : '/booking-history';
-  const historyButtonLabel = isVolunteerSchedule ? 'View shift history' : 'View booking history';
   const pageTitle =
     location.pathname.startsWith('/book-appointment') && userRole === 'shopper'
       ? 'Book shopping appointment'
@@ -237,6 +234,8 @@ export default function BookingUI<T = Slot>({
     : location.pathname.startsWith('/book-appointment')
       ? '/booking-history'
       : null;
+  const historyButtonLabel =
+    historyPath === '/volunteer/history' ? 'View shift history' : 'View booking history';
   const historyLabel =
     historyPath === '/volunteer/history' ? 'View volunteer history' : 'View booking history';
   const displayName = shopperName ?? authName ?? 'John Shopper';
@@ -431,9 +430,13 @@ export default function BookingUI<T = Slot>({
                 </Typography>
                 <Typography>
                   If you need to reschedule, please do so from your bookings{' '}
-                  <Link component={RouterLink} to={historyPath} underline="hover">
-                    page
-                  </Link>
+                  {historyPath ? (
+                    <Link component={RouterLink} to={historyPath} underline="hover">
+                      page
+                    </Link>
+                  ) : (
+                    'page'
+                  )}
                   .
                 </Typography>
                 <Typography>
@@ -511,18 +514,20 @@ export default function BookingUI<T = Slot>({
         <Typography variant="h5" sx={{ flexGrow: 1 }}>
           {`Booking for ${displayName}`}
         </Typography>
-        <Button
-          component={RouterLink}
-          to={historyPath}
-          variant="outlined"
-          size="medium"
-          sx={{
-            minHeight: 48,
-            width: { xs: '100%', sm: 'auto' },
-          }}
-        >
-          {historyButtonLabel}
-        </Button>
+        {embedded && historyPath && (
+          <Button
+            component={RouterLink}
+            to={historyPath}
+            variant="outlined"
+            size="medium"
+            sx={{
+              minHeight: 48,
+              width: { xs: '100%', sm: 'auto' },
+            }}
+          >
+            {historyButtonLabel}
+          </Button>
+        )}
       </Stack>
       <Typography
         variant="subtitle1"


### PR DESCRIPTION
## Summary
- ensure volunteer coverage data satisfies the CoverageItem type and narrows period values
- compute the booking history path once, avoid duplicate history links, and guard the reschedule link when unavailable

## Testing
- CI=1 npm run build
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc27911c24832db01ed1cb7ab9b1c4