### PR TITLE
Remove aggregations access before enforcing staff constraint

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000065_remove_aggregations_from_staff_access.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000065_remove_aggregations_from_staff_access.ts
@@ -2,6 +2,9 @@ import type { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.dropConstraint('staff', 'staff_access_check');
+  pgm.sql(
+    "UPDATE staff SET access = array_remove(access, 'aggregations') WHERE 'aggregations' = ANY(access);",
+  );
   pgm.addConstraint('staff', 'staff_access_check', {
     check: "access <@ ARRAY['pantry','volunteer_management','warehouse','admin','donor_management','payroll_management']",
   });


### PR DESCRIPTION
## Summary
- remove the obsolete aggregations role from existing staff access lists before re-adding the constraint

## Testing
- not run (per request)

------
https://chatgpt.com/codex/tasks/task_e_68cc51b1d870832db133bc707cc4535a