### PR TITLE
Fix duplicate donor API update export

### DIFF
--- a/MJ_FB_Frontend/src/api/donors.ts
+++ b/MJ_FB_Frontend/src/api/donors.ts
@@ -51,6 +51,11 @@ export async function createDonor(data: DonorPayload): Promise<Donor> {
   return handleResponse(res);
 }
 
+export async function getDonor(id: number): Promise<DonorDetail> {
+  const res = await apiFetch(`${API_BASE}/donors/${id}`);
+  return handleResponse(res);
+}
+
 export async function updateDonor(
   id: number,
   data: DonorPayload,
@@ -61,28 +66,6 @@ export async function updateDonor(
     body: JSON.stringify(data),
   });
   return handleResponse(res);
-}
-
-export async function getDonor(id: number): Promise<DonorDetail> {
-  const res = await apiFetch(`${API_BASE}/donors/${id}`);
-  return handleResponse(res);
-}
-
-export async function updateDonor(
-  id: number,
-  data: {
-    firstName: string;
-    lastName: string;
-    email?: string;
-    phone?: string;
-  },
-): Promise<void> {
-  const res = await apiFetch(`${API_BASE}/donors/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-  await handleResponse(res);
 }
 
 export async function getDonorDonations(


### PR DESCRIPTION
## Summary
- remove the duplicated donor update export by reusing the shared payload type

## Testing
- npm test -- --runTestsByPath src/api/__tests__/monetaryDonorsApi.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc4b4fa17c832da2ee2990e4df310d