### PR TITLE
Render event details with line breaks

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerDashboard.test.tsx
@@ -167,6 +167,35 @@ describe('VolunteerDashboard', () => {
     expect(await screen.findByText(/Volunteer Event/)).toBeInTheDocument();
   });
 
+  it('preserves line breaks in event details', async () => {
+    (getMyVolunteerBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerRolesForVolunteer as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({
+      today: [
+        {
+          id: 1,
+          title: 'Volunteer Event',
+          startDate: new Date().toISOString(),
+          endDate: new Date().toISOString(),
+          createdBy: 1,
+          createdByName: 'Staff',
+          priority: 0,
+          details: 'First line\nSecond line',
+        },
+      ],
+      upcoming: [],
+      past: [],
+    });
+
+    await renderDashboard();
+
+    const details = await screen.findByText(
+      (_, element) => element?.textContent === 'First line\nSecond line',
+    );
+    expect(details).toBeInTheDocument();
+    expect(window.getComputedStyle(details).whiteSpace).toBe('pre-line');
+  });
+
   it('shows an error message if events cannot be fetched', async () => {
     const consoleErrorSpy = jest
       .spyOn(console, 'error')

--- a/MJ_FB_Frontend/src/components/EventList.tsx
+++ b/MJ_FB_Frontend/src/components/EventList.tsx
@@ -49,7 +49,12 @@ export default function EventList({ events, limit, onDelete, onChange, onEdit }:
             secondary={
               <>
                 {ev.details && (
-                  <Typography variant="body2" component="span" display="block">
+                  <Typography
+                    variant="body2"
+                    component="span"
+                    display="block"
+                    sx={{ whiteSpace: 'pre-line' }}
+                  >
                     {ev.details}
                   </Typography>
                 )}


### PR DESCRIPTION
## Summary
- ensure EventList respects newline characters in event details
- cover the News & Events card with a multiline details test on the volunteer dashboard

## Testing
- npm test -- --runTestsByPath src/__tests__/VolunteerDashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cd760560b0832d9342685c528686b6