### PR TITLE
Add pet food tracking to warehouse analytics

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Aggregations.test.tsx
@@ -105,6 +105,7 @@ describe('Aggregations page', () => {
     fireEvent.change(screen.getByLabelText(/total donations/i), { target: { value: '1' } });
     fireEvent.change(screen.getByLabelText(/surplus/i), { target: { value: '2' } });
     fireEvent.change(screen.getByLabelText(/pig pound/i), { target: { value: '3' } });
+    fireEvent.change(screen.getByLabelText(/pet food/i), { target: { value: '5' } });
     fireEvent.change(screen.getByLabelText(/outgoing donations/i), {
       target: { value: '4' },
     });
@@ -118,6 +119,7 @@ describe('Aggregations page', () => {
         donations: 1,
         surplus: 2,
         pigPound: 3,
+        petFood: 5,
         outgoingDonations: 4,
       }),
     );

--- a/MJ_FB_Frontend/src/__tests__/FoodBankTrends.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/FoodBankTrends.test.tsx
@@ -48,6 +48,7 @@ jest.mock('../components/dashboard/WarehouseCompositionChart', () => ({
             donations: 1200,
             surplus: 300,
             pigPound: 150,
+            petFood: 100,
             outgoing: 800,
           },
         })
@@ -96,6 +97,7 @@ describe('FoodBankTrends page', () => {
         donations: 1200,
         surplus: 300,
         pigPound: 150,
+        petFood: 100,
         outgoingDonations: 800,
       },
     ]);
@@ -175,6 +177,8 @@ describe('FoodBankTrends page', () => {
     expect(screen.getByText('300 lbs')).toBeInTheDocument();
     expect(screen.getByText('Pig Pound')).toBeInTheDocument();
     expect(screen.getByText('150 lbs')).toBeInTheDocument();
+    expect(screen.getByText('Pet Food')).toBeInTheDocument();
+    expect(screen.getByText('100 lbs')).toBeInTheDocument();
     expect(screen.getByText('Outgoing')).toBeInTheDocument();
     expect(screen.getByText('800 lbs')).toBeInTheDocument();
   });

