### PR TITLE
Fix assign modals overlapping text and buttons

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -21,6 +21,7 @@ import VolunteerScheduleTable from "../../components/VolunteerScheduleTable";
 import ScheduleCards from "../../components/ScheduleCards";
 import FeedbackSnackbar from "../../components/FeedbackSnackbar";
 import {
+  Box,
   Button,
   type AlertColor,
   useTheme,
@@ -483,20 +484,39 @@ export default function PantrySchedule({
               {userResults.map((u) => (
                 <ListItem
                   key={u.client_id}
-                  sx={{ mb: 0.5 }}
-                  secondaryAction={
-                    <Button
-                      onClick={() => assignExistingUser(u)}
-                      variant="outlined"
-                      color="primary"
-                      
-                      sx={{ ml: 0.5 }}
-                    >
-                      Assign
-                    </Button>
-                  }
+                  disableGutters
+                  sx={{
+                    mb: 0.5,
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 1,
+                  }}
                 >
-                  <ListItemText primary={`${u.name} (${u.client_id})`} />
+                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontWeight: 500, wordBreak: "break-word" }}
+                    >
+                      {u.name} ({u.client_id})
+                    </Typography>
+                    {(u.email || u.phone) && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: "block", wordBreak: "break-word" }}
+                      >
+                        {[u.email, u.phone].filter(Boolean).join(" · ")}
+                      </Typography>
+                    )}
+                  </Box>
+                  <Button
+                    onClick={() => assignExistingUser(u)}
+                    variant="outlined"
+                    color="primary"
+                    sx={{ flexShrink: 0 }}
+                  >
+                    Assign
+                  </Button>
                 </ListItem>
               ))}
               {searchTerm.length >= 3 && userResults.length === 0 && (

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -1379,10 +1379,20 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
               />
             <ul style={{ listStyle: 'none', paddingLeft: 0, maxHeight: '150px', overflowY: 'auto' }}>
               {assignResults.map(v => (
-                <li key={v.id} style={{ marginBottom: 4 }}>
-                  {v.name}
+                <li
+                  key={v.id}
+                  style={{
+                    marginBottom: 4,
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 8,
+                  }}
+                >
+                  <span style={{ flexGrow: 1, minWidth: 0, wordBreak: 'break-word' }}>
+                    {v.name}
+                  </span>
                   <Button
-                    style={{ marginLeft: 4 }}
+                    style={{ marginLeft: 'auto', flexShrink: 0 }}
                     onClick={() => assignVolunteer(v)}
                     variant="outlined"
                     color="primary"


### PR DESCRIPTION
## Summary
- update the pantry Assign User results to use a flex two-column layout with wrapped details and a dedicated assign button column
- adjust the volunteer Assign Volunteer quick search list to align names and actions side by side so buttons no longer overlap long names

## Testing
- npm test -- --runTestsByPath src/pages/staff/__tests__/PantrySchedule.test.tsx src/pages/volunteer-management/__tests__/VolunteerManagement.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cdac12aef0832d808cd28314e98410