### PR TITLE
Refactor donor contacts and aggregation tests

### DIFF
--- a/MJ_FB_Backend/src/controllers/donorController.ts
+++ b/MJ_FB_Backend/src/controllers/donorController.ts
@@ -7,7 +7,7 @@ import asyncHandler from '../middleware/asyncHandler';
 export const listDonors = asyncHandler(async (req: Request, res: Response) => {
   const search = (req.query.search as string) ?? '';
   const result = await pool.query(
-    `SELECT id, first_name AS "firstName", last_name AS "lastName", email
+    `SELECT id, first_name AS "firstName", last_name AS "lastName", email, phone
        FROM donors
        WHERE CAST(id AS TEXT) ILIKE $1
           OR first_name ILIKE $1
@@ -20,13 +20,32 @@ export const listDonors = asyncHandler(async (req: Request, res: Response) => {
 });
 
 export const addDonor = asyncHandler(async (req: Request, res: Response) => {
-  const { firstName, lastName, email } = req.body;
+  const { firstName, lastName, email, phone } = req.body;
   try {
     const result = await pool.query(
-      'INSERT INTO donors (first_name, last_name, email) VALUES ($1, $2, $3) RETURNING id, first_name AS "firstName", last_name AS "lastName", email',
-      [firstName, lastName, email],
+      'INSERT INTO donors (first_name, last_name, email, phone) VALUES ($1, $2, $3, $4) RETURNING id, first_name AS "firstName", last_name AS "lastName", email, phone',
+      [firstName, lastName, email ?? null, phone ?? null],
     );
     res.status(201).json(result.rows[0]);
+  } catch (error: any) {
+    if (error.code === '23505') {
+      return res.status(409).json({ message: 'Donor already exists' });
+    }
+    throw error;
+  }
+});
+
+export const updateDonor = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const { firstName, lastName, email, phone } = req.body;
+  try {
+    const result = await pool.query(
+      'UPDATE donors SET first_name = $2, last_name = $3, email = $4, phone = $5 WHERE id = $1 RETURNING id, first_name AS "firstName", last_name AS "lastName", email, phone',
+      [id, firstName, lastName, email ?? null, phone ?? null],
+    );
+    if ((result.rowCount ?? 0) === 0)
+      return res.status(404).json({ message: 'Donor not found' });
+    res.json(result.rows[0]);
   } catch (error: any) {
     if (error.code === '23505') {
       return res.status(409).json({ message: 'Donor already exists' });
@@ -49,7 +68,7 @@ export const topDonors = asyncHandler(async (req: Request, res: Response) => {
 
   const result = await pool.query(
     `SELECT o.first_name || ' ' || o.last_name AS name, SUM(d.weight)::int AS "totalLbs", TO_CHAR(MAX(d.date), 'YYYY-MM-DD') AS "lastDonationISO"
-       FROM donations d JOIN donors o ON d.donor_email = o.email
+       FROM donations d JOIN donors o ON d.donor_id = o.id
        WHERE EXTRACT(YEAR FROM d.date) = $1
        GROUP BY o.id, o.first_name, o.last_name
        ORDER BY "totalLbs" DESC, MAX(d.date) DESC
@@ -62,13 +81,13 @@ export const topDonors = asyncHandler(async (req: Request, res: Response) => {
 export const getDonor = asyncHandler(async (req: Request, res: Response) => {
   const { id } = req.params;
   const result = await pool.query(
-    `SELECT d.id, d.first_name AS "firstName", d.last_name AS "lastName", d.email,
+    `SELECT d.id, d.first_name AS "firstName", d.last_name AS "lastName", d.email, d.phone,
             COALESCE(SUM(n.weight), 0)::int AS "totalLbs",
             TO_CHAR(MAX(n.date), 'YYYY-MM-DD') AS "lastDonationISO"
        FROM donors d
-       LEFT JOIN donations n ON n.donor_email = d.email
+       LEFT JOIN donations n ON n.donor_id = d.id
        WHERE d.id = $1
-       GROUP BY d.id, d.first_name, d.last_name, d.email`,
+       GROUP BY d.id, d.first_name, d.last_name, d.email, d.phone`,
     [id],
   );
   if ((result.rowCount ?? 0) === 0)
@@ -81,7 +100,7 @@ export const donorDonations = asyncHandler(async (req: Request, res: Response) =
   const result = await pool.query(
     `SELECT n.id, n.date, n.weight
        FROM donations n
-       JOIN donors d ON n.donor_email = d.email
+       JOIN donors d ON n.donor_id = d.id
        WHERE d.id = $1
        ORDER BY n.date DESC, n.id DESC`,
     [id],

--- a/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
+++ b/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
@@ -32,11 +32,11 @@ export async function refreshWarehouseOverall(year: number, month: number) {
       [year, month],
     ),
     pool.query(
-      `SELECT o.email AS "donorEmail", COALESCE(SUM(d.weight)::int, 0) AS total
+      `SELECT o.id AS "donorId", COALESCE(SUM(d.weight)::int, 0) AS total
          FROM donations d
-         JOIN donors o ON d.donor_email = o.email
+         JOIN donors o ON d.donor_id = o.id
          WHERE EXTRACT(YEAR FROM d.date) = $1 AND EXTRACT(MONTH FROM d.date) = $2
-         GROUP BY o.email`,
+         GROUP BY o.id`,
       [year, month],
     ),
   ]);
@@ -58,15 +58,15 @@ export async function refreshWarehouseOverall(year: number, month: number) {
   );
 
   // Refresh donor aggregations for the given month
-  const donorRows = donorAggRes.rows as { donorEmail: string; total: number }[];
+  const donorRows = donorAggRes.rows as { donorId: number; total: number }[];
   await pool.query('DELETE FROM donor_aggregations WHERE year = $1 AND month = $2', [year, month]);
   if (donorRows.length > 0) {
     const valueClauses = donorRows
       .map((_, i) => `($1, $2, $${i * 2 + 3}, $${i * 2 + 4})`)
       .join(',');
-    const params = [year, month, ...donorRows.flatMap(r => [r.donorEmail, r.total])];
+    const params = [year, month, ...donorRows.flatMap(r => [r.donorId, r.total])];
     await pool.query(
-      `INSERT INTO donor_aggregations (year, month, donor_email, total) VALUES ${valueClauses}`,
+      `INSERT INTO donor_aggregations (year, month, donor_id, total) VALUES ${valueClauses}`,
       params,
     );
   }

--- a/MJ_FB_Backend/src/migrations/1700000000064_update_donor_contacts.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000064_update_donor_contacts.ts
@@ -1,0 +1,136 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('donors', {
+    phone: { type: 'text' },
+  });
+
+  pgm.addColumn('donations', {
+    donor_id: { type: 'integer' },
+  });
+  pgm.addColumn('donor_aggregations', {
+    donor_id: { type: 'integer' },
+  });
+
+  pgm.sql(`
+    UPDATE donations d
+    SET donor_id = o.id
+    FROM donors o
+    WHERE d.donor_email = o.email
+  `);
+
+  pgm.sql(`
+    UPDATE donor_aggregations a
+    SET donor_id = o.id
+    FROM donors o
+    WHERE a.donor_email = o.email
+  `);
+
+  pgm.alterColumn('donations', 'donor_id', { notNull: true });
+  pgm.alterColumn('donor_aggregations', 'donor_id', { notNull: true });
+
+  pgm.addConstraint('donations', 'donations_donor_id_fkey', {
+    foreignKeys: {
+      columns: 'donor_id',
+      references: 'donors(id)',
+    },
+  });
+
+  pgm.addConstraint('donor_aggregations', 'donor_aggregations_donor_id_fkey', {
+    foreignKeys: {
+      columns: 'donor_id',
+      references: 'donors(id)',
+    },
+  });
+
+  pgm.createIndex('donations', ['donor_id'], { name: 'donations_donor_id_idx' });
+
+  pgm.dropConstraint('donor_aggregations', 'donor_aggregations_pkey');
+  pgm.dropConstraint('donations', 'donations_donor_email_fkey');
+  pgm.dropConstraint('donor_aggregations', 'donor_aggregations_donor_email_fkey');
+  pgm.dropIndex('donations', ['donor_email'], { name: 'donations_donor_email_idx' });
+
+  pgm.dropColumn('donations', 'donor_email');
+  pgm.dropColumn('donor_aggregations', 'donor_email');
+
+  pgm.addConstraint('donor_aggregations', 'donor_aggregations_pkey', {
+    primaryKey: ['year', 'month', 'donor_id'],
+  });
+
+  pgm.dropConstraint('donors', 'donors_pkey');
+  pgm.dropConstraint('donors', 'donors_id_unique');
+  pgm.alterColumn('donors', 'email', { notNull: false });
+  pgm.addConstraint('donors', 'donors_pkey', { primaryKey: 'id' });
+  pgm.createIndex('donors', ['email'], {
+    name: 'donors_email_unique_idx',
+    unique: true,
+    where: 'email IS NOT NULL',
+  });
+
+  pgm.sql(`
+    UPDATE donors
+    SET email = NULL
+    WHERE email LIKE 'donor%@example.com'
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    UPDATE donors
+    SET email = CONCAT('donor', id, '@example.com')
+    WHERE email IS NULL
+  `);
+
+  pgm.dropConstraint('donor_aggregations', 'donor_aggregations_donor_id_fkey');
+  pgm.dropConstraint('donations', 'donations_donor_id_fkey');
+
+  pgm.dropIndex('donors', ['email'], { name: 'donors_email_unique_idx' });
+  pgm.dropConstraint('donors', 'donors_pkey');
+  pgm.addConstraint('donors', 'donors_id_unique', { unique: 'id' });
+  pgm.alterColumn('donors', 'email', { notNull: true });
+  pgm.addConstraint('donors', 'donors_pkey', { primaryKey: 'email' });
+
+  pgm.dropConstraint('donor_aggregations', 'donor_aggregations_pkey');
+  pgm.addColumn('donor_aggregations', {
+    donor_email: { type: 'text' },
+  });
+  pgm.sql(`
+    UPDATE donor_aggregations a
+    SET donor_email = o.email
+    FROM donors o
+    WHERE a.donor_id = o.id
+  `);
+  pgm.alterColumn('donor_aggregations', 'donor_email', { notNull: true });
+  pgm.dropColumn('donor_aggregations', 'donor_id');
+  pgm.addConstraint('donor_aggregations', 'donor_aggregations_donor_email_fkey', {
+    foreignKeys: {
+      columns: 'donor_email',
+      references: 'donors(email)',
+    },
+  });
+  pgm.addConstraint('donor_aggregations', 'donor_aggregations_pkey', {
+    primaryKey: ['year', 'month', 'donor_email'],
+  });
+
+  pgm.addColumn('donations', {
+    donor_email: { type: 'text' },
+  });
+  pgm.sql(`
+    UPDATE donations d
+    SET donor_email = o.email
+    FROM donors o
+    WHERE d.donor_id = o.id
+  `);
+  pgm.alterColumn('donations', 'donor_email', { notNull: true });
+  pgm.dropIndex('donations', ['donor_id'], { name: 'donations_donor_id_idx' });
+  pgm.dropColumn('donations', 'donor_id');
+  pgm.addConstraint('donations', 'donations_donor_email_fkey', {
+    foreignKeys: {
+      columns: 'donor_email',
+      references: 'donors(email)',
+    },
+  });
+  pgm.createIndex('donations', ['donor_email'], { name: 'donations_donor_email_idx' });
+
+  pgm.dropColumn('donors', 'phone');
+}

--- a/MJ_FB_Backend/src/routes/donors.ts
+++ b/MJ_FB_Backend/src/routes/donors.ts
@@ -2,13 +2,14 @@ import { Router } from 'express';
 import {
   listDonors,
   addDonor,
+  updateDonor,
   topDonors,
   getDonor,
   donorDonations,
 } from '../controllers/donorController';
 import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
-import { addDonorSchema } from '../schemas/donorSchemas';
+import { addDonorSchema, updateDonorSchema } from '../schemas/donorSchemas';
 
 const router = Router();
 
@@ -16,6 +17,13 @@ const router = Router();
 router.get('/top', topDonors);
 router.get('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), listDonors);
 router.post('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), validate(addDonorSchema), addDonor);
+router.put(
+  '/:id',
+  authMiddleware,
+  authorizeAccess('warehouse', 'donation_entry'),
+  validate(updateDonorSchema),
+  updateDonor,
+);
 router.get('/:id', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), getDonor);
 router.get('/:id/donations', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), donorDonations);
 

--- a/MJ_FB_Backend/src/schemas/donorSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/donorSchemas.ts
@@ -1,9 +1,22 @@
 import { z } from 'zod';
 
-export const addDonorSchema = z.object({
+const donorContactSchema = z.object({
   firstName: z.string().min(1),
   lastName: z.string().min(1),
-  email: z.string().email(),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .nullable(),
+  phone: z
+    .string()
+    .min(1)
+    .optional()
+    .nullable(),
 });
 
+export const addDonorSchema = donorContactSchema;
+export const updateDonorSchema = donorContactSchema;
+
 export type AddDonorSchema = z.infer<typeof addDonorSchema>;
+export type UpdateDonorSchema = z.infer<typeof updateDonorSchema>;

--- a/MJ_FB_Backend/src/schemas/warehouse/donationSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/warehouse/donationSchemas.ts
@@ -12,7 +12,7 @@ export const updateDonationSchema = donationSchema;
 export const manualDonorAggregationSchema = z.object({
   year: z.number().int(),
   month: z.number().int(),
-  donorEmail: z.string().email(),
+  donorId: z.number().int(),
   total: z.number().int().optional(),
 });
 

--- a/MJ_FB_Backend/tests/controllers/warehouse/warehouseOverallController.test.ts
+++ b/MJ_FB_Backend/tests/controllers/warehouse/warehouseOverallController.test.ts
@@ -20,7 +20,7 @@ describe('warehouseOverallController', () => {
         .mockResolvedValueOnce({ rows: [{ total: 15 }] })
         .mockResolvedValueOnce({ rows: [{ total: 8 }] })
         .mockResolvedValueOnce({
-          rows: [{ donorEmail: 'donor@example.com', total: 60 }],
+          rows: [{ donorId: 42, total: 60 }],
         })
         .mockResolvedValueOnce({})
         .mockResolvedValueOnce({})
@@ -66,7 +66,7 @@ describe('warehouseOverallController', () => {
       expect(mockDb.query).toHaveBeenNthCalledWith(
         8,
         expect.stringContaining('INSERT INTO donor_aggregations'),
-        [2024, 5, 'donor@example.com', 60],
+        [2024, 5, 42, 60],
       );
     });
 

--- a/MJ_FB_Backend/tests/donationAggregations.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregations.test.ts
@@ -33,12 +33,21 @@ describe('GET /donations/aggregations', () => {
     const months = Array.from({ length: 12 }, (_, i) => i + 1);
     const rows = [
       ...months.map(month => ({
+        donorId: 1,
         donor: 'Alice',
         email: 'alice@example.com',
+        phone: '306-555-1000',
         month,
         total: month === 1 ? 100 : month === 2 ? 50 : 0,
       })),
-      ...months.map(month => ({ donor: 'Bob', email: 'bob@example.com', month, total: 0 })),
+      ...months.map(month => ({
+        donorId: 2,
+        donor: 'Bob',
+        email: 'bob@example.com',
+        phone: null,
+        month,
+        total: 0,
+      })),
     ];
 
     (pool.query as jest.Mock)
@@ -57,14 +66,18 @@ describe('GET /donations/aggregations', () => {
     );
     expect(res.body).toEqual([
       {
+        donorId: 1,
         donor: 'Alice',
         email: 'alice@example.com',
+        phone: '306-555-1000',
         monthlyTotals: [100, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         total: 150,
       },
       {
+        donorId: 2,
         donor: 'Bob',
         email: 'bob@example.com',
+        phone: null,
         monthlyTotals: Array(12).fill(0),
         total: 0,
       },

--- a/MJ_FB_Backend/tests/donationAggregationsManual.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregationsManual.test.ts
@@ -35,7 +35,7 @@ describe('POST /donations/aggregations/manual', () => {
       .mockResolvedValueOnce({});
 
     const year = new Date().getFullYear();
-    const body = { year, month: 5, donorEmail: 'alice@example.com', total: 100 };
+    const body = { year, month: 5, donorId: 7, total: 100 };
     const res = await request(app)
       .post('/donations/aggregations/manual')
       .set('Authorization', 'Bearer token')
@@ -45,7 +45,7 @@ describe('POST /donations/aggregations/manual', () => {
     expect(res.body).toEqual({ message: 'Saved' });
     expect(pool.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO donor_aggregations'),
-      [year, 5, 'alice@example.com', 100],
+      [year, 5, 7, 100],
     );
   });
 });

--- a/MJ_FB_Backend/tests/donationsMonth.test.ts
+++ b/MJ_FB_Backend/tests/donationsMonth.test.ts
@@ -49,6 +49,7 @@ describe('GET /donations?month=', () => {
             firstName: 'Alice',
             lastName: 'Smith',
             email: 'a@example.com',
+            phone: '555-1111',
           },
           {
             id: 2,
@@ -58,6 +59,7 @@ describe('GET /donations?month=', () => {
             firstName: 'Bob',
             lastName: 'Brown',
             email: 'b@example.com',
+            phone: null,
           },
         ],
       });
@@ -75,8 +77,8 @@ describe('GET /donations?month=', () => {
     expect(pool.query).toHaveBeenNthCalledWith(
       2,
       `SELECT d.id, d.date, d.weight, o.id as "donorId",
-              o.first_name as "firstName", o.last_name as "lastName", o.email
-         FROM donations d JOIN donors o ON d.donor_email = o.email
+              o.first_name as "firstName", o.last_name as "lastName", o.email, o.phone
+         FROM donations d JOIN donors o ON d.donor_id = o.id
          WHERE d.date >= $1 AND d.date < $2 ORDER BY d.date, d.id`,
       [`${year}-${month}-01`, `${year}-${nextMonth}-01`],
     );
@@ -89,6 +91,7 @@ describe('GET /donations?month=', () => {
         firstName: 'Alice',
         lastName: 'Smith',
         email: 'a@example.com',
+        phone: '555-1111',
       },
       {
         id: 2,
@@ -98,6 +101,7 @@ describe('GET /donations?month=', () => {
         firstName: 'Bob',
         lastName: 'Brown',
         email: 'b@example.com',
+        phone: null,
       },
     ]);
   });

--- a/MJ_FB_Backend/tests/donorDonations.test.ts
+++ b/MJ_FB_Backend/tests/donorDonations.test.ts
@@ -52,7 +52,7 @@ describe('GET /donors/:id/donations', () => {
       2,
       `SELECT n.id, n.date, n.weight
        FROM donations n
-       JOIN donors d ON n.donor_email = d.email
+       JOIN donors d ON n.donor_id = d.id
        WHERE d.id = $1
        ORDER BY n.date DESC, n.id DESC`,
       ['5'],


### PR DESCRIPTION
## Summary
- add a migration to move donor relationships back to donor_id, add nullable phone numbers, and enforce the new email uniqueness rules
- update donor and warehouse controllers plus validation/routes to surface optional email and phone data and allow editing donors
- refresh donor and warehouse aggregation tests to cover donor_id joins and phone-aware responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2d38fa9c832d84762629d93358bd