### PR TITLE
Reuse delivery settings during delivery order creation

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -163,7 +163,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
   const normalizedSelections = normalizeSelections(selections);
 
   const deliverySettings = await getDeliverySettings();
-  const { monthlyOrderLimit } = deliverySettings;
+  const { monthlyOrderLimit, requestEmail } = deliverySettings;
 
   const isClient = req.user.role === 'delivery';
   const isStaff = req.user.role === 'staff' || req.user.role === 'admin';
@@ -208,7 +208,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
   const monthlyOrderCount = Number(monthlyOrderCountResult.rows[0]?.count ?? 0);
   if (monthlyOrderCount >= monthlyOrderLimit) {
     return res.status(400).json({
-      message: `You have already used the food bank ${monthlyOrderCount} times this month, please request again next month`,
+      message: `You have already used the food bank ${monthlyOrderCount} times this month, which is the limit of ${monthlyOrderLimit}. Please request again next month`,
     });
   }
 
@@ -340,7 +340,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
 
   try {
     await sendTemplatedEmail({
-      to: deliverySettings.requestEmail,
+      to: requestEmail,
       templateId: config.deliveryRequestTemplateId,
       params: {
         orderId: order.id,

--- a/MJ_FB_Backend/src/utils/parseOptionalPaginationParams.ts
+++ b/MJ_FB_Backend/src/utils/parseOptionalPaginationParams.ts
@@ -15,12 +15,7 @@ export function parseOptionalPaginationParams(
     return {};
   }
 
-  const { limit, offset } = parsePaginationParams(
-    { query: { limit: limitParam, offset: offsetParam } } as Request,
-    1,
-    maxLimit,
-    0,
-  );
+  const { limit, offset } = parsePaginationParams(req, 1, maxLimit, 0);
 
   const result: { limit?: number; offset?: number } = {};
   if (hasLimit) {


### PR DESCRIPTION
## Summary
- reuse the delivery settings fetched at the start of `createDeliveryOrder` for both the monthly limit guard and staff notification email
- expand the monthly limit error message to include the configured limit value
- simplify optional pagination parsing by delegating directly to `parsePaginationParams`

## Testing
- npm run build
- npm test -- deliveryOrderController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cda7aa4da4832d93f0bb1758b081ef