### PR TITLE
Fix recurring volunteer booking days array type

### DIFF
--- a/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
+++ b/MJ_FB_Backend/src/controllers/volunteer/volunteerBookingController.ts
@@ -1180,7 +1180,7 @@ export async function createRecurringVolunteerBooking(
 
     const recurringRes = await pool.query(
       `INSERT INTO volunteer_recurring_bookings (volunteer_id, slot_id, start_date, end_date, pattern, days_of_week, active)
-       VALUES ($1,$2,$3,$4,$5,$6,true)
+       VALUES ($1,$2,$3,$4,$5,$6::integer[],true)
        RETURNING id`,
       [user.id, roleId, startDate, endDate, pattern, daysOfWeek],
     );
@@ -1382,7 +1382,7 @@ export async function createRecurringVolunteerBookingForVolunteer(
 
     const recurringRes = await pool.query(
       `INSERT INTO volunteer_recurring_bookings (volunteer_id, slot_id, start_date, end_date, pattern, days_of_week, active)
-       VALUES ($1,$2,$3,$4,$5,$6,true)
+       VALUES ($1,$2,$3,$4,$5,$6::integer[],true)
        RETURNING id`,
       [volunteerId, roleId, startDate, endDate, pattern, daysOfWeek],
     );


### PR DESCRIPTION
## Summary
- cast the days_of_week parameter to integer[] when inserting recurring volunteer bookings so Postgres accepts weekly schedules from staff or volunteers

## Testing
- npm test tests/volunteerRecurringBookingsStaff.test.ts
- npm test tests/volunteerRecurringBookings.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdba4b25a4832d8dc504671921a80b