### PR TITLE
Allow staff to bypass aggregation access guards

### DIFF
--- a/MJ_FB_Backend/src/routes/pantry/aggregations.ts
+++ b/MJ_FB_Backend/src/routes/pantry/aggregations.ts
@@ -11,69 +11,71 @@ import {
   manualPantryAggregate,
   manualWeeklyPantryAggregate,
 } from '../../controllers/pantryAggregationController';
-import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess, authorizeStaffOrAccess } from '../../middleware/authMiddleware';
+
+const staffOrAccess = authorizeStaffOrAccess ?? authorizeAccess;
 
 const router = Router();
 
 router.get(
   '/weekly',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   listWeeklyAggregations,
 );
 router.get(
   '/monthly',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   listMonthlyAggregations,
 );
 router.get(
   '/yearly',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   listYearlyAggregations,
 );
 router.get(
   '/years',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   listAvailableYears,
 );
 router.get(
   '/months',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   listAvailableMonths,
 );
 router.get(
   '/weeks',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   listAvailableWeeks,
 );
 router.get(
   '/export',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   exportAggregations,
 );
 router.post(
   '/rebuild',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   rebuildAggregations,
 );
 router.post(
   '/manual',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   // Body: { year, month, week?, orders?, adults?, children?, people?, weight? }
   manualPantryAggregate,
 );
 router.post(
   '/manual/weekly',
   authMiddleware,
-  authorizeAccess('pantry', 'warehouse', 'donor_management'),
+  staffOrAccess('pantry', 'warehouse', 'donor_management'),
   // Body: { year, month, week, orders?, adults?, children?, people?, weight? }
   manualWeeklyPantryAggregate,
 );

--- a/MJ_FB_Backend/src/routes/warehouse/donations.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/donations.ts
@@ -8,7 +8,7 @@ import {
   exportDonorAggregations,
   manualDonorAggregation,
 } from '../../controllers/warehouse/donationController';
