### PR TITLE
Fix volunteer management booking refresh for departments

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -413,6 +413,18 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
       } catch {
         // ignore
       }
+    } else if (selectedDepartment) {
+      try {
+        const roles =
+          groupedRoles.find(g => g.category === selectedDepartment)?.roles || [];
+        const ids = roles.flatMap(r => nameToSlotIds.get(r.name) || []);
+        const data = await getVolunteerBookingsByRoles(ids);
+        setBookings(data);
+      } catch {
+        // ignore
+      }
+    } else {
+      setBookings([]);
     }
     if (selectedVolunteer) {
       void loadVolunteerStats(selectedVolunteer.id);


### PR DESCRIPTION
## Summary
- update handleManageUpdated so department selections reload volunteer bookings like the schedule effect
- ensure schedule data clears when no role or department is selected so status colors update immediately

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cd9b758fe8832da25160d074956f06