### PR TITLE
Normalize volunteer status colours

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -14,7 +14,10 @@ import {
   type VolunteerSearchResult,
   type VolunteerStatsByIdResponse,
 } from '../../api/volunteers';
-import type { VolunteerBookingDetail } from '../../types';
+import type {
+  VolunteerBookingDetail,
+  VolunteerBookingStatus,
+} from '../../types';
 import { formatTime } from '../../utils/time';
 import VolunteerScheduleTable from '../../components/VolunteerScheduleTable';
 import { fromZonedTime } from 'date-fns-tz';
@@ -128,8 +131,9 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
 
   const theme = useTheme();
   const approvedColor = lighten(theme.palette.success.light, 0.4);
-  const statusColors: Record<string, string> = {
+  const statusColors: Record<VolunteerBookingStatus, string> = {
     approved: approvedColor,
+    cancelled: 'rgb(255, 200, 200)',
     no_show: 'rgb(255, 200, 200)',
     completed: 'rgb(111,146,113)',
   };
@@ -715,10 +719,15 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
           time: `${formatTime(role.start_time || '')} - ${formatTime(role.end_time || '')}`,
           cells: Array.from({ length: role.max_volunteers }).map((_, i) => {
             const booking = slotBookings[i];
+            const statusKey = booking
+              ? (booking.status.toLowerCase() as VolunteerBookingStatus)
+              : undefined;
             return {
               content: booking ? booking.volunteer_name : 'Available',
               backgroundColor: booking
-                ? statusColors[booking.status] || approvedColor
+                ? statusKey
+                  ? statusColors[statusKey] || approvedColor
+                  : approvedColor
                 : undefined,
               onClick: () => {
                 if (booking) {
@@ -903,10 +912,15 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                       cells: Array.from({ length: role.max_volunteers }).map(
                         (_, i) => {
                           const booking = slotBookings[i];
+                          const statusKey = booking
+                            ? (booking.status.toLowerCase() as VolunteerBookingStatus)
+                            : undefined;
                           return {
                             content: booking ? booking.volunteer_name : 'Available',
                             backgroundColor: booking
-                              ? statusColors[booking.status] || approvedColor
+                              ? statusKey
+                                ? statusColors[statusKey] || approvedColor
+                                : approvedColor
                               : undefined,
                             onClick: () => {
                               if (booking) {


### PR DESCRIPTION
## Summary
- normalize volunteer booking status strings before mapping to schedule cell colours
- type the status colour map with VolunteerBookingStatus to keep keys in sync

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cd748abf20832db3c667c4651e53fc