### PR TITLE
Add FormDialog helper and standardize dialog widths

### DIFF
--- a/MJ_FB_Frontend/src/components/BookingManagementBase.tsx
+++ b/MJ_FB_Frontend/src/components/BookingManagementBase.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -25,6 +24,7 @@ import getApiErrorMessage from '../utils/getApiErrorMessage';
 import { formatReginaDate, toDayjs, toDate } from '../utils/date';
 import { formatTime } from '../utils/time';
 import type { Booking, Slot } from '../types';
+import FormDialog from './FormDialog';
 
 interface User {
   name?: string;
@@ -331,7 +331,7 @@ export default function BookingManagementBase({
             setMessage(m);
           },
         })}
-      <Dialog open={cancelId !== null} onClose={() => setCancelId(null)}>
+      <FormDialog open={cancelId !== null} onClose={() => setCancelId(null)} maxWidth="xs">
         <DialogCloseButton onClose={() => setCancelId(null)} />
         <DialogTitle>Cancel booking</DialogTitle>
         <DialogContent>
@@ -346,11 +346,12 @@ export default function BookingManagementBase({
             Cancel booking
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
       {onDeleteVisit && (
-        <Dialog
+        <FormDialog
           open={deleteVisitId !== null}
           onClose={() => setDeleteVisitId(null)}
+          maxWidth="xs"
         >
           <DialogCloseButton onClose={() => setDeleteVisitId(null)} />
           <DialogTitle>Delete visit</DialogTitle>
@@ -366,7 +367,7 @@ export default function BookingManagementBase({
               Delete visit
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
       )}
       <FeedbackSnackbar
         open={!!message}

--- a/MJ_FB_Frontend/src/components/ConfirmDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
-import { Dialog, DialogActions, DialogContent, Button, Typography } from '@mui/material';
+import { DialogActions, DialogContent, Button, Typography } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
+import FormDialog from './FormDialog';
 
 interface ConfirmDialogProps {
   message: string;
@@ -11,7 +12,7 @@ interface ConfirmDialogProps {
 
 export default function ConfirmDialog({ message, onConfirm, onCancel, children }: ConfirmDialogProps) {
   return (
-    <Dialog open onClose={onCancel}>
+    <FormDialog open onClose={onCancel} maxWidth="xs">
       <DialogCloseButton onClose={onCancel} />
       <DialogContent>
         <Typography>{message}</Typography>
@@ -20,6 +21,6 @@ export default function ConfirmDialog({ message, onConfirm, onCancel, children }
       <DialogActions>
         <Button onClick={onConfirm} variant="outlined" color="primary">Confirm</Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }

--- a/MJ_FB_Frontend/src/components/EventForm.tsx
+++ b/MJ_FB_Frontend/src/components/EventForm.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import {
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -17,6 +16,7 @@ import type { Dayjs } from 'dayjs';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import { createEvent, updateEvent, type Event } from '../api/events';
 import DialogCloseButton from './DialogCloseButton';
+import FormDialog from './FormDialog';
 
 interface EventFormProps {
   open: boolean;
@@ -106,7 +106,7 @@ export default function EventForm({ open, onClose, onSaved, event }: EventFormPr
 
   return (
     <>
-        <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <FormDialog open={open} onClose={onClose}>
           <DialogCloseButton onClose={onClose} />
           <DialogTitle>{event ? 'Edit Event' : 'Create Event'}</DialogTitle>
         <DialogContent>
@@ -178,7 +178,7 @@ export default function EventForm({ open, onClose, onSaved, event }: EventFormPr
               {event ? 'Save' : 'Create'}
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
       <FeedbackSnackbar
         open={!!success}
         message={success}

--- a/MJ_FB_Frontend/src/components/FeedbackModal.tsx
+++ b/MJ_FB_Frontend/src/components/FeedbackModal.tsx
@@ -1,7 +1,8 @@
 import type { AlertColor } from '@mui/material';
-import { Dialog, DialogContent, Alert } from '@mui/material';
+import { DialogContent, Alert } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
 import type { ReactNode } from 'react';
+import FormDialog from './FormDialog';
 
 interface FeedbackModalProps {
   open: boolean;
@@ -12,11 +13,11 @@ interface FeedbackModalProps {
 
 export default function FeedbackModal({ open, onClose, message, severity = 'success' }: FeedbackModalProps) {
   return (
-    <Dialog open={open} onClose={onClose}>
+    <FormDialog open={open} onClose={onClose} maxWidth="xs">
       <DialogCloseButton onClose={onClose} />
       <DialogContent>
         <Alert severity={severity}>{message}</Alert>
       </DialogContent>
-    </Dialog>
+    </FormDialog>
   );
 }

--- a/MJ_FB_Frontend/src/components/FormDialog.tsx
+++ b/MJ_FB_Frontend/src/components/FormDialog.tsx
@@ -1,0 +1,12 @@
+import { forwardRef } from 'react';
+import { Dialog, type DialogProps } from '@mui/material';
+
+const FormDialog = forwardRef<HTMLDivElement, DialogProps>(
+  ({ fullWidth = true, maxWidth = 'sm', ...props }, ref) => (
+    <Dialog ref={ref} fullWidth={fullWidth} maxWidth={maxWidth} {...props} />
+  ),
+);
+
+FormDialog.displayName = 'FormDialog';
+
+export default FormDialog;

--- a/MJ_FB_Frontend/src/components/InstallAppButton.tsx
+++ b/MJ_FB_Frontend/src/components/InstallAppButton.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Typography from '@mui/material/Typography';
 import { useLocation } from 'react-router-dom';
+import FormDialog from './FormDialog';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -83,7 +83,7 @@ export default function InstallAppButton() {
   return (
     <>
       {showOnboarding && (
-        <Dialog open onClose={() => setShowOnboarding(false)}>
+        <FormDialog open onClose={() => setShowOnboarding(false)} maxWidth="xs">
           <DialogTitle sx={{ textTransform: 'none' }}>Install App</DialogTitle>
           <DialogContent>
             <Typography>
@@ -110,10 +110,10 @@ export default function InstallAppButton() {
               Install App
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
       )}
       {showIosInstructions && (
-        <Dialog open onClose={() => setShowIosInstructions(false)}>
+        <FormDialog open onClose={() => setShowIosInstructions(false)} maxWidth="xs">
           <DialogTitle sx={{ textTransform: 'none' }}>Install App</DialogTitle>
           <DialogContent>
             <Typography>
@@ -125,7 +125,7 @@ export default function InstallAppButton() {
               Close
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
       )}
       <Box sx={{ position: 'fixed', bottom: 16, right: 16 }}>
         <Button

--- a/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageBookingDialog.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import {
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -14,6 +13,7 @@ import {
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
 import FeedbackSnackbar from './FeedbackSnackbar';
+import FormDialog from './FormDialog';
 import {
   getSlots,
   rescheduleBookingByToken,
@@ -173,7 +173,7 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
   }
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth>
+    <FormDialog open={open} onClose={onClose} maxWidth="md">
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>Manage Booking</DialogTitle>
       <DialogContent sx={{ pt: 2 }}>
@@ -303,7 +303,6 @@ export default function ManageBookingDialog({ open, booking, onClose, onUpdated 
           Submit
         </Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }
-

--- a/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ManageVolunteerShiftDialog.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import {
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -13,6 +12,7 @@ import {
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
 import FeedbackSnackbar from './FeedbackSnackbar';
+import FormDialog from './FormDialog';
 import {
   getRoleShifts,
   getVolunteerBookingsByRole,
@@ -162,7 +162,7 @@ export default function ManageVolunteerShiftDialog({
   const availableShifts = shifts.filter(s => !isShiftDisabled(s));
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth>
+    <FormDialog open={open} onClose={onClose}>
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>Manage Shift</DialogTitle>
       <DialogContent sx={{ pt: 2 }}>
@@ -238,6 +238,6 @@ export default function ManageVolunteerShiftDialog({
           Submit
         </Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }

--- a/MJ_FB_Frontend/src/components/OnboardingModal.tsx
+++ b/MJ_FB_Frontend/src/components/OnboardingModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+import { DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+import FormDialog from './FormDialog';
 
 interface OnboardingModalProps {
   storageKey: string;
@@ -23,7 +24,7 @@ export default function OnboardingModal({ storageKey, title, body }: OnboardingM
   };
 
   return (
-    <Dialog open={open} onClose={handleClose}>
+    <FormDialog open={open} onClose={handleClose} maxWidth="xs">
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
         <Typography>{body}</Typography>
@@ -31,7 +32,7 @@ export default function OnboardingModal({ storageKey, title, body }: OnboardingM
       <DialogActions>
         <Button onClick={handleClose}>Close</Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }
 

--- a/MJ_FB_Frontend/src/components/OverlapBookingDialog.tsx
+++ b/MJ_FB_Frontend/src/components/OverlapBookingDialog.tsx
@@ -1,5 +1,4 @@
 import {
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -10,6 +9,7 @@ import {
 import { formatTime } from '../utils/time';
 import { formatReginaDate } from '../utils/date';
 import type { VolunteerBookingInfo } from '../types';
+import FormDialog from './FormDialog';
 
 interface Props {
   open: boolean;
@@ -27,7 +27,7 @@ export default function OverlapBookingDialog({
   onResolve,
 }: Props) {
   return (
-    <Dialog open={open} onClose={onClose}>
+    <FormDialog open={open} onClose={onClose}>
       <DialogTitle>Shift Conflict</DialogTitle>
       <DialogContent dividers>
         <Typography sx={{ mb: 2 }}>
@@ -64,6 +64,6 @@ export default function OverlapBookingDialog({
           Replace with New Shift
         </Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }

--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { Dialog, DialogContent, DialogTitle, Button, TextField, Typography } from '@mui/material';
+import { DialogContent, DialogTitle, Button, TextField, Typography } from '@mui/material';
 import { requestPasswordReset } from '../api/users';
 import type { PasswordResetBody } from '../types';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormCard from './FormCard';
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
+import FormDialog from './FormDialog';
 
 export default function PasswordResetDialog({
   open,
@@ -40,7 +41,7 @@ export default function PasswordResetDialog({
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} aria-labelledby="password-reset-dialog-title">
+      <FormDialog open={open} onClose={onClose} aria-labelledby="password-reset-dialog-title">
         <DialogCloseButton onClose={onClose} />
         <DialogTitle id="password-reset-dialog-title" sx={{ display: 'none' }}>
           {formTitle}
@@ -68,7 +69,7 @@ export default function PasswordResetDialog({
             />
           </FormCard>
         </DialogContent>
-      </Dialog>
+      </FormDialog>
       <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity={snackbarSeverity} />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </>

--- a/MJ_FB_Frontend/src/components/PrivacyNoticeModal.tsx
+++ b/MJ_FB_Frontend/src/components/PrivacyNoticeModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, Typography, Link } from '@mui/material';
+import { DialogTitle, DialogContent, Typography, Link } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
+import FormDialog from './FormDialog';
 
 const STORAGE_KEY = 'privacy_consent';
 
@@ -44,11 +45,12 @@ export default function PrivacyNoticeModal() {
   }, []);
 
   return (
-    <Dialog
+    <FormDialog
       open={open}
       onClose={() => {
         void handleClose();
       }}
+      maxWidth="xs"
     >
       <DialogTitle sx={{ pr: 6 }}>
         Privacy notice
@@ -63,7 +65,7 @@ export default function PrivacyNoticeModal() {
           By using this app, you agree to our <Link href="/privacy">privacy policy</Link>.
         </Typography>
       </DialogContent>
-    </Dialog>
+    </FormDialog>
   );
 }
 

--- a/MJ_FB_Frontend/src/components/RecurringBookingsDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RecurringBookingsDialog.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import {
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -31,7 +30,7 @@ export default function RecurringBookingsDialog({ open, roles, onClose, onSubmit
   }
 
   return (
-    <Dialog open={open} onClose={onClose} data-testid="recurring-bookings-dialog">
+    <FormDialog open={open} onClose={onClose} data-testid="recurring-bookings-dialog">
       <DialogTitle>Recurring Booking</DialogTitle>
       <DialogContent>
         <FormControl fullWidth>
@@ -59,7 +58,8 @@ export default function RecurringBookingsDialog({ open, roles, onClose, onSubmit
           Submit
         </Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }
 
+import FormDialog from './FormDialog';

--- a/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
+++ b/MJ_FB_Frontend/src/components/RescheduleDialog.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import {
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -10,6 +9,7 @@ import {
 } from '@mui/material';
 import DialogCloseButton from './DialogCloseButton';
 import FeedbackSnackbar from './FeedbackSnackbar';
+import FormDialog from './FormDialog';
 import { formatReginaDate } from '../utils/date';
 import type { AlertColor } from '@mui/material';
 
@@ -81,7 +81,7 @@ export default function RescheduleDialog({
   }
 
   return (
-    <Dialog open={open} onClose={onClose}>
+    <FormDialog open={open} onClose={onClose}>
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
@@ -122,7 +122,7 @@ export default function RescheduleDialog({
           {submitLabel}
         </Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }
 

--- a/MJ_FB_Frontend/src/components/ResendPasswordSetupDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ResendPasswordSetupDialog.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { Dialog, DialogContent, DialogTitle, Button, TextField, Typography } from '@mui/material';
+import { DialogContent, DialogTitle, Button, TextField, Typography } from '@mui/material';
 import { resendPasswordSetup } from '../api/users';
 import FeedbackSnackbar from './FeedbackSnackbar';
 import FormCard from './FormCard';
 import DialogCloseButton from './DialogCloseButton';
+import FormDialog from './FormDialog';
 
 export default function ResendPasswordSetupDialog({
   open,
@@ -33,7 +34,7 @@ export default function ResendPasswordSetupDialog({
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} aria-labelledby="resend-setup-dialog-title">
+      <FormDialog open={open} onClose={onClose} aria-labelledby="resend-setup-dialog-title">
         <DialogCloseButton onClose={onClose} />
         <DialogTitle id="resend-setup-dialog-title" sx={{ display: 'none' }}>
           Resend password setup link
@@ -60,7 +61,7 @@ export default function ResendPasswordSetupDialog({
             />
           </FormCard>
         </DialogContent>
-      </Dialog>
+      </FormDialog>
       <FeedbackSnackbar open={!!message} onClose={() => setMessage('')} message={message} severity="success" />
       <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
     </>

--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -5,7 +5,6 @@ import {
   ListItemText,
   Chip,
   ListItemButton,
-  Dialog,
   DialogTitle,
   DialogContent,
   ListSubheader,
@@ -18,6 +17,7 @@ import { formatReginaDate, formatTime } from '../../utils/time';
 import { toDate, toDayjs } from '../../utils/date';
 import FeedbackSnackbar from '../FeedbackSnackbar';
 import DialogCloseButton from '../DialogCloseButton';
+import FormDialog from '../FormDialog';
 
 interface CoverageItem {
   roleName: string;
@@ -146,7 +146,7 @@ export default function VolunteerCoverageCard({
           ))}
         </List>
       </SectionCard>
-      <Dialog open={!!selected} onClose={() => setSelected(null)}>
+      <FormDialog open={!!selected} onClose={() => setSelected(null)}>
         <DialogTitle sx={{ position: 'relative' }}>
           {`Volunteers – ${selected?.roleName ?? ''}`}
           <DialogCloseButton onClose={() => setSelected(null)} />
@@ -164,7 +164,7 @@ export default function VolunteerCoverageCard({
             'No volunteer is available'
           )}
         </DialogContent>
-      </Dialog>
+      </FormDialog>
       <FeedbackSnackbar
         open={!!error}
         onClose={() => setError('')}

--- a/MJ_FB_Frontend/src/pages/BookingUI.tsx
+++ b/MJ_FB_Frontend/src/pages/BookingUI.tsx
@@ -26,7 +26,6 @@ import {
   Skeleton,
   Link,
   TextField,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -44,6 +43,7 @@ import useHolidays from '../hooks/useHolidays';
 import FeedbackSnackbar from '../components/FeedbackSnackbar';
 import FeedbackModal from '../components/FeedbackModal';
 import DialogCloseButton from '../components/DialogCloseButton';
+import FormDialog from '../components/FormDialog';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
 import Page from '../components/Page';
 import ClientBottomNav from '../components/ClientBottomNav';
@@ -648,7 +648,7 @@ export default function BookingUI<T = Slot>({
           </Paper>
         </Grid>
       </Grid>
-      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+      <FormDialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
         <DialogCloseButton onClose={() => setConfirmOpen(false)} />
         <DialogTitle>Confirm booking</DialogTitle>
         <DialogContent>
@@ -683,7 +683,7 @@ export default function BookingUI<T = Slot>({
             Confirm
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
       <FeedbackSnackbar
         open={snackbar.open}
         onClose={() => setSnackbar(s => ({ ...s, open: false }))}

--- a/MJ_FB_Frontend/src/pages/admin/components/MasterRoleDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/components/MasterRoleDialog.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import { DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import FormDialog from '../../../components/FormDialog';
 
 export type MasterRole = { id: number; name: string };
 
@@ -20,7 +21,7 @@ function MasterRoleDialog({ open, role, onClose, onSave }: MasterRoleDialogProps
   }, [open, role]);
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth>
+    <FormDialog open={open} onClose={onClose}>
       <DialogTitle>{role ? 'Edit Master Role' : 'Add Master Role'}</DialogTitle>
       <DialogContent>
         <TextField
@@ -40,7 +41,7 @@ function MasterRoleDialog({ open, role, onClose, onSave }: MasterRoleDialogProps
           Save
         </Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/admin/components/ShiftDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/components/ShiftDialog.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import { DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import FormDialog from '../../../components/FormDialog';
 
 interface ShiftDialogInitial {
   slotId?: number;
@@ -47,7 +48,7 @@ function ShiftDialog({ open, initial, onClose, onSave }: ShiftDialogProps) {
   }
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth>
+    <FormDialog open={open} onClose={onClose}>
       <DialogTitle>{initial?.slotId ? 'Edit Shift' : 'Add Shift'}</DialogTitle>
       <DialogContent>
         <TextField margin="dense" label="Name" fullWidth value={initial?.roleName || ''} disabled />
@@ -101,7 +102,7 @@ function ShiftDialog({ open, initial, onClose, onSave }: ShiftDialogProps) {
           Save
         </Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/admin/components/SubRoleDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/components/SubRoleDialog.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import { DialogTitle, DialogContent, TextField, DialogActions, Button } from '@mui/material';
+import FormDialog from '../../../components/FormDialog';
 
 interface SubRoleDialogProps {
   open: boolean;
@@ -48,7 +49,7 @@ function SubRoleDialog({ open, onClose, onSave }: SubRoleDialogProps) {
   }
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth>
+    <FormDialog open={open} onClose={onClose}>
       <DialogTitle>Add Sub-role</DialogTitle>
       <DialogContent>
         <TextField
@@ -113,7 +114,7 @@ function SubRoleDialog({ open, onClose, onSave }: SubRoleDialogProps) {
           Save
         </Button>
       </DialogActions>
-    </Dialog>
+    </FormDialog>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/admin/settings/DeliverySettingsTab.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/settings/DeliverySettingsTab.tsx
@@ -10,7 +10,6 @@ import {
   Stack,
   Typography,
   IconButton,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -25,6 +24,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { AlertColor } from '@mui/material';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import FormDialog from '../../../components/FormDialog';
 import {
   getDeliveryCategories,
   createDeliveryCategory,
@@ -335,7 +335,7 @@ export default function DeliverySettingsTab() {
           </Card>
         </Grid>
       </Grid>
-      <Dialog open={categoryDialog.open} onClose={closeCategoryDialog} fullWidth>
+      <FormDialog open={categoryDialog.open} onClose={closeCategoryDialog}>
         <DialogTitle>
           {categoryDialog.id !== null ? 'Edit category' : 'Add category'}
         </DialogTitle>
@@ -380,8 +380,8 @@ export default function DeliverySettingsTab() {
             {categoryDialog.id !== null ? 'Save changes' : 'Create category'}
           </Button>
         </DialogActions>
-      </Dialog>
-      <Dialog open={itemDialog.open} onClose={closeItemDialog} fullWidth>
+      </FormDialog>
+      <FormDialog open={itemDialog.open} onClose={closeItemDialog}>
         <DialogTitle>{itemDialog.itemId !== null ? 'Edit item' : 'Add item'}</DialogTitle>
         <DialogContent>
           <TextField
@@ -406,8 +406,12 @@ export default function DeliverySettingsTab() {
             {itemDialog.itemId !== null ? 'Save changes' : 'Add item'}
           </Button>
         </DialogActions>
-      </Dialog>
-      <Dialog open={categoryToDelete !== null} onClose={() => setCategoryToDelete(null)} fullWidth>
+      </FormDialog>
+      <FormDialog
+        open={categoryToDelete !== null}
+        onClose={() => setCategoryToDelete(null)}
+        maxWidth="xs"
+      >
         <DialogTitle>Delete category</DialogTitle>
         <DialogContent>
           <DialogContentText>
@@ -429,8 +433,12 @@ export default function DeliverySettingsTab() {
             Delete category
           </Button>
         </DialogActions>
-      </Dialog>
-      <Dialog open={itemToDelete !== null} onClose={() => setItemToDelete(null)} fullWidth>
+      </FormDialog>
+      <FormDialog
+        open={itemToDelete !== null}
+        onClose={() => setItemToDelete(null)}
+        maxWidth="xs"
+      >
         <DialogTitle>Delete item</DialogTitle>
         <DialogContent>
           <DialogContentText>
@@ -451,7 +459,7 @@ export default function DeliverySettingsTab() {
             Delete item
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
       <FeedbackSnackbar
         open={!!snackbar}
         onClose={() => setSnackbar(null)}

--- a/MJ_FB_Frontend/src/pages/admin/settings/VolunteerSettingsTab.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/settings/VolunteerSettingsTab.tsx
@@ -5,7 +5,6 @@ import {
   AccordionSummary,
   Box,
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -26,6 +25,7 @@ import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import MasterRoleDialog, { type MasterRole } from '../components/MasterRoleDialog';
 import SubRoleDialog from '../components/SubRoleDialog';
 import ShiftDialog from '../components/ShiftDialog';
+import FormDialog from '../../../components/FormDialog';
 import {
   getVolunteerMasterRoles,
   getVolunteerRoles,
@@ -524,7 +524,7 @@ export default function VolunteerSettingsTab() {
         onSave={handleShiftSave}
       />
 
-      <Dialog open={roleToDelete !== null} onClose={() => setRoleToDelete(null)}>
+      <FormDialog open={roleToDelete !== null} onClose={() => setRoleToDelete(null)} maxWidth="xs">
         <DialogTitle>Delete role</DialogTitle>
         <DialogContent>
           <Typography>Deleting this role will remove all shifts. Are you sure?</Typography>
@@ -537,9 +537,9 @@ export default function VolunteerSettingsTab() {
             Delete
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={shiftToDelete !== null} onClose={() => setShiftToDelete(null)}>
+      <FormDialog open={shiftToDelete !== null} onClose={() => setShiftToDelete(null)} maxWidth="xs">
         <DialogTitle>Delete shift</DialogTitle>
         <DialogContent>
           <Typography>Are you sure you want to delete this shift?</Typography>
@@ -552,9 +552,9 @@ export default function VolunteerSettingsTab() {
             Delete
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={deleteMasterId !== null} onClose={() => setDeleteMasterId(null)}>
+      <FormDialog open={deleteMasterId !== null} onClose={() => setDeleteMasterId(null)} maxWidth="xs">
         <DialogTitle>Delete master role</DialogTitle>
         <DialogContent>
           <Typography>Deleting this master role will remove all sub roles and shifts. Are you sure?</Typography>
@@ -567,9 +567,9 @@ export default function VolunteerSettingsTab() {
             Delete
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={restoreDialog} onClose={() => setRestoreDialog(false)}>
+      <FormDialog open={restoreDialog} onClose={() => setRestoreDialog(false)} maxWidth="xs">
         <DialogTitle>Restore roles?</DialogTitle>
         <DialogContent>
           <Typography>
@@ -584,7 +584,7 @@ export default function VolunteerSettingsTab() {
             Restore
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
       <FeedbackSnackbar
         open={snack.open}

--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -9,7 +9,6 @@ import {
   ListItem,
   ListItemText,
   Chip,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -30,6 +29,7 @@ import EventList from '../../components/EventList';
 import { toDate } from '../../utils/date';
 import Page from '../../components/Page';
 import OnboardingModal from '../../components/OnboardingModal';
+import FormDialog from '../../components/FormDialog';
 
 interface NextSlot {
   date: string;
@@ -380,7 +380,7 @@ export default function ClientDashboard() {
           </Stack>
         </Grid>
       </Grid>
-        <Dialog open={cancelId !== null} onClose={() => setCancelId(null)}>
+        <FormDialog open={cancelId !== null} onClose={() => setCancelId(null)} maxWidth="xs">
           <DialogCloseButton onClose={() => setCancelId(null)} />
           <DialogTitle>Cancel booking</DialogTitle>
           <DialogContent>
@@ -397,7 +397,7 @@ export default function ClientDashboard() {
               Cancel booking
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
       <FeedbackSnackbar
         open={!!message}
         onClose={() => setMessage('')}

--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -8,7 +8,6 @@ import {
   Checkbox,
   CircularProgress,
   Container,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -37,6 +36,7 @@ import type { DeliveryCategory, DeliveryItem } from '../../types';
 import { useAuth } from '../../hooks/useAuth';
 import { getUserProfile } from '../../api/users';
 import { useNavigate } from 'react-router-dom';
+import FormDialog from '../../components/FormDialog';
 
 type SelectionState = Record<number, boolean>;
 
@@ -331,10 +331,11 @@ export default function BookDelivery() {
 
   return (
     <>
-      <Dialog
+      <FormDialog
         open={successDialogOpen}
         onClose={handleSuccessDialogClose}
         aria-labelledby="delivery-request-submitted-title"
+        maxWidth="xs"
       >
         <DialogTitle id="delivery-request-submitted-title">
           Delivery request submitted
@@ -361,7 +362,7 @@ export default function BookDelivery() {
             View Delivery History
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
       <Container
         component="form"
         onSubmit={handleSubmit}

--- a/MJ_FB_Frontend/src/pages/donor-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonationLog.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import {
   Button,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -16,6 +15,7 @@ import { Edit, Delete } from '@mui/icons-material';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import FormDialog from '../../components/FormDialog';
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 import DonorQuickLinks from '../../components/DonorQuickLinks';
 import {
@@ -345,7 +345,7 @@ export default function DonationLog() {
 
         {table}
 
-        <Dialog
+        <FormDialog
           open={recordOpen}
           onClose={() => {
             setRecordOpen(false);
@@ -389,14 +389,15 @@ export default function DonationLog() {
             Save
           </Button>
         </DialogActions>
-        </Dialog>
+        </FormDialog>
 
-        <Dialog
+        <FormDialog
           open={deleteOpen}
           onClose={() => {
             setDeleteOpen(false);
             setToDelete(null);
           }}
+          maxWidth="xs"
         >
           <DialogCloseButton
             onClose={() => {
@@ -415,9 +416,9 @@ export default function DonationLog() {
               Delete
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
 
-        <Dialog open={newDonorOpen} onClose={() => setNewDonorOpen(false)}>
+        <FormDialog open={newDonorOpen} onClose={() => setNewDonorOpen(false)}>
           <DialogCloseButton onClose={() => setNewDonorOpen(false)} />
           <DialogTitle>Add Donor</DialogTitle>
           <DialogContent sx={{ pt: 2 }}>
@@ -448,7 +449,7 @@ export default function DonationLog() {
               Save
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
 
         <FeedbackSnackbar
           open={snackbar.open}

--- a/MJ_FB_Frontend/src/pages/donor-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonorProfile.tsx
@@ -12,7 +12,6 @@ import {
   TableBody,
   Paper,
   IconButton,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -23,6 +22,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { useQuery } from '@tanstack/react-query';
 import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import FormDialog from '../../components/FormDialog';
 import DonorQuickLinks from '../../components/DonorQuickLinks';
 import {
   getMonetaryDonor,
@@ -244,7 +244,7 @@ export default function DonorProfile() {
           </Table>
         </TableContainer>
 
-        <Dialog open={editOpen} onClose={() => setEditOpen(false)}>
+        <FormDialog open={editOpen} onClose={() => setEditOpen(false)}>
           <DialogTitle>Edit Donor</DialogTitle>
           <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
             <TextField
@@ -276,9 +276,9 @@ export default function DonorProfile() {
               Save
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
 
-        <Dialog open={formOpen} onClose={() => setFormOpen(false)}>
+        <FormDialog open={formOpen} onClose={() => setFormOpen(false)}>
           <DialogTitle>{form.id ? 'Edit Donation' : 'Add Donation'}</DialogTitle>
           <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
             <TextField
@@ -301,9 +301,9 @@ export default function DonorProfile() {
               Save
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
 
-        <Dialog open={deleteId !== null} onClose={() => setDeleteId(null)}>
+        <FormDialog open={deleteId !== null} onClose={() => setDeleteId(null)} maxWidth="xs">
           <DialogTitle>Delete Donation?</DialogTitle>
           <DialogActions>
             <Button onClick={() => setDeleteId(null)}>Cancel</Button>
@@ -311,7 +311,7 @@ export default function DonorProfile() {
               Delete
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
 
         <FeedbackSnackbar
           open={snackbar.open}

--- a/MJ_FB_Frontend/src/pages/staff/BookingManagementBase.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/BookingManagementBase.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, type ReactNode } from 'react';
 import {
   Box,
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -17,6 +16,7 @@ import BookingHistoryTable, {
 import RescheduleDialog from '../../components/RescheduleDialog';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import FormDialog from '../../components/FormDialog';
 
 interface Option {
   id: string;
@@ -209,7 +209,7 @@ export default function BookingManagementBase<
           )}
         </Box>
       )}
-      <Dialog open={cancelId !== null} onClose={() => setCancelId(null)}>
+      <FormDialog open={cancelId !== null} onClose={() => setCancelId(null)} maxWidth="xs">
         <DialogCloseButton onClose={() => setCancelId(null)} />
         <DialogTitle>Cancel booking</DialogTitle>
         <DialogContent>
@@ -220,7 +220,7 @@ export default function BookingManagementBase<
             Cancel booking
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
       {reschedule && (
         <RescheduleDialog
           open={!!reschedule}

--- a/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/LeaveManagement.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -21,6 +20,7 @@ import {
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 import { formatLocaleDate } from '../../utils/date';
 import { useState } from 'react';
+import FormDialog from '../../components/FormDialog';
 
 export default function LeaveManagement() {
   const { timesheets } = useTimesheets();
@@ -79,7 +79,7 @@ export default function LeaveManagement() {
           >
             Request Vacation
           </Button>
-          <Dialog open={open} onClose={() => setOpen(false)}>
+          <FormDialog open={open} onClose={() => setOpen(false)}>
             <Box
               component="form"
               onSubmit={e => {
@@ -140,7 +140,7 @@ export default function LeaveManagement() {
                 </Button>
               </DialogActions>
             </Box>
-          </Dialog>
+          </FormDialog>
 
           <ResponsiveTable
             columns={columns}

--- a/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryAggregations.tsx
@@ -8,7 +8,6 @@ import {
   Stack,
   Button,
   CircularProgress,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -19,6 +18,7 @@ import Page from '../../components/Page';
 import StyledTabs from '../../components/StyledTabs';
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import FormDialog from '../../components/FormDialog';
 import {
   getPantryWeekly,
   getPantryMonthly,
@@ -612,7 +612,7 @@ export default function PantryAggregations() {
   return (
     <Page title="Pantry Aggregations">
       <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
-      <Dialog open={insertOpen} onClose={() => setInsertOpen(false)}>
+      <FormDialog open={insertOpen} onClose={() => setInsertOpen(false)}>
         <DialogTitle>Insert Aggregate</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
@@ -717,7 +717,7 @@ export default function PantryAggregations() {
             {insertLoading ? <CircularProgress size={20} /> : 'Save'}
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
       <FeedbackSnackbar
         open={snackbar.open}
         onClose={() => setSnackbar({ ...snackbar, open: false })}

--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -22,7 +22,6 @@ import {
   TextField,
   Typography,
   Stack,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -36,6 +35,7 @@ import {
 import ManageBookingDialog from "../../components/ManageBookingDialog";
 import PantryQuickLinks from "../../components/PantryQuickLinks";
 import Page from "../../components/Page";
+import FormDialog from "../../components/FormDialog";
 import {
   LocalizationProvider,
   DatePicker,
@@ -450,10 +450,9 @@ export default function PantrySchedule({
       )}
 
       {assignSlot && (
-        <Dialog
+        <FormDialog
           open={!!assignSlot}
           onClose={handleAssignClose}
-          fullWidth
           maxWidth="xs"
           sx={{ zIndex: (t) => t.zIndex.modal }}
           PaperProps={{ sx: { p: 2, borderRadius: 2 } }}
@@ -547,7 +546,7 @@ export default function PantrySchedule({
               </Button>
             )}
           </DialogActions>
-        </Dialog>
+        </FormDialog>
       )}
 
       {manageBooking && (

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Button,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -23,6 +22,7 @@ import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import FormDialog from '../../components/FormDialog';
 import PantryQuickLinks from '../../components/PantryQuickLinks';
 import ResponsiveTable from '../../components/ResponsiveTable';
 import {
@@ -544,7 +544,14 @@ export default function PantryVisits() {
       </Stack>
       <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
-      <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
+      <FormDialog
+        open={recordOpen}
+        onClose={() => {
+          setRecordOpen(false);
+          setEditing(null);
+        }}
+        maxWidth="md"
+      >
         <DialogCloseButton onClose={() => { setRecordOpen(false); setEditing(null); }} />
         <DialogTitle>{editing ? 'Edit Visit' : 'Record Visit'}</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
@@ -672,9 +679,16 @@ export default function PantryVisits() {
             Save
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={deleteOpen} onClose={() => { setDeleteOpen(false); setToDelete(null); }}>
+      <FormDialog
+        open={deleteOpen}
+        onClose={() => {
+          setDeleteOpen(false);
+          setToDelete(null);
+        }}
+        maxWidth="xs"
+      >
         <DialogCloseButton onClose={() => { setDeleteOpen(false); setToDelete(null); }} />
         <DialogTitle>Delete Visit</DialogTitle>
         <DialogContent>
@@ -699,7 +713,7 @@ export default function PantryVisits() {
             Delete
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
       <FeedbackSnackbar
         open={!!snackbar}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import {
-  Dialog,
   DialogTitle,
   FormControlLabel,
   Switch,
@@ -11,6 +10,7 @@ import {
 } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from '../../../components/DialogCloseButton';
+import FormDialog from '../../../components/FormDialog';
 import { getUserByClientId, updateUserInfo, requestPasswordReset } from '../../../api/users';
 import getApiErrorMessage from '../../../utils/getApiErrorMessage';
 import EditClientForm, {
@@ -108,7 +108,7 @@ export default function EditClientDialog({
   }, [open, clientId, onUpdated]);
 
   return (
-    <Dialog open={open} onClose={onClose}>
+    <FormDialog open={open} onClose={onClose}>
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>Edit Client</DialogTitle>
       <Stack spacing={2} sx={{ px: 3, pt: 1 }}>
@@ -146,7 +146,7 @@ export default function EditClientDialog({
         onSendReset={data => handleSendReset(clientId, data, onClientUpdated, onUpdated, onClose)}
         showOnlineAccessToggle={false}
       />
-    </Dialog>
+    </FormDialog>
   );
 }
 

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import {
   Box,
   Button,
-  Dialog,
   DialogTitle,
   Link,
   Typography,
@@ -10,6 +9,7 @@ import {
 } from "@mui/material";
 import FeedbackSnackbar from "../../../components/FeedbackSnackbar";
 import DialogCloseButton from "../../../components/DialogCloseButton";
+import FormDialog from "../../../components/FormDialog";
 import {
   getIncompleteUsers,
   updateUserInfo,
@@ -179,7 +179,7 @@ export default function UpdateClientData() {
         />
       </TableContainer>
 
-      <Dialog open={!!selected} onClose={() => setSelected(null)}>
+      <FormDialog open={!!selected} onClose={() => setSelected(null)}>
         <DialogCloseButton onClose={() => setSelected(null)} />
         <DialogTitle>
           Edit Client -{" "}
@@ -199,7 +199,7 @@ export default function UpdateClientData() {
           onSave={handleSave}
           onSendReset={handleSendReset}
         />
-      </Dialog>
+      </FormDialog>
 
       <FeedbackSnackbar
         open={!!snackbar}

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
@@ -22,7 +22,6 @@ import {
   Checkbox,
   Chip,
   Container,
-  Dialog,
   DialogActions,
   DialogContent,
   FormControl,
@@ -48,6 +47,7 @@ import BookingHistoryTable from '../../../components/BookingHistoryTable';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import ConfirmDialog from '../../../components/ConfirmDialog';
 import DialogCloseButton from '../../../components/DialogCloseButton';
+import FormDialog from '../../../components/FormDialog';
 import PasswordField from '../../../components/PasswordField';
 
 export default function EditVolunteer() {
@@ -616,7 +616,7 @@ export default function EditVolunteer() {
         </Box>
       )}
       {shopperOpen && (
-        <Dialog open onClose={() => setShopperOpen(false)}>
+        <FormDialog open onClose={() => setShopperOpen(false)}>
           <DialogCloseButton onClose={() => setShopperOpen(false)} />
           <DialogContent>
             <TextField
@@ -648,7 +648,7 @@ export default function EditVolunteer() {
               Create
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
       )}
       {removeShopperOpen && (
         <ConfirmDialog

--- a/MJ_FB_Frontend/src/pages/volunteer-management/EditVolunteerDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/EditVolunteerDialog.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import {
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -17,6 +16,7 @@ import type { AlertColor } from '@mui/material';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import PasswordField from '../../components/PasswordField';
+import FormDialog from '../../components/FormDialog';
 import { updateVolunteer, type VolunteerSearchResult } from '../../api/volunteers';
 import { getApiErrorMessage } from '../../api/helpers';
 
@@ -102,7 +102,7 @@ export default function EditVolunteerDialog({ volunteer, onClose, onSaved }: Edi
   }
 
   return (
-    <Dialog open={!!volunteer} onClose={onClose}>
+    <FormDialog open={!!volunteer} onClose={onClose}>
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>Edit Volunteer</DialogTitle>
       <DialogContent>
@@ -187,6 +187,6 @@ export default function EditVolunteerDialog({ volunteer, onClose, onSaved }: Edi
         message={snackbar?.message || ''}
         severity={snackbar?.severity}
       />
-    </Dialog>
+    </FormDialog>
   );
 }

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerBookingHistory.tsx
@@ -14,7 +14,6 @@ import VolunteerBottomNav from '../../components/VolunteerBottomNav';
 import BookingHistoryTable from '../../components/BookingHistoryTable';
 import {
   Button,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -23,6 +22,7 @@ import {
 import type { AlertColor } from '@mui/material';
 import { getVolunteerRolesForVolunteer } from '../../api/volunteers';
 import { formatTime } from '../../utils/time';
+import FormDialog from '../../components/FormDialog';
 
 export default function VolunteerBookingHistory() {
   const [history, setHistory] = useState<VolunteerBooking[]>([]);
@@ -137,7 +137,7 @@ export default function VolunteerBookingHistory() {
         />
       )}
 
-      <Dialog open={!!cancelBooking} onClose={() => setCancelBooking(null)}>
+      <FormDialog open={!!cancelBooking} onClose={() => setCancelBooking(null)} maxWidth="xs">
         <DialogCloseButton onClose={() => setCancelBooking(null)} />
         <DialogTitle>Cancel booking</DialogTitle>
         <DialogContent dividers>
@@ -148,9 +148,13 @@ export default function VolunteerBookingHistory() {
             Confirm
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={cancelSeriesId != null} onClose={() => setCancelSeriesId(null)}>
+      <FormDialog
+        open={cancelSeriesId != null}
+        onClose={() => setCancelSeriesId(null)}
+        maxWidth="xs"
+      >
         <DialogCloseButton onClose={() => setCancelSeriesId(null)} />
         <DialogTitle>Cancel series</DialogTitle>
         <DialogContent dividers>
@@ -161,7 +165,7 @@ export default function VolunteerBookingHistory() {
             Confirm
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
       <RescheduleDialog
         open={!!rescheduleBooking}

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -34,7 +34,6 @@ import {
   Checkbox,
   FormControlLabel,
   Switch,
-  Dialog,
   DialogActions,
   DialogContent,
   Typography,
@@ -52,6 +51,7 @@ const Dashboard = React.lazy(
 );
 import EntitySearch from '../../components/EntitySearch';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import FormDialog from '../../components/FormDialog';
 import { formatDate, addDays } from '../../utils/date';
 import dayjs from '../../utils/date';
 import Page from '../../components/Page';
@@ -1170,7 +1170,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
         </>
       )}
         {shopperOpen && (
-          <Dialog open onClose={() => setShopperOpen(false)}>
+          <FormDialog open onClose={() => setShopperOpen(false)}>
             <DialogCloseButton onClose={() => setShopperOpen(false)} />
             <DialogContent>
             <TextField
@@ -1208,7 +1208,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                 Create
               </Button>
             </DialogActions>
-          </Dialog>
+          </FormDialog>
         )}
 
       {removeShopperOpen && (

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerSchedule.tsx
@@ -28,6 +28,7 @@ import FeedbackSnackbar from "../../components/FeedbackSnackbar";
 import RescheduleDialog from "../../components/RescheduleDialog";
 import DialogCloseButton from "../../components/DialogCloseButton";
 import OverlapBookingDialog from "../../components/OverlapBookingDialog";
+import FormDialog from "../../components/FormDialog";
 import type { ApiError } from "../../api/client";
 import type { VolunteerBookingConflict } from "../../types";
 import {
@@ -37,7 +38,6 @@ import {
   Select,
   MenuItem,
   Button,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -566,7 +566,7 @@ export default function VolunteerSchedule() {
           </Typography>
         ) : null}
 
-        <Dialog open={!!requestRole} onClose={() => setRequestRole(null)}>
+        <FormDialog open={!!requestRole} onClose={() => setRequestRole(null)}>
           <DialogCloseButton onClose={() => setRequestRole(null)} />
           <DialogTitle>Request Booking</DialogTitle>
           <DialogContent dividers>
@@ -636,9 +636,9 @@ export default function VolunteerSchedule() {
               Submit
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
 
-        <Dialog
+        <FormDialog
           open={!!decisionBooking}
           onClose={() => {
             setDecisionBooking(null);
@@ -696,7 +696,7 @@ export default function VolunteerSchedule() {
               Cancel Booking
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
         {conflict && (
           <OverlapBookingDialog
             open

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -8,7 +8,6 @@ import {
   Stack,
   CircularProgress,
   Button,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -30,6 +29,7 @@ import {
 } from '../../api/donations';
 import { getDonors, type Donor } from '../../api/donors';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import FormDialog from '../../components/FormDialog';
 import StyledTabs from '../../components/StyledTabs';
 import { toDate } from '../../utils/date';
 import { exportTableToExcel } from '../../utils/exportTableToExcel';
@@ -412,7 +412,7 @@ export default function Aggregations() {
   return (
     <Page title="Warehouse Aggregations">
       <StyledTabs tabs={tabs} value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }} />
-      <Dialog open={donorInsertOpen} onClose={() => setDonorInsertOpen(false)}>
+      <FormDialog open={donorInsertOpen} onClose={() => setDonorInsertOpen(false)}>
         <DialogTitle>Insert Aggregate</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
@@ -502,8 +502,8 @@ export default function Aggregations() {
             {donorInsertLoading ? <CircularProgress size={20} /> : 'Save'}
           </Button>
         </DialogActions>
-      </Dialog>
-      <Dialog open={insertOpen} onClose={() => setInsertOpen(false)}>
+      </FormDialog>
+      <FormDialog open={insertOpen} onClose={() => setInsertOpen(false)}>
         <DialogTitle>Insert Aggregate</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
@@ -577,7 +577,7 @@ export default function Aggregations() {
             {insertLoading ? <CircularProgress size={20} /> : 'Save'}
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
         <FeedbackSnackbar
           open={snackbar.open}
           onClose={() => setSnackbar({ ...snackbar, open: false })}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   Button,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -18,6 +17,7 @@ import Page from '../../components/Page';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import FormDialog from '../../components/FormDialog';
 import useSnackbar from '../../hooks/useSnackbar';
 import { getDonors, createDonor } from '../../api/donors';
 import {
@@ -252,7 +252,13 @@ export default function DonationLog() {
 
         {table}
 
-      <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
+      <FormDialog
+        open={recordOpen}
+        onClose={() => {
+          setRecordOpen(false);
+          setEditing(null);
+        }}
+      >
         <DialogCloseButton onClose={() => { setRecordOpen(false); setEditing(null); }} />
         <DialogTitle>{editing ? 'Edit Donation' : 'Record Donation'}</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
@@ -288,9 +294,16 @@ export default function DonationLog() {
             Save
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={deleteOpen} onClose={() => { setDeleteOpen(false); setToDelete(null); }}>
+      <FormDialog
+        open={deleteOpen}
+        onClose={() => {
+          setDeleteOpen(false);
+          setToDelete(null);
+        }}
+        maxWidth="xs"
+      >
         <DialogCloseButton onClose={() => { setDeleteOpen(false); setToDelete(null); }} />
         <DialogTitle>Delete Donation</DialogTitle>
         <DialogContent>
@@ -320,9 +333,9 @@ export default function DonationLog() {
             Delete
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={newDonorOpen} onClose={() => setNewDonorOpen(false)}>
+      <FormDialog open={newDonorOpen} onClose={() => setNewDonorOpen(false)}>
         <DialogCloseButton onClose={() => setNewDonorOpen(false)} />
         <DialogTitle>Add Donor</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
@@ -363,7 +376,7 @@ export default function DonationLog() {
             Save
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
       <FeedbackSnackbar
         open={open}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Card,
   CardContent,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -27,6 +26,7 @@ import { formatLocaleDate } from '../../utils/date';
 import Page from '../../components/Page';
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
 import { getApiErrorMessage } from '../../api/helpers';
+import FormDialog from '../../components/FormDialog';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -224,7 +224,7 @@ export default function DonorProfile() {
           severity={snackbar.severity}
         />
       </Box>
-      <Dialog open={editOpen} onClose={handleCloseEdit} fullWidth maxWidth="sm">
+      <FormDialog open={editOpen} onClose={handleCloseEdit}>
         <DialogCloseButton onClose={handleCloseEdit} />
         <DialogTitle>Edit Donor</DialogTitle>
         <DialogContent>
@@ -273,7 +273,7 @@ export default function DonorProfile() {
             {saving ? 'Saving…' : 'Save'}
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackOutgoingDonations.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   Button,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -19,6 +18,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import FormDialog from '../../components/FormDialog';
 import { getOutgoingReceivers, createOutgoingReceiver } from '../../api/outgoingReceivers';
 import { getOutgoingDonations, createOutgoingDonation, updateOutgoingDonation, deleteOutgoingDonation } from '../../api/outgoingDonations';
 import type { OutgoingReceiver } from '../../api/outgoingReceivers';
@@ -191,7 +191,13 @@ export default function TrackOutgoingDonations() {
         </Stack>
         <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
-      <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
+      <FormDialog
+        open={recordOpen}
+        onClose={() => {
+          setRecordOpen(false);
+          setEditing(null);
+        }}
+      >
         <DialogCloseButton onClose={() => { setRecordOpen(false); setEditing(null); }} />
         <DialogTitle>{editing ? 'Edit Outgoing Donation' : 'Record Outgoing Donation'}</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
@@ -228,9 +234,16 @@ export default function TrackOutgoingDonations() {
         <DialogActions>
           <Button onClick={handleSaveDonation} disabled={!form.receiverId || !form.weight}>Save</Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={deleteOpen} onClose={() => { setDeleteOpen(false); setToDelete(null); }}>
+      <FormDialog
+        open={deleteOpen}
+        onClose={() => {
+          setDeleteOpen(false);
+          setToDelete(null);
+        }}
+        maxWidth="xs"
+      >
         <DialogCloseButton onClose={() => { setDeleteOpen(false); setToDelete(null); }} />
         <DialogTitle>Delete Outgoing Donation</DialogTitle>
         <DialogContent>
@@ -257,9 +270,9 @@ export default function TrackOutgoingDonations() {
             Delete
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={newReceiverOpen} onClose={() => setNewReceiverOpen(false)}>
+      <FormDialog open={newReceiverOpen} onClose={() => setNewReceiverOpen(false)}>
         <DialogCloseButton onClose={() => setNewReceiverOpen(false)} />
         <DialogTitle>Add Donation Receiver</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
@@ -273,7 +286,7 @@ export default function TrackOutgoingDonations() {
         <DialogActions>
           <Button onClick={handleAddReceiver} disabled={!receiverName}>Save</Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
         <FeedbackSnackbar
           open={snackbar.open}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackPigpound.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import {
   Button,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -18,6 +17,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import FormDialog from '../../components/FormDialog';
 import useSnackbar from '../../hooks/useSnackbar';
 import {
   getPigPounds,
@@ -151,7 +151,7 @@ export default function TrackPigpound() {
         </Button>
         <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
-        <Dialog
+        <FormDialog
           open={recordOpen}
           onClose={() => {
             setRecordOpen(false);
@@ -185,14 +185,15 @@ export default function TrackPigpound() {
               Save
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
 
-        <Dialog
+        <FormDialog
           open={deleteOpen}
           onClose={() => {
             setDeleteOpen(false);
             setToDelete(null);
           }}
+          maxWidth="xs"
         >
           <DialogCloseButton onClose={() => {
             setDeleteOpen(false);
@@ -228,7 +229,7 @@ export default function TrackPigpound() {
               Delete
             </Button>
           </DialogActions>
-        </Dialog>
+        </FormDialog>
 
         <FeedbackSnackbar
           open={open}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/TrackSurplus.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -18,6 +17,7 @@ import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
 import StyledTabs from '../../components/StyledTabs';
 import DialogCloseButton from '../../components/DialogCloseButton';
+import FormDialog from '../../components/FormDialog';
 import useSnackbar from '../../hooks/useSnackbar';
 import {
   getSurplus,
@@ -173,7 +173,13 @@ export default function TrackSurplus() {
         </Button>
         <StyledTabs tabs={tabs} value={tab} onChange={(_e, v) => setTab(v)} sx={{ mb: 2 }} />
 
-      <Dialog open={recordOpen} onClose={() => { setRecordOpen(false); setEditing(null); }}>
+      <FormDialog
+        open={recordOpen}
+        onClose={() => {
+          setRecordOpen(false);
+          setEditing(null);
+        }}
+      >
         <DialogCloseButton onClose={() => { setRecordOpen(false); setEditing(null); }} />
         <DialogTitle>{editing ? 'Edit Surplus' : 'Record Surplus'}</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
@@ -206,9 +212,16 @@ export default function TrackSurplus() {
         <DialogActions>
           <Button onClick={handleSave} disabled={!form.date || !form.count}>Save</Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
-      <Dialog open={deleteOpen} onClose={() => { setDeleteOpen(false); setToDelete(null); }}>
+      <FormDialog
+        open={deleteOpen}
+        onClose={() => {
+          setDeleteOpen(false);
+          setToDelete(null);
+        }}
+        maxWidth="xs"
+      >
         <DialogCloseButton onClose={() => { setDeleteOpen(false); setToDelete(null); }} />
         <DialogTitle>Delete Surplus</DialogTitle>
         <DialogContent>Are you sure you want to delete this surplus record?</DialogContent>
@@ -236,7 +249,7 @@ export default function TrackSurplus() {
             Delete
           </Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
         <FeedbackSnackbar
           open={open}

--- a/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/WarehouseDashboard.tsx
@@ -15,7 +15,6 @@ import {
   MenuItem,
   Alert,
   Stack,
-  Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -57,6 +56,7 @@ import { getEvents, type EventGroups } from '../../api/events';
 import type { AlertColor } from '@mui/material';
 import Page from '../../components/Page';
 import WarehouseQuickLinks from '../../components/WarehouseQuickLinks';
+import FormDialog from '../../components/FormDialog';
 
 interface MonthlyTotal {
   year: number;
@@ -579,10 +579,9 @@ export default function WarehouseDashboard() {
         </Card>
       </Box>
 
-      <Dialog
+      <FormDialog
         open={Boolean(selectedComposition)}
         onClose={() => setSelectedComposition(null)}
-        fullWidth
         maxWidth="xs"
       >
         <DialogTitle>
@@ -610,7 +609,7 @@ export default function WarehouseDashboard() {
         <DialogActions>
           <Button onClick={() => setSelectedComposition(null)}>Close</Button>
         </DialogActions>
-      </Dialog>
+      </FormDialog>
 
       </Box>
       <FeedbackSnackbar


### PR DESCRIPTION
## Summary
- add a reusable `FormDialog` component that applies `fullWidth` and a default `maxWidth="sm"`
- convert client, volunteer, admin, delivery, and warehouse dialogs to use `FormDialog`, keeping confirmation modals compact with `maxWidth="xs"`
- ensure success and management dialogs share consistent sizing so content no longer shifts while typing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc4a705a00832d8bcd68d10647b7f7