-import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess, authorizeStaffOrAccess } from '../../middleware/authMiddleware';
 import { validate } from '../../middleware/validate';
 import {
   addDonationSchema,
@@ -18,23 +18,25 @@ import {
 
 const router = Router();
 
+const staffOrAccess = authorizeStaffOrAccess ?? authorizeAccess;
+
 router.get('/', authMiddleware, authorizeAccess('warehouse', 'donation_entry'), listDonations);
 router.get(
   '/aggregations',
   authMiddleware,
-  authorizeAccess('warehouse', 'donation_entry', 'donor_management'),
+  staffOrAccess('warehouse', 'donation_entry', 'donor_management'),
   donorAggregations,
 );
 router.get(
   '/aggregations/export',
   authMiddleware,
-  authorizeAccess('warehouse', 'donation_entry', 'donor_management'),
+  staffOrAccess('warehouse', 'donation_entry', 'donor_management'),
   exportDonorAggregations,
 );
 router.post(
   '/aggregations/manual',
   authMiddleware,
-  authorizeAccess('warehouse', 'donor_management'),
+  staffOrAccess('warehouse', 'donor_management'),
   validate(manualDonorAggregationSchema),
   manualDonorAggregation,
 );

--- a/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
+++ b/MJ_FB_Backend/src/routes/warehouse/warehouseOverall.ts
@@ -6,38 +6,40 @@ import {
   listAvailableYears,
   manualWarehouseOverall,
 } from '../../controllers/warehouse/warehouseOverallController';
-import { authMiddleware, authorizeAccess } from '../../middleware/authMiddleware';
+import { authMiddleware, authorizeAccess, authorizeStaffOrAccess } from '../../middleware/authMiddleware';
+
+const staffOrAccess = authorizeStaffOrAccess ?? authorizeAccess;
 
 const router = Router();
 
 router.get(
   '/',
   authMiddleware,
-  authorizeAccess('warehouse', 'donor_management'),
+  staffOrAccess('warehouse', 'donor_management'),
   listWarehouseOverall,
 );
 router.post(
   '/manual',
   authMiddleware,
-  authorizeAccess('warehouse', 'donor_management'),
+  staffOrAccess('warehouse', 'donor_management'),
   manualWarehouseOverall,
 );
 router.post(
   '/rebuild',
   authMiddleware,
-  authorizeAccess('warehouse', 'donor_management'),
+  staffOrAccess('warehouse', 'donor_management'),
   rebuildWarehouseOverall,
 );
 router.get(
   '/export',
   authMiddleware,
-  authorizeAccess('warehouse', 'donor_management'),
+  staffOrAccess('warehouse', 'donor_management'),
   exportWarehouseOverall,
 );
 router.get(
   '/years',
   authMiddleware,
-  authorizeAccess('warehouse', 'donor_management'),
+  staffOrAccess('warehouse', 'donor_management'),
   listAvailableYears,
 );
 

--- a/MJ_FB_Backend/tests/donationAggregationsAccess.test.ts
+++ b/MJ_FB_Backend/tests/donationAggregationsAccess.test.ts
@@ -1,9 +1,47 @@
 import request from 'supertest';
 import express from 'express';
+import jwt from 'jsonwebtoken';
 import donationsRoutes from '../src/routes/warehouse/donations';
+import pool from '../src/db';
+import './utils/mockDb';
+
+jest.mock('jsonwebtoken');
+
+jest.mock('../src/controllers/warehouse/donationController', () => ({
+  listDonations: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  addDonation: (_req: express.Request, res: express.Response) => res.status(201).json({ id: 1 }),
+  updateDonation: (_req: express.Request, res: express.Response) => res.status(200).json({}),
+  deleteDonation: (_req: express.Request, res: express.Response) => res.status(200).json({}),
+  donorAggregations: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  exportDonorAggregations: (_req: express.Request, res: express.Response) => res.status(200).send('ok'),
+  manualDonorAggregation: (_req: express.Request, res: express.Response) => res.status(200).json({}),
+}));
 
 const app = express();
+app.use(express.json());
 app.use('/donations', donationsRoutes);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+beforeEach(() => {
+  (jwt.verify as jest.Mock).mockReset();
+  (pool.query as jest.Mock).mockReset();
+  (pool.query as jest.Mock).mockResolvedValue({
+    rowCount: 1,
+    rows: [
+      {
+        id: 1,
+        first_name: 'Test',
+        last_name: 'Staff',
+        email: 'staff@example.com',
+        role: 'staff',
+      },
+    ],
+  });
+});
 const year = new Date().getFullYear();
 
 describe('donation aggregations auth', () => {
@@ -20,5 +58,26 @@ describe('donation aggregations auth', () => {
   it('requires auth for manual insert', async () => {
     const res = await request(app).post('/donations/aggregations/manual');
     expect(res.status).toBe(401);
+  });
+
+  it('allows staff without warehouse access to view donation aggregations', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff', access: [] });
+
+    const res = await request(app)
+      .get(`/donations/aggregations?year=${year}`)
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('allows staff without warehouse access to insert manual aggregations', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff', access: [] });
+
+    const res = await request(app)
+      .post('/donations/aggregations/manual')
+      .set('Authorization', 'Bearer token')
+      .send({ year, month: 1, donorId: 1, total: 0 });
+
+    expect(res.status).toBe(200);
   });
 });

--- a/MJ_FB_Backend/tests/pantryAggregationsAuth.test.ts
+++ b/MJ_FB_Backend/tests/pantryAggregationsAuth.test.ts
@@ -1,10 +1,50 @@
 import request from 'supertest';
 import express from 'express';
+import jwt from 'jsonwebtoken';
 import pantryAggregationsRoutes from '../src/routes/pantry/aggregations';
+import pool from '../src/db';
+import './utils/mockDb';
+
+jest.mock('jsonwebtoken');
+
+jest.mock('../src/controllers/pantryAggregationController', () => ({
+  listWeeklyAggregations: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  listMonthlyAggregations: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  listYearlyAggregations: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  listAvailableYears: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  listAvailableMonths: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  listAvailableWeeks: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  exportAggregations: (_req: express.Request, res: express.Response) => res.status(200).send('ok'),
+  rebuildAggregations: (_req: express.Request, res: express.Response) => res.status(200).json({}),
+  manualPantryAggregate: (_req: express.Request, res: express.Response) => res.status(200).json({}),
+  manualWeeklyPantryAggregate: (_req: express.Request, res: express.Response) => res.status(200).json({}),
+}));
 
 const app = express();
 app.use(express.json());
 app.use('/pantry-aggregations', pantryAggregationsRoutes);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+beforeEach(() => {
+  (jwt.verify as jest.Mock).mockReset();
+  (pool.query as jest.Mock).mockReset();
+  (pool.query as jest.Mock).mockResolvedValue({
+    rowCount: 1,
+    rows: [
+      {
+        id: 1,
+        first_name: 'Test',
+        last_name: 'Staff',
+        email: 'staff@example.com',
+        role: 'staff',
+      },
+    ],
+  });
+});
 
 describe('pantry aggregations auth', () => {
   it('requires auth for weekly aggregations', async () => {
@@ -34,5 +74,15 @@ describe('pantry aggregations auth', () => {
   it('requires auth for manual weekly aggregate', async () => {
     const res = await request(app).post('/pantry-aggregations/manual/weekly');
     expect(res.status).toBe(401);
+  });
+
+  it('allows staff without aggregations access to view weekly data', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff', access: [] });
+
+    const res = await request(app)
+      .get('/pantry-aggregations/weekly')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
   });
 });

--- a/MJ_FB_Backend/tests/warehouseOverallAuth.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallAuth.test.ts
@@ -1,9 +1,44 @@
 import request from 'supertest';
 import express from 'express';
+import jwt from 'jsonwebtoken';
 import warehouseOverallRoutes from '../src/routes/warehouse/warehouseOverall';
+import pool from '../src/db';
+import './utils/mockDb';
+
+jest.mock('jsonwebtoken');
+
+jest.mock('../src/controllers/warehouse/warehouseOverallController', () => ({
+  listWarehouseOverall: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  rebuildWarehouseOverall: (_req: express.Request, res: express.Response) => res.status(200).json({}),
+  exportWarehouseOverall: (_req: express.Request, res: express.Response) => res.status(200).send('ok'),
+  listAvailableYears: (_req: express.Request, res: express.Response) => res.status(200).json([]),
+  manualWarehouseOverall: (_req: express.Request, res: express.Response) => res.status(200).json({}),
+}));
 
 const app = express();
 app.use('/warehouse-overall', warehouseOverallRoutes);
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_REFRESH_SECRET = 'testrefreshsecret';
+});
+
+beforeEach(() => {
+  (jwt.verify as jest.Mock).mockReset();
+  (pool.query as jest.Mock).mockReset();
+  (pool.query as jest.Mock).mockResolvedValue({
+    rowCount: 1,
+    rows: [
+      {
+        id: 1,
+        first_name: 'Test',
+        last_name: 'Staff',
+        email: 'staff@example.com',
+        role: 'staff',
+      },
+    ],
+  });
+});
 
 describe('warehouse overall auth', () => {
   it('requires auth for list', async () => {
@@ -19,5 +54,15 @@ describe('warehouse overall auth', () => {
   it('requires auth for years', async () => {
     const res = await request(app).get('/warehouse-overall/years');
     expect(res.status).toBe(401);
+  });
+
+  it('allows staff without warehouse access to read overall stats', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ id: 1, role: 'staff', type: 'staff', access: [] });
+
+    const res = await request(app)
+      .get('/warehouse-overall')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- add `authorizeStaffOrAccess` middleware so authenticated staff skip per-area access checks while other roles still require matching access flags
- update pantry and warehouse aggregation routes to use the new guard with a fallback to existing access guards for legacy mocks
- expand aggregation authorization tests to cover staff tokens and ensure unauthenticated calls remain blocked

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc45f31698832d9aebcd4b1ed68ec1