### PR TITLE
Handle maintenance mode for WebAuthn logins

### DIFF
--- a/MJ_FB_Backend/tests/webauthnController.test.ts
+++ b/MJ_FB_Backend/tests/webauthnController.test.ts
@@ -4,6 +4,7 @@ import { verifyAuthenticationResponse } from '@simplewebauthn/server';
 import webauthnRoutes from '../src/routes/webauthn';
 import pool from '../src/db';
 import { clearChallenges } from '../src/utils/webauthnChallengeStore';
+import issueAuthTokens from '../src/utils/authUtils';
 
 jest.mock('../src/db');
 jest.mock('@simplewebauthn/server', () => ({
@@ -169,6 +170,9 @@ describe('webauthn routes', () => {
         expect(params?.[1]).toBe(2);
         return Promise.resolve({ rowCount: 1 });
       }
+      if (query.includes('FROM app_config')) {
+        return Promise.resolve({ rowCount: 1, rows: [{ value: 'false' }] });
+      }
       if (query.includes('FROM clients')) {
         return Promise.resolve({
           rowCount: 1,
@@ -216,5 +220,70 @@ describe('webauthn routes', () => {
       id: 123,
       consent: true,
     });
+  });
+
+  it('returns 503 when maintenance mode is enabled for passkey logins', async () => {
+    (pool.query as jest.Mock).mockImplementation((query: string, params?: unknown[]) => {
+      if (query.includes('FROM webauthn_credentials')) {
+        return Promise.resolve({
+          rowCount: 1,
+          rows: [
+            {
+              user_identifier: '123',
+              credential_id: storedCredentialId,
+              public_key: Buffer.from('public-key', 'utf8').toString('base64'),
+              sign_count: 1,
+            },
+          ],
+        });
+      }
+      if (query.startsWith('UPDATE webauthn_credentials')) {
+        expect(params?.[0]).toBe(storedCredentialId);
+        expect(params?.[1]).toBe(2);
+        return Promise.resolve({ rowCount: 1 });
+      }
+      if (query.includes('FROM app_config')) {
+        return Promise.resolve({ rowCount: 1, rows: [{ value: 'true' }] });
+      }
+      if (query.includes('FROM clients')) {
+        return Promise.resolve({
+          rowCount: 1,
+          rows: [
+            {
+              client_id: 123,
+              first_name: 'John',
+              last_name: 'Doe',
+              role: 'shopper',
+              consent: true,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ rowCount: 0, rows: [] });
+    });
+
+    mockedVerify.mockResolvedValueOnce({
+      verified: true,
+      authenticationInfo: { newCounter: 2 },
+    } as any);
+
+    const challengeRes = await request(app)
+      .post('/api/v1/webauthn/challenge')
+      .send({});
+    const challenge = challengeRes.body.challenge as string;
+
+    const assertion = buildAssertion({
+      challenge,
+      rawId: storedCredentialId,
+      origin: process.env.WEBAUTHN_ORIGIN ?? 'http://localhost:3000',
+    });
+
+    const res = await request(app)
+      .post('/api/v1/webauthn/verify')
+      .send(assertion);
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ message: 'Service unavailable due to maintenance' });
+    expect(issueAuthTokens).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- load the maintenance flag during WebAuthn logins and block volunteer or client sign-ins while it is enabled
- surface the maintenance response to callers of the WebAuthn controller without issuing tokens
- add a passkey login test that verifies a 503 response when maintenance mode is active

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda6815078832d9e5fac47e3b585dc