### PR TITLE
Add reusable online access controls and update volunteer creation

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerManagement.test.tsx
@@ -98,7 +98,7 @@ describe('VolunteerManagement create volunteer', () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /select roles/i }));
+    fireEvent.mouseDown(screen.getByLabelText('Roles'));
     expect(await screen.findByText('Front')).toBeInTheDocument();
     expect(await screen.findByText('Back')).toBeInTheDocument();
   });
@@ -130,8 +130,25 @@ describe('VolunteerManagement create volunteer', () => {
     fireEvent.change(screen.getByLabelText('Last Name'), {
       target: { value: 'Doe' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /select roles/i }));
-    fireEvent.click(await screen.findByLabelText('Greeter'));
+    const rolesField = screen.getByRole('combobox', { name: 'Roles' });
+    fireEvent.mouseDown(rolesField);
+    fireEvent.click(await screen.findByRole('option', { name: 'Greeter' }));
+    const listbox = await screen.findByRole('listbox', { name: 'Roles' });
+    fireEvent.keyDown(listbox, {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      charCode: 27,
+    });
+    fireEvent.keyUp(listbox, {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      charCode: 27,
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole('listbox', { name: 'Roles' })).not.toBeInTheDocument()
+    );
     fireEvent.click(screen.getByLabelText(/online access/i));
     fireEvent.click(screen.getByRole('button', { name: /add volunteer/i }));
 
@@ -166,10 +183,27 @@ describe('VolunteerManagement create volunteer', () => {
     fireEvent.change(screen.getByLabelText('Last Name'), {
       target: { value: 'Doe' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /select roles/i }));
-    fireEvent.click(await screen.findByLabelText('Greeter'));
+    const rolesField = screen.getByRole('combobox', { name: 'Roles' });
+    fireEvent.mouseDown(rolesField);
+    fireEvent.click(await screen.findByRole('option', { name: 'Greeter' }));
+    const listbox = await screen.findByRole('listbox', { name: 'Roles' });
+    fireEvent.keyDown(listbox, {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      charCode: 27,
+    });
+    fireEvent.keyUp(listbox, {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      charCode: 27,
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole('listbox', { name: 'Roles' })).not.toBeInTheDocument()
+    );
     fireEvent.click(screen.getByLabelText(/online access/i));
-    fireEvent.click(await screen.findByLabelText(/send password setup link/i));
+    fireEvent.click(await screen.findByRole('button', { name: /set password/i }));
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: 'john@example.com' },
     });

--- a/MJ_FB_Frontend/src/components/ContactInfoFields.tsx
+++ b/MJ_FB_Frontend/src/components/ContactInfoFields.tsx
@@ -1,0 +1,57 @@
+import { type ChangeEvent, type ComponentProps } from 'react';
+import TextField from '@mui/material/TextField';
+import { Stack } from '@mui/material';
+
+type TextFieldProps = ComponentProps<typeof TextField>;
+
+type ContactInfoFieldsProps = {
+  onlineAccess: boolean;
+  email: string;
+  onEmailChange: (value: string) => void;
+  phone: string;
+  onPhoneChange: (value: string) => void;
+  emailTextFieldProps?: Omit<TextFieldProps, 'value' | 'onChange' | 'required' | 'type'>;
+  phoneTextFieldProps?: Omit<TextFieldProps, 'value' | 'onChange' | 'type'>;
+};
+
+export default function ContactInfoFields({
+  onlineAccess,
+  email,
+  onEmailChange,
+  phone,
+  onPhoneChange,
+  emailTextFieldProps,
+  phoneTextFieldProps,
+}: ContactInfoFieldsProps) {
+  const emailLabel = emailTextFieldProps?.label ?? (onlineAccess ? 'Email' : 'Email (optional)');
+  const emailType = emailTextFieldProps?.type ?? 'email';
+  const emailRequired = emailTextFieldProps?.required ?? onlineAccess;
+
+  const handleEmailChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onEmailChange(event.target.value);
+  };
+
+  const handlePhoneChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onPhoneChange(event.target.value);
+  };
+
+  return (
+    <Stack spacing={2}>
+      <TextField
+        {...emailTextFieldProps}
+        label={emailLabel}
+        type={emailType}
+        required={emailRequired}
+        value={email}
+        onChange={handleEmailChange}
+      />
+      <TextField
+        {...phoneTextFieldProps}
+        label={phoneTextFieldProps?.label ?? 'Phone (optional)'}
+        type={phoneTextFieldProps?.type ?? 'tel'}
+        value={phone}
+        onChange={handlePhoneChange}
+      />
+    </Stack>
+  );
+}

