### PR TITLE
Add warehouse refresh helper and update controllers

### DIFF
--- a/MJ_FB_Backend/src/controllers/warehouse/pigPoundController.ts
+++ b/MJ_FB_Backend/src/controllers/warehouse/pigPoundController.ts
@@ -1,8 +1,10 @@
 import { Request, Response } from 'express';
 import pool from '../../db';
-import { refreshWarehouseOverall } from './warehouseOverallController';
-import { reginaStartOfDayISO } from '../../utils/dateUtils';
 import asyncHandler from '../../middleware/asyncHandler';
+import {
+  refreshWarehouseForDate,
+  refreshWarehouseForDateChange,
+} from '../../utils/warehouseRefresh';
 
 export const listPigPounds = asyncHandler(async (req: Request, res: Response) => {
   const date = req.query.date as string;
@@ -20,8 +22,7 @@ export const addPigPound = asyncHandler(async (req: Request, res: Response) => {
     'INSERT INTO pig_pound_log (date, weight) VALUES ($1, $2) RETURNING id, date, weight',
     [date, weight],
   );
-  const dt = new Date(reginaStartOfDayISO(date));
-  await refreshWarehouseOverall(dt.getUTCFullYear(), dt.getUTCMonth() + 1);
+  await refreshWarehouseForDate(date);
   res.status(201).json(result.rows[0]);
 });
 
@@ -34,17 +35,7 @@ export const updatePigPound = asyncHandler(async (req: Request, res: Response) =
     'UPDATE pig_pound_log SET date = $1, weight = $2 WHERE id = $3 RETURNING id, date, weight',
     [date, weight, id],
   );
-  const newDt = new Date(reginaStartOfDayISO(date));
-  await refreshWarehouseOverall(newDt.getUTCFullYear(), newDt.getUTCMonth() + 1);
-  if (oldDate) {
-    const oldDt = new Date(reginaStartOfDayISO(oldDate));
-    if (
-      oldDt.getUTCFullYear() !== newDt.getUTCFullYear() ||
-      oldDt.getUTCMonth() !== newDt.getUTCMonth()
-    ) {
-      await refreshWarehouseOverall(oldDt.getUTCFullYear(), oldDt.getUTCMonth() + 1);
-    }
-  }
+  await refreshWarehouseForDateChange(date, oldDate);
   res.json(result.rows[0]);
 });
 
@@ -53,8 +44,7 @@ export const deletePigPound = asyncHandler(async (req: Request, res: Response) =
   const existing = await pool.query('SELECT date FROM pig_pound_log WHERE id = $1', [id]);
   await pool.query('DELETE FROM pig_pound_log WHERE id = $1', [id]);
   if (existing.rows[0]) {
-    const dt = new Date(reginaStartOfDayISO(existing.rows[0].date));
-    await refreshWarehouseOverall(dt.getUTCFullYear(), dt.getUTCMonth() + 1);
+    await refreshWarehouseForDate(existing.rows[0].date);
   }
   res.json({ message: 'Deleted' });
 });

--- a/MJ_FB_Backend/src/utils/warehouseRefresh.ts
+++ b/MJ_FB_Backend/src/utils/warehouseRefresh.ts
@@ -1,0 +1,34 @@
+import { refreshWarehouseOverall } from '../controllers/warehouse/warehouseOverallController';
+import { reginaStartOfDayISO } from './dateUtils';
+
+function getYearMonth(date: string | Date) {
+  const dt = new Date(reginaStartOfDayISO(date));
+  return {
+    year: dt.getUTCFullYear(),
+    month: dt.getUTCMonth() + 1,
+  };
+}
+
+export async function refreshWarehouseForDate(date: string | Date) {
+  const { year, month } = getYearMonth(date);
+  await refreshWarehouseOverall(year, month);
+}
+
+export async function refreshWarehouseForDateChange(
+  newDate: string | Date,
+  oldDate?: string | Date | null,
+) {
+  const { year: newYear, month: newMonth } = getYearMonth(newDate);
+  await refreshWarehouseOverall(newYear, newMonth);
+
+  if (!oldDate) {
+    return;
+  }
+
+  const { year: oldYear, month: oldMonth } = getYearMonth(oldDate);
+  if (oldYear === newYear && oldMonth === newMonth) {
+    return;
+  }
+
+  await refreshWarehouseOverall(oldYear, oldMonth);
+}

--- a/MJ_FB_Backend/tests/outgoingDonationController.test.ts
+++ b/MJ_FB_Backend/tests/outgoingDonationController.test.ts
@@ -5,10 +5,14 @@ import {
   updateOutgoingDonation,
   deleteOutgoingDonation,
 } from '../src/controllers/warehouse/outgoingDonationController';
