### PR TITLE
Add pet food donor flag across donors

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000067_add_is_pet_food_to_donors.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000067_add_is_pet_food_to_donors.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('donors', {
+    is_pet_food: { type: 'boolean', notNull: true, default: false },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('donors', 'is_pet_food');
+}

--- a/MJ_FB_Backend/src/models/donor.ts
+++ b/MJ_FB_Backend/src/models/donor.ts
@@ -3,4 +3,5 @@ export interface Donor {
   firstName: string;
   lastName: string;
   email: string;
+  isPetFood: boolean;
 }

--- a/MJ_FB_Backend/src/schemas/donorSchemas.ts
+++ b/MJ_FB_Backend/src/schemas/donorSchemas.ts
@@ -13,6 +13,7 @@ const donorContactSchema = z.object({
     .min(1)
     .optional()
     .nullable(),
+  isPetFood: z.boolean().default(false),
 });
 
 export const addDonorSchema = donorContactSchema;

--- a/MJ_FB_Backend/tests/donors.test.ts
+++ b/MJ_FB_Backend/tests/donors.test.ts
@@ -44,6 +44,7 @@ describe('donor routes', () => {
             lastName: 'Smith',
             email: 'alice@example.com',
             phone: '306-555-1234',
+            isPetFood: false,
           },
         ],
       });
@@ -58,7 +59,7 @@ describe('donor routes', () => {
     );
     expect(pool.query).toHaveBeenNthCalledWith(
       2,
-      `SELECT id, first_name AS "firstName", last_name AS "lastName", email, phone
+      `SELECT id, first_name AS "firstName", last_name AS "lastName", email, phone, is_pet_food AS "isPetFood"
        FROM donors
        WHERE CAST(id AS TEXT) ILIKE $1
           OR first_name ILIKE $1
@@ -74,6 +75,7 @@ describe('donor routes', () => {
         lastName: 'Smith',
         email: 'alice@example.com',
         phone: '306-555-1234',
+        isPetFood: false,
       },
     ]);
   });
@@ -90,13 +92,14 @@ describe('donor routes', () => {
             lastName: 'Brown',
             email: 'bob@example.com',
             phone: '555-0000',
+            isPetFood: true,
           },
         ],
       });
     const res = await request(app)
       .post('/donors')
       .set('Authorization', 'Bearer token')
-      .send({ firstName: 'Bob', lastName: 'Brown', email: 'bob@example.com', phone: '555-0000' });
+      .send({ firstName: 'Bob', lastName: 'Brown', email: 'bob@example.com', phone: '555-0000', isPetFood: true });
     expect(res.status).toBe(201);
     expect(pool.query).toHaveBeenNthCalledWith(
       1,
@@ -105,8 +108,8 @@ describe('donor routes', () => {
     );
     expect(pool.query).toHaveBeenNthCalledWith(
       2,
-      'INSERT INTO donors (first_name, last_name, email, phone) VALUES ($1, $2, $3, $4) RETURNING id, first_name AS "firstName", last_name AS "lastName", email, phone',
-      ['Bob', 'Brown', 'bob@example.com', '555-0000'],
+      'INSERT INTO donors (first_name, last_name, email, phone, is_pet_food) VALUES ($1, $2, $3, $4, $5) RETURNING id, first_name AS "firstName", last_name AS "lastName", email, phone, is_pet_food AS "isPetFood"',
+      ['Bob', 'Brown', 'bob@example.com', '555-0000', true],
     );
     expect(res.body).toEqual({
       id: 3,
@@ -114,6 +117,7 @@ describe('donor routes', () => {
       lastName: 'Brown',
       email: 'bob@example.com',
       phone: '555-0000',
+      isPetFood: true,
     });
   });
 
@@ -129,6 +133,7 @@ describe('donor routes', () => {
             lastName: 'Jones',
             email: null,
             phone: null,
+            isPetFood: false,
           },
         ],
       });
@@ -139,10 +144,10 @@ describe('donor routes', () => {
     expect(res.status).toBe(201);
     expect(pool.query).toHaveBeenNthCalledWith(
       2,
-      'INSERT INTO donors (first_name, last_name, email, phone) VALUES ($1, $2, $3, $4) RETURNING id, first_name AS "firstName", last_name AS "lastName", email, phone',
-      ['Cara', 'Jones', null, null],
+      'INSERT INTO donors (first_name, last_name, email, phone, is_pet_food) VALUES ($1, $2, $3, $4, $5) RETURNING id, first_name AS "firstName", last_name AS "lastName", email, phone, is_pet_food AS "isPetFood"',
+      ['Cara', 'Jones', null, null, false],
     );
-    expect(res.body).toEqual({ id: 4, firstName: 'Cara', lastName: 'Jones', email: null, phone: null });
+    expect(res.body).toEqual({ id: 4, firstName: 'Cara', lastName: 'Jones', email: null, phone: null, isPetFood: false });
   });
 
   it('returns 409 for duplicate donor email', async () => {
@@ -230,18 +235,19 @@ describe('donor routes', () => {
             lastName: 'Brown',
             email: 'bob@example.com',
             phone: '555-0000',
+            isPetFood: true,
           },
         ],
       });
     const res = await request(app)
       .put('/donors/3')
       .set('Authorization', 'Bearer token')
