### PR TITLE
Add monetary donation dashboard charts

### DIFF
--- a/MJ_FB_Frontend/src/components/dashboard/MonetaryDonationTrendChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/MonetaryDonationTrendChart.tsx
@@ -1,0 +1,179 @@
+import { useTheme } from '@mui/material/styles';
+import { format, parse } from 'date-fns';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import type { TooltipProps } from 'recharts';
+import type { CategoricalChartFunc } from 'recharts/types/chart/types';
+import type { MouseHandlerDataParam } from 'recharts/types/synchronisation/types';
+
+export interface MonetaryDonationTrendDatum {
+  month: string;
+  amount: number;
+  donationCount: number;
+  donorCount: number;
+  averageGift: number;
+}
+
+type ChartState = MouseHandlerDataParam & {
+  activePayload?: Array<{ payload?: unknown }>;
+};
+
+interface ChartDatumWithLabel extends MonetaryDonationTrendDatum {
+  monthLabel: string;
+}
+
+interface Props<T extends MonetaryDonationTrendDatum = MonetaryDonationTrendDatum> {
+  data: T[];
+  onPointSelect?: (datum: T) => void;
+}
+
+const currencyFormatter = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+});
+
+function formatMonthLabel(month: string) {
+  const parsed = parse(month, 'yyyy-MM', new Date());
+  if (Number.isNaN(parsed.getTime())) {
+    return month;
+  }
+  return format(parsed, 'MMM yyyy');
+}
+
+function buildChartData<T extends MonetaryDonationTrendDatum>(data: T[]): ChartDatumWithLabel[] {
+  const chartData = data.map(datum => ({
+    ...datum,
+    monthLabel: formatMonthLabel(datum.month),
+  }));
+
+  if (chartData.length === 1) {
+    const single = chartData[0];
+    return [
+      single,
+      {
+        ...single,
+        month: '',
+        monthLabel: '',
+        amount: 0,
+        donationCount: 0,
+        donorCount: 0,
+        averageGift: 0,
+      },
+    ];
+  }
+
+  return chartData;
+}
+
+function TrendTooltip({ active, payload, label }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const datum = payload[0]?.payload as ChartDatumWithLabel | undefined;
+
+  if (!datum) return null;
+
+  return (
+    <div
+      style={{
+        background: 'rgba(255, 255, 255, 0.9)',
+        border: '1px solid rgba(0, 0, 0, 0.1)',
+        padding: '0.75rem',
+        borderRadius: 8,
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+      }}
+    >
+      <strong>{label}</strong>
+      <div>Amount: {currencyFormatter.format(datum.amount)}</div>
+      <div>Donations: {datum.donationCount}</div>
+      <div>Donors: {datum.donorCount}</div>
+      <div>Avg. Gift: {currencyFormatter.format(datum.averageGift)}</div>
+    </div>
+  );
+}
+
+export default function MonetaryDonationTrendChart<T extends MonetaryDonationTrendDatum>({
+  data,
+  onPointSelect,
+}: Props<T>) {
+  const theme = useTheme();
+  const chartData = buildChartData(data);
+
+  const handleClick: CategoricalChartFunc = state => {
+    if (!onPointSelect) return;
+    const payload = (state as ChartState | undefined)?.activePayload?.[0]?.payload as T | undefined;
+    if (payload) {
+      onPointSelect(payload);
+    }
+  };
+
+  return (
+    <ResponsiveContainer width="100%" height={320} data-testid="monetary-donation-trend-chart">
+      <LineChart data={chartData} onClick={handleClick}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="monthLabel" />
+        <YAxis
+          yAxisId="amount"
+          tickFormatter={value => currencyFormatter.format(value as number)}
+          width={90}
+        />
+        <YAxis yAxisId="count" orientation="right" allowDecimals={false} />
+        <Tooltip content={<TrendTooltip />} />
+        <Legend />
+        <Line
+          isAnimationActive={false}
+          type="monotone"
+          dataKey="amount"
+          name="Amount"
+          stroke={theme.palette.primary.main}
+          strokeWidth={2}
+          dot={{ r: 4 }}
+          activeDot={{ r: 6 }}
+          yAxisId="amount"
+        />
+        <Line
+          isAnimationActive={false}
+          type="monotone"
+          dataKey="averageGift"
+          name="Average Gift"
+          stroke={theme.palette.success.main}
+          strokeWidth={2}
+          dot={{ r: 4 }}
+          activeDot={{ r: 6 }}
+          yAxisId="amount"
+        />
+        <Line
+          isAnimationActive={false}
+          type="monotone"
+          dataKey="donationCount"
+          name="Donations"
+          stroke={theme.palette.info.main}
+          strokeWidth={2}
+          dot={{ r: 4 }}
+          activeDot={{ r: 6 }}
+          yAxisId="count"
+        />
+        <Line
+          isAnimationActive={false}
+          type="monotone"
+          dataKey="donorCount"
+          name="Donors"
+          stroke={theme.palette.warning.main}
+          strokeWidth={2}
+          dot={{ r: 4 }}
+          activeDot={{ r: 6 }}
+          yAxisId="count"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/MJ_FB_Frontend/src/components/dashboard/MonetaryGivingTierChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/MonetaryGivingTierChart.tsx
@@ -1,0 +1,136 @@
+import { alpha, useTheme } from '@mui/material/styles';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  LabelList,
+} from 'recharts';
+import type { TooltipProps, LabelProps } from 'recharts';
+
+export interface MonetaryGivingTierDatum {
+  tierLabel: string;
+  donorCount: number;
+  amount: number;
+  deltaFromPreviousMonth?: number;
+}
+
+const currencyFormatter = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+});
+
+function TierTooltip({ active, payload, label }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const datum = payload[0]?.payload as MonetaryGivingTierDatum | undefined;
+
+  if (!datum) return null;
+
+  return (
+    <div
+      style={{
+        background: 'rgba(255, 255, 255, 0.9)',
+        border: '1px solid rgba(0, 0, 0, 0.1)',
+        padding: '0.75rem',
+        borderRadius: 8,
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+      }}
+    >
+      <strong>{label}</strong>
+      <div>Amount: {currencyFormatter.format(datum.amount)}</div>
+      <div>Donors: {datum.donorCount}</div>
+      {typeof datum.deltaFromPreviousMonth === 'number' && (
+        <div>
+          Change: {datum.deltaFromPreviousMonth > 0 ? '+' : ''}
+          {datum.deltaFromPreviousMonth}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DeltaBadge({ value, x = 0, y = 0, width = 0, height = 0 }: LabelProps) {
+  if (typeof value !== 'number') {
+    return null;
+  }
+
+  const theme = useTheme();
+  const fill =
+    value > 0
+      ? theme.palette.success.main
+      : value < 0
+        ? theme.palette.error.main
+        : theme.palette.info.main;
+
+  const badgeText = `${value > 0 ? '+' : ''}${value}`;
+  const badgeWidth = badgeText.length * 7 + 20;
+  const badgeHeight = 22;
+  const numericWidth = typeof width === 'number' ? width : parseFloat(width ?? '0');
+  const numericHeight = typeof height === 'number' ? height : parseFloat(height ?? '0');
+  const badgeX = x + numericWidth + 12;
+  const badgeY = y + (numericHeight ? numericHeight / 2 - badgeHeight / 2 : -badgeHeight / 2);
+
+  return (
+    <g>
+      <rect
+        x={badgeX}
+        y={badgeY}
+        width={badgeWidth}
+        height={badgeHeight}
+        rx={badgeHeight / 2}
+        ry={badgeHeight / 2}
+        fill={alpha(fill, 0.12)}
+        stroke={fill}
+      />
+      <text
+        x={badgeX + badgeWidth / 2}
+        y={badgeY + badgeHeight / 2 + 4}
+        fill={fill}
+        fontSize={12}
+        fontWeight={600}
+        textAnchor="middle"
+      >
+        {badgeText}
+      </text>
+    </g>
+  );
+}
+
+export default function MonetaryGivingTierChart({ data }: { data: MonetaryGivingTierDatum[] }) {
+  const theme = useTheme();
+
+  return (
+    <ResponsiveContainer width="100%" height={320} data-testid="monetary-giving-tier-chart">
+      <BarChart data={data} layout="vertical" margin={{ left: 16, right: 48 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis type="number" tickFormatter={value => currencyFormatter.format(value as number)} />
+        <YAxis type="category" dataKey="tierLabel" width={140} />
+        <Tooltip content={<TierTooltip />} />
+        <Legend />
+        <Bar
+          isAnimationActive={false}
+          dataKey="amount"
+          name="Amount"
+          fill={theme.palette.primary.main}
+          radius={[0, 8, 8, 0]}
+        >
+          <LabelList
+            dataKey="donorCount"
+            position="insideLeft"
+            offset={12}
+            formatter={value => `${value} donors`}
+            fill="#fff"
+          />
+          <LabelList dataKey="deltaFromPreviousMonth" content={props => <DeltaBadge {...props} />} />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/MJ_FB_Frontend/src/components/dashboard/__tests__/MonetaryDonationTrendChart.test.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/__tests__/MonetaryDonationTrendChart.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import MonetaryDonationTrendChart, {
+  type MonetaryDonationTrendDatum,
+} from '../MonetaryDonationTrendChart';
+
+describe('MonetaryDonationTrendChart', () => {
+  const sampleData: MonetaryDonationTrendDatum[] = [
+    {
+      month: '2024-01',
+      amount: 1000,
+      donationCount: 12,
+      donorCount: 10,
+      averageGift: 83.33,
+    },
+    {
+      month: '2024-02',
+      amount: 1500,
+      donationCount: 18,
+      donorCount: 14,
+      averageGift: 83.33,
+    },
+  ];
+
+  it('renders formatted month labels', () => {
+    render(<MonetaryDonationTrendChart data={sampleData} />);
+
+    expect(screen.getByText('Jan 2024')).toBeInTheDocument();
+    expect(screen.getByText('Feb 2024')).toBeInTheDocument();
+  });
+
+  it('shows tooltip details when hovering a point', () => {
+    render(<MonetaryDonationTrendChart data={sampleData} />);
+
+    const chart = screen.getByTestId('monetary-donation-trend-chart');
+    const dots = chart.querySelectorAll('.recharts-dot');
+
+    expect(dots.length).toBeGreaterThan(0);
+
+    fireEvent.mouseOver(dots[0]);
+
+    expect(screen.getByText('Amount: $1,000.00')).toBeInTheDocument();
+    expect(screen.getByText('Donations: 12')).toBeInTheDocument();
+    expect(screen.getByText('Donors: 10')).toBeInTheDocument();
+    expect(screen.getByText('Avg. Gift: $83.33')).toBeInTheDocument();
+  });
+});

--- a/MJ_FB_Frontend/src/components/dashboard/__tests__/MonetaryGivingTierChart.test.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/__tests__/MonetaryGivingTierChart.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import MonetaryGivingTierChart, {
+  type MonetaryGivingTierDatum,
+} from '../MonetaryGivingTierChart';
+
+describe('MonetaryGivingTierChart', () => {
+  const sampleData: MonetaryGivingTierDatum[] = [
+    { tierLabel: 'Community Champions', donorCount: 15, amount: 5000, deltaFromPreviousMonth: 3 },
+    { tierLabel: 'Sustaining Friends', donorCount: 10, amount: 2500, deltaFromPreviousMonth: -2 },
+  ];
+
+  it('renders tier labels and delta badges', () => {
+    render(<MonetaryGivingTierChart data={sampleData} />);
+
+    expect(screen.getByText('Community Champions')).toBeInTheDocument();
+    expect(screen.getByText('Sustaining Friends')).toBeInTheDocument();
+    expect(screen.getByText('+3')).toBeInTheDocument();
+    expect(screen.getByText('-2')).toBeInTheDocument();
+  });
+
+  it('shows tooltip details when hovering a bar', () => {
+    render(<MonetaryGivingTierChart data={sampleData} />);
+
+    const chart = screen.getByTestId('monetary-giving-tier-chart');
+    const bars = chart.querySelectorAll('.recharts-rectangle');
+
+    expect(bars.length).toBeGreaterThan(0);
+
+    fireEvent.mouseMove(bars[0]);
+
+    expect(screen.getByText('Amount: $5,000.00')).toBeInTheDocument();
+    expect(screen.getByText('Donors: 15')).toBeInTheDocument();
+    expect(screen.getByText('Change: +3')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a MonetaryDonationTrendChart component that formats month labels and charts donation metrics
- add a MonetaryGivingTierChart component with donor badges and rich tooltips for tier data
- cover the new components with focused rendering tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03d2ea3c4832daf3d3806356075f5