### PR TITLE
Use date range filters for monthly aggregations

### DIFF
--- a/MJ_FB_Backend/src/controllers/donorController.ts
+++ b/MJ_FB_Backend/src/controllers/donorController.ts
@@ -66,14 +66,17 @@ export const topDonors = asyncHandler(async (req: Request, res: Response) => {
     return res.status(400).json({ message: (err as Error).message });
   }
 
+  const startDate = new Date(Date.UTC(year, 0, 1)).toISOString().slice(0, 10);
+  const endDate = new Date(Date.UTC(year + 1, 0, 1)).toISOString().slice(0, 10);
+
   const result = await pool.query(
     `SELECT o.first_name || ' ' || o.last_name AS name, SUM(d.weight)::int AS "totalLbs", TO_CHAR(MAX(d.date), 'YYYY-MM-DD') AS "lastDonationISO"
        FROM donations d JOIN donors o ON d.donor_id = o.id
-       WHERE EXTRACT(YEAR FROM d.date) = $1
+       WHERE d.date >= $1 AND d.date < $2
        GROUP BY o.id, o.first_name, o.last_name
        ORDER BY "totalLbs" DESC, MAX(d.date) DESC
-       LIMIT $2`,
-    [year, limit],
+       LIMIT $3`,
+    [startDate, endDate, limit],
   );
   res.json(result.rows);
 });

--- a/MJ_FB_Backend/src/controllers/sunshineBagController.ts
+++ b/MJ_FB_Backend/src/controllers/sunshineBagController.ts
@@ -9,12 +9,14 @@ import {
 } from './pantry/pantryAggregationController';
 
 export async function refreshSunshineBagOverall(year: number, month: number) {
+  const startDate = new Date(Date.UTC(year, month - 1, 1)).toISOString().slice(0, 10);
+  const endDate = new Date(Date.UTC(year, month, 1)).toISOString().slice(0, 10);
   const result = await pool.query(
     `SELECT COALESCE(SUM(weight)::int, 0) AS weight,
             COALESCE(SUM(client_count)::int, 0) AS client_count
        FROM sunshine_bag_log
-       WHERE EXTRACT(YEAR FROM date) = $1 AND EXTRACT(MONTH FROM date) = $2`,
-    [year, month],
+       WHERE date >= $1 AND date < $2`,
+    [startDate, endDate],
   );
   const weight = Number(result.rows[0]?.weight ?? 0);
   const clientCount = Number(result.rows[0]?.client_count ?? 0);

--- a/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
+++ b/MJ_FB_Backend/src/controllers/warehouse/warehouseOverallController.ts
@@ -6,38 +6,41 @@ import { reginaStartOfDayISO } from '../../utils/dateUtils';
 import asyncHandler from '../../middleware/asyncHandler';
 
 export async function refreshWarehouseOverall(year: number, month: number) {
+  const startDate = new Date(Date.UTC(year, month - 1, 1)).toISOString().slice(0, 10);
+  const endDate = new Date(Date.UTC(year, month, 1)).toISOString().slice(0, 10);
+
   const [donationsRes, surplusRes, pigRes, outgoingRes, donorAggRes] = await Promise.all([
     pool.query(
       `SELECT COALESCE(SUM(weight)::int, 0) AS total
          FROM donations
-         WHERE EXTRACT(YEAR FROM date) = $1 AND EXTRACT(MONTH FROM date) = $2`,
-      [year, month],
+         WHERE date >= $1 AND date < $2`,
+      [startDate, endDate],
     ),
     pool.query(
       `SELECT COALESCE(SUM(weight)::int, 0) AS total
          FROM surplus_log
-         WHERE EXTRACT(YEAR FROM date) = $1 AND EXTRACT(MONTH FROM date) = $2`,
-      [year, month],
+         WHERE date >= $1 AND date < $2`,
+      [startDate, endDate],
     ),
     pool.query(
       `SELECT COALESCE(SUM(weight)::int, 0) AS total
          FROM pig_pound_log
-         WHERE EXTRACT(YEAR FROM date) = $1 AND EXTRACT(MONTH FROM date) = $2`,
-      [year, month],
+         WHERE date >= $1 AND date < $2`,
+      [startDate, endDate],
     ),
     pool.query(
       `SELECT COALESCE(SUM(weight)::int, 0) AS total
          FROM outgoing_donation_log
-         WHERE EXTRACT(YEAR FROM date) = $1 AND EXTRACT(MONTH FROM date) = $2`,
-      [year, month],
+         WHERE date >= $1 AND date < $2`,
+      [startDate, endDate],
     ),
     pool.query(
       `SELECT o.id AS "donorId", COALESCE(SUM(d.weight)::int, 0) AS total
          FROM donations d
          JOIN donors o ON d.donor_id = o.id
-         WHERE EXTRACT(YEAR FROM d.date) = $1 AND EXTRACT(MONTH FROM d.date) = $2
+         WHERE d.date >= $1 AND d.date < $2
          GROUP BY o.id`,
-      [year, month],
+      [startDate, endDate],
     ),
   ]);
 

--- a/MJ_FB_Backend/tests/controllers/warehouse/warehouseOverallController.test.ts
+++ b/MJ_FB_Backend/tests/controllers/warehouse/warehouseOverallController.test.ts
@@ -28,30 +28,33 @@ describe('warehouseOverallController', () => {
 
       await refreshWarehouseOverall(2024, 5);
 
+      const startDate = new Date(Date.UTC(2024, 4, 1)).toISOString().slice(0, 10);
+      const endDate = new Date(Date.UTC(2024, 5, 1)).toISOString().slice(0, 10);
+
       expect(mockDb.query).toHaveBeenNthCalledWith(
         1,
         expect.stringContaining('FROM donations'),
-        [2024, 5],
+        [startDate, endDate],
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM surplus_log'),
-        [2024, 5],
+        [startDate, endDate],
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         3,
         expect.stringContaining('FROM pig_pound_log'),
-        [2024, 5],
+        [startDate, endDate],
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         4,
         expect.stringContaining('FROM outgoing_donation_log'),
-        [2024, 5],
+        [startDate, endDate],
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         5,
         expect.stringContaining('FROM donations d'),
-        [2024, 5],
+        [startDate, endDate],
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         6,


### PR DESCRIPTION
## Summary
- replace EXTRACT-based month filters with start/end date ranges in warehouse, sunshine bag, donor, and outgoing receiver controllers
- ensure donor aggregation refresh shares the same bounds as other warehouse queries
- update unit tests to expect range parameters for the revised SQL

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda2017990832dbf8ce77c1ca1e468