### PR TITLE
Optimize delivery order monthly limit query

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -6,6 +6,7 @@ import config from '../config';
 import { sendTemplatedEmail } from '../utils/emailUtils';
 import { getDeliverySettings } from '../utils/deliverySettings';
 import logger from '../utils/logger';
+import { reginaStartOfDayISO } from '../utils/dateUtils';
 import {
   createDeliveryOrderSchema,
   type DeliveryOrderSelectionInput,
@@ -59,6 +60,20 @@ type NormalizedSelection = { itemId: number; quantity: number };
 
 interface CountRow {
   count: string;
+}
+
+function getReginaMonthBounds(reference: Date = new Date()): {
+  startOfMonthUtc: Date;
+  startOfNextMonthUtc: Date;
+} {
+  const reginaStartOfDay = new Date(reginaStartOfDayISO(reference));
+  const startOfMonthUtc = new Date(reginaStartOfDay);
+  startOfMonthUtc.setUTCDate(1);
+
+  const startOfNextMonthUtc = new Date(startOfMonthUtc);
+  startOfNextMonthUtc.setUTCMonth(startOfNextMonthUtc.getUTCMonth() + 1);
+
+  return { startOfMonthUtc, startOfNextMonthUtc };
 }
 
 function normalizeSelections(selections: DeliveryOrderSelectionInput[]): NormalizedSelection[] {
@@ -162,8 +177,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
   const { clientId, address, phone, email, selections } = parsed.data;
   const normalizedSelections = normalizeSelections(selections);
 
-  const deliverySettings = await getDeliverySettings();
-  const { monthlyOrderLimit } = deliverySettings;
+  const { monthlyOrderLimit, requestEmail } = await getDeliverySettings();
 
   const isClient = req.user.role === 'delivery';
   const isStaff = req.user.role === 'staff' || req.user.role === 'admin';
@@ -192,17 +206,16 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
     clientName = currentName.length > 0 ? currentName : null;
   }
 
-  // created_at is stored in UTC, so convert to Regina time before truncating to the month
+  const { startOfMonthUtc, startOfNextMonthUtc } = getReginaMonthBounds();
+
   const monthlyOrderCountResult = await pool.query<CountRow>(
     `SELECT COUNT(*)::int AS count
        FROM delivery_orders
       WHERE client_id = $1
         AND status <> 'cancelled'
-        AND date_trunc(
-              'month',
-              (created_at AT TIME ZONE 'UTC') AT TIME ZONE 'America/Regina'
-            ) = date_trunc('month', timezone('America/Regina', now()))`,
-    [clientId],
+        AND created_at >= $2
+        AND created_at < $3`,
+    [clientId, startOfMonthUtc, startOfNextMonthUtc],
   );
 
   const monthlyOrderCount = Number(monthlyOrderCountResult.rows[0]?.count ?? 0);
@@ -340,7 +353,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
 
   try {
     await sendTemplatedEmail({
-      to: deliverySettings.requestEmail,
+      to: requestEmail,
       templateId: config.deliveryRequestTemplateId,
       params: {
         orderId: order.id,

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -81,12 +81,20 @@ describe('deliveryOrderController', () => {
       expect(mockDb.query).toHaveBeenCalledTimes(2);
       expect(mockDb.query).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('America/Regina'),
-        [123],
+        expect.stringContaining('created_at >= $2'),
+        [123, expect.any(Date), expect.any(Date)],
+      );
+      const [, firstParams] = (mockDb.query as jest.Mock).mock.calls[0];
+      expect(firstParams[1]).toBeInstanceOf(Date);
+      expect(firstParams[2]).toBeInstanceOf(Date);
+      expect((firstParams[1] as Date).getTime()).toBeLessThan(
+        (firstParams[2] as Date).getTime(),
       );
       const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
       expect(firstQuery).toContain('FROM delivery_orders');
       expect(firstQuery).toContain("status <> 'cancelled'");
+      expect(firstQuery).toContain('created_at >= $2');
+      expect(firstQuery).toContain('created_at < $3');
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM delivery_items'),
@@ -139,12 +147,20 @@ describe('deliveryOrderController', () => {
       expect(mockDb.query).toHaveBeenCalledTimes(2);
       expect(mockDb.query).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('America/Regina'),
-        [123],
+        expect.stringContaining('created_at >= $2'),
+        [123, expect.any(Date), expect.any(Date)],
+      );
+      const [, firstParams] = (mockDb.query as jest.Mock).mock.calls[0];
+      expect(firstParams[1]).toBeInstanceOf(Date);
+      expect(firstParams[2]).toBeInstanceOf(Date);
+      expect((firstParams[1] as Date).getTime()).toBeLessThan(
+        (firstParams[2] as Date).getTime(),
       );
       const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
       expect(firstQuery).toContain('FROM delivery_orders');
       expect(firstQuery).toContain("status <> 'cancelled'");
+      expect(firstQuery).toContain('created_at >= $2');
+      expect(firstQuery).toContain('created_at < $3');
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM delivery_items'),
@@ -219,12 +235,20 @@ describe('deliveryOrderController', () => {
 
       expect(mockDb.query).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('America/Regina'),
-        [456],
+        expect.stringContaining('created_at >= $2'),
+        [456, expect.any(Date), expect.any(Date)],
+      );
+      const [, firstParams] = (mockDb.query as jest.Mock).mock.calls[0];
+      expect(firstParams[1]).toBeInstanceOf(Date);
+      expect(firstParams[2]).toBeInstanceOf(Date);
+      expect((firstParams[1] as Date).getTime()).toBeLessThan(
+        (firstParams[2] as Date).getTime(),
       );
       const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
       expect(firstQuery).toContain('FROM delivery_orders');
       expect(firstQuery).toContain("status <> 'cancelled'");
+      expect(firstQuery).toContain('created_at >= $2');
+      expect(firstQuery).toContain('created_at < $3');
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM clients'),
@@ -351,12 +375,20 @@ describe('deliveryOrderController', () => {
 
       expect(mockDb.query).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('America/Regina'),
-        [555],
+        expect.stringContaining('created_at >= $2'),
+        [555, expect.any(Date), expect.any(Date)],
+      );
+      const [, firstParams] = (mockDb.query as jest.Mock).mock.calls[0];
+      expect(firstParams[1]).toBeInstanceOf(Date);
+      expect(firstParams[2]).toBeInstanceOf(Date);
+      expect((firstParams[1] as Date).getTime()).toBeLessThan(
+        (firstParams[2] as Date).getTime(),
       );
       const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
       expect(firstQuery).toContain('FROM delivery_orders');
       expect(firstQuery).toContain("status <> 'cancelled'");
+      expect(firstQuery).toContain('created_at >= $2');
+      expect(firstQuery).toContain('created_at < $3');
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM delivery_items'),
@@ -529,12 +561,20 @@ describe('deliveryOrderController', () => {
       });
       expect(mockDb.query).toHaveBeenCalledTimes(1);
       expect(mockDb.query).toHaveBeenCalledWith(
-        expect.stringContaining('America/Regina'),
-        [321],
+        expect.stringContaining('created_at >= $2'),
+        [321, expect.any(Date), expect.any(Date)],
+      );
+      const [, firstParams] = (mockDb.query as jest.Mock).mock.calls[0];
+      expect(firstParams[1]).toBeInstanceOf(Date);
+      expect(firstParams[2]).toBeInstanceOf(Date);
+      expect((firstParams[1] as Date).getTime()).toBeLessThan(
+        (firstParams[2] as Date).getTime(),
       );
       const firstQuery = (mockDb.query as jest.Mock).mock.calls[0][0];
       expect(firstQuery).toContain('FROM delivery_orders');
       expect(firstQuery).toContain("status <> 'cancelled'");
+      expect(firstQuery).toContain('created_at >= $2');
+      expect(firstQuery).toContain('created_at < $3');
       expect(sendTemplatedEmail).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary
- compute the Regina-local month boundaries once and reuse them for the monthly limit check
- switch the monthly limit query to a created_at range so the existing index can be used and reuse delivery settings data
- refresh delivery order controller tests to cover the new query parameters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda66fb474832da327008921d4e9ac