### PR TITLE
Allow staff access to aggregation routes

### DIFF
--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -201,3 +201,18 @@ export function authorizeAccess(...allowed: string[]) {
     next();
   };
 }
+
+export function authorizeAccessOrStaff(...allowed: string[]) {
+  const accessCheck = authorizeAccess(...allowed);
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    if (req.user.type === 'staff') {
+      return next();
+    }
+
+    return accessCheck(req, res, next);
+  };
+}

--- a/MJ_FB_Backend/src/routes/pantry/aggregations.ts
+++ b/MJ_FB_Backend/src/routes/pantry/aggregations.ts
@@ -11,64 +11,71 @@ import {
   manualPantryAggregate,
   manualWeeklyPantryAggregate,
 } from '../../controllers/pantryAggregationController';
-import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware';
+import {
+  authMiddleware,
+  authorizeAccess,
+  authorizeAccessOrStaff as baseAuthorizeAccessOrStaff,
+} from '../../middleware/authMiddleware';
+
+const authorizeAggregationsAccess =
+  (baseAuthorizeAccessOrStaff as typeof authorizeAccess | undefined) ?? authorizeAccess;
 
 const router = Router();
 
 router.get(
   '/weekly',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   listWeeklyAggregations,
 );
 router.get(
   '/monthly',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   listMonthlyAggregations,
 );
 router.get(
   '/yearly',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   listYearlyAggregations,
 );
 router.get(
   '/years',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   listAvailableYears,
 );
 router.get(
   '/months',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   listAvailableMonths,
 );
 router.get(
   '/weeks',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   listAvailableWeeks,
 );
 router.get(
   '/export',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   exportAggregations,
 );
-router.post('/rebuild', authMiddleware, authorizeAccess('pantry', 'aggregations'), rebuildAggregations);
+router.post('/rebuild', authMiddleware, authorizeAggregationsAccess('pantry', 'aggregations'), rebuildAggregations);
 router.post(
   '/manual',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   // Body: { year, month, week?, orders?, adults?, children?, people?, weight? }
   manualPantryAggregate,
 );
 router.post(
   '/manual/weekly',
   authMiddleware,
-  authorizeAccess('pantry', 'aggregations'),
+  authorizeAggregationsAccess('pantry', 'aggregations'),
   // Body: { year, month, week, orders?, adults?, children?, people?, weight? }
   manualWeeklyPantryAggregate,
 );

--- a/MJ_FB_Backend/src/routes/warehouse/donations.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/donations.ts
@@ -8,7 +8,11 @@ import {
   exportDonorAggregations,
   manualDonorAggregation,
 } from '../../controllers/warehouse/donationController';
