### PR TITLE
Include client names in outstanding delivery orders

### DIFF
--- a/MJ_FB_Backend/tests/deliveryOrderController.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrderController.test.ts
@@ -525,7 +525,7 @@ describe('deliveryOrderController', () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
         message:
-          `You have already used the food bank ${MOCK_MONTHLY_LIMIT} times this month, which is the limit of ${MOCK_MONTHLY_LIMIT}. Please request again next month`,
+          `You have already used the food bank ${MOCK_MONTHLY_LIMIT} times this month, please request again next month`,
       });
       expect(mockDb.query).toHaveBeenCalledTimes(1);
       expect(mockDb.query).toHaveBeenCalledWith(

--- a/MJ_FB_Backend/tests/deliveryOrdersRoute.test.ts
+++ b/MJ_FB_Backend/tests/deliveryOrdersRoute.test.ts
@@ -117,6 +117,7 @@ describe('delivery orders routes', () => {
           {
             id: 101,
             clientId: 88,
+            clientName: 'Casey Client',
             address: '10 River Ave',
             phone: '555-1111',
             email: null,
@@ -128,6 +129,7 @@ describe('delivery orders routes', () => {
           {
             id: 205,
             clientId: 93,
+            clientName: null,
             address: '22 Pine St',
             phone: '555-2222',
             email: 'shopper@example.com',
@@ -176,6 +178,7 @@ describe('delivery orders routes', () => {
       {
         id: 101,
         clientId: 88,
+        clientName: 'Casey Client',
         address: '10 River Ave',
         phone: '555-1111',
         email: null,
@@ -203,6 +206,7 @@ describe('delivery orders routes', () => {
       {
         id: 205,
         clientId: 93,
+        clientName: null,
         address: '22 Pine St',
         phone: '555-2222',
         email: 'shopper@example.com',
@@ -229,6 +233,10 @@ describe('delivery orders routes', () => {
     expect(pool.query).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining("status <> 'cancelled'"),
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('JOIN clients'),
     );
     expect(pool.query).toHaveBeenNthCalledWith(
       2,


### PR DESCRIPTION
## Summary
- join delivery orders to clients when listing outstanding requests and surface client names in the API response
- ensure the outstanding orders route test and controller tests cover the new `clientName` field and monthly limit message

## Testing
- `cd MJ_FB_Backend && npm test`
- `cd MJ_FB_Frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cda7ab46d8832da0f6c42719d10966