### PR TITLE
Improve accordion contrast

### DIFF
--- a/MJ_FB_Frontend/src/theme.ts
+++ b/MJ_FB_Frontend/src/theme.ts
@@ -125,6 +125,18 @@ let theme = createTheme({
       },
     },
 
+    MuiAccordion: {
+      styleOverrides: {
+        root: ({ theme }: { theme: Theme }) => ({
+          border: `1px solid ${darken(theme.palette.divider, 0.35)}`,
+          borderRadius: theme.shape.borderRadius,
+          boxShadow: 'none',
+          '&::before': { display: 'none' },
+          '& + &': { marginTop: theme.spacing(1.5) },
+        }),
+      },
+    },
+
     // Navbar solid green (like site)
     MuiAppBar: { styleOverrides: { root: { backgroundColor: BRAND_PRIMARY } } },
 


### PR DESCRIPTION
## Summary
- add a MuiAccordion theme override to draw a higher-contrast border against light backgrounds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc7afe05c832d9ab535cec870254d