### PR TITLE
Fix delivery category title formatting

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -400,11 +400,12 @@ export default function BookDelivery() {
               const limit = resolveCategoryLimit(category);
               const remaining = remainingSelections(category);
               const selectedId = category.items.find(item => selectedItems[item.id])?.id;
+              const title = Number.isFinite(limit)
+                ? `${category.name} (Select ${limit})`
+                : category.name;
               return (
                 <Card key={category.id}>
-                  <CardHeader
-                    title={`${category.name}$${Number.isFinite(limit) ? ` (Select ${limit})` : ''}`.replace('$', '')}
-                  />
+                  <CardHeader title={title} />
                   <CardContent>
                     {category.description && (
                       <Typography color="text.secondary" sx={{ mb: 2 }}>

--- a/MJ_FB_Frontend/tests/BookDeliveryPage.test.tsx
+++ b/MJ_FB_Frontend/tests/BookDeliveryPage.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import BookDelivery from '../src/pages/delivery/BookDelivery';
+import { apiFetch } from '../src/api/client';
+import { getUserProfile } from '../src/api/users';
+import { useAuth } from '../src/hooks/useAuth';
+
+jest.mock('../src/api/client', () => {
+  const actual = jest.requireActual('../src/api/client');
+  return {
+    ...actual,
+    apiFetch: jest.fn(),
+  };
+});
+
+jest.mock('../src/api/users', () => {
+  const actual = jest.requireActual('../src/api/users');
+  return {
+    ...actual,
+    getUserProfile: jest.fn(),
+  };
+});
+
+jest.mock('../src/hooks/useAuth', () => ({
+  useAuth: jest.fn(),
+}));
+
+describe('BookDelivery page', () => {
+  const mockedApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>;
+  const mockedGetUserProfile = getUserProfile as jest.MockedFunction<
+    typeof getUserProfile
+  >;
+  const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetUserProfile.mockResolvedValue({
+      address: '123 Main St',
+      phone: '306-555-0101',
+      email: 'client@example.com',
+    } as any);
+    mockedUseAuth.mockReturnValue({
+      id: 42,
+      role: 'delivery',
+      isAuthenticated: true,
+      name: 'Test User',
+      userRole: 'delivery',
+      access: [],
+      login: jest.fn(),
+      logout: jest.fn(),
+      cardUrl: '',
+      ready: true,
+    } as any);
+  });
+
+  it('renders category names containing a dollar sign without stripping the character', async () => {
+    const categories = [
+      {
+        id: 1,
+        name: 'Fresh $tart',
+        description: null,
+        limit: 2,
+        maxItems: null,
+        maxSelections: null,
+        limitPerOrder: null,
+        items: [
+          { id: 10, categoryId: 1, name: 'Apples', description: null, maxQuantity: null, maxPerOrder: null, unit: null },
+        ],
+      },
+    ];
+
+    mockedApiFetch.mockImplementation(async input => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/delivery/categories')) {
+        return new Response(JSON.stringify(categories), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(null, { status: 204 });
+    });
+
+    render(
+      <MemoryRouter>
+        <BookDelivery />
+      </MemoryRouter>,
+    );
+
+    const categoryTitle = await screen.findByText('Fresh $tart (Select 2)');
+    expect(categoryTitle).toBeInTheDocument();
+    const dollarMatches = categoryTitle.textContent?.match(/\$/g) ?? [];
+    expect(dollarMatches).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- simplify the Book Delivery category header title construction so limits append without stripping characters from the name
- add a unit test to ensure category names containing a dollar sign render correctly

## Testing
- npm test -- BookDelivery

------
https://chatgpt.com/codex/tasks/task_e_68cda7ac47f8832dae31d0c728387026