### PR TITLE
Handle SameSite compatibility for auth cookies

### DIFF
--- a/MJ_FB_Backend/src/controllers/userController.ts
+++ b/MJ_FB_Backend/src/controllers/userController.ts
@@ -14,6 +14,7 @@ import { normalizeEmail } from '../utils/normalizeEmail';
 export async function loginUser(req: Request, res: Response, next: NextFunction) {
   const { email, password, clientId } = req.body;
   const normalizedEmail = normalizeEmail(email);
+  const userAgent = req.get('user-agent');
 
   if (!password) {
     return res.status(400).json({ message: 'Password required' });
@@ -74,7 +75,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
                 userRole: volunteer.user_role || 'shopper',
               }),
             };
-            await issueAuthTokens(res, payload, `volunteer:${volunteer.id}`);
+            await issueAuthTokens(res, payload, `volunteer:${volunteer.id}`, userAgent);
             return res.json({
               role: 'volunteer',
               name: `${volunteer.first_name} ${volunteer.last_name}`,
@@ -109,7 +110,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
               type: 'staff',
               access: staff.access || [],
             };
-            await issueAuthTokens(res, payload, `staff:${staff.id}`);
+            await issueAuthTokens(res, payload, `staff:${staff.id}`, userAgent);
             return res.json({
               role,
               name: `${staff.first_name} ${staff.last_name}`,
@@ -144,7 +145,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
               role: userRow.role,
               type: 'user',
             };
-            await issueAuthTokens(res, payload, `user:${userRow.client_id}`);
+            await issueAuthTokens(res, payload, `user:${userRow.client_id}`, userAgent);
             return res.json({
               role: userRow.role,
               name: `${userRow.first_name} ${userRow.last_name}`,
@@ -223,8 +224,8 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
           userId: userRow.client_id,
           userRole: userRow.role,
         };
-        await issueAuthTokens(res, payload, `volunteer:${volunteer.id}`);
-        return res.json({
+            await issueAuthTokens(res, payload, `volunteer:${volunteer.id}`, userAgent);
+            return res.json({
           role: 'volunteer',
           name: `${volunteer.first_name} ${volunteer.last_name}`,
           userRole: userRow.role,
@@ -239,7 +240,7 @@ export async function loginUser(req: Request, res: Response, next: NextFunction)
         role: userRow.role,
         type: 'user',
       };
-      await issueAuthTokens(res, payload, `user:${userRow.client_id}`);
+      await issueAuthTokens(res, payload, `user:${userRow.client_id}`, userAgent);
       return res.json({
         role: userRow.role,
         name: `${userRow.first_name} ${userRow.last_name}`,

--- a/MJ_FB_Backend/src/middleware/authMiddleware.ts
+++ b/MJ_FB_Backend/src/middleware/authMiddleware.ts
@@ -4,7 +4,7 @@ import jwt, { TokenExpiredError } from 'jsonwebtoken';
 import config from '../config';
 import logger from '../utils/logger';
 import cookie from 'cookie';
-import { cookieOptions } from '../utils/authUtils';
+import { getCookieOptions } from '../utils/authUtils';
 import type { RequestUser } from '../types/RequestUser';
 
 function getTokenFromCookies(req: Request) {
@@ -132,6 +132,7 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     return next();
   }
   if (result.status === 'expired') {
+    const cookieOptions = getCookieOptions(req.get('user-agent'));
     res.clearCookie('token', cookieOptions);
     return res.status(401).json({ message: 'Token expired' });
   }
@@ -150,6 +151,7 @@ export async function optionalAuthMiddleware(
     return next();
   }
   if (result.status === 'expired') {
+    const cookieOptions = getCookieOptions(req.get('user-agent'));
     res.clearCookie('token', cookieOptions);
     return res.status(401).json({ message: 'Token expired' });
   }

--- a/MJ_FB_Backend/tests/userController.test.ts
+++ b/MJ_FB_Backend/tests/userController.test.ts
@@ -60,6 +60,19 @@ const mockBuildPasswordSetupEmailParams =
 const mockSendTemplatedEmail =
   sendTemplatedEmail as jest.MockedFunction<typeof sendTemplatedEmail>;
 
+const defaultUserAgent = 'jest-agent/1.0';
+function buildReq(overrides: Record<string, unknown> = {}) {
+  const base = {
+    get: jest.fn().mockImplementation((header: string) => {
+      if (header && header.toLowerCase() === 'user-agent') {
+        return defaultUserAgent;
+      }
+      return undefined;
+    }),
+  };
+  return { ...base, ...overrides } as Record<string, unknown>;
+}
+
 describe('userController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -256,9 +269,9 @@ describe('userController', () => {
         });
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      const req: any = {
+      const req: any = buildReq({
         body: { email: 'jane@example.com', password: 'pw' },
-      };
+      });
       const res: any = {
         cookie: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -278,6 +291,7 @@ describe('userController', () => {
         res,
         { id: 5, role: 'staff', type: 'staff', access: ['admin'] },
         'staff:5',
+        defaultUserAgent,
       );
     });
 
@@ -302,9 +316,9 @@ describe('userController', () => {
         });
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      const req: any = {
+      const req: any = buildReq({
         body: { email: '  CASE@EXAMPLE.COM  ', password: 'pw' },
-      };
+      });
       const res: any = {
         cookie: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -339,7 +353,7 @@ describe('userController', () => {
         .mockResolvedValueOnce({ rowCount: 0, rows: [] });
       (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
-      const req: any = { body: { email: 'a', password: 'pw' } };
+      const req: any = buildReq({ body: { email: 'a', password: 'pw' } });
       const res: any = {
         cookie: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -387,7 +401,9 @@ describe('userController', () => {
         .mockResolvedValueOnce(false)
         .mockResolvedValueOnce(true);
 
-      const req: any = { body: { email: 'client@example.com', password: 'pw' } };
+      const req: any = buildReq({
+        body: { email: 'client@example.com', password: 'pw' },
+      });
       const res: any = {
         cookie: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -400,6 +416,7 @@ describe('userController', () => {
         res,
         { id: 42, role: 'shopper', type: 'user' },
         'user:42',
+        defaultUserAgent,
       );
       expect(res.json).toHaveBeenCalledWith({
         role: 'shopper',
@@ -440,7 +457,9 @@ describe('userController', () => {
         });
       (bcrypt.compare as jest.Mock).mockResolvedValueOnce(true);
 
-      const req: any = { body: { email: 'ready@example.com', password: 'secret' } };
+      const req: any = buildReq({
+        body: { email: 'ready@example.com', password: 'secret' },
+      });
       const res: any = {
         cookie: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -453,6 +472,7 @@ describe('userController', () => {
         res,
         { id: 88, role: 'delivery', type: 'user' },
         'user:88',
+        defaultUserAgent,
       );
       expect(res.json).toHaveBeenCalledWith({
         role: 'delivery',
@@ -484,7 +504,9 @@ describe('userController', () => {
         });
       (bcrypt.compare as jest.Mock).mockResolvedValueOnce(true);
 
-      const req: any = { body: { email: 'vol@example.com', password: 'pw' } };
+      const req: any = buildReq({
+        body: { email: 'vol@example.com', password: 'pw' },
+      });
       const res: any = {
         cookie: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -497,6 +519,7 @@ describe('userController', () => {
         res,
         { id: 17, role: 'volunteer', type: 'volunteer' },
         'volunteer:17',
+        defaultUserAgent,
       );
       expect(res.json).toHaveBeenCalledWith({
         role: 'volunteer',
@@ -523,7 +546,7 @@ describe('userController', () => {
         })
         .mockResolvedValueOnce({ rowCount: 1 });
 
-      const req: any = { headers: { cookie: `refreshToken=${token}` } };
+      const req: any = buildReq({ headers: { cookie: `refreshToken=${token}` } });
       const res: any = {
         cookie: jest.fn(),
         clearCookie: jest.fn(),
@@ -546,7 +569,7 @@ describe('userController', () => {
       });
       (pool.query as jest.Mock).mockResolvedValueOnce({ rowCount: 0, rows: [] });
 
-      const req: any = { headers: { cookie: `refreshToken=${token}` } };
+      const req: any = buildReq({ headers: { cookie: `refreshToken=${token}` } });
       const res: any = {
         cookie: jest.fn(),
         clearCookie: jest.fn(),

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Booking and volunteer management for the Moose Jaw Food Bank. This monorepo incl
 - Clients and volunteers see blocked slots as fully booked; reasons are visible only to staff.
 - Staff deliveries management queue tracks each delivery request from submission through completion, including status updates (Pending, Approved, Scheduled, Completed, Cancelled), scheduled drop-off times, and completion notes mirrored in the client Delivery History.
 - All users sign in at a consolidated `/login` page using their client ID or email and password. The page offers contact and password reset guidance and notes that staff and volunteers also sign in here. Community partners now coordinate bookings by contacting staff instead of logging in directly.
+- Authentication cookies detect incompatible browsers in production. Supported browsers receive `SameSite=None; Secure` cookies for cross-site requests, while older WebKit builds (iOS 12 Safari, embedded WebViews, and similar clients) fall back to `SameSite=Lax` so sessions remain stable. Ops should expect these legacy clients to keep signing in successfully even though they cannot use cross-site cookies.
 - The login page automatically surfaces passkey prompts via WebAuthn on supported devices.
 - A privacy notice prompts for consent after login; once agreed, it isn't shown again.
 - The privacy policy page includes contact information for account deletion requests and is accessible without logging in; a link is available on the login screen and in the profile menu.


### PR DESCRIPTION
## Summary
- add user agent detection to authUtils so incompatible browsers fall back to SameSite=Lax cookies in production
- propagate the resolved cookie options through login, refresh, middleware, and WebAuthn flows to keep legacy clients signed in
- extend auth tests to cover modern vs legacy SameSite handling and document the ops impact in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd9d6b8488832da2a41fe79d8a61bf