### PR TITLE
Improve layout for assign user results

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -481,36 +481,54 @@ export default function PantrySchedule({
                   disableGutters
                   sx={{
                     mb: 0.5,
-                    display: "flex",
-                    alignItems: "flex-start",
-                    gap: 1,
+                    px: 0,
                   }}
                 >
-                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                    <Typography
-                      variant="body2"
-                      sx={{ fontWeight: 500, wordBreak: "break-word" }}
-                    >
-                      {u.name} ({u.client_id})
-                    </Typography>
-                    {(u.email || u.phone) && (
-                      <Typography
-                        variant="caption"
-                        color="text.secondary"
-                        sx={{ display: "block", wordBreak: "break-word" }}
-                      >
-                        {[u.email, u.phone].filter(Boolean).join(" · ")}
-                      </Typography>
-                    )}
-                  </Box>
-                  <Button
-                    onClick={() => assignExistingUser(u)}
-                    variant="outlined"
-                    color="primary"
-                    sx={{ flexShrink: 0 }}
+                  <Box
+                    sx={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr auto",
+                      columnGap: 1,
+                      alignItems: "center",
+                      width: "100%",
+                    }}
                   >
-                    Assign
-                  </Button>
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontWeight: 500,
+                          wordBreak: "break-word",
+                          whiteSpace: "normal",
+                          overflowWrap: "anywhere",
+                        }}
+                      >
+                        {u.name} ({u.client_id})
+                      </Typography>
+                      {(u.email || u.phone) && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{
+                            display: "block",
+                            wordBreak: "break-word",
+                            whiteSpace: "normal",
+                            overflowWrap: "anywhere",
+                          }}
+                        >
+                          {[u.email, u.phone].filter(Boolean).join(" · ")}
+                        </Typography>
+                      )}
+                    </Box>
+                    <Button
+                      onClick={() => assignExistingUser(u)}
+                      variant="outlined"
+                      color="primary"
+                      sx={{ flexShrink: 0, alignSelf: "center" }}
+                    >
+                      Assign
+                    </Button>
+                  </Box>
                 </ListItem>
               ))}
               {searchTerm.length >= 3 && userResults.length === 0 && (

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -1377,34 +1377,69 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                 
                 fullWidth
               />
-            <ul style={{ listStyle: 'none', paddingLeft: 0, maxHeight: '150px', overflowY: 'auto' }}>
+            <Box
+              component="ul"
+              sx={{
+                listStyle: 'none',
+                pl: 0,
+                maxHeight: 150,
+                overflowY: 'auto',
+                mt: 2,
+              }}
+            >
               {assignResults.map(v => (
-                <li
+                <Box
+                  component="li"
                   key={v.id}
-                  style={{
-                    marginBottom: 4,
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    gap: 8,
+                  sx={{
+                    mb: 0.5,
+                    display: 'grid',
+                    gridTemplateColumns: '1fr auto',
+                    columnGap: 1,
+                    alignItems: 'center',
                   }}
                 >
-                  <span style={{ flexGrow: 1, minWidth: 0, wordBreak: 'break-word' }}>
-                    {v.name}
-                  </span>
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: 500,
+                        whiteSpace: 'normal',
+                        overflowWrap: 'anywhere',
+                      }}
+                    >
+                      {v.name}
+                    </Typography>
+                    {(v.email || v.phone) && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{
+                          display: 'block',
+                          whiteSpace: 'normal',
+                          overflowWrap: 'anywhere',
+                        }}
+                      >
+                        {[v.email, v.phone].filter(Boolean).join(' · ')}
+                      </Typography>
+                    )}
+                  </Box>
                   <Button
-                    style={{ marginLeft: 'auto', flexShrink: 0 }}
+                    sx={{ ml: 1, flexShrink: 0 }}
                     onClick={() => assignVolunteer(v)}
                     variant="outlined"
                     color="primary"
                   >
                     Assign
                   </Button>
-                </li>
+                </Box>
               ))}
               {assignSearch.length >= 3 && assignResults.length === 0 && (
-                <li>No search results.</li>
+                <Box component="li" sx={{ mb: 0.5 }}>
+                  <Typography variant="body2">No search results.</Typography>
+                </Box>
               )}
-            </ul>
+            </Box>
             <Button
               onClick={() => {
                 setAssignSlot(null);


### PR DESCRIPTION
## Summary
- align Assign User modal results in the pantry schedule with a responsive two-column grid so long details wrap without covering the button
- apply the same two-column layout and wrapping rules to the volunteer management assign overlay to keep buttons fixed on the right

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cdb5ec6f3c832d908444d9901816da