### PR TITLE
Add donor management test coverage for updated payloads

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
@@ -136,9 +136,13 @@ describe('Aggregations page', () => {
 
     fireEvent.change(screen.getByLabelText(/month/i), { target: { value: '5' } });
     const donorInput = screen.getByRole('combobox', { name: /donor/i });
-    fireEvent.change(donorInput, { target: { value: 'Jane' } });
+    fireEvent.change(donorInput, { target: { value: '42' } });
 
-    const option = await screen.findByRole('option', { name: /jane doe/i });
+    await waitFor(() => expect(mockGetDonors).toHaveBeenCalledWith('42'));
+
+    const option = await screen.findByRole('option', {
+      name: /jane doe \(306-555-0100\)/i,
+    });
     fireEvent.click(option);
     fireEvent.change(screen.getByLabelText(/total/i), { target: { value: '100' } });
 
@@ -153,6 +157,19 @@ describe('Aggregations page', () => {
       }),
     );
     await waitFor(() => expect(mockGetDonorAggregations).toHaveBeenCalledTimes(2));
+  });
+
+  it('searches donors by ID when inserting donor aggregate', async () => {
+    render(<Aggregations />);
+
+    await waitFor(() => expect(mockGetDonorAggregations).toHaveBeenCalled());
+
+    fireEvent.click(await screen.findByRole('button', { name: /insert aggregate/i }));
+
+    const donorInput = screen.getByRole('combobox', { name: /donor/i });
+    fireEvent.change(donorInput, { target: { value: '007' } });
+
+    await waitFor(() => expect(mockGetDonors).toHaveBeenCalledWith('007'));
   });
 });
 