-import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware';
+import {
+  authMiddleware,
+  authorizeAccess,
+  authorizeAccessOrStaff as baseAuthorizeAccessOrStaff,
+} from '../../middleware/authMiddleware';
 import { validate } from '../../middleware/validate';
 import {
   addDonationSchema,
@@ -18,23 +22,26 @@ import {
 
 const router = Router();
 
+const authorizeWarehouseAccess =
+  (baseAuthorizeAccessOrStaff as typeof authorizeAccess | undefined) ?? authorizeAccess;
+
 router.get('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), listDonations);
 router.get(
   '/aggregations',
   authMiddleware,
-  authorizeAccess('warehouse', 'donation_entry', 'aggregations'),
+  authorizeWarehouseAccess('warehouse', 'donation_entry', 'aggregations'),
   donorAggregations,
 );
 router.get(
   '/aggregations/export',
   authMiddleware,
-  authorizeAccess('warehouse', 'donation_entry', 'aggregations'),
+  authorizeWarehouseAccess('warehouse', 'donation_entry', 'aggregations'),
   exportDonorAggregations,
 );
 router.post(
   '/aggregations/manual',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeWarehouseAccess('warehouse', 'aggregations'),
   validate(manualDonorAggregationSchema),
   manualDonorAggregation,
 );

--- a/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
@@ -6,38 +6,45 @@ import {
   listAvailableYears,
   manualWarehouseOverall,
 } from '../../controllers/warehouse/warehouseOverallController';
-import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware';
+import {
+  authMiddleware,
+  authorizeAccess,
+  authorizeAccessOrStaff as baseAuthorizeAccessOrStaff,
+} from '../../middleware/authMiddleware';
+
+const authorizeWarehouseAggregations =
+  (baseAuthorizeAccessOrStaff as typeof authorizeAccess | undefined) ?? authorizeAccess;
 
 const router = Router();
 
 router.get(
   '/',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeWarehouseAggregations('warehouse', 'aggregations'),
   listWarehouseOverall,
 );
 router.post(
   '/manual',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeWarehouseAggregations('warehouse', 'aggregations'),
   manualWarehouseOverall,
 );
 router.post(
   '/rebuild',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeWarehouseAggregations('warehouse', 'aggregations'),
   rebuildWarehouseOverall,
 );
 router.get(
   '/export',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeWarehouseAggregations('warehouse', 'aggregations'),
   exportWarehouseOverall,
 );
 router.get(
   '/years',
   authMiddleware,
-  authorizeAccess('warehouse', 'aggregations'),
+  authorizeWarehouseAggregations('warehouse', 'aggregations'),
   listAvailableYears,
 );
 

--- a/MJ_FB_Backend/tests/aggregationsStaffAccess.test.ts
+++ b/MJ_FB_Backend/tests/aggregationsStaffAccess.test.ts
@@ -1,0 +1,105 @@
+import request from 'supertest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import pool from '../src/db';
+import pantryAggregationsRoutes from '../src/routes/pantry/aggregations';
+import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';
+import donationsRoutes from '../src/routes/warehouse/donations';
+import './utils/mockDb';
+
+jest.mock('jsonwebtoken');
+
+jest.mock('../src/controllers/pantryAggregationController', () => ({
+  listWeeklyAggregations: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  listMonthlyAggregations: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  listYearlyAggregations: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  listAvailableYears: (_req: express.Request, res: express.Response) => res.json({ years: [] }),
+  listAvailableMonths: (_req: express.Request, res: express.Response) => res.json({ months: [] }),
+  listAvailableWeeks: (_req: express.Request, res: express.Response) => res.json({ weeks: [] }),
+  exportAggregations: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  rebuildAggregations: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  manualPantryAggregate: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  manualWeeklyPantryAggregate: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+}));
+
+jest.mock('../src/controllers/warehouse/warehouseOverallController', () => ({
+  listWarehouseOverall: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  rebuildWarehouseOverall: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  exportWarehouseOverall: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  listAvailableYears: (_req: express.Request, res: express.Response) => res.json({ years: [] }),
+  manualWarehouseOverall: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+}));
+
+jest.mock('../src/controllers/warehouse/donationController', () => ({
+  listDonations: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  addDonation: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  updateDonation: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  deleteDonation: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  donorAggregations: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  exportDonorAggregations: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+  manualDonorAggregation: (_req: express.Request, res: express.Response) => res.json({ ok: true }),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/pantry-aggregations', pantryAggregationsRoutes);
+app.use('/warehouse-overall', warehouseOverallRoutes);
+app.use('/donations', donationsRoutes);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'test';
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (pool.query as jest.Mock).mockResolvedValue({
+    rowCount: 1,
+    rows: [
+      {
+        id: 1,
+        first_name: 'Staff',
+        last_name: 'Member',
+        email: 'staff@example.com',
+        role: 'staff',
+      },
+    ],
+  });
+  (jwt.verify as jest.Mock).mockReturnValue({ id: 1, type: 'staff', role: 'staff' });
+});
+
+describe('aggregations access for staff', () => {
+  it('allows staff without explicit pantry access to view pantry aggregations', async () => {
+    const res = await request(app)
+      .get('/pantry-aggregations/weekly?year=2024')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+  });
+
+  it('allows staff without explicit warehouse access to view warehouse overall aggregations', async () => {
+    const res = await request(app)
+      .get('/warehouse-overall/?year=2024')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+  });
+
+  it('allows staff without explicit donation access to view donor aggregations', async () => {
+    const res = await request(app)
+      .get('/donations/aggregations?year=2024')
+      .set('Authorization', 'Bearer token');
+    expect(res.status).toBe(200);
+  });
+
+  it('allows staff to submit manual donor aggregations', async () => {
+    const res = await request(app)
+      .post('/donations/aggregations/manual')
+      .set('Authorization', 'Bearer token')
+      .send({ year: 2024, month: 1, donorId: 10, total: 5 });
+    expect(res.status).toBe(200);
+  });
+
+  it('still rejects unauthenticated requests', async () => {
+    (jwt.verify as jest.Mock).mockReset();
+    const res = await request(app).get('/pantry-aggregations/weekly?year=2024');
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add authorizeAccessOrStaff middleware to let authenticated staff bypass area-based access checks without affecting volunteer donation permissions
- apply the shared guard to pantry and warehouse aggregation routes, including donor aggregation export and manual insert paths
- add regression tests that ensure staff tokens without pantry/warehouse access are accepted while anonymous calls remain unauthorized

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc408f21d8832da255fb8fa9288219