### PR TITLE
Add reusable warehouse trend chart with selection summaries

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/WarehouseTrendChart.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/WarehouseTrendChart.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import WarehouseTrendChart, {
+  type WarehouseTrendPoint,
+} from '../components/dashboard/WarehouseTrendChart';
+
+jest.mock('recharts', () => {
+  const Recharts = jest.requireActual('recharts');
+  return {
+    ...Recharts,
+    ResponsiveContainer: ({ children }: any) => (
+      <div className="recharts-wrapper" style={{ width: 800, height: 300 }}>
+        {React.cloneElement(children, { width: 800, height: 300 })}
+      </div>
+    ),
+    LineChart: ({ children, onClick, data }: any) => (
+      <div data-testid="line-chart" onClick={() => onClick?.({ activePayload: [{ payload: data?.[0] }] })}>
+        {children}
+      </div>
+    ),
+    Tooltip: () => null,
+  };
+});
+
+const data: WarehouseTrendPoint[] = [
+  { month: 'Jan', incoming: 150, outgoing: 120 },
+  { month: 'Feb', incoming: 180, outgoing: 140 },
+];
+
+test('calls onPointSelect when a data point is clicked', () => {
+  const handleSelect = jest.fn();
+  const { getByTestId } = render(
+    <ThemeProvider theme={createTheme()}>
+      <WarehouseTrendChart data={data} onPointSelect={handleSelect} />
+    </ThemeProvider>,
+  );
+
+  fireEvent.click(getByTestId('line-chart'));
+
+  expect(handleSelect).toHaveBeenCalledWith(expect.objectContaining(data[0]));
+});

--- a/MJ_FB_Frontend/src/components/dashboard/WarehouseTrendChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/WarehouseTrendChart.tsx
@@ -1,0 +1,76 @@
+import { useTheme } from '@mui/material/styles';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Legend,
+  Tooltip,
+} from 'recharts';
+import type { CategoricalChartFunc } from 'recharts/types/chart/types';
+import type { MouseHandlerDataParam } from 'recharts/types/synchronisation/types';
+
+export interface WarehouseTrendPoint {
+  month: string;
+  incoming: number;
+  outgoing: number;
+}
+
+type ChartState = MouseHandlerDataParam & {
+  activePayload?: Array<{ payload?: unknown }>;
+};
+
+interface Props {
+  data: WarehouseTrendPoint[];
+  onPointSelect?: (point: WarehouseTrendPoint) => void;
+}
+
+export default function WarehouseTrendChart({ data, onPointSelect }: Props) {
+  const theme = useTheme();
+  const chartData =
+    data.length === 1
+      ? [...data, { month: '', incoming: 0, outgoing: 0 }]
+      : data;
+
+  const handleClick: CategoricalChartFunc = state => {
+    if (!onPointSelect) return;
+    const payload = (state as ChartState | undefined)?.activePayload?.[0]?.payload as
+      | WarehouseTrendPoint
+      | undefined;
+    if (payload && payload.month) {
+      onPointSelect(payload);
+    }
+  };
+
+  return (
+    <ResponsiveContainer width="100%" height={300} data-testid="warehouse-trend-chart">
+      <LineChart data={chartData} onClick={handleClick}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="month" />
+        <YAxis />
+        <Tooltip trigger="click" />
+        <Legend />
+        <Line
+          type="monotone"
+          dataKey="incoming"
+          name="Incoming"
+          stroke={theme.palette.success.main}
+          strokeWidth={2}
+          dot={{ r: 4, cursor: 'pointer' }}
+          activeDot={{ r: 6 }}
+        />
+        <Line
+          type="monotone"
+          dataKey="outgoing"
+          name="Outgoing"
+          stroke={theme.palette.error.main}
+          strokeWidth={2}
+          dot={{ r: 4, cursor: 'pointer' }}
+          activeDot={{ r: 6 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `WarehouseTrendChart` component with clickable points and a `Tooltip`
- replace inline Recharts usage in the warehouse dashboard and food bank trends pages to show selected month summaries
- add interaction tests covering the chart component and page selection UIs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc82bbe594832db47235cf901ad36c