### PR TITLE
Stack warehouse trend charts vertically

### DIFF
--- a/MJ_FB_Frontend/src/pages/aggregations/FoodBankTrends.tsx
+++ b/MJ_FB_Frontend/src/pages/aggregations/FoodBankTrends.tsx
@@ -390,11 +390,7 @@ export default function FoodBankTrends() {
                   </FormControl>
                 </Stack>
 
-                <Box
-                  display="grid"
-                  gridTemplateColumns={{ xs: '1fr', lg: '2fr 1fr' }}
-                  gap={2}
-                >
+                <Stack spacing={2}>
                   <Card variant="outlined">
                     <CardHeader title="Monthly Trend" />
                     <CardContent sx={{ height: 300 }}>
@@ -489,7 +485,7 @@ export default function FoodBankTrends() {
                       )}
                     </CardContent>
                   </Card>
-                </Box>
+                </Stack>
 
                 <Box
                   display="grid"


### PR DESCRIPTION
## Summary
- stack the Monthly Trend and Composition cards in the warehouse overview so each uses a full row on the trends page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc547e005c832d8b8c379768e9dd79