-      .send({ firstName: 'Bob', lastName: 'Brown', email: 'bob@example.com', phone: '555-0000' });
+      .send({ firstName: 'Bob', lastName: 'Brown', email: 'bob@example.com', phone: '555-0000', isPetFood: true });
     expect(res.status).toBe(200);
     expect(pool.query).toHaveBeenNthCalledWith(
       2,
-      'UPDATE donors SET first_name = $2, last_name = $3, email = $4, phone = $5 WHERE id = $1 RETURNING id, first_name AS "firstName", last_name AS "lastName", email, phone',
-      ['3', 'Bob', 'Brown', 'bob@example.com', '555-0000'],
+      'UPDATE donors SET first_name = $2, last_name = $3, email = $4, phone = $5, is_pet_food = $6 WHERE id = $1 RETURNING id, first_name AS "firstName", last_name AS "lastName", email, phone, is_pet_food AS "isPetFood"',
+      ['3', 'Bob', 'Brown', 'bob@example.com', '555-0000', true],
     );
     expect(res.body).toEqual({
       id: 3,
@@ -249,6 +255,7 @@ describe('donor routes', () => {
       lastName: 'Brown',
       email: 'bob@example.com',
       phone: '555-0000',
+      isPetFood: true,
     });
   });
 
@@ -260,7 +267,7 @@ describe('donor routes', () => {
     const res = await request(app)
       .put('/donors/99')
       .set('Authorization', 'Bearer token')
-      .send({ firstName: 'X', lastName: 'Y', email: null, phone: null });
+      .send({ firstName: 'X', lastName: 'Y', email: null, phone: null, isPetFood: false });
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ message: 'Donor not found' });
   });
@@ -273,7 +280,7 @@ describe('donor routes', () => {
     const res = await request(app)
       .put('/donors/3')
       .set('Authorization', 'Bearer token')
-      .send({ firstName: 'Bob', lastName: 'Brown', email: 'bob@example.com', phone: null });
+      .send({ firstName: 'Bob', lastName: 'Brown', email: 'bob@example.com', phone: null, isPetFood: false });
     expect(res.status).toBe(409);
     expect(res.body).toEqual({ message: 'Donor already exists' });
   });
@@ -286,6 +293,6 @@ describe('donor routes', () => {
     const res = await request(app)
       .put('/donors/3')
       .set('Authorization', 'Bearer token')
-      .send({ firstName: 'Bob', lastName: 'Brown', email: 'bob@example.com', phone: null });
+      .send({ firstName: 'Bob', lastName: 'Brown', email: 'bob@example.com', phone: null, isPetFood: false });
     expect(res.status).toBe(500);
   });

--- a/MJ_FB_Frontend/src/__tests__/WarehouseDonationLog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/WarehouseDonationLog.test.tsx
@@ -41,6 +41,7 @@ describe('Warehouse Donation Log', () => {
         lastName: 'Email',
         email: null,
         phone: null,
+        isPetFood: false,
       },
       {
         id: 2,
@@ -48,6 +49,7 @@ describe('Warehouse Donation Log', () => {
         lastName: 'Donor',
         email: 'jane@example.com',
         phone: '306-555-0199',
+        isPetFood: true,
       },
     ]);
     (getDonationsByMonth as jest.Mock).mockResolvedValue([
@@ -60,6 +62,7 @@ describe('Warehouse Donation Log', () => {
           lastName: 'Email',
           email: null,
           phone: null,
+          isPetFood: false,
         },
         weight: 120,
       },
@@ -73,6 +76,7 @@ describe('Warehouse Donation Log', () => {
       lastName: 'Donor',
       email: null,
       phone: '306-555-0123',
+      isPetFood: true,
     });
   });
 
@@ -159,6 +163,7 @@ describe('Warehouse Donation Log', () => {
     await userEvent.type(firstName, ' Added ');
     await userEvent.type(lastName, ' Donor ');
     await userEvent.type(phone, ' 306-555-0123 ');
+    await userEvent.click(screen.getByLabelText(/pet food donor/i));
 
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
@@ -168,6 +173,7 @@ describe('Warehouse Donation Log', () => {
         lastName: 'Donor',
         email: null,
         phone: '306-555-0123',
+        isPetFood: true,
       }),
     );
   });