--- a/MJ_FB_Frontend/src/__tests__/WarehouseDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/WarehouseDashboard.test.tsx
@@ -69,7 +69,7 @@ describe('WarehouseDashboard', () => {
     jest.clearAllMocks();
     mockGetWarehouseOverallYears.mockResolvedValue([2024]);
     mockGetWarehouseOverall.mockResolvedValue([
-      { month: 1, donations: 100, surplus: 20, pigPound: 10, outgoingDonations: 50 },
+      { month: 1, donations: 100, surplus: 20, pigPound: 10, petFood: 5, outgoingDonations: 50 },
     ]);
     mockGetTopDonors.mockResolvedValue(donors);
     mockGetTopReceivers.mockResolvedValue([

--- a/MJ_FB_Frontend/src/api/warehouseOverall.ts
+++ b/MJ_FB_Frontend/src/api/warehouseOverall.ts
@@ -5,6 +5,7 @@ export interface WarehouseOverall {
   donations: number;
   surplus: number;
   pigPound: number;
+  petFood: number;
   outgoingDonations: number;
 }
 
@@ -29,6 +30,7 @@ export interface ManualWarehouseOverall {
   donations: number;
   surplus: number;
   pigPound: number;
+  petFood: number;
   outgoingDonations: number;
 }
 

--- a/MJ_FB_Frontend/src/components/dashboard/WarehouseCompositionChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/WarehouseCompositionChart.tsx
@@ -14,6 +14,7 @@ export interface WarehouseCompositionDatum {
   donations: number;
   surplus: number;
   pigPound: number;
+  petFood: number;
   outgoing: number;
 }
 
@@ -51,6 +52,13 @@ export default function WarehouseCompositionChart({ data, onBarClick }: Warehous
           name="Pig Pound"
           stackId="a"
           fill={theme.palette.info.main}
+          onClick={onBarClick}
+        />
+        <Bar
+          dataKey="petFood"
+          name="Pet Food"
+          stackId="a"
+          fill={theme.palette.secondary.main}
           onClick={onBarClick}
         />
         <Bar

--- a/MJ_FB_Frontend/src/components/dashboard/WarehouseTrendChart.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/WarehouseTrendChart.tsx
@@ -16,6 +16,7 @@ export interface WarehouseTrendDatum {
   month: string;
   incoming: number;
   outgoing: number;
+  petFood: number;
 }
 
 type ChartState = MouseHandlerDataParam & {
@@ -34,7 +35,7 @@ export default function WarehouseTrendChart<T extends WarehouseTrendDatum>({
   const theme = useTheme();
   const chartData =
     data.length === 1
-      ? [...data, { month: '', incoming: 0, outgoing: 0 } as T]
+      ? [...data, { month: '', incoming: 0, outgoing: 0, petFood: 0 } as T]
       : data;
 
   const handleClick: CategoricalChartFunc = state => {
@@ -67,6 +68,15 @@ export default function WarehouseTrendChart<T extends WarehouseTrendDatum>({
           dataKey="outgoing"
           name="Outgoing"
           stroke={theme.palette.error.main}
+          strokeWidth={2}
+          dot={{ r: 4, cursor: 'pointer' }}
+          activeDot={{ r: 5 }}
+        />
+        <Line
+          type="monotone"
+          dataKey="petFood"
+          name="Pet Food"
+          stroke={theme.palette.secondary.main}
           strokeWidth={2}
           dot={{ r: 4, cursor: 'pointer' }}
           activeDot={{ r: 5 }}

--- a/MJ_FB_Frontend/src/components/dashboard/__tests__/WarehouseTrendChart.test.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/__tests__/WarehouseTrendChart.test.tsx
@@ -3,8 +3,8 @@ import WarehouseTrendChart, { type WarehouseTrendDatum } from '../WarehouseTrend
 
 describe('WarehouseTrendChart', () => {
   const sampleData: WarehouseTrendDatum[] = [
-    { month: 'Jan', incoming: 1200, outgoing: 900 },
-    { month: 'Feb', incoming: 1500, outgoing: 1100 },
+    { month: 'Jan', incoming: 1200, outgoing: 900, petFood: 150 },
+    { month: 'Feb', incoming: 1500, outgoing: 1100, petFood: 200 },
   ];
 
   it('invokes onPointSelect when a chart point is clicked', () => {

--- a/MJ_FB_Frontend/src/pages/aggregations/FoodBankTrends.tsx
+++ b/MJ_FB_Frontend/src/pages/aggregations/FoodBankTrends.tsx
@@ -110,6 +110,7 @@ export default function FoodBankTrends() {
     donations: number;
     surplus: number;
     pigPound: number;
+    petFood: number;
     outgoing: number;
   } | null>(null);
   const [selectedWarehousePoint, setSelectedWarehousePoint] = useState<WarehouseTrendDatum | null>(null);
@@ -315,11 +316,13 @@ export default function FoodBankTrends() {
         incoming:
           (total.donations ?? 0) +
           (total.surplus ?? 0) +
-          (total.pigPound ?? 0),
+          (total.pigPound ?? 0) +
+          (total.petFood ?? 0),
         outgoing: total.outgoingDonations ?? 0,
         donations: total.donations ?? 0,
         surplus: total.surplus ?? 0,
         pigPound: total.pigPound ?? 0,
+        petFood: total.petFood ?? 0,
       })),
     [warehouseTotals],
   );
@@ -329,7 +332,12 @@ export default function FoodBankTrends() {
       if (!prev) return null;
       const match = chartData.find(d => d.month === prev.month);
       return match
-        ? { month: match.month, incoming: match.incoming, outgoing: match.outgoing }
+        ? {
+            month: match.month,
+            incoming: match.incoming,
+            outgoing: match.outgoing,
+            petFood: match.petFood,
+          }
         : null;
     });
   }, [chartData]);
@@ -342,6 +350,7 @@ export default function FoodBankTrends() {
         donations: data.payload.donations ?? 0,
         surplus: data.payload.surplus ?? 0,
         pigPound: data.payload.pigPound ?? 0,
+        petFood: data.payload.petFood ?? 0,
         outgoing: data.payload.outgoing ?? 0,
       });
     },
@@ -508,6 +517,7 @@ export default function FoodBankTrends() {
                                   month: datum.month,
                                   incoming: datum.incoming,
                                   outgoing: datum.outgoing,
+                                  petFood: datum.petFood,
                                 })
                               }
                             />
@@ -535,6 +545,12 @@ export default function FoodBankTrends() {
                                   color="error"
                                   variant="outlined"
                                   data-testid="warehouse-trend-outgoing"
+                                />
+                                <Chip
+                                  label={`Pet Food: ${fmtLbs(selectedWarehousePoint.petFood)}`}
+                                  color="secondary"
+                                  variant="outlined"
+                                  data-testid="warehouse-trend-pet-food"
                                 />
                               </Stack>
                             </Stack>
@@ -714,6 +730,13 @@ export default function FoodBankTrends() {
               <ListItemText
                 primary="Pig Pound"
                 secondary={fmtLbs(selectedComposition?.pigPound)}
+              />
+            </ListItem>
+            <Divider component="li" />
+            <ListItem>
+              <ListItemText
+                primary="Pet Food"
+                secondary={fmtLbs(selectedComposition?.petFood)}
               />
             </ListItem>
             <Divider component="li" />

--- a/MJ_FB_Frontend/src/pages/aggregations/__tests__/FoodBankTrends.test.tsx
+++ b/MJ_FB_Frontend/src/pages/aggregations/__tests__/FoodBankTrends.test.tsx
@@ -1,6 +1,6 @@
 import type { VisitStat } from '../../../api/clientVisits';
 
-type TrendDatum = { month: string; incoming: number; outgoing: number };
+type TrendDatum = { month: string; incoming: number; outgoing: number; petFood: number };
 
 const mockVisitTrendChart = jest.fn();
 const mockVisitBreakdownChart = jest.fn();
@@ -82,10 +82,10 @@ describe('FoodBankTrends', () => {
   const futureMonth = currentMonth + 1;
   const previousYear = currentYear - 1;
 
-  const warehouseTotals = [
-    { month: 1, donations: 1000, surplus: 150, pigPound: 50, outgoingDonations: 700 },
-    { month: 2, donations: 900, surplus: 100, pigPound: 40, outgoingDonations: 650 },
-  ];
+const warehouseTotals = [
+  { month: 1, donations: 1000, surplus: 150, pigPound: 50, petFood: 120, outgoingDonations: 700 },
+  { month: 2, donations: 900, surplus: 100, pigPound: 40, petFood: 90, outgoingDonations: 650 },
+];
 
   beforeAll(() => {
     jest.useFakeTimers();
@@ -123,8 +123,13 @@ describe('FoodBankTrends', () => {
     (getTopReceivers as jest.Mock).mockResolvedValue([]);
     mockTrendPoint = {
       month: 'Jan',
-      incoming: warehouseTotals[0].donations + warehouseTotals[0].surplus + warehouseTotals[0].pigPound,
+      incoming:
+        warehouseTotals[0].donations +
+        warehouseTotals[0].surplus +
+        warehouseTotals[0].pigPound +
+        warehouseTotals[0].petFood,
       outgoing: warehouseTotals[0].outgoingDonations,
+      petFood: warehouseTotals[0].petFood,
     };
   });
 
@@ -142,12 +147,15 @@ describe('FoodBankTrends', () => {
 
     const incomingChip = await screen.findByTestId('warehouse-trend-incoming');
     const outgoingChip = await screen.findByTestId('warehouse-trend-outgoing');
+    const petFoodChip = await screen.findByTestId('warehouse-trend-pet-food');
 
     const incomingValue = Number((incomingChip.textContent ?? '').replace(/[^0-9]/g, ''));
     const outgoingValue = Number((outgoingChip.textContent ?? '').replace(/[^0-9]/g, ''));
+    const petFoodValue = Number((petFoodChip.textContent ?? '').replace(/[^0-9]/g, ''));
 
     expect(incomingValue).toBe(mockTrendPoint.incoming);
     expect(outgoingValue).toBe(mockTrendPoint.outgoing);
+    expect(petFoodValue).toBe(mockTrendPoint.petFood);
   }, 15000);
 
   it('excludes future months from visit charts', async () => {

--- a/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/Aggregations.tsx
@@ -55,6 +55,7 @@ export default function Aggregations() {
   const [insertDonations, setInsertDonations] = useState('');
   const [insertSurplus, setInsertSurplus] = useState('');
   const [insertPigPound, setInsertPigPound] = useState('');
+  const [insertPetFood, setInsertPetFood] = useState('');
   const [insertOutgoing, setInsertOutgoing] = useState('');
   const [insertLoading, setInsertLoading] = useState(false);
   const [donorInsertOpen, setDonorInsertOpen] = useState(false);
@@ -175,6 +176,7 @@ export default function Aggregations() {
       donations: row?.donations || 0,
       surplus: row?.surplus || 0,
       pigPound: row?.pigPound || 0,
+      petFood: row?.petFood || 0,
       outgoingDonations: row?.outgoingDonations || 0,
     };
   });
@@ -184,9 +186,10 @@ export default function Aggregations() {
       donations: acc.donations + r.donations,
       surplus: acc.surplus + r.surplus,
       pigPound: acc.pigPound + r.pigPound,
+      petFood: acc.petFood + r.petFood,
       outgoingDonations: acc.outgoingDonations + r.outgoingDonations,
     }),
-    { donations: 0, surplus: 0, pigPound: 0, outgoingDonations: 0 },
+    { donations: 0, surplus: 0, pigPound: 0, petFood: 0, outgoingDonations: 0 },
   );
 
   async function handleExportOverall() {
@@ -372,6 +375,7 @@ export default function Aggregations() {
             setInsertDonations('');
             setInsertSurplus('');
             setInsertPigPound('');
+            setInsertPetFood('');
             setInsertOutgoing('');
             setInsertOpen(true);
           }}
@@ -393,6 +397,7 @@ export default function Aggregations() {
               { field: 'donations', header: 'Donations' },
               { field: 'surplus', header: 'Surplus' },
               { field: 'pigPound', header: 'Pig Pound' },
+              { field: 'petFood', header: 'Pet Food' },
               { field: 'outgoingDonations', header: 'Outgoing Donations' },
             ];
 
@@ -406,6 +411,7 @@ export default function Aggregations() {
               donations: totals.donations,
               surplus: totals.surplus,
               pigPound: totals.pigPound,
+              petFood: totals.petFood,
               outgoingDonations: totals.outgoingDonations,
             });
 
@@ -554,6 +560,13 @@ export default function Aggregations() {
               size="medium"
             />
             <TextField
+              label="Pet Food"
+              type="number"
+              value={insertPetFood}
+              onChange={e => setInsertPetFood(e.target.value)}
+              size="medium"
+            />
+            <TextField
               label="Outgoing Donations"
               type="number"
               value={insertOutgoing}
@@ -578,6 +591,7 @@ export default function Aggregations() {
                   donations: Number(insertDonations) || 0,
                   surplus: Number(insertSurplus) || 0,
                   pigPound: Number(insertPigPound) || 0,
+                  petFood: Number(insertPetFood) || 0,
                   outgoingDonations: Number(insertOutgoing) || 0,
                 });
                 setSnackbar({ open: true, message: 'Aggregate saved', severity: 'success' });

--- a/MJ_FB_Frontend/src/pages/warehouse-management/__tests__/WarehouseDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/__tests__/WarehouseDashboard.test.tsx
@@ -1,6 +1,6 @@
-type TrendDatum = { month: string; incoming: number; outgoing: number };
+type TrendDatum = { month: string; incoming: number; outgoing: number; petFood: number };
 
-let mockTrendPoint: TrendDatum = { month: 'Jan', incoming: 0, outgoing: 0 };
+let mockTrendPoint: TrendDatum = { month: 'Jan', incoming: 0, outgoing: 0, petFood: 0 };
 
 jest.mock('../../../api/warehouseOverall', () => ({
   getWarehouseOverall: jest.fn(),
@@ -52,8 +52,8 @@ import { getEvents } from '../../../api/events';
 
 describe('WarehouseDashboard', () => {
   const mockTotals = [
-    { month: 1, donations: 1000, surplus: 200, pigPound: 50, outgoingDonations: 800 },
-    { month: 2, donations: 1200, surplus: 150, pigPound: 60, outgoingDonations: 900 },
+    { month: 1, donations: 1000, surplus: 200, pigPound: 50, petFood: 110, outgoingDonations: 800 },
+    { month: 2, donations: 1200, surplus: 150, pigPound: 60, petFood: 90, outgoingDonations: 900 },
   ];
 
   beforeEach(() => {
@@ -67,8 +67,13 @@ describe('WarehouseDashboard', () => {
     (getEvents as jest.Mock).mockResolvedValue({ today: [], upcoming: [], past: [] });
     mockTrendPoint = {
       month: 'Jan',
-      incoming: mockTotals[0].donations,
+      incoming:
+        mockTotals[0].donations +
+        mockTotals[0].surplus +
+        mockTotals[0].pigPound +
+        mockTotals[0].petFood,
       outgoing: mockTotals[0].outgoingDonations,
+      petFood: mockTotals[0].petFood,
     };
   });
 
@@ -86,11 +91,14 @@ describe('WarehouseDashboard', () => {
 
     const incomingChip = await screen.findByTestId('warehouse-trend-incoming');
     const outgoingChip = await screen.findByTestId('warehouse-trend-outgoing');
+    const petFoodChip = await screen.findByTestId('warehouse-trend-pet-food');
 
     const incomingValue = Number((incomingChip.textContent ?? '').replace(/[^0-9]/g, ''));
     const outgoingValue = Number((outgoingChip.textContent ?? '').replace(/[^0-9]/g, ''));
+    const petFoodValue = Number((petFoodChip.textContent ?? '').replace(/[^0-9]/g, ''));
 
     expect(incomingValue).toBe(mockTrendPoint.incoming);
     expect(outgoingValue).toBe(mockTrendPoint.outgoing);
+    expect(petFoodValue).toBe(mockTrendPoint.petFood);
   }, 15000);
 });


### PR DESCRIPTION
## Summary
- add the pet food field to warehouse overall API helpers and manual entry payloads
- surface pet food totals throughout the warehouse aggregation table, dashboards, trend charts, and selection dialogs
- update chart components and related tests to render and assert the new pet food metrics

## Testing
- npm test -- --runInBand
- npm test -- --runInBand RescheduleBooking

------
https://chatgpt.com/codex/tasks/task_e_68d03d843ed4832d963c2a6012c97ed9