### PR TITLE
Fix build errors for Food Bank trends layout

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -4,7 +4,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 const Dashboard = React.lazy(
   () => import('./components/dashboard/Dashboard')
 );
-import Navbar, { type NavGroup, type NavLink } from './components/Navbar';
+import Navbar from './components/Navbar';
 import FeedbackSnackbar from './components/FeedbackSnackbar';
 import MainLayout from './components/layout/MainLayout';
 import { useAuth, DonorManagementGuard } from './hooks/useAuth';

--- a/MJ_FB_Frontend/src/pages/aggregations/FoodBankTrends.tsx
+++ b/MJ_FB_Frontend/src/pages/aggregations/FoodBankTrends.tsx
@@ -7,7 +7,6 @@ import {
   Chip,
   CircularProgress,
   FormControl,
-  Grid,
   InputLabel,
   MenuItem,
   Select,
@@ -15,6 +14,7 @@ import {
   Typography,
   type AlertColor,
 } from '@mui/material';
+import Grid from '@mui/material/Grid';
 import Announcement from '@mui/icons-material/Announcement';
 import { useTheme } from '@mui/material/styles';
 import {
@@ -311,7 +311,7 @@ export default function FoodBankTrends() {
       />
 
       <Grid container spacing={2}>
-        <Grid item xs={12} lg={8}>
+        <Grid size={{ xs: 12, lg: 8 }}>
           <Stack spacing={3}>
             <SectionCard title="Pantry & Community">
               <Box
@@ -579,7 +579,7 @@ export default function FoodBankTrends() {
             </SectionCard>
           </Stack>
         </Grid>
-        <Grid item xs={12} lg={4}>
+        <Grid size={{ xs: 12, lg: 4 }}>
           <SectionCard title="Notices & Events" icon={<Announcement color="primary" />}>
             {eventsLoading ? (
               <Box display="flex" justifyContent="center" py={2}>


### PR DESCRIPTION
## Summary
- remove unused Navbar type imports from App to satisfy strict build settings
- switch FoodBankTrends to the current MUI Grid API so the production build succeeds

## Testing
- CI=1 npm run build
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc4f78ae84832d89e93dc31abe9439