-import { refreshWarehouseOverall } from '../src/controllers/warehouse/warehouseOverallController';
+import {
+  refreshWarehouseForDate,
+  refreshWarehouseForDateChange,
+} from '../src/utils/warehouseRefresh';
 
-jest.mock('../src/controllers/warehouse/warehouseOverallController', () => ({
-  refreshWarehouseOverall: jest.fn(),
+jest.mock('../src/utils/warehouseRefresh', () => ({
+  refreshWarehouseForDate: jest.fn(),
+  refreshWarehouseForDateChange: jest.fn(),
 }));
 
 const flushPromises = () => new Promise(process.nextTick);
@@ -16,7 +20,8 @@ const flushPromises = () => new Promise(process.nextTick);
 describe('outgoingDonationController', () => {
   beforeEach(() => {
     (mockDb.query as jest.Mock).mockReset();
-    (refreshWarehouseOverall as jest.Mock).mockReset();
+    (refreshWarehouseForDate as jest.Mock).mockReset();
+    (refreshWarehouseForDateChange as jest.Mock).mockReset();
   });
 
   it('lists outgoing donations for a date', async () => {
@@ -95,7 +100,7 @@ describe('outgoingDonationController', () => {
       null,
     ]);
     expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), [2]);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDate).toHaveBeenCalledWith('2024-05-20');
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith({
       id: 1,
@@ -149,7 +154,7 @@ describe('outgoingDonationController', () => {
       null,
       '1',
     ]);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDateChange).toHaveBeenCalledWith('2024-05-21', '2024-05-20');
     expect(res.json).toHaveBeenCalledWith({
       id: 1,
       date: '2024-05-21',
@@ -183,7 +188,7 @@ describe('outgoingDonationController', () => {
     await flushPromises();
     expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
     expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), ['1']);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDate).toHaveBeenCalledWith('2024-05-20');
     expect(res.json).toHaveBeenCalledWith({ message: 'Deleted' });
   });
 

--- a/MJ_FB_Backend/tests/pigPoundController.test.ts
+++ b/MJ_FB_Backend/tests/pigPoundController.test.ts
@@ -5,10 +5,14 @@ import {
   updatePigPound,
   deletePigPound,
 } from '../src/controllers/warehouse/pigPoundController';
-import { refreshWarehouseOverall } from '../src/controllers/warehouse/warehouseOverallController';
+import {
+  refreshWarehouseForDate,
+  refreshWarehouseForDateChange,
+} from '../src/utils/warehouseRefresh';
 
-jest.mock('../src/controllers/warehouse/warehouseOverallController', () => ({
-  refreshWarehouseOverall: jest.fn(),
+jest.mock('../src/utils/warehouseRefresh', () => ({
+  refreshWarehouseForDate: jest.fn(),
+  refreshWarehouseForDateChange: jest.fn(),
 }));
 
 const flushPromises = () => new Promise(process.nextTick);
@@ -16,7 +20,8 @@ const flushPromises = () => new Promise(process.nextTick);
 describe('pigPoundController', () => {
   beforeEach(() => {
     (mockDb.query as jest.Mock).mockReset();
-    (refreshWarehouseOverall as jest.Mock).mockReset();
+    (refreshWarehouseForDate as jest.Mock).mockReset();
+    (refreshWarehouseForDateChange as jest.Mock).mockReset();
   });
 
   it('lists pig pounds for a date', async () => {
@@ -66,7 +71,7 @@ describe('pigPoundController', () => {
       '2024-05-20',
       10,
     ]);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDate).toHaveBeenCalledWith('2024-05-20');
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith({ id: 1, date: '2024-05-20', weight: 10 });
   });
@@ -97,7 +102,7 @@ describe('pigPoundController', () => {
       12,
       '1',
     ]);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDateChange).toHaveBeenCalledWith('2024-05-21', '2024-05-20');
     expect(res.json).toHaveBeenCalledWith({ id: 1, date: '2024-05-21', weight: 12 });
   });
 
@@ -121,7 +126,7 @@ describe('pigPoundController', () => {
     await flushPromises();
     expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
     expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), ['1']);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDate).toHaveBeenCalledWith('2024-05-20');
     expect(res.json).toHaveBeenCalledWith({ message: 'Deleted' });
   });
 

--- a/MJ_FB_Backend/tests/surplusController.test.ts
+++ b/MJ_FB_Backend/tests/surplusController.test.ts
@@ -5,15 +5,19 @@ import {
   updateSurplus,
   deleteSurplus,
 } from '../src/controllers/warehouse/surplusController';
-import { refreshWarehouseOverall } from '../src/controllers/warehouse/warehouseOverallController';
 import { getWarehouseSettings } from '../src/utils/warehouseSettings';
-
-jest.mock('../src/controllers/warehouse/warehouseOverallController', () => ({
-  refreshWarehouseOverall: jest.fn(),
-}));
+import {
+  refreshWarehouseForDate,
+  refreshWarehouseForDateChange,
+} from '../src/utils/warehouseRefresh';
 
 jest.mock('../src/utils/warehouseSettings', () => ({
   getWarehouseSettings: jest.fn(),
+}));
+
+jest.mock('../src/utils/warehouseRefresh', () => ({
+  refreshWarehouseForDate: jest.fn(),
+  refreshWarehouseForDateChange: jest.fn(),
 }));
 
 const flushPromises = () => new Promise(process.nextTick);
@@ -21,8 +25,9 @@ const flushPromises = () => new Promise(process.nextTick);
 describe('surplusController', () => {
   beforeEach(() => {
     (mockDb.query as jest.Mock).mockReset();
-    (refreshWarehouseOverall as jest.Mock).mockReset();
     (getWarehouseSettings as jest.Mock).mockReset();
+    (refreshWarehouseForDate as jest.Mock).mockReset();
+    (refreshWarehouseForDateChange as jest.Mock).mockReset();
   });
 
   it('lists surplus entries', async () => {
@@ -69,7 +74,7 @@ describe('surplusController', () => {
       2,
       1,
     ]);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDate).toHaveBeenCalledWith('2024-05-20');
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith({
       id: 1,
@@ -119,7 +124,7 @@ describe('surplusController', () => {
       1,
       '1',
     ]);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDateChange).toHaveBeenCalledWith('2024-05-21', '2024-05-20');
     expect(res.json).toHaveBeenCalledWith({
       id: 1,
       date: '2024-05-21',
@@ -152,7 +157,7 @@ describe('surplusController', () => {
     await flushPromises();
     expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.any(String), ['1']);
     expect(mockDb.query).toHaveBeenNthCalledWith(2, expect.any(String), ['1']);
-    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+    expect(refreshWarehouseForDate).toHaveBeenCalledWith('2024-05-20');
     expect(res.json).toHaveBeenCalledWith({ message: 'Deleted' });
   });
 

--- a/MJ_FB_Backend/tests/utils/warehouseRefresh.test.ts
+++ b/MJ_FB_Backend/tests/utils/warehouseRefresh.test.ts
@@ -1,0 +1,38 @@
+import {
+  refreshWarehouseForDate,
+  refreshWarehouseForDateChange,
+} from '../../src/utils/warehouseRefresh';
+import { refreshWarehouseOverall } from '../../src/controllers/warehouse/warehouseOverallController';
+
+jest.mock('../../src/controllers/warehouse/warehouseOverallController', () => ({
+  refreshWarehouseOverall: jest.fn(),
+}));
+
+describe('warehouseRefresh', () => {
+  beforeEach(() => {
+    (refreshWarehouseOverall as jest.Mock).mockReset();
+  });
+
+  it('refreshes aggregates for a single date', async () => {
+    await refreshWarehouseForDate('2024-05-15');
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+  });
+
+  it('refreshes only the new month when date change stays in same month', async () => {
+    await refreshWarehouseForDateChange('2024-05-15', '2024-05-01');
+    expect(refreshWarehouseOverall).toHaveBeenCalledTimes(1);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+  });
+
+  it('refreshes both months when date change crosses months', async () => {
+    await refreshWarehouseForDateChange('2024-05-01', '2024-04-30');
+    expect(refreshWarehouseOverall).toHaveBeenNthCalledWith(1, 2024, 5);
+    expect(refreshWarehouseOverall).toHaveBeenNthCalledWith(2, 2024, 4);
+  });
+
+  it('skips old month refresh when old date missing', async () => {
+    await refreshWarehouseForDateChange('2024-05-01');
+    expect(refreshWarehouseOverall).toHaveBeenCalledTimes(1);
+    expect(refreshWarehouseOverall).toHaveBeenCalledWith(2024, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- add a warehouse refresh utility with helpers for single-date and date-change aggregate updates
- refactor warehouse donation, surplus, pig pound, and outgoing donation controllers to use the shared utility
- cover the new utility with unit tests and update controller tests to verify helper usage across create, update, and delete flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda218402c832da95c98dc4a1639cb