### PR TITLE
Update docs for universal aggregations access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@
 - Admin settings include a Donor tab for managing test email addresses used when sending donor mail lists.
 - Donor donation log allows editing, deleting, and searching recorded donations by donor email, name, or amount.
 - Donor Management → Donors lists existing donors and lets staff edit donor details.
-- Aggregations pages are accessible to staff with aggregations or donor_management access.
+- Aggregations pages are accessible to all staff accounts; donor_management staff continue to see donor tools within those views.
 
 See `MJ_FB_Backend/AGENTS.md` for backend-specific guidance and `MJ_FB_Frontend/AGENTS.md` for frontend-specific guidance.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Staff dashboards include a Volunteer Coverage card; click a role to see which volunteers are on duty.
 - Staff dashboard charts pull pantry monthly aggregates to show total orders and adult/child breakdowns.
 
-- Staff with `aggregations` or `donor_management` access see an **Aggregations** navigation item with **Food Bank Trends**, **Pantry Aggregations**, and **Warehouse Aggregations** pages for reporting. Food Bank Trends consolidates pantry and warehouse metrics for staff who do not have direct access to those tools.
+- All staff accounts see an **Aggregations** navigation item with **Food Bank Trends**, **Pantry Aggregations**, and **Warehouse Aggregations** pages for reporting by default. Food Bank Trends consolidates pantry and warehouse metrics for staff who do not have direct access to those tools, while staff with `donor_management` access continue to manage donor exports from these views.
 
 Staff can reach **Timesheets** at `/timesheet` and **Leave Management** at
 `/leave-requests` from the profile menu once logged in. Admin users also see
@@ -58,8 +58,9 @@ Staff accounts may include any of the following access roles:
 - `admin`
 - `donor_management`
 - `payroll_management`
-- `aggregations`
 - `donation_entry` – volunteer-only access for the warehouse donation log
+
+All staff accounts automatically include aggregations access, so there is no separate `aggregations` role to manage.
 
 This repository uses Git submodules for the backend and frontend components. After cloning, pull in the submodules and install their dependencies.
 

--- a/docs/warehouseAggregations.md
+++ b/docs/warehouseAggregations.md
@@ -1,5 +1,5 @@
 # Warehouse Aggregations
 
-The Warehouse Aggregations page shows donor totals and yearly overall statistics for the warehouse. Staff with `aggregations` or `donor_management` access can also open **Aggregations → Food Bank Trends** for a consolidated view of pantry and warehouse metrics when they do not have direct access to those individual tools.
+The Warehouse Aggregations page shows donor totals and yearly overall statistics for the warehouse. All staff accounts can open **Aggregations → Food Bank Trends** for a consolidated view of pantry and warehouse metrics when they do not have direct access to those individual tools, and staff with `donor_management` access continue to manage donor exports from these views.
 Staff can use the **Insert Aggregate** button on the Donor tab to manually add or update monthly totals for a donor, and the same button on the Yearly Overall tab to edit overall monthly totals.
 


### PR DESCRIPTION
## Summary
- note in AGENTS.md that aggregations pages are now reachable by all staff members
- document the default aggregations navigation in the README and drop the obsolete role entry
- refresh the warehouse aggregations guide to describe the new access policy

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cc46b6b5e0832d8ac4f1bcbf8d51cb