### PR TITLE
Fix WebAuthn type resolution

### DIFF
--- a/MJ_FB_Backend/src/controllers/webauthnController.ts
+++ b/MJ_FB_Backend/src/controllers/webauthnController.ts
@@ -110,9 +110,9 @@ export async function verifyCredential(
         expectedChallenge: challenge,
         expectedOrigin: config.webauthnOrigin,
         expectedRPID: config.webauthnRpId,
-        authenticator: {
-          credentialID: Buffer.from(stored.credentialId, 'base64url'),
-          credentialPublicKey: Buffer.from(stored.publicKey, 'base64'),
+        credential: {
+          id: stored.credentialId,
+          publicKey: new Uint8Array(Buffer.from(stored.publicKey, 'base64')),
           counter: stored.signCount,
         },
         requireUserVerification: true,

--- a/MJ_FB_Backend/tsconfig.json
+++ b/MJ_FB_Backend/tsconfig.json
@@ -7,7 +7,12 @@
     "skipLibCheck": true,
     "rootDir": "src",
     "outDir": "dist",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@simplewebauthn/server": ["node_modules/@simplewebauthn/server/esm/index.d.ts"],
+      "@simplewebauthn/types": ["node_modules/@simplewebauthn/types/types/index.d.ts"]
+    }
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## Summary
- map SimpleWebAuthn packages to their published type declaration entry points so tsc can resolve them
- update WebAuthn verification to use the new credential argument shape when calling verifyAuthenticationResponse

## Testing
- npm run build
- npm test tests/webauthnController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc32aedecc832d9459e9ed460c7571