### PR TITLE
Fix staff routing for client booking endpoint

### DIFF
--- a/MJ_FB_Backend/src/routes/bookings.ts
+++ b/MJ_FB_Backend/src/routes/bookings.ts
@@ -23,10 +23,16 @@ const router = express.Router();
 
 // Wrapper to handle bookings created by staff or regular users (supports optional note)
 const handleCreateBooking = (req: Request, res: Response, next: NextFunction) => {
-  if (req.user?.role === 'staff') {
+  if (req.user?.type === 'staff') {
     // Allow staff to create a booking for themselves or another user
     if (!req.body.userId) {
-      req.body.userId = req.user.id;
+      const fallbackId = req.user.userId ?? req.user.id;
+      if (fallbackId !== undefined && fallbackId !== null) {
+        const parsedId = Number(fallbackId);
+        if (!Number.isNaN(parsedId)) {
+          req.body.userId = parsedId;
+        }
+      }
     }
     return createBookingForUser(req, res, next);
   }


### PR DESCRIPTION
## Summary
- ensure the /bookings route treats any authenticated staff account as staff when dispatching requests
- normalize fallback staff IDs into numeric user IDs before passing them to the staff booking controller
- validate and reuse numeric user IDs inside createBookingForUser to prevent invalid inserts

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cc6c00f12c832d87524353e94360a4