### PR TITLE
Add maintenance purge endpoint for legacy maintenance cleanup

### DIFF
--- a/MJ_FB_Backend/src/routes/maintenance.ts
+++ b/MJ_FB_Backend/src/routes/maintenance.ts
@@ -8,10 +8,11 @@ import {
   runVacuum,
   runVacuumForTable,
   getDeadRowStats,
+  purgeMaintenanceData,
 } from '../controllers/maintenanceController';
 import { authMiddleware, authorizeAccess } from '../middleware/authMiddleware';
 import { validate } from '../middleware/validate';
-import { maintenanceSchema } from '../schemas/maintenanceSchema';
+import { maintenanceSchema, maintenancePurgeSchema } from '../schemas/maintenanceSchema';
 
 const router = Router();
 
@@ -47,6 +48,14 @@ router.get(
   authMiddleware,
   authorizeAccess('admin'),
   getDeadRowStats,
+);
+
+router.post(
+  '/purge',
+  authMiddleware,
+  authorizeAccess('admin'),
+  validate(maintenancePurgeSchema),
+  purgeMaintenanceData,
 );
 
 export default router;

--- a/MJ_FB_Backend/src/schemas/maintenanceSchema.ts
+++ b/MJ_FB_Backend/src/schemas/maintenanceSchema.ts
@@ -6,3 +6,10 @@ export const maintenanceSchema = z.object({
 });
 
 export type MaintenancePayload = z.infer<typeof maintenanceSchema>;
+
+export const maintenancePurgeSchema = z.object({
+  tables: z.array(z.string()).min(1),
+  before: z.string(),
+});
+
+export type MaintenancePurgePayload = z.infer<typeof maintenancePurgeSchema>;

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -15,3 +15,18 @@ A scheduled window displays an upcoming maintenance banner to clients.
 
 Clients see the upcoming notice if a maintenance window is scheduled and the maintenance
 message if maintenance mode is currently enabled.
+
+## Historical data purge
+
+Admins can trigger a manual cleanup of legacy records via `POST /api/v1/maintenance/purge`.
+The request body must include:
+
+- `tables`: an array of whitelisted table names such as `bookings`, `client_visits`,
+  `volunteer_bookings`, `donations`, `monetary_donations`, `pig_pound_log`,
+  `outgoing_donation_log`, `surplus_log`, or `sunshine_bag_log`.
+- `before`: a cutoff date (`YYYY-MM-DD`) that must fall before January 1 of the current year.
+
+The purge endpoint refreshes pantry, warehouse, and sunshine bag aggregates for affected
+months, archives volunteer totals, deletes rows older than the cutoff inside a transaction,
+and VACUUMs each table. Requests using non-whitelisted tables or current-year dates are
+rejected with a 400 response to prevent accidental data loss.


### PR DESCRIPTION
## Summary
- add an admin-only `POST /maintenance/purge` route with schema validation
- implement purgeMaintenanceData to validate tables/dates, refresh aggregates, archive volunteer totals, and vacuum tables before deleting
- expand maintenance tests to cover purge success/error cases and document the new API endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03b188208832d8cc9f79c288486fe