### PR TITLE
Improve login error messaging

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -156,14 +156,17 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       }
 
       if (!foundAccount) {
-        return res.status(404).json({ message: 'Account not found' });
+        return res.status(404).json({
+          message:
+            "Hmm... you don't seem to have an account with us. Please contact hearvestpantry@mjfoodbank.org to have one created.",
+        });
       }
 
       if (pendingSetup && !invalidCredentials) {
         return res.status(410).json({ message: 'Password setup link expired' });
       }
 
-      return res.status(401).json({ message: 'Invalid credentials' });
+      return res.status(401).json({ message: 'Password is incorrect.' });
     }
 
     if (clientId) {
@@ -172,7 +175,10 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
         [clientId],
       );
       if ((userQuery.rowCount ?? 0) === 0) {
-        return res.status(401).json({ message: 'Invalid credentials' });
+        return res.status(404).json({
+          message:
+            "Hmm... you don't seem to have an account with us. Please contact hearvestpantry@mjfoodbank.org to have one created.",
+        });
       }
       const userRow = userQuery.rows[0];
       if (!userRow.password) {
@@ -180,7 +186,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
       }
       const match = await bcrypt.compare(password, userRow.password);
       if (!match) {
-        return res.status(401).json({ message: 'Invalid credentials' });
+        return res.status(401).json({ message: 'Password is incorrect.' });
       }
       if (maintenanceMode) {
         return res

--- a/MJ_FB_Backend/tests/userController.test.ts
+++ b/MJ_FB_Backend/tests/userController.test.ts
@@ -349,7 +349,7 @@ describe('userController', () => {
       await loginUser(req, res, jest.fn());
 
       expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.json).toHaveBeenCalledWith({ message: 'Invalid credentials' });
+      expect(res.json).toHaveBeenCalledWith({ message: 'Password is incorrect.' });
       expect(issueAuthTokens).not.toHaveBeenCalled();
     });
 

--- a/MJ_FB_Frontend/src/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Login.test.tsx
@@ -51,9 +51,7 @@ describe('Login component', () => {
       target: { value: 'pass' },
     });
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
-    expect(
-      await screen.findByText('Incorrect ID or email or password')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Password is incorrect.')).toBeInTheDocument();
     expect(onLogin).not.toHaveBeenCalled();
   });
 

--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -51,13 +51,13 @@ export default function Login({
     } catch (err: unknown) {
       const apiErr = err as ApiError;
       if (apiErr?.status === 401) {
-        setError('Incorrect ID or email or password');
+        setError('Password is incorrect.');
       } else if (apiErr?.status === 410) {
         setError('Password setup link expired');
         setResendOpen(true);
       } else if (apiErr?.status === 404) {
         setError(
-          'Hmm.. you dont seem to have an account with us. Please email harvestpantry@mjfoodbank.org to have an account created for you.',
+          "Hmm... you don't seem to have an account with us. Please contact hearvestpantry@mjfoodbank.org to have one created.",
         );
       } else {
         setError(err instanceof Error ? err.message : String(err));

--- a/MJ_FB_Frontend/src/pages/auth/__tests__/Login.test.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/__tests__/Login.test.tsx
@@ -24,7 +24,11 @@ beforeEach(() => {
 
 describe('Login error handling', () => {
   it('shows account not found message', async () => {
-    mockedLogin.mockRejectedValue({ status: 404, message: 'Account not found' });
+    mockedLogin.mockRejectedValue({
+      status: 404,
+      message:
+        "Hmm... you don't seem to have an account with us. Please contact hearvestpantry@mjfoodbank.org to have one created.",
+    });
     const onLogin = jest.fn().mockResolvedValue('/');
     render(
       <MemoryRouter>
@@ -40,7 +44,7 @@ describe('Login error handling', () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          'Hmm.. you dont seem to have an account with us. Please email harvestpantry@mjfoodbank.org to have an account created for you.',
+          "Hmm... you don't seem to have an account with us. Please contact hearvestpantry@mjfoodbank.org to have one created.",
         ),
       ).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- return clearer API responses when a login email or client ID is unknown or when the password is incorrect
- surface the new phrasing in the login form so clients see friendlier guidance
- update backend and frontend tests to match the revised messages

## Testing
- npm test tests/userController.test.ts
- npm test src/__tests__/Login.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cd99189004832da95975d8368e098a