### PR TITLE
Reuse delivery settings in delivery order controller

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -177,7 +177,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
   const { clientId, address, phone, email, selections } = parsed.data;
   const normalizedSelections = normalizeSelections(selections);
 
-  const { monthlyOrderLimit, requestEmail } = await getDeliverySettings();
+  const deliverySettings = await getDeliverySettings();
 
   const isClient = req.user.role === 'delivery';
   const isStaff = req.user.role === 'staff' || req.user.role === 'admin';
@@ -220,9 +220,9 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
   );
 
   const monthlyOrderCount = Number(monthlyOrderCountResult.rows[0]?.count ?? 0);
-  if (monthlyOrderCount >= monthlyOrderLimit) {
+  if (monthlyOrderCount >= deliverySettings.monthlyOrderLimit) {
     return res.status(400).json({
-      message: `You have already used the food bank ${monthlyOrderCount} times this month, please request again next month`,
+      message: `You have already used the food bank ${monthlyOrderCount} times this month, which is the limit of ${deliverySettings.monthlyOrderLimit}. Please request again next month`,
     });
   }
 
@@ -354,7 +354,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
 
   try {
     await sendTemplatedEmail({
-      to: requestEmail,
+      to: deliverySettings.requestEmail,
       templateId: config.deliveryRequestTemplateId,
       params: {
         orderId: order.id,

--- a/MJ_FB_Backend/src/utils/parseOptionalPaginationParams.ts
+++ b/MJ_FB_Backend/src/utils/parseOptionalPaginationParams.ts
@@ -16,7 +16,7 @@ export function parseOptionalPaginationParams(
   }
 
   const { limit, offset } = parsePaginationParams(
-    { query: { limit: limitParam, offset: offsetParam } } as Request,
+    { query: { limit: limitParam, offset: offsetParam } } as unknown as Request,
     1,
     maxLimit,
     0,


### PR DESCRIPTION
## Summary
- reuse a single delivery settings lookup in the delivery order controller for monthly limit validation and notification emails
- clarify the monthly order limit error message to reference the configured cap
- fix the optional pagination helper's type casting so the backend build succeeds

## Testing
- npm run build
- npm test -- deliveryOrderController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cda8f78550832d9cd9503551f9571b