### PR TITLE
Handle missing clients when creating staff bookings

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -30,6 +30,7 @@ import {
   checkSlotCapacity,
   insertBooking,
   lockClientRow,
+  ClientNotFoundError,
   fetchBookings as repoFetchBookings,
   fetchBookingById,
   updateBooking,
@@ -1006,6 +1007,12 @@ export async function createBookingForUser(
       await client.query('COMMIT');
     } catch (err: any) {
       await client.query('ROLLBACK');
+      if (err instanceof ClientNotFoundError) {
+        return res.status(err.status).json({ message: err.message });
+      }
+      if (err?.code === '23503') {
+        return res.status(404).json({ message: 'Client not found' });
+      }
       if (err instanceof SlotCapacityError || err?.code === '25P02') {
         if (err?.code === '25P02') {
           return res


### PR DESCRIPTION
## Summary
- add a ClientNotFoundError in the booking repository so missing client locks are reported
- short-circuit staff booking creation when the client record is missing before inserting a booking
- cover the missing client regression and keep existing booking controller behaviour in tests

## Testing
- npm test -- bookingController

------
https://chatgpt.com/codex/tasks/task_e_68cc6c1905ec832d942258034175f9b2