### PR TITLE
Refactor booking email helper usage

### DIFF
--- a/MJ_FB_Backend/src/controllers/bookingController.ts
+++ b/MJ_FB_Backend/src/controllers/bookingController.ts
@@ -15,13 +15,8 @@ import {
   LIMIT_MESSAGE,
   findUpcomingBooking,
 } from '../utils/bookingUtils';
-import { enqueueEmail } from '../utils/emailQueue';
-import {
-  buildCancelRescheduleLinks,
-  buildCalendarLinks,
-  saveIcsFile,
-} from '../utils/emailUtils';
-import { buildIcsFile } from '../utils/calendarLinks';
+import { buildCalendarLinks } from '../utils/emailUtils';
+import { sendBookingEmail } from '../utils/bookingEmailHelpers';
 import logger from '../utils/logger';
 import { isHoliday } from '../utils/holidayCache';
 import { parseIdParam } from '../utils/parseIdParam';
@@ -281,26 +276,27 @@ export async function createBooking(req: Request, res: Response, next: NextFunct
     const formattedDate = formatReginaDateWithDay(date);
     const body = `Date: ${formattedDate}${time}`;
     if (user.email) {
-      const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
-      const attachments = [
-        {
-          name: 'booking.ics',
-          content: Buffer.from(icsContent, 'utf8').toString('base64'),
-          type: 'text/calendar',
-        },
-      ];
-      enqueueEmail({
+      sendBookingEmail({
         to: user.email,
         templateId: config.bookingConfirmationTemplateId,
+        token,
         params: {
           body,
-          cancelLink,
-          rescheduleLink,
-          googleCalendarLink,
-          appleCalendarLink,
           type: emailType,
         },
-        attachments,
+        calendar: {
+          uid,
+          date,
+          startTime: start_time,
+          endTime: end_time,
+          sequence: 0,
+          fileName: 'booking.ics',
+        },
+        calendarLinks: {
+          googleCalendarLink,
+          appleCalendarLink,
+          icsContent,
+        },
       });
     } else {
       logger.warn(
@@ -703,68 +699,54 @@ export async function rescheduleBooking(req: Request, res: Response, next: NextF
     const { email, name: nameRes, first_name, last_name } = emailRes.rows[0] || {};
     const name =
       nameRes || (first_name && last_name ? `${first_name} ${last_name}` : 'Client');
+    const oldSlot = oldSlotRes.rows[0];
+    const newSlot = newSlotRes.rows[0];
     if (email) {
-      const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(newToken);
-      const oldTime = oldSlotRes.rows[0]
-        ? `${formatTimeToAmPm(oldSlotRes.rows[0].start_time)} to ${formatTimeToAmPm(oldSlotRes.rows[0].end_time)}`
+      const oldTime = oldSlot
+        ? `${formatTimeToAmPm(oldSlot.start_time)} to ${formatTimeToAmPm(oldSlot.end_time)}`
         : '';
-      const newTime = newSlotRes.rows[0]
-        ? `${formatTimeToAmPm(newSlotRes.rows[0].start_time)} to ${formatTimeToAmPm(newSlotRes.rows[0].end_time)}`
+      const newTime = newSlot
+        ? `${formatTimeToAmPm(newSlot.start_time)} to ${formatTimeToAmPm(newSlot.end_time)}`
         : '';
       const uid = `booking-${booking.id}@mjfb`;
-      const {
-        googleCalendarLink,
-        appleCalendarLink,
-        icsContent,
-      } = buildCalendarLinks(
+      const links = buildCalendarLinks(
         date,
-        newSlotRes.rows[0]?.start_time,
-        newSlotRes.rows[0]?.end_time,
+        newSlot?.start_time,
+        newSlot?.end_time,
         uid,
         1,
       );
-      const cancelIcs = buildIcsFile({
-        title: 'Harvest Pantry Booking',
-        start: `${booking.date}T${oldSlotRes.rows[0].start_time}-06:00`,
-        end: `${booking.date}T${oldSlotRes.rows[0].end_time}-06:00`,
-        description: 'Your booking at the Harvest Pantry',
-        location: 'Moose Jaw Food Bank',
-        uid,
-        method: 'CANCEL',
-        sequence: 1,
-      });
-      const cancelBase64 = Buffer.from(cancelIcs, 'utf8').toString('base64');
-      const cancelFileName = `${uid}-cancel.ics`;
-      const appleCalendarCancelLink = saveIcsFile(cancelFileName, cancelIcs);
-      const attachments = [
-        {
-          name: 'booking.ics',
-          content: Buffer.from(icsContent, 'utf8').toString('base64'),
-          type: 'text/calendar',
-        },
-        {
-          name: 'booking-cancel.ics',
-          content: cancelBase64,
-          type: 'text/calendar',
-        },
-      ];
-      enqueueEmail({
+      sendBookingEmail({
         to: email,
         templateId:
           config.clientRescheduleTemplateId || config.bookingConfirmationTemplateId,
+        token: newToken,
         params: {
           oldDate: formatReginaDateWithDay(booking.date),
           oldTime,
           newDate: formatReginaDateWithDay(date),
           newTime,
-          cancelLink,
-          rescheduleLink,
-          googleCalendarLink,
-          appleCalendarLink,
-          appleCalendarCancelLink,
           type: emailType,
         },
-        attachments,
+        calendar: {
+          uid,
+          date,
+          startTime: newSlot?.start_time,
+          endTime: newSlot?.end_time,
+          sequence: 1,
+          fileName: 'booking.ics',
+        },
+        calendarLinks: links,
+        cancelEvent:
+          oldSlot?.start_time && oldSlot?.end_time
+            ? {
+                date: booking.date,
+                startTime: oldSlot.start_time,
+                endTime: oldSlot.end_time,
+                sequence: 1,
+                fileName: 'booking-cancel.ics',
+              }
+            : undefined,
       });
     } else {
       logger.warn('Booking %s has no email. Skipping reschedule email.', booking.id);
@@ -1058,37 +1040,30 @@ export async function createBookingForUser(
       }
     }
     if (clientEmail) {
-        const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
-        const {
-          googleCalendarLink,
-          appleCalendarLink,
-          icsContent,
-        } = buildCalendarLinks(date, start_time, end_time, uid, 0);
-        const time =
-          start_time && end_time
-            ? ` from ${formatTimeToAmPm(start_time)} to ${formatTimeToAmPm(end_time)}`
-            : '';
-        const formattedDate = formatReginaDateWithDay(date);
-        const body = `Date: ${formattedDate}${time}`;
-        const attachments = [
-          {
-            name: 'booking.ics',
-            content: Buffer.from(icsContent, 'utf8').toString('base64'),
-            type: 'text/calendar',
-          },
-        ];
-      enqueueEmail({
+      const links = buildCalendarLinks(date, start_time, end_time, uid, 0);
+      const time =
+        start_time && end_time
+          ? ` from ${formatTimeToAmPm(start_time)} to ${formatTimeToAmPm(end_time)}`
+          : '';
+      const formattedDate = formatReginaDateWithDay(date);
+      const body = `Date: ${formattedDate}${time}`;
+      sendBookingEmail({
         to: clientEmail,
         templateId: config.bookingConfirmationTemplateId,
+        token,
         params: {
           body,
-          cancelLink,
-          rescheduleLink,
-          googleCalendarLink,
-          appleCalendarLink,
           type: emailType,
         },
-        attachments,
+        calendar: {
+          uid,
+          date,
+          startTime: start_time,
+          endTime: end_time,
+          sequence: 0,
+          fileName: 'booking.ics',
+        },
+        calendarLinks: links,
       });
     } else {
       logger.warn(

--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -6,10 +6,8 @@ import {
   sendTemplatedEmail,
   buildCancelRescheduleLinks,
   buildCalendarLinks,
-  saveIcsFile,
 } from '../../utils/emailUtils';
-import { buildIcsFile } from '../../utils/calendarLinks';
-import { enqueueEmail } from '../../utils/emailQueue';
+import { sendBookingEmail } from '../../utils/bookingEmailHelpers';
 import logger from '../../utils/logger';
 import {
   CreateRecurringVolunteerBookingRequest,
@@ -212,9 +210,6 @@ export async function createVolunteerBooking(
       let googleCalendarLink: string | undefined;
       let appleCalendarLink: string | undefined;
       if (user.email) {
-        const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(
-          token,
-        );
         const uid = `volunteer-booking-${insertRes.rows[0].id}@mjfb`;
         const links = buildCalendarLinks(
           date,
@@ -223,31 +218,29 @@ export async function createVolunteerBooking(
           uid,
           0,
         );
-        googleCalendarLink = links.googleCalendarLink;
-        appleCalendarLink = links.appleCalendarLink;
         const body = `Date: ${formatReginaDateWithDay(date)} from ${formatTimeToAmPm(
           slot.start_time,
         )} to ${formatTimeToAmPm(slot.end_time)}`;
-        const attachments = [
-          {
-            name: 'shift.ics',
-            content: Buffer.from(links.icsContent, 'utf8').toString('base64'),
-            type: 'text/calendar',
-          },
-        ];
-        enqueueEmail({
+        const result = sendBookingEmail({
           to: user.email,
           templateId: config.volunteerBookingConfirmationTemplateId,
+          token,
           params: {
             body,
-            cancelLink,
-            rescheduleLink,
-            googleCalendarLink,
-            appleCalendarLink,
             type: emailType,
           },
-          attachments,
+          calendar: {
+            uid,
+            date,
+            startTime: slot.start_time,
+            endTime: slot.end_time,
+            sequence: 0,
+            fileName: 'shift.ics',
+          },
+          calendarLinks: links,
         });
+        googleCalendarLink = result.googleCalendarLink;
+        appleCalendarLink = result.appleCalendarLink;
       } else {
         logger.warn(
           'Volunteer booking confirmation email not sent. Volunteer %s has no email.',
@@ -650,35 +643,28 @@ export async function resolveVolunteerBookingConflict(
     );
 
     if (user.email) {
-      const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
       const uid = `volunteer-booking-${insertRes.rows[0].id}@mjfb`;
-      const {
-        googleCalendarLink,
-        appleCalendarLink,
-        icsContent,
-      } = buildCalendarLinks(date!, slot.start_time, slot.end_time, uid, 0);
+      const links = buildCalendarLinks(date!, slot.start_time, slot.end_time, uid, 0);
       const body = `Date: ${formatReginaDateWithDay(date!)} from ${formatTimeToAmPm(
         slot.start_time,
       )} to ${formatTimeToAmPm(slot.end_time)}`;
-      const attachments = [
-        {
-          name: 'shift.ics',
-          content: Buffer.from(icsContent, 'utf8').toString('base64'),
-          type: 'text/calendar',
-        },
-      ];
-      enqueueEmail({
+      sendBookingEmail({
         to: user.email,
         templateId: config.volunteerBookingConfirmationTemplateId,
+        token,
         params: {
           body,
-          cancelLink,
-          rescheduleLink,
-          googleCalendarLink,
-          appleCalendarLink,
           type: emailType,
         },
-        attachments,
+        calendar: {
+          uid,
+          date: date!,
+          startTime: slot.start_time,
+          endTime: slot.end_time,
+          sequence: 0,
+          fileName: 'shift.ics',
+        },
+        calendarLinks: links,
       });
     } else {
       logger.warn(
@@ -1066,63 +1052,51 @@ export async function rescheduleVolunteerBooking(
     const { email, first_name, last_name } = emailRes.rows[0] || {};
     const name = first_name && last_name ? `${first_name} ${last_name}` : 'Volunteer';
     if (email) {
-        const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(newToken);
-        const oldTime = oldSlotRes.rows[0]
-          ? `${formatTimeToAmPm(oldSlotRes.rows[0].start_time)} to ${formatTimeToAmPm(
-              oldSlotRes.rows[0].end_time,
-            )}`
-          : '';
+      const oldSlot = oldSlotRes.rows[0];
+      const oldTime = oldSlot
+        ? `${formatTimeToAmPm(oldSlot.start_time)} to ${formatTimeToAmPm(
+            oldSlot.end_time,
+          )}`
+        : '';
       const uid = `volunteer-booking-${booking.id}@mjfb`;
-      const {
-        googleCalendarLink,
-        appleCalendarLink,
-        icsContent,
-      } = buildCalendarLinks(date, slot.start_time, slot.end_time, uid, 1);
-      const cancelIcs = buildIcsFile({
-        title: 'Volunteer Shift',
-        start: `${booking.date}T${oldSlotRes.rows[0].start_time}-06:00`,
-        end: `${booking.date}T${oldSlotRes.rows[0].end_time}-06:00`,
-        description: 'Your volunteer shift at the Harvest Pantry',
-        location: 'Moose Jaw Food Bank',
-        uid,
-        method: 'CANCEL',
-        sequence: 1,
-      });
-      const cancelBase64 = Buffer.from(cancelIcs, 'utf8').toString('base64');
-      const cancelFileName = `${uid}-cancel.ics`;
-      const appleCalendarCancelLink = saveIcsFile(cancelFileName, cancelIcs);
-      const attachments = [
-        {
-          name: 'shift.ics',
-          content: Buffer.from(icsContent, 'utf8').toString('base64'),
-          type: 'text/calendar',
-        },
-        {
-          name: 'shift-cancel.ics',
-          content: cancelBase64,
-          type: 'text/calendar',
-        },
-      ];
-      enqueueEmail({
+      const links = buildCalendarLinks(date, slot.start_time, slot.end_time, uid, 1);
+      sendBookingEmail({
         to: email,
         templateId:
           config.volunteerRescheduleTemplateId ||
           config.volunteerBookingConfirmationTemplateId,
+        token: newToken,
         params: {
           oldDate: formatReginaDateWithDay(booking.date),
           oldTime,
           newDate: formatReginaDateWithDay(date),
-            newTime: `${formatTimeToAmPm(slot.start_time)} to ${formatTimeToAmPm(
-              slot.end_time,
-            )}`,
-          cancelLink,
-          rescheduleLink,
-          googleCalendarLink,
-          appleCalendarLink,
-          appleCalendarCancelLink,
+          newTime: `${formatTimeToAmPm(slot.start_time)} to ${formatTimeToAmPm(
+            slot.end_time,
+          )}`,
           type: 'Volunteer Shift',
         },
-        attachments,
+        calendar: {
+          uid,
+          date,
+          startTime: slot.start_time,
+          endTime: slot.end_time,
+          sequence: 1,
+          fileName: 'shift.ics',
+        },
+        calendarLinks: links,
+        cancelEvent:
+          oldSlot?.start_time && oldSlot?.end_time
+            ? {
+                date: booking.date,
+                startTime: oldSlot.start_time,
+                endTime: oldSlot.end_time,
+                sequence: 1,
+                fileName: 'shift-cancel.ics',
+                title: 'Volunteer Shift',
+                description: 'Your volunteer shift at the Harvest Pantry',
+                location: 'Moose Jaw Food Bank',
+              }
+            : undefined,
       });
     } else {
       logger.warn(

--- a/MJ_FB_Backend/src/utils/bookingEmailHelpers.ts
+++ b/MJ_FB_Backend/src/utils/bookingEmailHelpers.ts
@@ -1,0 +1,125 @@
+import { enqueueEmail } from './emailQueue';
+import {
+  buildCancelRescheduleLinks,
+  buildCalendarLinks,
+  saveIcsFile,
+} from './emailUtils';
+import { buildIcsFile } from './calendarLinks';
+
+interface CalendarLinksResult {
+  googleCalendarLink: string;
+  appleCalendarLink: string;
+  icsContent: string;
+}
+
+interface BookingCalendarOptions {
+  uid: string;
+  date: string;
+  startTime?: string | null;
+  endTime?: string | null;
+  sequence?: number;
+  fileName?: string;
+}
+
+interface CancelEventOptions {
+  date: string;
+  startTime?: string | null;
+  endTime?: string | null;
+  sequence?: number;
+  fileName?: string;
+  title?: string;
+  description?: string;
+  location?: string;
+}
+
+export interface SendBookingEmailOptions {
+  to: string;
+  templateId: number;
+  token: string;
+  params: Record<string, unknown>;
+  calendar: BookingCalendarOptions;
+  calendarLinks?: CalendarLinksResult;
+  cancelEvent?: CancelEventOptions;
+}
+
+export interface SendBookingEmailResult {
+  googleCalendarLink: string;
+  appleCalendarLink: string;
+  appleCalendarCancelLink?: string;
+}
+
+function ensureLinks(
+  calendar: BookingCalendarOptions,
+  override?: CalendarLinksResult,
+): CalendarLinksResult {
+  if (override) {
+    return override;
+  }
+
+  const { date, startTime, endTime, uid, sequence } = calendar;
+  return buildCalendarLinks(date, startTime, endTime, uid, sequence);
+}
+
+export function sendBookingEmail({
+  to,
+  templateId,
+  token,
+  params,
+  calendar,
+  calendarLinks,
+  cancelEvent,
+}: SendBookingEmailOptions): SendBookingEmailResult {
+  const links = ensureLinks(calendar, calendarLinks);
+  const { cancelLink, rescheduleLink } = buildCancelRescheduleLinks(token);
+
+  const attachments = [
+    {
+      name: calendar.fileName ?? 'booking.ics',
+      content: Buffer.from(links.icsContent, 'utf8').toString('base64'),
+      type: 'text/calendar',
+    },
+  ];
+
+  let appleCalendarCancelLink: string | undefined;
+
+  if (cancelEvent?.startTime && cancelEvent?.endTime) {
+    const cancelIcs = buildIcsFile({
+      title: cancelEvent.title ?? 'Harvest Pantry Booking',
+      start: `${cancelEvent.date}T${cancelEvent.startTime}-06:00`,
+      end: `${cancelEvent.date}T${cancelEvent.endTime}-06:00`,
+      description:
+        cancelEvent.description ?? 'Your booking at the Harvest Pantry',
+      location: cancelEvent.location ?? 'Moose Jaw Food Bank',
+      uid: calendar.uid,
+      method: 'CANCEL',
+      sequence: cancelEvent.sequence ?? 1,
+    });
+    const cancelFileName = cancelEvent.fileName ?? 'booking-cancel.ics';
+    appleCalendarCancelLink = saveIcsFile(cancelFileName, cancelIcs);
+    attachments.push({
+      name: cancelFileName,
+      content: Buffer.from(cancelIcs, 'utf8').toString('base64'),
+      type: 'text/calendar',
+    });
+  }
+
+  const payloadParams: Record<string, unknown> = {
+    ...params,
+    cancelLink,
+    rescheduleLink,
+    googleCalendarLink: links.googleCalendarLink,
+    appleCalendarLink: links.appleCalendarLink,
+  };
+
+  if (appleCalendarCancelLink) {
+    payloadParams.appleCalendarCancelLink = appleCalendarCancelLink;
+  }
+
+  enqueueEmail({ to, templateId, params: payloadParams, attachments });
+
+  return {
+    googleCalendarLink: links.googleCalendarLink,
+    appleCalendarLink: links.appleCalendarLink,
+    appleCalendarCancelLink,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable sendBookingEmail helper that builds ICS attachments and cancel notices for booking emails
- update booking and volunteer controllers to use the helper for create and reschedule flows
- adjust booking and volunteer controller tests to mock the new helper

## Testing
- npm test *(fails: Jest encounters "Identifier 'deliverySettings' has already been declared" in deliveryOrderController.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cda6204e24832daa9f9f8df7ecfb61