### PR TITLE
Add reusable warehouse trend chart with selection tests

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/WarehouseTrendChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/WarehouseTrendChart.tsx
@@ -1,0 +1,77 @@
+import { useTheme } from '@mui/material/styles';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Legend,
+  Tooltip,
+} from 'recharts';
+import type { CategoricalChartFunc } from 'recharts/types/chart/types';
+import type { MouseHandlerDataParam } from 'recharts/types/synchronisation/types';
+
+export interface WarehouseTrendDatum {
+  month: string;
+  incoming: number;
+  outgoing: number;
+}
+
+type ChartState = MouseHandlerDataParam & {
+  activePayload?: Array<{ payload?: unknown }>;
+};
+
+interface Props<T extends WarehouseTrendDatum> {
+  data: T[];
+  onPointSelect?: (datum: T) => void;
+}
+
+export default function WarehouseTrendChart<T extends WarehouseTrendDatum>({
+  data,
+  onPointSelect,
+}: Props<T>) {
+  const theme = useTheme();
+  const chartData =
+    data.length === 1
+      ? [...data, { month: '', incoming: 0, outgoing: 0 } as T]
+      : data;
+
+  const handleClick: CategoricalChartFunc = state => {
+    if (!onPointSelect) return;
+    const payload = (state as ChartState | undefined)?.activePayload?.[0]?.payload as T | undefined;
+    if (payload) {
+      onPointSelect(payload);
+    }
+  };
+
+  return (
+    <ResponsiveContainer width="100%" height={300} data-testid="warehouse-trend-chart">
+      <LineChart data={chartData} onClick={handleClick}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="month" />
+        <YAxis />
+        <Tooltip trigger="click" />
+        <Legend />
+        <Line
+          type="monotone"
+          dataKey="incoming"
+          name="Incoming"
+          stroke={theme.palette.success.main}
+          strokeWidth={2}
+          dot={{ r: 4, cursor: 'pointer' }}
+          activeDot={{ r: 5 }}
+        />
+        <Line
+          type="monotone"
+          dataKey="outgoing"
+          name="Outgoing"
+          stroke={theme.palette.error.main}
+          strokeWidth={2}
+          dot={{ r: 4, cursor: 'pointer' }}
+          activeDot={{ r: 5 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/MJ_FB_Frontend/src/components/dashboard/__tests__/WarehouseTrendChart.test.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/__tests__/WarehouseTrendChart.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import WarehouseTrendChart, { type WarehouseTrendDatum } from '../WarehouseTrendChart';
+
+describe('WarehouseTrendChart', () => {
+  const sampleData: WarehouseTrendDatum[] = [
+    { month: 'Jan', incoming: 1200, outgoing: 900 },
+    { month: 'Feb', incoming: 1500, outgoing: 1100 },
+  ];
+
+  it('invokes onPointSelect when a chart point is clicked', () => {
+    const handleSelect = jest.fn();
+    render(<WarehouseTrendChart data={sampleData} onPointSelect={handleSelect} />);
+
+    const chart = screen.getByTestId('warehouse-trend-chart');
+    const dots = chart.querySelectorAll('.recharts-dot');
+
+    expect(dots.length).toBeGreaterThan(0);
+
+    fireEvent.click(dots[0]);
+
+    expect(handleSelect).toHaveBeenCalledTimes(1);
+    expect(handleSelect).toHaveBeenCalledWith(sampleData[0]);
+  });
+});

--- a/MJ_FB_Frontend/src/pages/aggregations/__tests__/FoodBankTrends.test.tsx
+++ b/MJ_FB_Frontend/src/pages/aggregations/__tests__/FoodBankTrends.test.tsx
@@ -1,0 +1,118 @@
+type TrendDatum = { month: string; incoming: number; outgoing: number };
+
+let mockTrendPoint: TrendDatum = { month: 'Jan', incoming: 0, outgoing: 0 };
+
+jest.mock('../../../api/pantryAggregations', () => ({
+  getPantryMonthly: jest.fn(),
+}));
+
+jest.mock('../../../api/events', () => ({
+  getEvents: jest.fn(),
+}));
+
+jest.mock('../../../api/warehouseOverall', () => ({
+  getWarehouseOverall: jest.fn(),
+  getWarehouseOverallYears: jest.fn(),
+}));
+
+jest.mock('../../../api/donors', () => ({
+  getTopDonors: jest.fn(),
+}));
+
+jest.mock('../../../api/outgoingReceivers', () => ({
+  getTopReceivers: jest.fn(),
+}));
+
+jest.mock('../../../components/dashboard/WarehouseTrendChart', () => ({
+  __esModule: true,
+  default: ({ onPointSelect }: { onPointSelect?: (datum: TrendDatum) => void }) => (
+    <button type="button" data-testid="mock-trend-chart" onClick={() => onPointSelect?.(mockTrendPoint)}>
+      Trend Chart
+    </button>
+  ),
+}));
+
+jest.mock('../../../components/dashboard/WarehouseCompositionChart', () => ({
+  __esModule: true,
+  default: () => <div data-testid="composition-chart" />,
+}));
+
+jest.mock('../../../components/EventList', () => ({
+  __esModule: true,
+  default: () => <div data-testid="event-list" />,
+}));
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FoodBankTrends from '../FoodBankTrends';
+import { getPantryMonthly } from '../../../api/pantryAggregations';
+import { getEvents } from '../../../api/events';
+import {
+  getWarehouseOverall,
+  getWarehouseOverallYears,
+} from '../../../api/warehouseOverall';
+import { getTopDonors } from '../../../api/donors';
+import { getTopReceivers } from '../../../api/outgoingReceivers';
+
+describe('FoodBankTrends', () => {
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1;
+  const previousYear = currentYear - 1;
+
+  const warehouseTotals = [
+    { month: 1, donations: 1000, surplus: 150, pigPound: 50, outgoingDonations: 700 },
+    { month: 2, donations: 900, surplus: 100, pigPound: 40, outgoingDonations: 650 },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getPantryMonthly as jest.Mock).mockImplementation((year: number) => {
+      if (year === currentYear) {
+        return Promise.resolve([
+          { month: currentMonth, orders: 20, adults: 35, children: 12 },
+        ]);
+      }
+      if (year === previousYear) {
+        return Promise.resolve([
+          { month: currentMonth, orders: 18, adults: 30, children: 10 },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    (getWarehouseOverallYears as jest.Mock).mockResolvedValue([2024]);
+    (getWarehouseOverall as jest.Mock).mockResolvedValue(warehouseTotals);
+    (getTopDonors as jest.Mock).mockResolvedValue([]);
+    (getTopReceivers as jest.Mock).mockResolvedValue([]);
+    mockTrendPoint = {
+      month: 'Jan',
+      incoming: warehouseTotals[0].donations + warehouseTotals[0].surplus + warehouseTotals[0].pigPound,
+      outgoing: warehouseTotals[0].outgoingDonations,
+    };
+  });
+
+  it('shows warehouse totals after clicking the trend chart', async () => {
+    render(
+      <MemoryRouter>
+        <FoodBankTrends />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Click a point to view totals for that month.');
+
+    const chartButton = await screen.findByTestId('mock-trend-chart');
+    fireEvent.click(chartButton);
+
+    const incomingChip = await screen.findByTestId('warehouse-trend-incoming');
+    const outgoingChip = await screen.findByTestId('warehouse-trend-outgoing');
+
+    const incomingValue = Number((incomingChip.textContent ?? '').replace(/[^0-9]/g, ''));
+    const outgoingValue = Number((outgoingChip.textContent ?? '').replace(/[^0-9]/g, ''));
+
+    expect(incomingValue).toBe(mockTrendPoint.incoming);
+    expect(outgoingValue).toBe(mockTrendPoint.outgoing);
+  }, 15000);
+});

--- a/MJ_FB_Frontend/src/pages/warehouse-management/__tests__/WarehouseDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/__tests__/WarehouseDashboard.test.tsx
@@ -1,0 +1,96 @@
+type TrendDatum = { month: string; incoming: number; outgoing: number };
+
+let mockTrendPoint: TrendDatum = { month: 'Jan', incoming: 0, outgoing: 0 };
+
+jest.mock('../../../api/warehouseOverall', () => ({
+  getWarehouseOverall: jest.fn(),
+  getWarehouseOverallYears: jest.fn(),
+}));
+
+jest.mock('../../../api/donors', () => ({
+  getTopDonors: jest.fn(),
+  getDonors: jest.fn(),
+}));
+
+jest.mock('../../../api/outgoingReceivers', () => ({
+  getTopReceivers: jest.fn(),
+}));
+
+jest.mock('../../../api/events', () => ({
+  getEvents: jest.fn(),
+}));
+
+jest.mock('../../../components/dashboard/WarehouseTrendChart', () => ({
+  __esModule: true,
+  default: ({ onPointSelect }: { onPointSelect?: (datum: TrendDatum) => void }) => (
+    <button type="button" data-testid="mock-trend-chart" onClick={() => onPointSelect?.(mockTrendPoint)}>
+      Trend Chart
+    </button>
+  ),
+}));
+
+jest.mock('../../../components/dashboard/VolunteerCoverageCard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="volunteer-coverage-card" />,
+}));
+
+jest.mock('../../../components/WarehouseQuickLinks', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import WarehouseDashboard from '../WarehouseDashboard';
+import {
+  getWarehouseOverall,
+  getWarehouseOverallYears,
+} from '../../../api/warehouseOverall';
+import { getTopDonors, getDonors } from '../../../api/donors';
+import { getTopReceivers } from '../../../api/outgoingReceivers';
+import { getEvents } from '../../../api/events';
+
+describe('WarehouseDashboard', () => {
+  const mockTotals = [
+    { month: 1, donations: 1000, surplus: 200, pigPound: 50, outgoingDonations: 800 },
+    { month: 2, donations: 1200, surplus: 150, pigPound: 60, outgoingDonations: 900 },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getWarehouseOverallYears as jest.Mock).mockResolvedValue([2024]);
+    (getWarehouseOverall as jest.Mock).mockResolvedValue(mockTotals);
+    (getTopDonors as jest.Mock).mockResolvedValue([]);
+    (getTopReceivers as jest.Mock).mockResolvedValue([]);
+    (getDonors as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
+    mockTrendPoint = {
+      month: 'Jan',
+      incoming: mockTotals[0].donations,
+      outgoing: mockTotals[0].outgoingDonations,
+    };
+  });
+
+  it('shows monthly totals after clicking the trend chart', async () => {
+    render(
+      <MemoryRouter>
+        <WarehouseDashboard />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Click a point to view totals for that month.');
+
+    const chartButton = await screen.findByTestId('mock-trend-chart');
+    fireEvent.click(chartButton);
+
+    const incomingChip = await screen.findByTestId('warehouse-trend-incoming');
+    const outgoingChip = await screen.findByTestId('warehouse-trend-outgoing');
+
+    const incomingValue = Number((incomingChip.textContent ?? '').replace(/[^0-9]/g, ''));
+    const outgoingValue = Number((outgoingChip.textContent ?? '').replace(/[^0-9]/g, ''));
+
+    expect(incomingValue).toBe(mockTrendPoint.incoming);
+    expect(outgoingValue).toBe(mockTrendPoint.outgoing);
+  }, 15000);
+});


### PR DESCRIPTION
## Summary
* Added new reusable `WarehouseTrendChart` component with click-triggered tooltip and point selection callback (`src/components/dashboard/WarehouseTrendChart.tsx`).
* Replaced inline line charts in `src/pages/warehouse-management/WarehouseDashboard.tsx` and `src/pages/aggregations/FoodBankTrends.tsx`, added selection summaries (chips) with `data-testid`s.
* Introduced Jest tests for the component and pages:
  * `src/components/dashboard/__tests__/WarehouseTrendChart.test.tsx`
  * `src/pages/warehouse-management/__tests__/WarehouseDashboard.test.tsx`
  * `src/pages/aggregations/__tests__/FoodBankTrends.test.tsx`

## Testing
* `npm test -- --runTestsByPath src/components/dashboard/__tests__/WarehouseTrendChart.test.tsx src/pages/warehouse-management/__tests__/WarehouseDashboard.test.tsx src/pages/aggregations/__tests__/FoodBankTrends.test.tsx`
* `npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68cc85e2a5b4832da06d16aaff537196