### PR TITLE
Make pantry trend charts clickable

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/ClientVisitBreakdownChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/ClientVisitBreakdownChart.tsx
@@ -10,20 +10,30 @@ import {
   Tooltip,
 } from 'recharts';
 import type { VisitStat } from '../../api/clientVisits';
+import type { CategoricalChartState } from 'recharts/types/chart/generateCategoricalChart';
 
 interface Props {
   data: VisitStat[];
+  onPointSelect?: (stat: VisitStat) => void;
 }
 
-export default function ClientVisitBreakdownChart({ data }: Props) {
+export default function ClientVisitBreakdownChart({ data, onPointSelect }: Props) {
   const theme = useTheme();
   const chartData =
     data.length === 1
       ? [...data, { month: '', clients: 0, adults: 0, children: 0 }]
       : data;
+
+  const handleClick = (state: CategoricalChartState | undefined) => {
+    if (!onPointSelect) return;
+    const payload = state?.activePayload?.[0]?.payload as VisitStat | undefined;
+    if (payload) {
+      onPointSelect(payload);
+    }
+  };
   return (
     <ResponsiveContainer width="100%" height={300} data-testid="visit-breakdown-chart">
-      <LineChart data={chartData}>
+      <LineChart data={chartData} onClick={handleClick}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="month" />
         <YAxis allowDecimals={false} />

--- a/MJ_FB_Frontend/src/components/dashboard/ClientVisitTrendChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/ClientVisitTrendChart.tsx
@@ -10,20 +10,30 @@ import {
   Tooltip,
 } from 'recharts';
 import type { VisitStat } from '../../api/clientVisits';
+import type { CategoricalChartState } from 'recharts/types/chart/generateCategoricalChart';
 
 interface Props {
   data: VisitStat[];
+  onPointSelect?: (stat: VisitStat) => void;
 }
 
-export default function ClientVisitTrendChart({ data }: Props) {
+export default function ClientVisitTrendChart({ data, onPointSelect }: Props) {
   const theme = useTheme();
   const chartData =
     data.length === 1
       ? [...data, { month: '', clients: 0, adults: 0, children: 0 }]
       : data;
+
+  const handleClick = (state: CategoricalChartState | undefined) => {
+    if (!onPointSelect) return;
+    const payload = state?.activePayload?.[0]?.payload as VisitStat | undefined;
+    if (payload) {
+      onPointSelect(payload);
+    }
+  };
   return (
     <ResponsiveContainer width="100%" height={300} data-testid="visit-trend-chart">
-      <LineChart data={chartData}>
+      <LineChart data={chartData} onClick={handleClick}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="month" />
         <YAxis allowDecimals={false} />


### PR DESCRIPTION
## Summary
- add click handlers to monthly visit trend and breakdown charts so selecting a point surfaces its data
- surface the selected month’s totals beneath each chart, reusing the most recent month by default
- share the selection state across both charts so tapping either graph updates the displayed chips

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cc549b2c74832d8b7ea8ef4fdc5621