### PR TITLE
Ensure assign user results wrap and align

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -524,7 +524,11 @@ export default function PantrySchedule({
                       onClick={() => assignExistingUser(u)}
                       variant="outlined"
                       color="primary"
-                      sx={{ flexShrink: 0, alignSelf: "center" }}
+                      sx={{
+                        flexShrink: 0,
+                        alignSelf: "center",
+                        justifySelf: "end",
+                      }}
                     >
                       Assign
                     </Button>

--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -1404,6 +1404,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                       variant="body2"
                       sx={{
                         fontWeight: 500,
+                        wordBreak: 'break-word',
                         whiteSpace: 'normal',
                         overflowWrap: 'anywhere',
                       }}
@@ -1416,6 +1417,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                         color="text.secondary"
                         sx={{
                           display: 'block',
+                          wordBreak: 'break-word',
                           whiteSpace: 'normal',
                           overflowWrap: 'anywhere',
                         }}
@@ -1425,7 +1427,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                     )}
                   </Box>
                   <Button
-                    sx={{ ml: 1, flexShrink: 0 }}
+                    sx={{ ml: 1, flexShrink: 0, justifySelf: 'end' }}
                     onClick={() => assignVolunteer(v)}
                     variant="outlined"
                     color="primary"


### PR DESCRIPTION
## Summary
- keep assign user results in the pantry modal on a two-column grid and anchor the action button to the right edge
- allow long volunteer search results to wrap cleanly and align the Assign button in the volunteer management overlay

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cdbc9eaf34832d9f03ba825e8bc5cc