### PR TITLE
Add maintenance vacuum endpoints and tests

### DIFF
--- a/MJ_FB_Backend/src/controllers/maintenanceController.ts
+++ b/MJ_FB_Backend/src/controllers/maintenanceController.ts
@@ -2,6 +2,107 @@ import { Request, Response, NextFunction } from 'express';
 import pool from '../db';
 import logger from '../utils/logger';
 
+const TABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function normalizeTables(tables?: unknown): string[] | undefined {
+  if (tables === undefined) return undefined;
+
+  if (!Array.isArray(tables)) {
+    const error = new Error('tables must be an array of table names');
+    (error as Error & { status?: number }).status = 400;
+    throw error;
+  }
+
+  const normalized = Array.from(
+    new Set(
+      tables
+        .map(table => (typeof table === 'string' ? table.trim() : String(table)))
+        .filter(Boolean),
+    ),
+  );
+
+  const invalid = normalized.filter(table => !TABLE_NAME_PATTERN.test(table));
+  if (invalid.length > 0) {
+    const error = new Error(`Invalid table names: ${invalid.join(', ')}`);
+    (error as Error & { status?: number }).status = 400;
+    throw error;
+  }
+
+  return normalized;
+}
+
+async function vacuumTables(tables?: string[]) {
+  if (!tables || tables.length === 0) {
+    await pool.query('VACUUM (ANALYZE)');
+    logger.info('VACUUM ANALYZE complete for entire database');
+    return { scope: 'database' as const, tables: [] as string[] };
+  }
+
+  for (const table of tables) {
+    await pool.query(`VACUUM (ANALYZE) ${table}`);
+    logger.info('VACUUM ANALYZE complete', { table });
+  }
+
+  return { scope: 'tables' as const, tables };
+}
+
+export async function runVacuum(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const tables = normalizeTables((req.body as { tables?: unknown })?.tables);
+    const result = await vacuumTables(tables);
+    res.json({
+      success: true,
+      ...result,
+    });
+  } catch (error) {
+    logger.error('Failed to run VACUUM ANALYZE', error);
+    next(error);
+  }
+}
+
+export async function runVacuumForTable(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const tables = normalizeTables([req.params.table]);
+    const result = await vacuumTables(tables);
+    res.json({
+      success: true,
+      ...result,
+    });
+  } catch (error) {
+    logger.error('Failed to run VACUUM ANALYZE', error);
+    next(error);
+  }
+}
+
+export async function getDeadRowStats(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const result = await pool.query(
+      `SELECT schemaname, relname, n_dead_tup FROM pg_stat_user_tables ORDER BY n_dead_tup DESC`,
+    );
+    const deadRows = result.rows.map(row => ({
+      schema: row.schemaname,
+      table: row.relname,
+      deadRows: Number(row.n_dead_tup) || 0,
+    }));
+    res.json({ deadRows });
+  } catch (error) {
+    logger.error('Failed to fetch dead row statistics', error);
+    next(error);
+  }
+}
+
 export async function getMaintenanceStatus(
   _req: Request,
   res: Response,

--- a/MJ_FB_Backend/src/routes/maintenance.ts
+++ b/MJ_FB_Backend/src/routes/maintenance.ts
@@ -5,6 +5,9 @@ import {
   setMaintenanceNotice,
   clearMaintenance,
   clearMaintenanceStats,
+  runVacuum,
+  runVacuumForTable,
+  getDeadRowStats,
 } from '../controllers/maintenanceController';
 import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
@@ -30,6 +33,20 @@ router.delete(
   authMiddleware,
   authorizeAccess('admin'),
   clearMaintenanceStats,
+);
+
+router.post('/vacuum', authMiddleware, authorizeAccess('admin'), runVacuum);
+router.post(
+  '/vacuum/:table',
+  authMiddleware,
+  authorizeAccess('admin'),
+  runVacuumForTable,
+);
+router.get(
+  '/vacuum/dead-rows',
+  authMiddleware,
+  authorizeAccess('admin'),
+  getDeadRowStats,
 );
 
 export default router;

--- a/MJ_FB_Backend/tests/maintenance.test.ts
+++ b/MJ_FB_Backend/tests/maintenance.test.ts
@@ -31,6 +31,17 @@ jest.mock('../src/middleware/authMiddleware', () => ({
 const app = express();
 app.use(express.json());
 app.use('/maintenance', maintenanceRouter);
+app.use(
+  (
+    err: any,
+    _req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+  ) => {
+    const status = err?.status ?? 500;
+    res.status(status).json({ message: err?.message ?? 'Internal Server Error' });
+  },
+);
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -75,6 +86,114 @@ describe('maintenance routes', () => {
     const res = await request(app).delete('/maintenance/stats');
     expect(res.status).toBe(204);
     expect((pool.query as jest.Mock).mock.calls[0][0]).toContain('DELETE FROM stats');
+  });
+
+  describe('vacuum endpoints', () => {
+    it('runs VACUUM ANALYZE for specific tables', async () => {
+      (pool.query as jest.Mock)
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({});
+
+      const res = await request(app)
+        .post('/maintenance/vacuum')
+        .send({ tables: ['bookings', 'volunteer_bookings'] });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        scope: 'tables',
+        tables: ['bookings', 'volunteer_bookings'],
+      });
+      expect(pool.query).toHaveBeenNthCalledWith(1, 'VACUUM (ANALYZE) bookings');
+      expect(pool.query).toHaveBeenNthCalledWith(
+        2,
+        'VACUUM (ANALYZE) volunteer_bookings',
+      );
+    });
+
+    it('runs VACUUM ANALYZE for the entire database when no tables are provided', async () => {
+      (pool.query as jest.Mock).mockResolvedValueOnce({});
+
+      const res = await request(app).post('/maintenance/vacuum').send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true, scope: 'database', tables: [] });
+      expect(pool.query).toHaveBeenCalledWith('VACUUM (ANALYZE)');
+    });
+
+    it('rejects invalid table names', async () => {
+      const res = await request(app)
+        .post('/maintenance/vacuum')
+        .send({ tables: ['bad-table!'] });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ message: 'Invalid table names: bad-table!' });
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to run VACUUM ANALYZE',
+        expect.any(Error),
+      );
+    });
+
+    it('runs VACUUM ANALYZE for a specific table via route param', async () => {
+      (pool.query as jest.Mock).mockResolvedValueOnce({});
+
+      const res = await request(app).post('/maintenance/vacuum/bookings');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        scope: 'tables',
+        tables: ['bookings'],
+      });
+      expect(pool.query).toHaveBeenCalledWith('VACUUM (ANALYZE) bookings');
+    });
+
+    it('logs and forwards errors when VACUUM ANALYZE fails', async () => {
+      const error = new Error('vacuum failed');
+      (pool.query as jest.Mock).mockRejectedValueOnce(error);
+
+      const res = await request(app).post('/maintenance/vacuum/bookings');
+
+      expect(res.status).toBe(500);
+      expect(pool.query).toHaveBeenCalledWith('VACUUM (ANALYZE) bookings');
+      expect(logger.error).toHaveBeenCalledWith('Failed to run VACUUM ANALYZE', error);
+    });
+
+    it('returns dead row counts', async () => {
+      (pool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [
+          { schemaname: 'public', relname: 'bookings', n_dead_tup: 5 },
+          { schemaname: 'public', relname: 'volunteer_bookings', n_dead_tup: 2 },
+        ],
+      });
+
+      const res = await request(app).get('/maintenance/vacuum/dead-rows');
+
+      expect(res.status).toBe(200);
+      expect(pool.query).toHaveBeenCalledWith(
+        'SELECT schemaname, relname, n_dead_tup FROM pg_stat_user_tables ORDER BY n_dead_tup DESC',
+      );
+      expect(res.body).toEqual({
+        deadRows: [
+          { schema: 'public', table: 'bookings', deadRows: 5 },
+          { schema: 'public', table: 'volunteer_bookings', deadRows: 2 },
+        ],
+      });
+    });
+
+    it('logs and forwards errors when fetching dead row counts fails', async () => {
+      const error = new Error('stats failed');
+      (pool.query as jest.Mock).mockRejectedValueOnce(error);
+
+      const res = await request(app).get('/maintenance/vacuum/dead-rows');
+
+      expect(res.status).toBe(500);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to fetch dead row statistics',
+        error,
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add controller helpers to validate table lists, run VACUUM ANALYZE, and report dead-row stats
- register admin-only maintenance routes for manual VACUUM operations and dead-row queries
- extend maintenance tests to cover success and failure flows for the new endpoints

## Testing
- npm test tests/maintenance.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d0349f6894832da5aee14c668aa469