### PR TITLE
refactor: unify account edit forms

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/EditClientDialog.tsx
@@ -1,21 +1,14 @@
 import { useEffect, useState } from 'react';
-import {
-  DialogTitle,
-  FormControlLabel,
-  Switch,
-  Stack,
-  FormHelperText,
-  FormControl,
-  Tooltip,
-} from '@mui/material';
+import { Chip, DialogTitle } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from '../../../components/DialogCloseButton';
 import FormDialog from '../../../components/FormDialog';
 import { getUserByClientId, updateUserInfo, requestPasswordReset } from '../../../api/users';
 import getApiErrorMessage from '../../../utils/getApiErrorMessage';
-import EditClientForm, {
-  type EditClientFormData,
-} from './EditClientForm';
+import AccountEditForm, {
+  type AccountEditFormData,
+} from '../../../components/account/AccountEditForm';
+import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
 
 interface Props {
   open: boolean;
@@ -27,7 +20,7 @@ interface Props {
 
 export async function handleSave(
   clientId: number,
-  data: EditClientFormData,
+  data: AccountEditFormData,
   onClientUpdated: (name: string) => void,
   onUpdated: (message: string, severity: AlertColor) => void,
   onClose: () => void,
@@ -53,7 +46,7 @@ export async function handleSave(
 
 export async function handleSendReset(
   clientId: number,
-  data: EditClientFormData,
+  data: AccountEditFormData,
   onClientUpdated: (name: string) => void,
   onUpdated: (message: string, severity: AlertColor) => void,
   onClose: () => void,
@@ -78,7 +71,7 @@ export default function EditClientDialog({
   onUpdated,
   onClientUpdated,
 }: Props) {
-  const [form, setForm] = useState<EditClientFormData>({
+  const [form, setForm] = useState<AccountEditFormData>({
     firstName: '',
     lastName: '',
     email: '',
@@ -111,40 +104,27 @@ export default function EditClientDialog({
     <FormDialog open={open} onClose={onClose}>
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>Edit Client</DialogTitle>
-      <Stack spacing={2} sx={{ px: 3, pt: 1 }}>
-        <Tooltip
-          title="Client already has a password"
-          disableHoverListener={!form.hasPassword}
-        >
-          <span>
-            <FormControl>
-              <FormControlLabel
-                control={
-                  <Switch
-                    name="online access"
-                    checked={form.onlineAccess}
-                    onChange={e =>
-                      setForm(prev => ({
-                        ...prev,
-                        onlineAccess: e.target.checked,
-                      }))
-                    }
-                    disabled={form.hasPassword}
-                  />
-                }
-                label="Online Access"
-              />
-              <FormHelperText>Allow the client to sign in online.</FormHelperText>
-            </FormControl>
-          </span>
-        </Tooltip>
-      </Stack>
-      <EditClientForm
+      <AccountEditForm
         open={open}
         initialData={form}
         onSave={data => handleSave(clientId, data, onClientUpdated, onUpdated, onClose)}
-        onSendReset={data => handleSendReset(clientId, data, onClientUpdated, onUpdated, onClose)}
-        showOnlineAccessToggle={false}
+        onSecondaryAction={data =>
+          handleSendReset(clientId, data, onClientUpdated, onUpdated, onClose)
+        }
+        secondaryActionLabel="Send password reset link"
+        onlineAccessHelperText="Allow the client to sign in online."
+        existingPasswordTooltip="Client already has a password"
+        secondaryActionTestId="send-reset-button"
+        titleAdornment={data =>
+          data.hasPassword ? (
+            <Chip
+              color="success"
+              icon={<CheckCircleOutline />}
+              label="Online account"
+              data-testid="online-badge"
+            />
+          ) : null
+        }
       />
     </FormDialog>
   );

--- a/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/UpdateClientData.tsx
@@ -6,6 +6,7 @@ import {
   Link,
   Typography,
   TableContainer,
+  Chip,
 } from "@mui/material";
 import FeedbackSnackbar from "../../../components/FeedbackSnackbar";
 import DialogCloseButton from "../../../components/DialogCloseButton";
@@ -20,14 +21,15 @@ import {
 import type { AlertColor } from "@mui/material";
 import getApiErrorMessage from "../../../utils/getApiErrorMessage";
 import ResponsiveTable, { type Column } from "../../../components/ResponsiveTable";
-import EditClientForm, {
-  type EditClientFormData,
-} from "./EditClientForm";
+import AccountEditForm, {
+  type AccountEditFormData,
+} from "../../../components/account/AccountEditForm";
+import CheckCircleOutline from "@mui/icons-material/CheckCircleOutline";
 
 export default function UpdateClientData() {
   const [clients, setClients] = useState<IncompleteUser[]>([]);
   const [selected, setSelected] = useState<IncompleteUser | null>(null);
-  const [form, setForm] = useState<EditClientFormData>({
+  const [form, setForm] = useState<AccountEditFormData>({
     firstName: "",
     lastName: "",
     email: "",
@@ -91,7 +93,7 @@ export default function UpdateClientData() {
     }
   }
 
-  async function handleSave(data: EditClientFormData): Promise<boolean> {
+  async function handleSave(data: AccountEditFormData): Promise<boolean> {
     if (!selected) return false;
     try {
       await updateUserInfo(selected.clientId, {
@@ -122,7 +124,7 @@ export default function UpdateClientData() {
     }
   }
 
-  async function handleSendReset(data: EditClientFormData) {
+  async function handleSendReset(data: AccountEditFormData) {
     if (!selected) return;
     const ok = await handleSave(data);
     if (!ok) return;
@@ -193,11 +195,25 @@ export default function UpdateClientData() {
             </Link>
           )}
         </DialogTitle>
-        <EditClientForm
+        <AccountEditForm
           open={!!selected}
           initialData={form}
           onSave={handleSave}
-          onSendReset={handleSendReset}
+          onSecondaryAction={handleSendReset}
+          secondaryActionLabel="Send password reset link"
+          onlineAccessHelperText="Allow the client to sign in online."
+          existingPasswordTooltip="Client already has a password"
+          secondaryActionTestId="send-reset-button"
+          titleAdornment={data =>
+            data.hasPassword ? (
+              <Chip
+                color="success"
+                icon={<CheckCircleOutline />}
+                label="Online account"
+                data-testid="online-badge"
+              />
+            ) : null
+          }
         />
       </FormDialog>
 

--- a/MJ_FB_Frontend/src/pages/volunteer-management/EditVolunteerDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/EditVolunteerDialog.tsx
@@ -1,24 +1,14 @@
 import { useEffect, useState } from 'react';
-import {
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  TextField,
-  Stack,
-  FormControlLabel,
-  Switch,
-  FormControl,
-  FormHelperText,
-  Tooltip,
-} from '@mui/material';
+import { DialogTitle } from '@mui/material';
 import type { AlertColor } from '@mui/material';
 import DialogCloseButton from '../../components/DialogCloseButton';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
-import PasswordField from '../../components/PasswordField';
 import FormDialog from '../../components/FormDialog';
 import { updateVolunteer, type VolunteerSearchResult } from '../../api/volunteers';
 import { getApiErrorMessage } from '../../api/helpers';
+import AccountEditForm, {
+  type AccountEditFormData,
+} from '../../components/account/AccountEditForm';
 
 interface EditVolunteerDialogProps {
   volunteer: VolunteerSearchResult | null;
@@ -27,7 +17,7 @@ interface EditVolunteerDialogProps {
 }
 
 export default function EditVolunteerDialog({ volunteer, onClose, onSaved }: EditVolunteerDialogProps) {
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<AccountEditFormData>({
     firstName: '',
     lastName: '',
     email: '',
@@ -56,17 +46,17 @@ export default function EditVolunteerDialog({ volunteer, onClose, onSaved }: Edi
     }
   }, [volunteer]);
 
-  async function handleSave() {
+  async function handleSave(data: AccountEditFormData) {
     if (!volunteer) return;
     try {
       await updateVolunteer(volunteer.id, {
-        firstName: form.firstName,
-        lastName: form.lastName,
-        email: form.email || undefined,
-        phone: form.phone || undefined,
-        onlineAccess: form.hasPassword ? true : form.onlineAccess,
-        ...(form.onlineAccess && !form.hasPassword && form.password
-          ? { password: form.password }
+        firstName: data.firstName,
+        lastName: data.lastName,
+        email: data.email || undefined,
+        phone: data.phone || undefined,
+        onlineAccess: data.hasPassword ? true : data.onlineAccess,
+        ...(data.onlineAccess && !data.hasPassword && data.password
+          ? { password: data.password }
           : {}),
       });
       setSnackbar({ open: true, message: 'Volunteer updated', severity: 'success' });
@@ -80,14 +70,14 @@ export default function EditVolunteerDialog({ volunteer, onClose, onSaved }: Edi
     }
   }
 
-  async function handleSendLink() {
+  async function handleSendLink(data: AccountEditFormData) {
     if (!volunteer) return;
     try {
       await updateVolunteer(volunteer.id, {
-        firstName: form.firstName,
-        lastName: form.lastName,
-        email: form.email || undefined,
-        phone: form.phone || undefined,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        email: data.email || undefined,
+        phone: data.phone || undefined,
         onlineAccess: true,
         sendPasswordLink: true,
       });
@@ -105,82 +95,17 @@ export default function EditVolunteerDialog({ volunteer, onClose, onSaved }: Edi
     <FormDialog open={!!volunteer} onClose={onClose}>
       <DialogCloseButton onClose={onClose} />
       <DialogTitle>Edit Volunteer</DialogTitle>
-      <DialogContent>
-          <Stack spacing={2} mt={1}>
-            <Tooltip title="Volunteer already has a password" disableHoverListener={!form.hasPassword}>
-              <span>
-                <FormControl>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={form.onlineAccess}
-                        onChange={e =>
-                          setForm({ ...form, onlineAccess: e.target.checked })
-                        }
-                        disabled={form.hasPassword}
-                        data-testid="online-access-toggle"
-                      />
-                    }
-                    label="Online Access"
-                  />
-                  <FormHelperText>
-                    Allow the volunteer to sign in online.
-                  </FormHelperText>
-                </FormControl>
-              </span>
-            </Tooltip>
-            <TextField
-              label="First Name"
-              value={form.firstName}
-              onChange={e => setForm({ ...form, firstName: e.target.value })}
-              required
-              fullWidth
-          />
-          <TextField
-            label="Last Name"
-            value={form.lastName}
-            onChange={e => setForm({ ...form, lastName: e.target.value })}
-            required
-            fullWidth
-          />
-          <TextField
-            label="Email (optional)"
-            type="email"
-            value={form.email}
-            onChange={e => setForm({ ...form, email: e.target.value })}
-            fullWidth
-          />
-          <TextField
-            label="Phone (optional)"
-            type="tel"
-            value={form.phone}
-            onChange={e => setForm({ ...form, phone: e.target.value })}
-            fullWidth
-          />
-          {form.onlineAccess && !form.hasPassword && (
-            <PasswordField
-              label="Password"
-              value={form.password}
-              onChange={e => setForm({ ...form, password: e.target.value })}
-              fullWidth
-            />
-          )}
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        {form.onlineAccess && (
-          <Button variant="outlined" onClick={handleSendLink}>
-            Send password setup link
-          </Button>
-        )}
-        <Button
-          onClick={handleSave}
-          disabled={!form.firstName || !form.lastName}
-          aria-label="Save volunteer"
-        >
-          Save
-        </Button>
-      </DialogActions>
+      <AccountEditForm
+        open={!!volunteer}
+        initialData={form}
+        onSave={handleSave}
+        onSecondaryAction={handleSendLink}
+        secondaryActionLabel="Send password setup link"
+        onlineAccessHelperText="Allow the volunteer to sign in online."
+        existingPasswordTooltip="Volunteer already has a password"
+        primaryActionLabel="Save"
+        secondaryActionTestId="send-password-setup-button"
+      />
       <FeedbackSnackbar
         open={!!snackbar}
         onClose={() => setSnackbar(null)}


### PR DESCRIPTION
## Summary
- add a reusable AccountEditForm that centralizes account/contact fields with configurable labels and callbacks
- update client editing flows to render the shared form while keeping the existing online account badge and handlers
- refactor the volunteer edit dialog to reuse the shared form and preserve volunteer-specific actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda1f276dc832db4602c507422c540