### PR TITLE
Use delivery settings monthly cap for delivery orders

### DIFF
--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -16,6 +16,7 @@ const flushPromises = () => new Promise(process.nextTick);
 const mockGetDeliverySettings = getDeliverySettings as jest.MockedFunction<
   typeof getDeliverySettings
 >;
+const MOCK_MONTHLY_LIMIT = 3;
 
 describe('deliveryOrderController', () => {
   beforeEach(() => {
@@ -24,6 +25,7 @@ describe('deliveryOrderController', () => {
     mockGetDeliverySettings.mockReset();
     mockGetDeliverySettings.mockResolvedValue({
       requestEmail: 'ops@example.com',
+      monthlyOrderLimit: MOCK_MONTHLY_LIMIT,
     });
   });
 
@@ -486,7 +488,7 @@ describe('deliveryOrderController', () => {
 
     it('rejects a third order in the same month', async () => {
       (mockDb.query as jest.Mock).mockResolvedValueOnce({
-        rows: [{ count: '2' }],
+        rows: [{ count: String(MOCK_MONTHLY_LIMIT) }],
         rowCount: 1,
       });
 
@@ -513,7 +515,7 @@ describe('deliveryOrderController', () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
         message:
-          'You have already used the food bank 2 times this month, please request again next month',
+          `You have already used the food bank ${MOCK_MONTHLY_LIMIT} times this month, please request again next month`,
       });
       expect(mockDb.query).toHaveBeenCalledTimes(1);
       expect(mockDb.query).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- fetch delivery settings before monthly cap checks and compare against the configured monthly order limit
- reuse the retrieved delivery settings when sending delivery notifications
- update delivery order controller tests to mock the configurable monthly limit and expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda2405d14832da16a99e6355513f8