### PR TITLE
Improve volunteer dashboard role filter layout

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -525,17 +525,29 @@ export default function VolunteerDashboard() {
             </SectionCard>
 
             <SectionCard title="Available in My Roles">
-              <Stack direction="row" spacing={1} alignItems="center" mb={2}>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                spacing={1.5}
+                alignItems={{ xs: 'stretch', sm: 'center' }}
+                justifyContent={{ xs: 'flex-start', md: 'space-between' }}
+                flexWrap={{ sm: 'wrap', md: 'nowrap' }}
+                rowGap={1.5}
+                mb={2}
+              >
                 <ToggleButtonGroup
                   size="medium"
                   value={dateMode}
                   exclusive
                   onChange={(_, v) => v && setDateMode(v)}
+                  sx={{ width: { xs: '100%', sm: 'auto' } }}
                 >
                   <ToggleButton value="today">Today</ToggleButton>
                   <ToggleButton value="week">Week</ToggleButton>
                 </ToggleButtonGroup>
-                <FormControl size="medium" sx={{ minWidth: 120 }}>
+                <FormControl
+                  size="medium"
+                  sx={{ minWidth: { sm: 160 }, width: { xs: '100%', sm: 'auto' } }}
+                >
                   <InputLabel id="role-filter-label">Role</InputLabel>
                   <Select
                     labelId="role-filter-label"


### PR DESCRIPTION
## Summary
- make the volunteer dashboard role filter stack vertically on extra-small screens and wrap on small screens
- keep controls aligned and spaced evenly on medium-plus breakpoints for a balanced layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03aece970832d99740f9ef58b3f21