### PR TITLE
Add optional pagination helper for booking history queries

### DIFF
--- a/MJ_FB_Backend/src/utils/parseOptionalPaginationParams.ts
+++ b/MJ_FB_Backend/src/utils/parseOptionalPaginationParams.ts
@@ -1,0 +1,36 @@
+import { Request } from 'express';
+import { parsePaginationParams } from './parsePaginationParams';
+
+export function parseOptionalPaginationParams(
+  req: Request,
+  maxLimit: number,
+): { limit?: number; offset?: number } {
+  const limitParam = req.query.limit;
+  const offsetParam = req.query.offset;
+
+  const hasLimit = limitParam !== undefined;
+  const hasOffset = offsetParam !== undefined;
+
+  if (!hasLimit && !hasOffset) {
+    return {};
+  }
+
+  const { limit, offset } = parsePaginationParams(
+    { query: { limit: limitParam, offset: offsetParam } } as Request,
+    1,
+    maxLimit,
+    0,
+  );
+
+  const result: { limit?: number; offset?: number } = {};
+  if (hasLimit) {
+    result.limit = limit;
+  }
+  if (hasOffset) {
+    result.offset = offset;
+  }
+
+  return result;
+}
+
+export default parseOptionalPaginationParams;

--- a/MJ_FB_Backend/tests/parseOptionalPaginationParams.test.ts
+++ b/MJ_FB_Backend/tests/parseOptionalPaginationParams.test.ts
@@ -1,0 +1,38 @@
+import { Request } from 'express';
+import { parseOptionalPaginationParams } from '../src/utils/parseOptionalPaginationParams';
+
+describe('parseOptionalPaginationParams', () => {
+  function mockReq(query: any): Request {
+    return { query } as unknown as Request;
+  }
+
+  it('returns an empty object when both parameters are omitted', () => {
+    const req = mockReq({});
+    expect(parseOptionalPaginationParams(req, 100)).toEqual({});
+  });
+
+  it('parses limit when provided', () => {
+    const req = mockReq({ limit: '5' });
+    expect(parseOptionalPaginationParams(req, 10)).toEqual({ limit: 5 });
+  });
+
+  it('parses offset when provided', () => {
+    const req = mockReq({ offset: '15' });
+    expect(parseOptionalPaginationParams(req, 10)).toEqual({ offset: 15 });
+  });
+
+  it('caps limit at the provided maxLimit', () => {
+    const req = mockReq({ limit: '50' });
+    expect(parseOptionalPaginationParams(req, 25)).toEqual({ limit: 25 });
+  });
+
+  it('throws on invalid limit', () => {
+    const req = mockReq({ limit: 'foo' });
+    expect(() => parseOptionalPaginationParams(req, 10)).toThrow('Invalid limit');
+  });
+
+  it('throws on invalid offset', () => {
+    const req = mockReq({ offset: '-1' });
+    expect(() => parseOptionalPaginationParams(req, 10)).toThrow('Invalid offset');
+  });
+});


### PR DESCRIPTION
## Summary
- add a parseOptionalPaginationParams utility that reuses existing pagination validation while supporting optional limit/offset
- update getBookingHistory to use the helper so callers can omit pagination values
- cover the new helper and controller behavior with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda2149154832db25cff5647c12714