### PR TITLE
Remove aggregations staff access flag

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000065_remove_aggregations_from_staff_access.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000065_remove_aggregations_from_staff_access.ts
@@ -1,0 +1,15 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('staff', 'staff_access_check');
+  pgm.addConstraint('staff', 'staff_access_check', {
+    check: "access <@ ARRAY['pantry','volunteer_management','warehouse','admin','donor_management','payroll_management']",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint('staff', 'staff_access_check');
+  pgm.addConstraint('staff', 'staff_access_check', {
+    check: "access <@ ARRAY['pantry','volunteer_management','warehouse','admin','donor_management','payroll_management','aggregations']",
+  });
+}

--- a/MJ_FB_Backend/src/models/staff.ts
+++ b/MJ_FB_Backend/src/models/staff.ts
@@ -7,8 +7,7 @@ export type StaffAccess =
   | 'admin'
   | 'donor_management'
   | 'payroll_management'
-  | 'donation_entry'
-  | 'aggregations';
+  | 'donation_entry';
 
 export interface Staff {
   id: number;

--- a/MJ_FB_Backend/src/routes/pantry/aggregations.ts
+++ b/MJ_FB_Backend/src/routes/pantry/aggregations.ts
@@ -18,57 +18,62 @@ const router = Router();
 router.get(
   '/weekly',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   listWeeklyAggregations,
 );
 router.get(
   '/monthly',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   listMonthlyAggregations,
 );
 router.get(
   '/yearly',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   listYearlyAggregations,
 );
 router.get(
   '/years',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   listAvailableYears,
 );
 router.get(
   '/months',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   listAvailableMonths,
 );
 router.get(
   '/weeks',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   listAvailableWeeks,
 );
 router.get(
   '/export',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   exportAggregations,
 );
-router.post('/rebuild', authMiddleware, authorizeAccess('pantry', 'aggregations'), rebuildAggregations);
+router.post(
+  '/rebuild',
+  authMiddleware,
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  rebuildAggregations,
+);
 router.post(
   '/manual',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   // Body: { year, month, week?, orders?, adults?, children?, people?, weight? }
   manualPantryAggregate,
 );
 router.post(
   '/manual/weekly',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAccess('pantry', 'warehouse', 'donor_management'),
   // Body: { year, month, week, orders?, adults?, children?, people?, weight? }
   manualWeeklyPantryAggregate,
 );

--- a/MJ_FB_Backend/src/routes/warehouse/donations.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/donations.ts
@@ -22,19 +22,19 @@ router.get('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), 
 router.get(
   '/aggregations',
   authMiddleware,
-  authorizeAccess('warehouse', 'donation_entry', 'aggregations'),
+  authorizeAccess('warehouse', 'donation_entry', 'donor_management'),
   donorAggregations,
 );
 router.get(
   '/aggregations/export',
   authMiddleware,
-  authorizeAccess('warehouse', 'donation_entry', 'aggregations'),
+  authorizeAccess('warehouse', 'donation_entry', 'donor_management'),
   exportDonorAggregations,
 );
 router.post(
   '/aggregations/manual',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeAccess('warehouse', 'donor_management'),
   validate(manualDonorAggregationSchema),
   manualDonorAggregation,
 );

--- a/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
@@ -13,31 +13,31 @@ const router = Router();
 router.get(
   '/',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeAccess('warehouse', 'donor_management'),
   listWarehouseOverall,
 );
 router.post(
   '/manual',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeAccess('warehouse', 'donor_management'),
   manualWarehouseOverall,
 );
 router.post(
   '/rebuild',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeAccess('warehouse', 'donor_management'),
   rebuildWarehouseOverall,
 );
 router.get(
   '/export',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeAccess('warehouse', 'donor_management'),
   exportWarehouseOverall,
 );
 router.get(
   '/years',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeAccess('warehouse', 'donor_management'),
   listAvailableYears,
 );
 

--- a/MJ_FB_Backend/src/schemas/admin/staffSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/admin/staffSchemas.ts
@@ -8,7 +8,6 @@ export const staffAccessEnum = z.enum([
   'admin',
   'donor_management',
   'payroll_management',
-  'aggregations',
 ]);
 
 export const createStaffSchema = z.object({

--- a/MJ_FB_Backend/tests/userController.test.ts
+++ b/MJ_FB_Backend/tests/userController.test.ts
@@ -977,7 +977,7 @@ describe('userController', () => {
             first_name: 'Staff',
             last_name: 'User',
             email: 'updated@example.com',
-            access: ['aggregations'],
+            access: ['donor_management'],
             consent: true,
           },
         ],
@@ -1003,7 +1003,7 @@ describe('userController', () => {
         phone: null,
         address: null,
         role: 'staff',
-        roles: ['aggregations'],
+        roles: ['donor_management'],
         consent: true,
       });
     });

--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -151,8 +151,7 @@ export default function App() {
   const showDonationLog = showWarehouse || showDonationEntry;
   const showAggregations =
     isStaff &&
-    (hasAccess('aggregations') ||
-      hasAccess('pantry') ||
+    (hasAccess('pantry') ||
       hasAccess('warehouse') ||
       hasAccess('donor_management'));
 

--- a/MJ_FB_Frontend/src/__tests__/StaffForm.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffForm.test.tsx
@@ -11,7 +11,6 @@ describe('StaffForm', () => {
     fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'Smith' } });
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@example.com' } });
     fireEvent.click(screen.getByLabelText(/pantry/i));
-    fireEvent.click(screen.getByLabelText(/aggregations/i));
     fireEvent.click(screen.getByRole('button', { name: /Add/i }));
 
     await waitFor(() =>
@@ -19,7 +18,7 @@ describe('StaffForm', () => {
         firstName: 'Alice',
         lastName: 'Smith',
         email: 'a@example.com',
-        access: ['pantry', 'aggregations'],
+        access: ['pantry'],
       }),
     );
     expect(screen.getByText(/email invitation/i)).toBeInTheDocument();
@@ -31,7 +30,7 @@ describe('StaffForm', () => {
       firstName: 'Jane',
       lastName: 'Doe',
       email: 'jane@example.com',
-      access: ['pantry', 'warehouse', 'aggregations'] as const,
+      access: ['pantry', 'warehouse'] as const,
     };
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(<StaffForm initial={initial} submitLabel="Save" onSubmit={onSubmit} />);
@@ -41,6 +40,5 @@ describe('StaffForm', () => {
     expect(screen.getByLabelText(/email/i)).toHaveValue('jane@example.com');
     expect(screen.getByLabelText(/pantry/i)).toBeChecked();
     expect(screen.getByLabelText(/warehouse/i)).toBeChecked();
-    expect(screen.getByLabelText(/aggregations/i)).toBeChecked();
   });
 });

--- a/MJ_FB_Frontend/src/__tests__/staffRootPath.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/staffRootPath.test.tsx
@@ -23,11 +23,6 @@ describe('getStaffRootPath', () => {
       description: 'single donor management access',
     },
     {
-      access: ['aggregations'],
-      expected: '/aggregations/pantry',
-      description: 'single aggregations access',
-    },
-    {
       access: ['volunteer_management'],
       expected: '/volunteer-management',
       description: 'single volunteer management access',

--- a/MJ_FB_Frontend/src/components/StaffForm.tsx
+++ b/MJ_FB_Frontend/src/components/StaffForm.tsx
@@ -143,15 +143,6 @@ export default function StaffForm({ initial, submitLabel, onSubmit }: StaffFormP
           }
           label="Payroll Management"
         />
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={access.includes('aggregations')}
-              onChange={() => toggleAccess('aggregations')}
-            />
-          }
-          label="Aggregations"
-        />
       </FormCard>
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
       <FeedbackSnackbar open={!!success} onClose={() => setSuccess('')} message={success} />

--- a/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/AdminStaffList.tsx
@@ -31,7 +31,6 @@ export default function AdminStaffList() {
     donor_management: 'Donor Management',
     payroll_management: 'Payroll Management',
     donation_entry: 'Donation Entry',
-    aggregations: 'Aggregations',
   };
 
   async function load() {

--- a/MJ_FB_Frontend/src/types.ts
+++ b/MJ_FB_Frontend/src/types.ts
@@ -8,8 +8,7 @@ export type StaffAccess =
   | 'admin'
   | 'donor_management'
   | 'payroll_management'
-  | 'donation_entry'
-  | 'aggregations';
+  | 'donation_entry';
 
 export interface DeliveryItem {
   id: number;

--- a/MJ_FB_Frontend/src/utils/staffRootPath.ts
+++ b/MJ_FB_Frontend/src/utils/staffRootPath.ts
@@ -7,7 +7,6 @@ export function getStaffRootPath(access: StaffAccess[]): string {
     if (first === 'volunteer_management') return '/volunteer-management';
     if (first === 'warehouse') return '/warehouse-management';
     if (first === 'donor_management') return '/donor-management';
-    if (first === 'aggregations') return '/aggregations/pantry';
   }
   return '/';
 }


### PR DESCRIPTION
## Summary
- remove the deprecated `aggregations` staff access option from frontend types, forms, navigation logic, and related tests
- update backend staff access typings, authorization guards, and validation to drop the `aggregations` role while keeping donor management access
- add a migration that recreates the `staff_access_check` constraint without the `aggregations` value

## Testing
- npm test -- --runTestsByPath src/__tests__/StaffForm.test.tsx src/__tests__/staffRootPath.test.tsx
- npm test -- userController.test.ts donationAggregationsAccess.test.ts pantryAggregationsAuth.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc407bebe4832db26dedda2f50ae30