### PR TITLE
Update monthly limit rejection test message

### DIFF
--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -525,7 +525,7 @@ describe('deliveryOrderController', () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
         message:
-          `You have already used the food bank ${MOCK_MONTHLY_LIMIT} times this month, please request again next month`,
+          `You have already used the food bank ${MOCK_MONTHLY_LIMIT} times this month, which is the limit of ${MOCK_MONTHLY_LIMIT}. Please request again next month`,
       });
       expect(mockDb.query).toHaveBeenCalledTimes(1);
       expect(mockDb.query).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- update the delivery order controller test to expect the revised rejection message that includes the configured monthly limit

## Testing
- npm test tests/deliveryOrderController.test.ts *(fails: existing SyntaxError in src/controllers/deliveryOrderController.ts about duplicate deliverySettings constant)*

------
https://chatgpt.com/codex/tasks/task_e_68cda5dc1b74832d898d82d10b676c48