### PR TITLE
Allow donor phone as optional contact

### DIFF
--- a/MJ_FB_Frontend/src/api/donations.ts
+++ b/MJ_FB_Frontend/src/api/donations.ts
@@ -5,9 +5,11 @@ export interface Donation {
   date: string;
   donorId: number;
   donor: {
+    id: number;
     firstName: string;
     lastName: string;
-    email: string;
+    email: string | null;
+    phone: string | null;
   };
   weight: number;
 }

--- a/MJ_FB_Frontend/src/api/donors.ts
+++ b/MJ_FB_Frontend/src/api/donors.ts
@@ -4,14 +4,16 @@ export interface Donor {
   id: number;
   firstName: string;
   lastName: string;
-  email: string;
+  email: string | null;
+  phone: string | null;
 }
 
 export interface TopDonor {
   id: number;
   firstName: string;
   lastName: string;
-  email: string;
+  email: string | null;
+  phone: string | null;
   totalLbs: number;
   lastDonationISO: string;
 }
@@ -36,7 +38,8 @@ export async function getDonors(search?: string): Promise<Donor[]> {
 export async function createDonor(data: {
   firstName: string;
   lastName: string;
-  email: string;
+  email: string | null;
+  phone: string | null;
 }): Promise<Donor> {
   const res = await apiFetch(`${API_BASE}/donors`, {
     method: 'POST',

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -90,6 +90,12 @@ function kpiDelta(curr: number, prev?: number) {
   return { pct, up: pct >= 0 };
 }
 
+function donorLabel(d: Donor) {
+  const base = `${d.firstName} ${d.lastName} (ID ${d.id})`;
+  const contact = d.phone || d.email;
+  return contact ? `${base} • ${contact}` : base;
+}
+
 export default function WarehouseDashboard() {
   const theme = useTheme();
   const navigate = useNavigate();
@@ -246,10 +252,13 @@ export default function WarehouseDashboard() {
     () =>
       donors.filter(d => {
         const term = search.toLowerCase();
+        const email = d.email?.toLowerCase() ?? '';
+        const phone = d.phone?.toLowerCase() ?? '';
         return (
           d.id.toString().includes(term) ||
           `${d.firstName} ${d.lastName}`.toLowerCase().includes(term) ||
-          d.email.toLowerCase().includes(term)
+          email.includes(term) ||
+          phone.includes(term)
         );
       }),
     [donors, search],
@@ -322,7 +331,7 @@ export default function WarehouseDashboard() {
           </FormControl>
           <Autocomplete
             options={donorOptions}
-            getOptionLabel={o => `${o.firstName} ${o.lastName} (${o.email})`}
+            getOptionLabel={donorLabel}
             inputValue={search}
             onInputChange={(_e, v) => setSearch(v)}
             onChange={(_e, v) => {


### PR DESCRIPTION
## Summary
- update donor API types to allow nullable email and phone details
- refresh donation log donor display, creation form, and autocomplete to prefer ID with optional phone
- adjust warehouse dashboard donor search and labels to handle donors without email addresses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc37b9c124832d8002477dc616fa4e