### PR TITLE
Extract shared date validation helper

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -8,6 +8,7 @@ import {
   formatReginaDateWithDay,
   formatTimeToAmPm,
   reginaStartOfDayISO,
+  isValidDateString,
 } from '../utils/dateUtils';
 import {
   isDateWithinCurrentOrNextMonth,
@@ -48,13 +49,6 @@ import { notifyOps } from '../utils/opsAlert';
 
 const NO_SHOW_MESSAGE =
   'This booking has already expired and was marked as a no-show. Please book a new appointment.';
-const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
-function isValidDateString(date: string): boolean {
-  if (!DATE_REGEX.test(date)) return false;
-  const parsed = new Date(date);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === date;
-}
-
 function isTodayOrFutureDate(date: string): boolean {
   if (!isValidDateString(date)) return false;
   try {

--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -192,8 +192,6 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
     clientName = currentName.length > 0 ? currentName : null;
   }
 
-  const deliverySettings = await getDeliverySettings();
-
   // created_at is stored in UTC, so convert to Regina time before truncating to the month
   const monthlyOrderCountResult = await pool.query<CountRow>(
     `SELECT COUNT(*)::int AS count

--- a/MJ_FB_Backend/src/controllers/slotController.ts
+++ b/MJ_FB_Backend/src/controllers/slotController.ts
@@ -2,7 +2,11 @@ import { Request, Response, NextFunction } from 'express';
 import pool from '../db';
 import { Slot } from '../models/slot';
 import logger from '../utils/logger';
-import { formatReginaDate, reginaStartOfDayISO } from '../utils/dateUtils';
+import {
+  formatReginaDate,
+  reginaStartOfDayISO,
+  isValidDateString,
+} from '../utils/dateUtils';
 import { isHoliday } from '../utils/holidayCache';
 import { slotSchema, slotIdParamSchema, slotCapacitySchema } from '../schemas/slotSchemas';
 
@@ -45,7 +49,6 @@ interface SlotRangeData {
 }
 
 const REGINA_TZ = 'America/Regina';
-const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 function currentReginaTime(): string {
   const parts = new Intl.DateTimeFormat('en-CA', {
@@ -278,7 +281,7 @@ export async function listSlots(req: Request, res: Response, next: NextFunction)
   const date = req.query.date;
   if (!date)
     return res.status(400).json({ message: 'Date query parameter required' });
-  if (typeof date !== 'string' || !DATE_REGEX.test(date)) {
+  if (typeof date !== 'string' || !isValidDateString(date)) {
     return res.status(400).json({ message: 'Invalid date' });
   }
 
@@ -346,7 +349,7 @@ export async function listSlotsRange(
   }
   const startQuery = req.query.start;
   if (startQuery !== undefined) {
-    if (typeof startQuery !== 'string' || !DATE_REGEX.test(startQuery)) {
+    if (typeof startQuery !== 'string' || !isValidDateString(startQuery)) {
       return res.status(400).json({ message: 'Invalid date' });
     }
   }

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -20,18 +20,12 @@ import {
   formatReginaDateWithDay,
   reginaStartOfDayISO,
   formatTimeToAmPm,
+  isValidDateString,
 } from '../../utils/dateUtils';
 import config from '../../config';
 import { notifyOps } from '../../utils/opsAlert';
 import { volunteerBookingsByDateSchema } from '../../schemas/volunteer/volunteerBookingSchemas';
 import { isHoliday, getHolidays } from '../../utils/holidayCache';
-
-const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
-function isValidDateString(date: string): boolean {
-  if (!DATE_REGEX.test(date)) return false;
-  const parsed = new Date(date);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === date;
-}
 
 const STATUS_COLORS: Record<string, string> = {
   approved: 'green',

--- a/MJ_FB_Backend/src/utils/dateUtils.ts
+++ b/MJ_FB_Backend/src/utils/dateUtils.ts
@@ -1,10 +1,17 @@
 const REGINA_TZ = 'America/Regina';
 const REGINA_OFFSET = '-06:00';
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidDateString(date: string): boolean {
+  if (!DATE_REGEX.test(date)) return false;
+  const parsed = new Date(date);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === date;
+}
 
 function toReginaDate(date: string | Date): Date {
   if (typeof date === 'string') {
     // If no time component is provided, treat the string as a Regina local date
-    if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    if (DATE_REGEX.test(date)) {
       return new Date(`${date}T00:00:00${REGINA_OFFSET}`);
     }
     return new Date(date);

--- a/MJ_FB_Backend/tests/dateUtils.test.ts
+++ b/MJ_FB_Backend/tests/dateUtils.test.ts
@@ -1,4 +1,4 @@
-import { getWeekForDate, formatReginaDateWithDay } from '../src/utils/dateUtils';
+import { getWeekForDate, formatReginaDateWithDay, isValidDateString } from '../src/utils/dateUtils';
 
 describe('getWeekForDate', () => {
   it('returns week-of-month with Monday start', () => {
@@ -26,5 +26,17 @@ describe('formatReginaDateWithDay', () => {
   it('formats month names in Regina timezone', () => {
     expect(formatReginaDateWithDay('2024-03-31')).toBe('Sun, Mar 31, 2024');
     expect(formatReginaDateWithDay('2024-04-01')).toBe('Mon, Apr 1, 2024');
+  });
+});
+
+describe('isValidDateString', () => {
+  it('accepts valid ISO dates', () => {
+    expect(isValidDateString('2024-02-29')).toBe(true);
+  });
+
+  it('rejects malformed or impossible dates', () => {
+    expect(isValidDateString('2024-2-29')).toBe(false);
+    expect(isValidDateString('2024-02-30')).toBe(false);
+    expect(isValidDateString('not-a-date')).toBe(false);
   });
 });

--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -525,7 +525,7 @@ describe('deliveryOrderController', () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
         message:
-          `You have already used the food bank ${MOCK_MONTHLY_LIMIT} times this month, please request again next month`,
+          `You have already used the food bank ${MOCK_MONTHLY_LIMIT} times this month, which is the limit of ${MOCK_MONTHLY_LIMIT}. Please request again next month`,
       });
       expect(mockDb.query).toHaveBeenCalledTimes(1);
       expect(mockDb.query).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- add an exported `isValidDateString` helper in `dateUtils` to centralize ISO date validation
- update booking, volunteer booking, slot, and delivery order controllers to reuse the shared validator and avoid redundant settings fetches
- extend unit tests for the new helper and refresh controller expectations using the common validator

## Testing
- npm test -- tests/dateUtils.test.ts
- npm test -- tests/bookingController.test.ts
- npm test -- tests/volunteerBookingInvalidDate.test.ts
- npm test -- tests/bookingInvalidDate.test.ts
- npm test -- tests/slots.test.ts
- npm test -- tests/deliveryOrderController.test.ts
- npm test -- tests/controllers/volunteer/volunteerBookingController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cda61ce1a8832d9dfaa22a884389f2