### PR TITLE
Add maintenance vacuum controls and APIs

### DIFF
--- a/MJ_FB_Frontend/src/api/maintenance.ts
+++ b/MJ_FB_Frontend/src/api/maintenance.ts
@@ -47,3 +47,37 @@ export async function clearMaintenanceStats(): Promise<void> {
   const res = await apiFetch(`${API_BASE}/maintenance/stats`, { method: 'DELETE' });
   await handleResponse(res);
 }
+
+export interface VacuumResponse {
+  message?: string;
+}
+
+export interface DeadRowInfo {
+  table: string;
+  deadRows: number;
+}
+
+export interface DeadRowsLookupResponse {
+  message?: string;
+  tables?: DeadRowInfo[];
+}
+
+export async function vacuumDatabase(): Promise<VacuumResponse> {
+  const res = await apiFetch(`${API_BASE}/maintenance/vacuum`, {
+    method: 'POST',
+  });
+  return handleResponse(res);
+}
+
+export async function vacuumTable(table: string): Promise<VacuumResponse> {
+  const res = await apiFetch(`${API_BASE}/maintenance/vacuum/${encodeURIComponent(table)}`, {
+    method: 'POST',
+  });
+  return handleResponse(res);
+}
+
+export async function getVacuumDeadRows(table?: string): Promise<DeadRowsLookupResponse> {
+  const query = table ? `?table=${encodeURIComponent(table)}` : '';
+  const res = await apiFetch(`${API_BASE}/maintenance/vacuum/dead-rows${query}`);
+  return handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/pages/admin/Maintenance.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/Maintenance.tsx
@@ -1,5 +1,15 @@
-import { useEffect, useState } from 'react';
-import { Box, FormControlLabel, Switch, TextField, Button } from '@mui/material';
+import { useEffect, useState, type ReactNode } from 'react';
+import {
+  Box,
+  FormControlLabel,
+  Switch,
+  TextField,
+  Tabs,
+  Tab,
+  Typography,
+  Paper,
+  Button,
+} from '@mui/material';
 import Grid from '@mui/material/GridLegacy';
 import Page from '../../components/Page';
 import ErrorBoundary from '../../components/ErrorBoundary';
@@ -8,14 +18,25 @@ import {
   getMaintenanceSettings,
   updateMaintenanceSettings,
   clearMaintenanceStats,
+  vacuumDatabase,
+  vacuumTable,
+  getVacuumDeadRows,
   type MaintenanceSettings,
 } from '../../api/maintenance';
 
 export default function Maintenance() {
+  const [activeTab, setActiveTab] = useState(0);
   const [maintenanceMode, setMaintenanceMode] = useState(false);
   const [upcomingNotice, setUpcomingNotice] = useState('');
+  const [vacuumTableName, setVacuumTableName] = useState('');
+  const [deadRowsTable, setDeadRowsTable] = useState('');
   const [error, setError] = useState('');
   const [message, setMessage] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isClearingStats, setIsClearingStats] = useState(false);
+  const [isVacuumingDatabase, setIsVacuumingDatabase] = useState(false);
+  const [isVacuumingTable, setIsVacuumingTable] = useState(false);
+  const [isCheckingDeadRows, setIsCheckingDeadRows] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -31,6 +52,9 @@ export default function Maintenance() {
 
   async function handleSave() {
     try {
+      setError('');
+      setMessage('');
+      setIsSaving(true);
       const settings: MaintenanceSettings = {
         maintenanceMode,
         upcomingNotice,
@@ -39,15 +63,78 @@ export default function Maintenance() {
       setMessage('Settings saved');
     } catch (err: any) {
       setError(err.message || String(err));
+    } finally {
+      setIsSaving(false);
     }
   }
 
   async function handleClearStats() {
     try {
+      setError('');
+      setMessage('');
+      setIsClearingStats(true);
       await clearMaintenanceStats();
       setMessage('Maintenance stats cleared');
     } catch (err: any) {
       setError(err.message || String(err));
+    } finally {
+      setIsClearingStats(false);
+    }
+  }
+
+  async function handleVacuumDatabase() {
+    try {
+      setError('');
+      setMessage('');
+      setIsVacuumingDatabase(true);
+      const result = await vacuumDatabase();
+      setMessage(result.message || 'Vacuum started');
+    } catch (err: any) {
+      setError(err.message || String(err));
+    } finally {
+      setIsVacuumingDatabase(false);
+    }
+  }
+
+  async function handleVacuumTable() {
+    const table = vacuumTableName.trim();
+    if (!table) return;
+    try {
+      setError('');
+      setMessage('');
+      setIsVacuumingTable(true);
+      const result = await vacuumTable(table);
+      setMessage(result.message || `Vacuum started for ${table}`);
+    } catch (err: any) {
+      setError(err.message || String(err));
+    } finally {
+      setIsVacuumingTable(false);
+    }
+  }
+
+  async function handleDeadRowsLookup() {
+    try {
+      setError('');
+      setMessage('');
+      setIsCheckingDeadRows(true);
+      const table = deadRowsTable.trim() || undefined;
+      const result = await getVacuumDeadRows(table);
+      if (result.message) {
+        setMessage(result.message);
+        return;
+      }
+      if (result.tables && result.tables.length > 0) {
+        const summary = result.tables
+          .map(item => `${item.table}: ${item.deadRows.toLocaleString()} dead rows`)
+          .join(', ');
+        setMessage(summary);
+      } else {
+        setMessage('No dead rows reported.');
+      }
+    } catch (err: any) {
+      setError(err.message || String(err));
+    } finally {
+      setIsCheckingDeadRows(false);
     }
   }
 
@@ -55,37 +142,122 @@ export default function Maintenance() {
     <ErrorBoundary>
       <Page title="Maintenance">
         <Box p={2}>
-          <Grid container spacing={2}>
-            <Grid item xs={12}>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={maintenanceMode}
-                    onChange={e => setMaintenanceMode(e.target.checked)}
-                    name="maintenanceMode"
+          <Paper elevation={1}>
+            <Tabs
+              value={activeTab}
+              onChange={(_, value) => setActiveTab(value)}
+              variant="scrollable"
+              scrollButtons="auto"
+              aria-label="Maintenance tabs"
+            >
+              <Tab label="Maintenance Mode" id="maintenance-tab-0" aria-controls="maintenance-tabpanel-0" />
+              <Tab label="Vacuum" id="maintenance-tab-1" aria-controls="maintenance-tabpanel-1" />
+            </Tabs>
+            <TabPanel value={activeTab} index={0}>
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={maintenanceMode}
+                        onChange={e => setMaintenanceMode(e.target.checked)}
+                        name="maintenanceMode"
+                      />
+                    }
+                    label="Maintenance Mode"
                   />
-                }
-                label="Maintenance Mode"
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                label="Upcoming Notice"
-                value={upcomingNotice}
-                onChange={e => setUpcomingNotice(e.target.value)}
-                fullWidth
-                size="medium"
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <Button variant="contained" onClick={handleSave} sx={{ mr: 2 }}>
-                Save
-              </Button>
-              <Button variant="outlined" color="error" onClick={handleClearStats}>
-                Clear Maintenance Stats
-              </Button>
-            </Grid>
-          </Grid>
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    label="Upcoming Notice"
+                    value={upcomingNotice}
+                    onChange={e => setUpcomingNotice(e.target.value)}
+                    fullWidth
+                    size="medium"
+                  />
+                </Grid>
+                <Grid item xs={12} sx={{ display: 'flex', gap: 2 }}>
+                  <Button
+                    variant="contained"
+                    onClick={handleSave}
+                    loading={isSaving}
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    color="error"
+                    onClick={handleClearStats}
+                    loading={isClearingStats}
+                  >
+                    Clear Maintenance Stats
+                  </Button>
+                </Grid>
+              </Grid>
+            </TabPanel>
+            <TabPanel value={activeTab} index={1}>
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <Typography variant="h6">Full Database Vacuum</Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Run a maintenance vacuum across the entire database during a low-traffic window.
+                  </Typography>
+                  <Button
+                    variant="contained"
+                    onClick={handleVacuumDatabase}
+                    loading={isVacuumingDatabase}
+                  >
+                    Vacuum Database
+                  </Button>
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <Typography variant="h6">Vacuum Specific Table</Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Target a single table when you notice bloat building up.
+                  </Typography>
+                  <TextField
+                    label="Table Name"
+                    value={vacuumTableName}
+                    onChange={e => setVacuumTableName(e.target.value)}
+                    fullWidth
+                    size="medium"
+                  />
+                  <Box mt={1}>
+                    <Button
+                      variant="outlined"
+                      onClick={handleVacuumTable}
+                      loading={isVacuumingTable}
+                      disabled={!vacuumTableName.trim()}
+                    >
+                      Vacuum Table
+                    </Button>
+                  </Box>
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <Typography variant="h6">Dead Rows Lookup</Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Check recent dead row counts to decide whether a manual vacuum is required.
+                  </Typography>
+                  <TextField
+                    label="Table Filter (optional)"
+                    value={deadRowsTable}
+                    onChange={e => setDeadRowsTable(e.target.value)}
+                    fullWidth
+                    size="medium"
+                  />
+                  <Box mt={1}>
+                    <Button
+                      variant="outlined"
+                      onClick={handleDeadRowsLookup}
+                      loading={isCheckingDeadRows}
+                    >
+                      Check Dead Rows
+                    </Button>
+                  </Box>
+                </Grid>
+              </Grid>
+            </TabPanel>
+          </Paper>
           <FeedbackSnackbar
             open={!!error || !!message}
             onClose={() => {
@@ -98,5 +270,24 @@ export default function Maintenance() {
         </Box>
       </Page>
     </ErrorBoundary>
+  );
+}
+
+interface TabPanelProps {
+  value: number;
+  index: number;
+  children: ReactNode;
+}
+
+function TabPanel({ value, index, children }: TabPanelProps) {
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`maintenance-tabpanel-${index}`}
+      aria-labelledby={`maintenance-tab-${index}`}
+    >
+      {value === index && <Box p={3}>{children}</Box>}
+    </div>
   );
 }

--- a/MJ_FB_Frontend/src/pages/admin/__tests__/Maintenance.test.tsx
+++ b/MJ_FB_Frontend/src/pages/admin/__tests__/Maintenance.test.tsx
@@ -8,12 +8,18 @@ jest.mock('../../../api/maintenance', () => ({
   getMaintenanceSettings: jest.fn().mockResolvedValue({ maintenanceMode: false, upcomingNotice: '' }),
   updateMaintenanceSettings: jest.fn().mockResolvedValue(undefined),
   clearMaintenanceStats: jest.fn().mockResolvedValue(undefined),
+  vacuumDatabase: jest.fn().mockResolvedValue({ message: 'Vacuum started' }),
+  vacuumTable: jest.fn().mockResolvedValue({ message: 'Table vacuum started' }),
+  getVacuumDeadRows: jest.fn().mockResolvedValue({ message: 'Dead rows fetched' }),
 }));
 
 import {
   getMaintenanceSettings,
   updateMaintenanceSettings,
   clearMaintenanceStats,
+  vacuumDatabase,
+  vacuumTable,
+  getVacuumDeadRows,
 } from '../../../api/maintenance';
 
 describe('Maintenance', () => {
@@ -37,5 +43,18 @@ describe('Maintenance', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Clear Maintenance Stats' }));
     await waitFor(() => expect(clearMaintenanceStats).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('tab', { name: /vacuum/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /vacuum database/i }));
+    await waitFor(() => expect(vacuumDatabase).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/table name/i), { target: { value: 'users' } });
+    fireEvent.click(screen.getByRole('button', { name: /vacuum table/i }));
+    await waitFor(() => expect(vacuumTable).toHaveBeenCalledWith('users'));
+
+    fireEvent.change(screen.getByLabelText(/table filter/i), { target: { value: 'orders' } });
+    fireEvent.click(screen.getByRole('button', { name: /check dead rows/i }));
+    await waitFor(() => expect(getVacuumDeadRows).toHaveBeenCalledWith('orders'));
   });
 });


### PR DESCRIPTION
## Summary
- refactor the admin maintenance page to use tabs and add vacuum and dead-row controls with loading feedback
- extend the maintenance API client with helpers for vacuum endpoints and update related unit tests

## Testing
- npm test -- --runTestsByPath src/api/__tests__/maintenance.api.test.ts src/pages/admin/__tests__/Maintenance.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d0335dc90c832da2efb6a1b9cdf95f