--- a/MJ_FB_Frontend/src/__tests__/FoodBankTrends.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/FoodBankTrends.test.tsx
@@ -79,6 +79,7 @@ describe('FoodBankTrends page', () => {
         firstName: 'Donor',
         lastName: 'One',
         email: 'donor@example.com',
+        phone: null,
         totalLbs: 420,
         lastDonationISO: '2024-04-01T12:00:00Z',
       },

--- a/MJ_FB_Frontend/src/__tests__/WarehouseDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/WarehouseDashboard.test.tsx
@@ -1,0 +1,124 @@
+import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
+import WarehouseDashboard from '../pages/warehouse-management/WarehouseDashboard';
+
+const navigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => navigate,
+}));
+
+const mockGetWarehouseOverall = jest.fn();
+const mockGetWarehouseOverallYears = jest.fn();
+const mockGetTopDonors = jest.fn();
+const mockGetTopReceivers = jest.fn();
+const mockGetEvents = jest.fn();
+const mockGetDonors = jest.fn();
+
+jest.mock('../api/warehouseOverall', () => ({
+  getWarehouseOverall: (...args: unknown[]) => mockGetWarehouseOverall(...args),
+  getWarehouseOverallYears: (...args: unknown[]) =>
+    mockGetWarehouseOverallYears(...args),
+}));
+
+jest.mock('../api/donors', () => ({
+  getTopDonors: (...args: unknown[]) => mockGetTopDonors(...args),
+  getDonors: (...args: unknown[]) => mockGetDonors(...args),
+}));
+
+jest.mock('../api/outgoingReceivers', () => ({
+  getTopReceivers: (...args: unknown[]) => mockGetTopReceivers(...args),
+}));
+
+jest.mock('../api/events', () => ({
+  getEvents: (...args: unknown[]) => mockGetEvents(...args),
+}));
+
+jest.mock('../components/dashboard/VolunteerCoverageCard', () => () => (
+  <div>Coverage</div>
+));
+jest.mock('../components/EventList', () => () => <div>Events</div>);
+jest.mock('../components/WarehouseQuickLinks', () => () => <div />);
+
+describe('WarehouseDashboard', () => {
+  const donors = [
+    {
+      id: 42,
+      firstName: 'Alice',
+      lastName: 'Donor',
+      email: null,
+      phone: '306-555-0100',
+      totalLbs: 1200,
+      lastDonationISO: '2024-04-01T12:00:00Z',
+    },
+    {
+      id: 99,
+      firstName: 'Bob',
+      lastName: 'Helper',
+      email: null,
+      phone: null,
+      totalLbs: 600,
+      lastDonationISO: '2024-03-01T12:00:00Z',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetWarehouseOverallYears.mockResolvedValue([2024]);
+    mockGetWarehouseOverall.mockResolvedValue([
+      { month: 1, donations: 100, surplus: 20, pigPound: 10, outgoingDonations: 50 },
+    ]);
+    mockGetTopDonors.mockResolvedValue(donors);
+    mockGetTopReceivers.mockResolvedValue([
+      { name: 'Community Partner', totalLbs: 900, lastPickupISO: '2024-04-15T12:00:00Z' },
+    ]);
+    mockGetEvents.mockResolvedValue({ today: [], upcoming: [], past: [] });
+    mockGetDonors.mockResolvedValue(donors);
+  });
+
+  function renderDashboard() {
+    return renderWithProviders(
+      <MemoryRouter>
+        <WarehouseDashboard />
+      </MemoryRouter>,
+    );
+  }
+
+  it('filters donors by ID search and navigates to the selected donor profile', async () => {
+    renderDashboard();
+
+    await waitFor(() => expect(mockGetWarehouseOverallYears).toHaveBeenCalled());
+
+    const searchInput = await screen.findByPlaceholderText(/find donor\/receiver/i);
+    await userEvent.type(searchInput, '42');
+
+    await waitFor(() => expect(mockGetDonors).toHaveBeenCalledWith('42'));
+
+    const option = await screen.findByText('Alice Donor (ID 42 • 306-555-0100)');
+    fireEvent.click(option);
+
+    expect(navigate).toHaveBeenCalledWith('/warehouse-management/donors/42');
+  });
+
+  it('shows donor autocomplete options without phone numbers and filters donor cards by phone', async () => {
+    renderDashboard();
+
+    const searchInput = await screen.findByPlaceholderText(/find donor\/receiver/i);
+
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    expect(await screen.findByText('Bob Helper (ID 99)')).toBeInTheDocument();
+
+    await userEvent.clear(searchInput);
+    await userEvent.type(searchInput, '555');
+
+    await waitFor(() => expect(mockGetDonors).toHaveBeenCalledWith('555'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Donor')).toBeInTheDocument();
+      expect(screen.queryByText('Bob Helper')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/WarehouseDonationLog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/WarehouseDonationLog.test.tsx
@@ -1,0 +1,174 @@
+import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
+import DonationLog from '../pages/warehouse-management/DonationLog';
+import {
+  getDonors,
+  createDonor,
+} from '../api/donors';
+import {
+  getDonationsByMonth,
+  createDonation,
+  updateDonation,
+  deleteDonation,
+} from '../api/donations';
+
+jest.mock('../components/WarehouseQuickLinks', () => () => <div />);
+
+jest.mock('../api/donors', () => ({
+  getDonors: jest.fn(),
+  createDonor: jest.fn(),
+}));
+
+jest.mock('../api/donations', () => ({
+  getDonationsByMonth: jest.fn(),
+  createDonation: jest.fn(),
+  updateDonation: jest.fn(),
+  deleteDonation: jest.fn(),
+}));
+
+describe('Warehouse Donation Log', () => {
+  let dateNowSpy: jest.SpyInstance<number, []>;
+  beforeEach(() => {
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(new Date('2024-05-15T12:00:00Z').getTime());
+    (getDonors as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        firstName: 'No',
+        lastName: 'Email',
+        email: null,
+        phone: null,
+      },
+      {
+        id: 2,
+        firstName: 'Jane',
+        lastName: 'Donor',
+        email: 'jane@example.com',
+        phone: '306-555-0199',
+      },
+    ]);
+    (getDonationsByMonth as jest.Mock).mockResolvedValue([
+      {
+        id: 10,
+        date: '2024-05-03',
+        donorId: 1,
+        donor: {
+          firstName: 'No',
+          lastName: 'Email',
+          email: null,
+          phone: null,
+        },
+        weight: 120,
+      },
+    ]);
+    (createDonation as jest.Mock).mockResolvedValue({});
+    (updateDonation as jest.Mock).mockResolvedValue({});
+    (deleteDonation as jest.Mock).mockResolvedValue({});
+    (createDonor as jest.Mock).mockResolvedValue({
+      id: 3,
+      firstName: 'Added',
+      lastName: 'Donor',
+      email: null,
+      phone: '306-555-0123',
+    });
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  function renderLog() {
+    return renderWithProviders(
+      <MemoryRouter>
+        <DonationLog />
+      </MemoryRouter>,
+    );
+  }
+
+  it('lists donations with donor fallback contact info', async () => {
+    renderLog();
+
+    expect(await screen.findByText('No Email (ID: 1)')).toBeInTheDocument();
+    expect(screen.getByText('120 lbs')).toBeInTheDocument();
+  });
+
+  it('records a donation by selecting a donor with an ID search', async () => {
+    renderLog();
+
+    await screen.findByText('Record Donation');
+    const monthInput = screen.getByLabelText(/month/i) as HTMLInputElement;
+    const expectedDate = `${monthInput.value}-01`;
+    fireEvent.click(screen.getByRole('button', { name: /record donation/i }));
+
+    const donorInput = screen.getByLabelText(/donor \(search by name or id\)/i);
+    fireEvent.change(donorInput, { target: { value: '2' } });
+
+    await waitFor(() => expect(getDonors).toHaveBeenCalledWith('2'));
+
+    const option = await screen.findByText('Jane Donor (ID: 2) • 306-555-0199');
+    fireEvent.click(option);
+
+    const weightInput = screen.getByLabelText(/weight \(lbs\)/i);
+    fireEvent.change(weightInput, { target: { value: '75' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(createDonation).toHaveBeenCalledWith({
+        date: expectedDate,
+        donorId: 2,
+        weight: 75,
+      }),
+    );
+    await waitFor(() => expect(getDonationsByMonth).toHaveBeenCalledTimes(2));
+  });
+
+  it('edits a donation and updates the existing record', async () => {
+    renderLog();
+
+    await screen.findByLabelText('Edit donation');
+    fireEvent.click(screen.getByLabelText('Edit donation'));
+
+    const weightInput = screen.getByLabelText(/weight \(lbs\)/i);
+    fireEvent.change(weightInput, { target: { value: '180' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(updateDonation).toHaveBeenCalledWith(10, {
+        date: '2024-05-03',
+        donorId: 1,
+        weight: 180,
+      }),
+    );
+  });
+
+  it('adds a donor with optional phone details', async () => {
+    renderLog();
+
+    fireEvent.click(screen.getByRole('button', { name: /add donor/i }));
+
+    const firstName = screen.getByLabelText(/first name/i);
+    const lastName = screen.getByLabelText(/last name/i);
+    const phone = screen.getByLabelText(/phone/i);
+
+    await userEvent.type(firstName, ' Added ');
+    await userEvent.type(lastName, ' Donor ');
+    await userEvent.type(phone, ' 306-555-0123 ');
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(createDonor).toHaveBeenCalledWith({
+        firstName: 'Added',
+        lastName: 'Donor',
+        email: null,
+        phone: '306-555-0123',
+      }),
+    );
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/WarehouseDonorProfile.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/WarehouseDonorProfile.test.tsx
@@ -1,0 +1,124 @@
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../testUtils/renderWithProviders';
+import DonorProfile from '../pages/warehouse-management/DonorProfile';
+import {
+  getDonor,
+  getDonorDonations,
+  updateDonor,
+} from '../api/donors';
+
+jest.mock('../components/WarehouseQuickLinks', () => () => <div />);
+
+jest.mock('../api/donors', () => ({
+  getDonor: jest.fn(),
+  getDonorDonations: jest.fn(),
+  updateDonor: jest.fn(),
+}));
+
+describe('Warehouse Donor Profile', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function renderProfile() {
+    return renderWithProviders(
+      <MemoryRouter initialEntries={["/warehouse-management/donors/42"]}>
+        <Routes>
+          <Route path="/warehouse-management/donors/:id" element={<DonorProfile />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('shows fallback contact information when email or phone are missing', async () => {
+    (getDonor as jest.Mock).mockResolvedValue({
+      id: 42,
+      firstName: 'No',
+      lastName: 'Contact',
+      email: null,
+      phone: null,
+      totalLbs: 540,
+      lastDonationISO: null,
+    });
+    (getDonorDonations as jest.Mock).mockResolvedValue([
+      { id: 1, date: '2024-04-01', weight: 120 },
+    ]);
+
+    renderProfile();
+
+    expect(await screen.findByText('No Contact')).toBeInTheDocument();
+    expect(screen.getByText('Email: Email not provided')).toBeInTheDocument();
+    expect(screen.getByText('Phone: Phone not provided')).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '120' })).toBeInTheDocument();
+  });
+
+  it('validates edit form fields and saves trimmed phone numbers', async () => {
+    (getDonor as jest.Mock)
+      .mockResolvedValueOnce({
+        id: 42,
+        firstName: 'Alice',
+        lastName: 'Donor',
+        email: 'alice@example.com',
+        phone: null,
+        totalLbs: 800,
+        lastDonationISO: '2024-04-10T12:00:00Z',
+      })
+      .mockResolvedValueOnce({
+        id: 42,
+        firstName: 'Alicia',
+        lastName: 'Donor',
+        email: null,
+        phone: '306-555-0100',
+        totalLbs: 800,
+        lastDonationISO: '2024-04-10T12:00:00Z',
+      });
+    (getDonorDonations as jest.Mock).mockResolvedValue([]);
+    (updateDonor as jest.Mock).mockResolvedValue({});
+
+    renderProfile();
+
+    const editButton = await screen.findByRole('button', { name: /edit/i });
+    await userEvent.click(editButton);
+
+    const firstName = screen.getByLabelText(/first name/i);
+    const lastName = screen.getByLabelText(/last name/i);
+    const email = screen.getByLabelText(/email \(optional\)/i);
+    const phone = screen.getByLabelText(/phone \(optional\)/i);
+    const save = screen.getByRole('button', { name: /save donor/i });
+
+    await userEvent.clear(firstName);
+    await userEvent.clear(lastName);
+    await userEvent.click(save);
+
+    expect(screen.getByText('First name is required')).toBeInTheDocument();
+    expect(screen.getByText('Last name is required')).toBeInTheDocument();
+    expect(updateDonor).not.toHaveBeenCalled();
+
+    await userEvent.type(firstName, ' Alicia ');
+    await userEvent.type(lastName, ' Donor ');
+    await userEvent.clear(email);
+    await userEvent.type(email, 'invalid');
+    await userEvent.click(save);
+
+    expect(screen.getByText('Enter a valid email')).toBeInTheDocument();
+    expect(updateDonor).not.toHaveBeenCalled();
+
+    await userEvent.clear(email);
+    await userEvent.type(email, '   ');
+    await userEvent.type(phone, ' 306-555-0100 ');
+    await userEvent.click(save);
+
+    await waitFor(() =>
+      expect(updateDonor).toHaveBeenCalledWith(42, {
+        firstName: 'Alicia',
+        lastName: 'Donor',
+        email: undefined,
+        phone: '306-555-0100',
+      }),
+    );
+
+    await waitFor(() => expect(getDonor).toHaveBeenCalledTimes(2));
+  });
+});

--- a/MJ_FB_Frontend/src/__tests__/donorsApi.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/donorsApi.test.tsx
@@ -1,0 +1,39 @@
+import { apiFetch, handleResponse } from '../api/client';
+import { updateDonor } from '../api/donors';
+
+jest.mock('../api/client', () => ({
+  API_BASE: '/api/v1',
+  apiFetch: jest.fn(),
+  handleResponse: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('donors api', () => {
+  beforeEach(() => {
+    (apiFetch as jest.Mock).mockResolvedValue(new Response(null));
+    jest.clearAllMocks();
+  });
+
+  it('updates a donor with optional contact information', async () => {
+    await updateDonor(7, {
+      firstName: 'Alice',
+      lastName: 'Helper',
+      email: 'alice@example.com',
+      phone: '306-555-0100',
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/v1/donors/7',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: 'Alice',
+          lastName: 'Helper',
+          email: 'alice@example.com',
+          phone: '306-555-0100',
+        }),
+      }),
+    );
+    expect(handleResponse).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- update the Aggregations tests to search for donors by ID and assert the new donor display payload
- add donation log, dashboard, and profile tests that cover donor fallbacks, optional phone fields, and edit flows
- exercise the donors API `updateDonor` payload and align existing mocks with nullable email/optional phone

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cc4a6ace90832d87a0e07e74a63746