### PR TITLE
Include completed volunteer bookings in coverage card

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/VolunteerCoverageCard.tsx
@@ -76,7 +76,7 @@ export default function VolunteerCoverageCard({
               const bookings = await getVolunteerBookingsByRole(s.id);
               const todayBookings = bookings.filter(
                 (b: any) =>
-                  b.status === 'approved' &&
+                  (b.status === 'approved' || b.status === 'completed') &&
                   formatReginaDate(toDate(b.date)) === todayStr,
               );
               const volunteers = todayBookings


### PR DESCRIPTION
## Summary
- treat completed volunteer bookings as filled coverage alongside approved bookings
- ensure volunteer detail dialog shows completed volunteer names in the list
- add regression test covering completed booking counts and details

## Testing
- npm test -- VolunteerCoverageCard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cd75fc2cc0832db01d9181fbf857bc