--- a/MJ_FB_Frontend/src/__tests__/WarehouseDonorProfile.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/WarehouseDonorProfile.test.tsx
@@ -41,6 +41,7 @@ describe('Warehouse Donor Profile', () => {
       phone: null,
       totalLbs: 540,
       lastDonationISO: null,
+      isPetFood: false,
     });
     (getDonorDonations as jest.Mock).mockResolvedValue([
       { id: 1, date: '2024-04-01', weight: 120 },
@@ -51,6 +52,7 @@ describe('Warehouse Donor Profile', () => {
     expect(await screen.findByText('No Contact')).toBeInTheDocument();
     expect(screen.getByText('Email: Email not provided')).toBeInTheDocument();
     expect(screen.getByText('Phone: Phone not provided')).toBeInTheDocument();
+    expect(screen.getByText('Pet food donor: No')).toBeInTheDocument();
     expect(screen.getByRole('cell', { name: '120' })).toBeInTheDocument();
   });
 
@@ -64,6 +66,7 @@ describe('Warehouse Donor Profile', () => {
         phone: null,
         totalLbs: 800,
         lastDonationISO: '2024-04-10T12:00:00Z',
+        isPetFood: false,
       })
       .mockResolvedValueOnce({
         id: 42,
@@ -73,6 +76,7 @@ describe('Warehouse Donor Profile', () => {
         phone: '306-555-0100',
         totalLbs: 800,
         lastDonationISO: '2024-04-10T12:00:00Z',
+        isPetFood: true,
       });
     (getDonorDonations as jest.Mock).mockResolvedValue([]);
     (updateDonor as jest.Mock).mockResolvedValue({});
@@ -86,6 +90,7 @@ describe('Warehouse Donor Profile', () => {
     const lastName = screen.getByLabelText(/last name/i);
     const email = screen.getByLabelText(/email \(optional\)/i);
     const phone = screen.getByLabelText(/phone \(optional\)/i);
+    const petFood = screen.getByLabelText(/pet food donor/i);
     const save = screen.getByRole('button', { name: /save donor/i });
 
     await userEvent.clear(firstName);
@@ -108,6 +113,7 @@ describe('Warehouse Donor Profile', () => {
     await userEvent.clear(email);
     await userEvent.type(email, '   ');
     await userEvent.type(phone, ' 306-555-0100 ');
+    await userEvent.click(petFood);
     await userEvent.click(save);
 
     await waitFor(() =>
@@ -116,6 +122,7 @@ describe('Warehouse Donor Profile', () => {
         lastName: 'Donor',
         email: undefined,
         phone: '306-555-0100',
+        isPetFood: true,
       }),
     );
 

--- a/MJ_FB_Frontend/src/__tests__/donorsApi.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/donorsApi.test.tsx
@@ -21,6 +21,7 @@ describe('donors api', () => {
       lastName: 'Helper',
       email: 'alice@example.com',
       phone: '306-555-0100',
+      isPetFood: true,
     });
 
     expect(jsonApiFetch).toHaveBeenCalledWith(
@@ -32,6 +33,7 @@ describe('donors api', () => {
           lastName: 'Helper',
           email: 'alice@example.com',
           phone: '306-555-0100',
+          isPetFood: true,
         },
       }),
     );

--- a/MJ_FB_Frontend/src/api/donors.ts
+++ b/MJ_FB_Frontend/src/api/donors.ts
@@ -6,6 +6,7 @@ export interface Donor {
   lastName: string;
   email?: string | null;
   phone?: string | null;
+  isPetFood: boolean;
 }
 
 export interface TopDonor {
@@ -40,12 +41,13 @@ interface DonorPayload {
   lastName: string;
   email?: string | null;
   phone?: string | null;
+  isPetFood?: boolean;
 }
 
 export async function createDonor(data: DonorPayload): Promise<Donor> {
   const res = await jsonApiFetch(`${API_BASE}/donors`, {
     method: 'POST',
-    body: data,
+    body: { ...data, isPetFood: data.isPetFood ?? false },
   });
   return handleResponse(res);
 }
@@ -61,7 +63,7 @@ export async function updateDonor(
 ): Promise<Donor> {
   const res = await jsonApiFetch(`${API_BASE}/donors/${id}`, {
     method: 'PUT',
-    body: data,
+    body: { ...data, isPetFood: data.isPetFood ?? false },
   });
   return handleResponse(res);
 }

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -10,6 +10,8 @@ import {
   Stack,
   Autocomplete,
   IconButton,
+  Checkbox,
+  FormControlLabel,
 } from '@mui/material';
 import Edit from '@mui/icons-material/Edit';
 import Delete from '@mui/icons-material/Delete';
@@ -78,6 +80,7 @@ export default function DonationLog() {
     lastName: '',
     email: '',
     phone: '',
+    isPetFood: false,
   });
 
   type DonationRow = Donation & { actions?: string };
@@ -183,12 +186,14 @@ export default function DonationLog() {
     const lastName = newDonor.lastName.trim();
     const email = newDonor.email.trim();
     const phone = newDonor.phone.trim();
+    const isPetFood = newDonor.isPetFood;
     if (firstName && lastName) {
       createDonor({
         firstName,
         lastName,
         email: email || null,
         phone: phone || null,
+        isPetFood,
       })
         .then(d => {
           setDonorOptions(prev =>
@@ -202,7 +207,7 @@ export default function DonationLog() {
           showSnackbar(err.message || 'Failed to add donor', 'error');
         });
     }
-    setNewDonor({ firstName: '', lastName: '', email: '', phone: '' });
+    setNewDonor({ firstName: '', lastName: '', email: '', phone: '', isPetFood: false });
     setNewDonorOpen(false);
   }
 
@@ -372,6 +377,15 @@ export default function DonationLog() {
               value={newDonor.phone}
               onChange={e => setNewDonor({ ...newDonor, phone: e.target.value })}
               fullWidth
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={newDonor.isPetFood}
+                  onChange={e => setNewDonor({ ...newDonor, isPetFood: e.target.checked })}
+                />
+              }
+              label="Pet food donor"
             />
           </Stack>
         </DialogContent>

--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonorProfile.tsx
@@ -11,6 +11,8 @@ import {
   Stack,
   TextField,
   Typography,
+  Checkbox,
+  FormControlLabel,
   type AlertColor,
 } from '@mui/material';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
@@ -45,6 +47,7 @@ export default function DonorProfile() {
     lastName: '',
     email: '',
     phone: '',
+    isPetFood: false,
   });
   const [formErrors, setFormErrors] = useState<{
     firstName?: string;
@@ -94,6 +97,7 @@ export default function DonorProfile() {
         lastName: donor.lastName,
         email: donor.email ?? '',
         phone: donor.phone ?? '',
+        isPetFood: donor.isPetFood,
       });
     }
   }, [donor]);
@@ -112,6 +116,7 @@ export default function DonorProfile() {
         lastName: donor.lastName,
         email: donor.email ?? '',
         phone: donor.phone ?? '',
+        isPetFood: donor.isPetFood,
       });
     }
   };
@@ -123,6 +128,7 @@ export default function DonorProfile() {
       lastName: form.lastName.trim(),
       email: form.email.trim(),
       phone: form.phone.trim(),
+      isPetFood: form.isPetFood,
     };
     const errors: typeof formErrors = {};
     if (!trimmed.firstName) errors.firstName = 'First name is required';
@@ -140,6 +146,7 @@ export default function DonorProfile() {
         lastName: trimmed.lastName,
         email: trimmed.email || undefined,
         phone: trimmed.phone || undefined,
+        isPetFood: form.isPetFood,
       });
       setSnackbar({ open: true, message: 'Donor updated', severity: 'success' });
       setEditOpen(false);
@@ -186,6 +193,9 @@ export default function DonorProfile() {
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
                     Phone: {phoneDisplay}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Pet food donor: {donor.isPetFood ? 'Yes' : 'No'}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
                     Total: {donor.totalLbs.toLocaleString()} lbs
@@ -262,6 +272,15 @@ export default function DonorProfile() {
               value={form.phone}
               onChange={e => setForm({ ...form, phone: e.target.value })}
               fullWidth
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={form.isPetFood}
+                  onChange={e => setForm({ ...form, isPetFood: e.target.checked })}
+                />
+              }
+              label="Pet food donor"
             />
           </Stack>
         </DialogContent>


### PR DESCRIPTION
## Summary
- add an is_pet_food column to donors with validation defaults and expose it in donor API endpoints
- accept and persist the isPetFood flag through donor controllers, frontend API helpers, and donor management UIs
- update donor dialogs and profile views with a pet food donor toggle and adjust tests to cover the new field

## Testing
- npm test (backend)
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d03d7a6f94832d9e068690c3af9d33