--- a/MJ_FB_Frontend/src/components/OnlineAccessControls.tsx
+++ b/MJ_FB_Frontend/src/components/OnlineAccessControls.tsx
@@ -1,0 +1,97 @@
+import { useCallback, type ChangeEvent, type ComponentProps, type MouseEvent } from 'react';
+import { Checkbox, FormControlLabel, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import PasswordField from './PasswordField';
+
+type PasswordFieldProps = ComponentProps<typeof PasswordField>;
+
+type OnlineAccessControlsProps = {
+  onlineAccess: boolean;
+  onOnlineAccessChange: (value: boolean) => void;
+  sendPasswordLink: boolean;
+  onSendPasswordLinkChange: (value: boolean) => void;
+  password: string;
+  onPasswordChange: (value: string) => void;
+  checkboxLabel?: string;
+  sendLinkOptionLabel?: string;
+  setPasswordOptionLabel?: string;
+  invitationMessage?: string;
+  passwordFieldLabel?: string;
+  passwordFieldProps?: Omit<PasswordFieldProps, 'value' | 'onChange'>;
+};
+
+export default function OnlineAccessControls({
+  onlineAccess,
+  onOnlineAccessChange,
+  sendPasswordLink,
+  onSendPasswordLinkChange,
+  password,
+  onPasswordChange,
+  checkboxLabel = 'Online Access',
+  sendLinkOptionLabel = 'Send link',
+  setPasswordOptionLabel = 'Set password',
+  invitationMessage = 'An email invitation will be sent.',
+  passwordFieldLabel = 'Password',
+  passwordFieldProps,
+}: OnlineAccessControlsProps) {
+  const handleOnlineAccessChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const next = event.target.checked;
+      onOnlineAccessChange(next);
+      if (!next) {
+        onSendPasswordLinkChange(true);
+        onPasswordChange('');
+      }
+    },
+    [onOnlineAccessChange, onPasswordChange, onSendPasswordLinkChange],
+  );
+
+  const handleSendPasswordChange = useCallback(
+    (_: MouseEvent<HTMLElement>, value: 'link' | 'password' | null) => {
+      if (!value) return;
+      const useLink = value === 'link';
+      onSendPasswordLinkChange(useLink);
+      if (useLink) {
+        onPasswordChange('');
+      }
+    },
+    [onPasswordChange, onSendPasswordLinkChange],
+  );
+
+  return (
+    <Stack spacing={1.5}>
+      <FormControlLabel
+        control={<Checkbox checked={onlineAccess} onChange={handleOnlineAccessChange} />}
+        label={checkboxLabel}
+      />
+      {onlineAccess && (
+        <Stack spacing={1}>
+          <ToggleButtonGroup
+            value={sendPasswordLink ? 'link' : 'password'}
+            exclusive
+            onChange={handleSendPasswordChange}
+            color="primary"
+          >
+            <ToggleButton value="link">{sendLinkOptionLabel}</ToggleButton>
+            <ToggleButton value="password">{setPasswordOptionLabel}</ToggleButton>
+          </ToggleButtonGroup>
+          {sendPasswordLink ? (
+            <Typography variant="body2" color="text.secondary">
+              {invitationMessage}
+            </Typography>
+          ) : (
+            <PasswordField
+              {...passwordFieldProps}
+              label={passwordFieldProps?.label ?? passwordFieldLabel}
+              value={password}
+              onChange={event => onPasswordChange(event.target.value)}
+              visibilityIconButtonProps={{
+                'aria-label': 'Toggle password visibility',
+                ...passwordFieldProps?.visibilityIconButtonProps,
+              }}
+            />
+          )}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/AddClient.tsx
@@ -4,19 +4,9 @@ import { addUser } from '../../../api/users';
 import type { UserRole } from '../../../types';
 import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
 import FeedbackModal from '../../../components/FeedbackModal';
-import {
-  Box,
-  Button,
-  Stack,
-  TextField,
-  MenuItem,
-  Typography,
-  FormControlLabel,
-  Checkbox,
-  ToggleButtonGroup,
-  ToggleButton,
-} from '@mui/material';
-import PasswordField from '../../../components/PasswordField';
+import { Box, Button, Stack, TextField, MenuItem, Typography } from '@mui/material';
+import OnlineAccessControls from '../../../components/OnlineAccessControls';
+import ContactInfoFields from '../../../components/ContactInfoFields';
 
 export default function AddClient() {
   const [searchParams] = useSearchParams();
@@ -86,61 +76,23 @@ export default function AddClient() {
           <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
           <FeedbackModal open={!!success} onClose={() => setSuccess('')} message={success} />
           <Stack spacing={2}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={onlineAccess}
-                onChange={e => {
-                  setOnlineAccess(e.target.checked);
-                  if (!e.target.checked) {
-                    setSendPasswordLink(true);
-                    setPassword('');
-                  }
-                }}
-              />
-            }
-            label="Online Access"
+          <OnlineAccessControls
+            onlineAccess={onlineAccess}
+            onOnlineAccessChange={setOnlineAccess}
+            sendPasswordLink={sendPasswordLink}
+            onSendPasswordLinkChange={setSendPasswordLink}
+            password={password}
+            onPasswordChange={setPassword}
           />
-          {onlineAccess && (
-            <>
-              <ToggleButtonGroup
-                
-                value={sendPasswordLink ? 'link' : 'password'}
-                exclusive
-                onChange={(_, v) => v && setSendPasswordLink(v === 'link')}
-              >
-                <ToggleButton value="link">Send link</ToggleButton>
-                <ToggleButton value="password">Set password</ToggleButton>
-              </ToggleButtonGroup>
-              {sendPasswordLink ? (
-                <Typography variant="body2" color="text.secondary">
-                  An email invitation will be sent.
-                </Typography>
-                ) : (
-                <PasswordField
-                  label="Password"
-                  value={password}
-                  onChange={e => setPassword(e.target.value)}
-                  visibilityIconButtonProps={{ 'aria-label': 'Toggle password visibility' }}
-                />
-              )}
-            </>
-          )}
           <TextField label="First Name" value={firstName} onChange={e => setFirstName(e.target.value)} />
           <TextField label="Last Name" value={lastName} onChange={e => setLastName(e.target.value)} />
           <TextField label="Client ID" value={clientId} onChange={e => setClientId(e.target.value)} />
-          <TextField
-            label={onlineAccess ? 'Email' : 'Email (optional)'}
-            type="email"
-            required={onlineAccess}
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-          />
-          <TextField
-            label="Phone (optional)"
-            type="tel"
-            value={phone}
-            onChange={e => setPhone(e.target.value)}
+          <ContactInfoFields
+            onlineAccess={onlineAccess}
+            email={email}
+            onEmailChange={setEmail}
+            phone={phone}
+            onPhoneChange={setPhone}
           />
           <TextField select label="Role" value={role} onChange={e => setRole(e.target.value as UserRole)}>
             <MenuItem value="shopper">Shopper</MenuItem>


### PR DESCRIPTION
## Summary
- add an OnlineAccessControls component for shared online access toggles and password handling
- add a ContactInfoFields helper for consistent email/phone inputs
- update Add Client and Volunteer Management create flows to use the new components and an MUI Select with checkable role items
- refresh volunteer management tests to exercise the new interactions

## Testing
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd9d5a5528832d9d2cff4f70011230