### PR TITLE
Implement donor dashboard insights layout

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/DonorQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DonorQuickLinks.test.tsx
@@ -10,6 +10,9 @@ describe('DonorQuickLinks', () => {
       </MemoryRouter>
     );
     expect(
+      screen.getByRole('link', { name: /Dashboard/i })
+    ).toHaveAttribute('href', '/donor-management');
+    expect(
       screen.getByRole('link', { name: /Donors/i })
     ).toHaveAttribute('href', '/donor-management/donors');
     expect(
@@ -21,6 +24,7 @@ describe('DonorQuickLinks', () => {
   });
 
   it.each([
+    ['/donor-management', /Dashboard/i],
     ['/donor-management/donors', /Donors/i],
     ['/donor-management/donation-log', /Donor Log/i],
     ['/donor-management/mail-lists', /Mail Lists/i],
@@ -31,6 +35,30 @@ describe('DonorQuickLinks', () => {
       </MemoryRouter>
     );
     expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('disables donor link for nested routes', () => {
+    render(
+      <MemoryRouter initialEntries={["/donor-management/donors/1"]}>
+        <DonorQuickLinks />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /Donors/i })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('keeps dashboard link enabled on sub pages', () => {
+    render(
+      <MemoryRouter initialEntries={["/donor-management/donors"]}>
+        <DonorQuickLinks />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /Dashboard/i })).not.toHaveAttribute(
       'aria-disabled',
       'true'
     );

--- a/MJ_FB_Frontend/src/api/monetaryDonorInsights.ts
+++ b/MJ_FB_Frontend/src/api/monetaryDonorInsights.ts
@@ -1,0 +1,96 @@
+import { API_BASE, apiFetch, handleResponse } from './client';
+
+export interface MonetaryDonorMonthlySummary {
+  month: string;
+  totalAmount: number;
+  donationCount: number;
+  donorCount: number;
+  averageGift: number;
+}
+
+export interface MonetaryDonorYtdSummary {
+  totalAmount: number;
+  donationCount: number;
+  donorCount: number;
+  averageGift: number;
+  averageDonationsPerDonor: number;
+  lastDonationISO: string | null;
+}
+
+export interface MonetaryDonorTopDonor {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  windowAmount: number;
+  lifetimeAmount: number;
+  lastDonationISO: string | null;
+}
+
+export type MonetaryDonorTier =
+  | '1-100'
+  | '101-500'
+  | '501-1000'
+  | '1001-10000'
+  | '10001-30000';
+
+export interface MonetaryDonorTierTallies {
+  month: string;
+  tiers: Record<MonetaryDonorTier, { donorCount: number; totalAmount: number }>;
+}
+
+export interface MonetaryDonorFirstTimeDonor {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  firstDonationISO: string;
+  amount: number;
+}
+
+export interface MonetaryDonorPantryImpact {
+  families: number;
+  adults: number;
+  children: number;
+  pounds: number;
+}
+
+export interface MonetaryDonorInsightsResponse {
+  window: {
+    startMonth: string;
+    endMonth: string;
+    months: number;
+  };
+  monthly: MonetaryDonorMonthlySummary[];
+  ytd: MonetaryDonorYtdSummary;
+  topDonors: MonetaryDonorTopDonor[];
+  givingTiers: {
+    currentMonth: MonetaryDonorTierTallies;
+    previousMonth: MonetaryDonorTierTallies;
+  };
+  firstTimeDonors: MonetaryDonorFirstTimeDonor[];
+  pantryImpact: MonetaryDonorPantryImpact;
+}
+
+export interface MonetaryDonorInsightsParams {
+  months?: number;
+  endMonth?: string;
+}
+
+export async function getMonetaryDonorInsights(
+  params: MonetaryDonorInsightsParams = {},
+): Promise<MonetaryDonorInsightsResponse> {
+  const searchParams = new URLSearchParams();
+  if (typeof params.months === 'number') {
+    searchParams.set('months', String(params.months));
+  }
+  if (typeof params.endMonth === 'string' && params.endMonth) {
+    searchParams.set('endMonth', params.endMonth);
+  }
+
+  const query = searchParams.toString();
+  const res = await apiFetch(
+    `${API_BASE}/monetary-donors/insights${query ? `?${query}` : ''}`,
+  );
+  return handleResponse(res);
+}

--- a/MJ_FB_Frontend/src/components/DonorQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/DonorQuickLinks.tsx
@@ -8,10 +8,18 @@ export default function DonorQuickLinks() {
     '&:hover': { color: 'primary.main' },
   } as const;
   const links = [
+    { to: '/donor-management', label: 'Dashboard' },
     { to: '/donor-management/donors', label: 'Donors' },
     { to: '/donor-management/donation-log', label: 'Donor Log' },
     { to: '/donor-management/mail-lists', label: 'Mail Lists' },
   ];
+
+  const isActive = (to: string) => {
+    if (to === '/donor-management') {
+      return pathname === to || pathname === `${to}/`;
+    }
+    return pathname === to || pathname.startsWith(`${to}/`);
+  };
 
   return (
     <Stack
@@ -26,7 +34,7 @@ export default function DonorQuickLinks() {
           sx={{ ...buttonSx, flex: 1 }}
           component={RouterLink}
           to={link.to}
-          disabled={pathname === link.to}
+          disabled={isActive(link.to)}
         >
           {link.label}
         </Button>

--- a/MJ_FB_Frontend/src/hooks/useMonetaryDonorInsights.ts
+++ b/MJ_FB_Frontend/src/hooks/useMonetaryDonorInsights.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import type { ApiError } from '../api/client';
+import {
+  getMonetaryDonorInsights,
+  type MonetaryDonorInsightsParams,
+  type MonetaryDonorInsightsResponse,
+} from '../api/monetaryDonorInsights';
+
+export default function useMonetaryDonorInsights(
+  params: MonetaryDonorInsightsParams = {},
+) {
+  const { months, endMonth } = params;
+  const query = useQuery<MonetaryDonorInsightsResponse, ApiError>({
+    queryKey: ['monetary-donor-insights', months ?? null, endMonth ?? null],
+    queryFn: () => getMonetaryDonorInsights(params),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+
+  return {
+    insights: query.data,
+    isLoading: query.isFetching && !query.data,
+    isRefetching: query.isRefetching,
+    refetch: query.refetch,
+    error: query.error ?? null,
+  };
+}

--- a/MJ_FB_Frontend/src/pages/donor-management/DonorDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonorDashboard.tsx
@@ -1,11 +1,495 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import {
+  ResponsiveContainer,
+  LineChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  Line,
+  BarChart,
+  Bar,
+} from 'recharts';
+import { format, isValid, parseISO } from 'date-fns';
 import Page from '../../components/Page';
 import DonorQuickLinks from '../../components/DonorQuickLinks';
+import SectionCard from '../../components/dashboard/SectionCard';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import useMonetaryDonorInsights from '../../hooks/useMonetaryDonorInsights';
+import type {
+  MonetaryDonorInsightsResponse,
+  MonetaryDonorTier,
+} from '../../api/monetaryDonorInsights';
+
+const TIERS: MonetaryDonorTier[] = [
+  '1-100',
+  '101-500',
+  '501-1000',
+  '1001-10000',
+  '10001-30000',
+];
+
+function formatMonthLabel(month: string) {
+  const date = parseISO(`${month}-01`);
+  return isValid(date) ? format(date, 'MMM yyyy') : month;
+}
+
+function formatDateLabel(dateIso: string | null | undefined) {
+  if (!dateIso) return 'No donations yet';
+  const date = parseISO(dateIso.length === 7 ? `${dateIso}-01` : dateIso);
+  return isValid(date) ? format(date, 'MMM d, yyyy') : 'No donations yet';
+}
+
+function MonetaryTrendChart({
+  data,
+  currency,
+  numberFormatter,
+}: {
+  data: Array<
+    MonetaryDonorInsightsResponse['monthly'][number] & {
+      monthLabel: string;
+    }
+  >;
+  currency: Intl.NumberFormat;
+  numberFormatter: Intl.NumberFormat;
+}) {
+  const theme = useTheme();
+
+  return (
+    <ResponsiveContainer width="100%" height={300} data-testid="monetary-trend-chart">
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="monthLabel" />
+        <YAxis
+          yAxisId="amount"
+          tickFormatter={value => currency.format(value as number)}
+          width={90}
+        />
+        <YAxis
+          yAxisId="count"
+          orientation="right"
+          tickFormatter={value => numberFormatter.format(value as number)}
+          width={70}
+          allowDecimals={false}
+        />
+        <Tooltip
+          formatter={(value: number, name) =>
+            name === 'Total raised'
+              ? currency.format(value)
+              : numberFormatter.format(value)
+          }
+          labelFormatter={label => label as string}
+        />
+        <Legend />
+        <Line
+          yAxisId="amount"
+          type="monotone"
+          dataKey="totalAmount"
+          name="Total raised"
+          stroke={theme.palette.primary.main}
+          strokeWidth={2}
+          dot={{ r: 4 }}
+        />
+        <Line
+          yAxisId="count"
+          type="monotone"
+          dataKey="donationCount"
+          name="Donations"
+          stroke={theme.palette.secondary.main}
+          strokeWidth={2}
+          dot={{ r: 4 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function GivingTierChart({
+  data,
+  currentLabel,
+  previousLabel,
+  currency,
+}: {
+  data: Array<{ tier: MonetaryDonorTier; currentAmount: number; previousAmount: number }>;
+  currentLabel: string;
+  previousLabel: string;
+  currency: Intl.NumberFormat;
+}) {
+  const theme = useTheme();
+  return (
+    <ResponsiveContainer width="100%" height={300} data-testid="giving-tier-chart">
+      <BarChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="tier" />
+        <YAxis tickFormatter={value => currency.format(value as number)} width={90} />
+        <Tooltip
+          formatter={(value: number) => currency.format(value)}
+          labelFormatter={label => `${label} CAD`}
+        />
+        <Legend />
+        <Bar
+          dataKey="currentAmount"
+          name={currentLabel}
+          fill={theme.palette.primary.main}
+        />
+        <Bar
+          dataKey="previousAmount"
+          name={previousLabel}
+          fill={theme.palette.info.light}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
 
 export default function DonorDashboard() {
+  const { insights, isLoading, isRefetching, error } = useMonetaryDonorInsights();
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+
+  useEffect(() => {
+    if (error) {
+      setSnackbarOpen(true);
+    }
+  }, [error]);
+
+  const currency = useMemo(
+    () => new Intl.NumberFormat('en-CA', { style: 'currency', currency: 'CAD' }),
+    [],
+  );
+  const compactCurrency = useMemo(
+    () =>
+      new Intl.NumberFormat('en-CA', {
+        style: 'currency',
+        currency: 'CAD',
+        maximumFractionDigits: 0,
+      }),
+    [],
+  );
+  const numberFormatter = useMemo(() => new Intl.NumberFormat('en-CA'), []);
+  const decimalFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat('en-CA', {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }),
+    [],
+  );
+
+  const trendData = useMemo(
+    () =>
+      (insights?.monthly ?? []).map(month => ({
+        ...month,
+        monthLabel: formatMonthLabel(month.month),
+      })),
+    [insights?.monthly],
+  );
+
+  const givingTierData = useMemo(
+    () =>
+      !insights
+        ? []
+        : TIERS.map(tier => ({
+            tier,
+            currentAmount: insights.givingTiers.currentMonth.tiers[tier].totalAmount,
+            previousAmount: insights.givingTiers.previousMonth.tiers[tier].totalAmount,
+          })),
+    [insights?.givingTiers],
+  );
+
+  const hasGivingTierData = givingTierData.some(
+    entry => entry.currentAmount > 0 || entry.previousAmount > 0,
+  );
+  const hasTrendData = trendData.length > 0;
+  const topDonors = insights?.topDonors ?? [];
+  const firstTimeDonors = insights?.firstTimeDonors ?? [];
+  const pantryImpact = insights?.pantryImpact;
+  const hasPantryImpact = Boolean(
+    pantryImpact &&
+      (pantryImpact.families || pantryImpact.adults || pantryImpact.children || pantryImpact.pounds),
+  );
+
+  const errorMessage = error
+    ? error.status === 403
+      ? 'You do not have permission to view donor insights.'
+      : 'Unable to load donor insights. Please try again.'
+    : '';
+  const showLoadingState = isLoading && !insights;
+  const showFallback = !insights && !showLoadingState;
+
   return (
     <>
       <DonorQuickLinks />
-      <Page title="Donor Dashboard">{null}</Page>
+      <Page title="Donor Dashboard">
+        {isRefetching && insights ? (
+          <Box display="flex" justifyContent="flex-end" mb={1}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <CircularProgress size={16} aria-label="Refreshing donor insights" />
+              <Typography variant="caption" color="text.secondary">
+                Refreshing data…
+              </Typography>
+            </Stack>
+          </Box>
+        ) : null}
+        <Grid container spacing={2} sx={{ mb: 4 }}>
+          <Grid item xs={12} md={6} lg={4} data-testid="ytd-card">
+            <SectionCard title="Year-to-date Giving">
+              {showLoadingState ? (
+                <Stack spacing={1} data-testid="ytd-loading">
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <Skeleton key={index} variant="text" height={28} />
+                  ))}
+                </Stack>
+              ) : showFallback ? (
+                <Typography color="text.secondary">
+                  Unable to load donor insights.
+                </Typography>
+              ) : (
+                <Stack spacing={2}>
+                  <Grid container spacing={2}>
+                    <Grid item xs={6}>
+                      <Typography variant="body2" color="text.secondary">
+                        Total raised
+                      </Typography>
+                      <Typography variant="h6">
+                        {currency.format(insights.ytd.totalAmount)}
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={6}>
+                      <Typography variant="body2" color="text.secondary">
+                        Donations
+                      </Typography>
+                      <Typography variant="h6">
+                        {numberFormatter.format(insights.ytd.donationCount)}
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={6}>
+                      <Typography variant="body2" color="text.secondary">
+                        Donors
+                      </Typography>
+                      <Typography variant="h6">
+                        {numberFormatter.format(insights.ytd.donorCount)}
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={6}>
+                      <Typography variant="body2" color="text.secondary">
+                        Average gift
+                      </Typography>
+                      <Typography variant="h6">
+                        {currency.format(insights.ytd.averageGift)}
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                      <Typography variant="body2" color="text.secondary">
+                        Gifts per donor
+                      </Typography>
+                      <Typography variant="h6">
+                        {decimalFormatter.format(insights.ytd.averageDonationsPerDonor)}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                  <Divider />
+                  <Typography variant="body2" color="text.secondary">
+                    Last donation: {formatDateLabel(insights.ytd.lastDonationISO)}
+                  </Typography>
+                </Stack>
+              )}
+            </SectionCard>
+          </Grid>
+          <Grid item xs={12} md={6} lg={4} data-testid="pantry-impact-card">
+            <SectionCard title="Pantry Impact">
+              {showLoadingState ? (
+                <Stack spacing={1} data-testid="pantry-loading">
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <Skeleton key={index} variant="text" height={28} />
+                  ))}
+                </Stack>
+              ) : showFallback ? (
+                <Typography color="text.secondary">
+                  Unable to load donor insights.
+                </Typography>
+              ) : hasPantryImpact ? (
+                <Grid container spacing={2}>
+                  <Grid item xs={6}>
+                    <Typography variant="body2" color="text.secondary">
+                      Families supported
+                    </Typography>
+                    <Typography variant="h6">
+                      {numberFormatter.format(pantryImpact.families)}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={6}>
+                    <Typography variant="body2" color="text.secondary">
+                      Adults helped
+                    </Typography>
+                    <Typography variant="h6">
+                      {numberFormatter.format(pantryImpact.adults)}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={6}>
+                    <Typography variant="body2" color="text.secondary">
+                      Children helped
+                    </Typography>
+                    <Typography variant="h6">
+                      {numberFormatter.format(pantryImpact.children)}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={6}>
+                    <Typography variant="body2" color="text.secondary">
+                      Pounds distributed
+                    </Typography>
+                    <Typography variant="h6">
+                      {numberFormatter.format(pantryImpact.pounds)}
+                    </Typography>
+                  </Grid>
+                </Grid>
+              ) : (
+                <Typography color="text.secondary">
+                  Impact statistics will appear after donations are recorded.
+                </Typography>
+              )}
+            </SectionCard>
+          </Grid>
+          <Grid item xs={12} md={12} lg={4} data-testid="first-time-card">
+            <SectionCard title="First-time Donors">
+              {showLoadingState ? (
+                <Stack spacing={1} data-testid="first-time-loading">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <Skeleton key={index} variant="text" height={24} />
+                  ))}
+                </Stack>
+              ) : showFallback ? (
+                <Typography color="text.secondary">
+                  Unable to load donor insights.
+                </Typography>
+              ) : firstTimeDonors.length > 0 ? (
+                <List dense disablePadding>
+                  {firstTimeDonors.map(donor => (
+                    <ListItem key={donor.id} disableGutters>
+                      <ListItemText
+                        primary={`${donor.firstName} ${donor.lastName}`.trim()}
+                        secondary={`${currency.format(donor.amount)} · First gift on ${formatDateLabel(
+                          donor.firstDonationISO,
+                        )}`}
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              ) : (
+                <Typography color="text.secondary">
+                  Welcome gifts will be highlighted here once new donors give.
+                </Typography>
+              )}
+            </SectionCard>
+          </Grid>
+          <Grid item xs={12} lg={8} data-testid="trend-card">
+            <SectionCard title="Giving Trends">
+              {showLoadingState ? (
+                <Skeleton variant="rounded" height={300} data-testid="trend-loading" />
+              ) : showFallback ? (
+                <Typography color="text.secondary">
+                  Unable to load donor insights.
+                </Typography>
+              ) : hasTrendData ? (
+                <MonetaryTrendChart
+                  data={trendData}
+                  currency={compactCurrency}
+                  numberFormatter={numberFormatter}
+                />
+              ) : (
+                <Typography color="text.secondary">
+                  No donation history yet. Trends will appear after donations are recorded.
+                </Typography>
+              )}
+            </SectionCard>
+          </Grid>
+          <Grid item xs={12} lg={4} data-testid="giving-tier-card">
+            <SectionCard title="Giving Tiers">
+              {showLoadingState ? (
+                <Skeleton variant="rounded" height={300} data-testid="tiers-loading" />
+              ) : showFallback ? (
+                <Typography color="text.secondary">
+                  Unable to load donor insights.
+                </Typography>
+              ) : hasGivingTierData ? (
+                <Stack spacing={1}>
+                  <Typography variant="body2" color="text.secondary">
+                    Comparing {formatMonthLabel(insights.givingTiers.currentMonth.month)} with{' '}
+                    {formatMonthLabel(insights.givingTiers.previousMonth.month)}
+                  </Typography>
+                  <GivingTierChart
+                    data={givingTierData}
+                    currentLabel={formatMonthLabel(insights.givingTiers.currentMonth.month)}
+                    previousLabel={formatMonthLabel(insights.givingTiers.previousMonth.month)}
+                    currency={compactCurrency}
+                  />
+                </Stack>
+              ) : (
+                <Typography color="text.secondary">
+                  Tier comparisons will appear after at least one month of giving data is
+                  available.
+                </Typography>
+              )}
+            </SectionCard>
+          </Grid>
+          <Grid item xs={12} lg={6} data-testid="top-donors-card">
+            <SectionCard title="Top Donors">
+              {showLoadingState ? (
+                <Stack spacing={1} data-testid="top-donors-loading">
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <Skeleton key={index} variant="text" height={28} />
+                  ))}
+                </Stack>
+              ) : showFallback ? (
+                <Typography color="text.secondary">
+                  Unable to load donor insights.
+                </Typography>
+              ) : topDonors.length > 0 ? (
+                <List dense disablePadding>
+                  {topDonors.map((donor, index) => (
+                    <ListItem
+                      key={donor.id}
+                      disableGutters
+                      divider={index < topDonors.length - 1}
+                      sx={{ py: 1 }}
+                    >
+                      <ListItemText
+                        primary={`${donor.firstName} ${donor.lastName}`.trim()}
+                        secondary={`${currency.format(donor.windowAmount)} in window · Last gift ${formatDateLabel(
+                          donor.lastDonationISO,
+                        )}`}
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              ) : (
+                <Typography color="text.secondary">
+                  Once donations arrive, top supporters will appear here.
+                </Typography>
+              )}
+            </SectionCard>
+          </Grid>
+        </Grid>
+      </Page>
+      <FeedbackSnackbar
+        open={snackbarOpen}
+        onClose={() => setSnackbarOpen(false)}
+        message={errorMessage}
+        severity="error"
+      />
     </>
   );
 }

--- a/MJ_FB_Frontend/src/pages/donor-management/__tests__/DonorDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/__tests__/DonorDashboard.test.tsx
@@ -1,0 +1,226 @@
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import {
+  renderWithProviders,
+  screen,
+} from '../../../../testUtils/renderWithProviders';
+import DonorDashboard from '../DonorDashboard';
+import useMonetaryDonorInsights from '../../../hooks/useMonetaryDonorInsights';
+import type { MonetaryDonorInsightsResponse } from '../../../api/monetaryDonorInsights';
+import type { ApiError } from '../../../api/client';
+
+jest.mock('../../../hooks/useMonetaryDonorInsights');
+
+const mockUseMonetaryDonorInsights = useMonetaryDonorInsights as jest.MockedFunction<
+  typeof useMonetaryDonorInsights
+>;
+
+const baseInsights: MonetaryDonorInsightsResponse = {
+  window: { startMonth: '2024-01', endMonth: '2024-06', months: 6 },
+  monthly: [
+    { month: '2024-01', totalAmount: 1200, donationCount: 10, donorCount: 8, averageGift: 120 },
+    { month: '2024-02', totalAmount: 1800, donationCount: 12, donorCount: 9, averageGift: 150 },
+  ],
+  ytd: {
+    totalAmount: 5000,
+    donationCount: 45,
+    donorCount: 30,
+    averageGift: 111.11,
+    averageDonationsPerDonor: 1.5,
+    lastDonationISO: '2024-06-15',
+  },
+  topDonors: [
+    {
+      id: 1,
+      firstName: 'Alex',
+      lastName: 'Smith',
+      email: 'alex@example.com',
+      windowAmount: 2500,
+      lifetimeAmount: 6000,
+      lastDonationISO: '2024-06-10',
+    },
+    {
+      id: 2,
+      firstName: 'Jamie',
+      lastName: 'Lee',
+      email: 'jamie@example.com',
+      windowAmount: 1500,
+      lifetimeAmount: 3500,
+      lastDonationISO: '2024-05-22',
+    },
+  ],
+  givingTiers: {
+    currentMonth: {
+      month: '2024-06',
+      tiers: {
+        '1-100': { donorCount: 5, totalAmount: 400 },
+        '101-500': { donorCount: 4, totalAmount: 900 },
+        '501-1000': { donorCount: 2, totalAmount: 1200 },
+        '1001-10000': { donorCount: 1, totalAmount: 1000 },
+        '10001-30000': { donorCount: 0, totalAmount: 0 },
+      },
+    },
+    previousMonth: {
+      month: '2024-05',
+      tiers: {
+        '1-100': { donorCount: 3, totalAmount: 300 },
+        '101-500': { donorCount: 2, totalAmount: 600 },
+        '501-1000': { donorCount: 1, totalAmount: 700 },
+        '1001-10000': { donorCount: 0, totalAmount: 0 },
+        '10001-30000': { donorCount: 0, totalAmount: 0 },
+      },
+    },
+  },
+  firstTimeDonors: [
+    {
+      id: 3,
+      firstName: 'Taylor',
+      lastName: 'Morgan',
+      email: 'taylor@example.com',
+      firstDonationISO: '2024-06-05',
+      amount: 200,
+    },
+  ],
+  pantryImpact: {
+    families: 120,
+    adults: 340,
+    children: 210,
+    pounds: 12345,
+  },
+};
+
+function renderDashboard() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={["/donor-management"]}>
+      <Routes>
+        <Route path="/donor-management" element={<DonorDashboard />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('DonorDashboard', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders donor insights data', () => {
+    mockUseMonetaryDonorInsights.mockReturnValue({
+      insights: baseInsights,
+      isLoading: false,
+      isRefetching: false,
+      refetch: jest.fn(),
+      error: null,
+    });
+
+    renderDashboard();
+
+    expect(screen.getByText(/\$5,000\.00/)).toBeInTheDocument();
+    expect(screen.getByText('45')).toBeInTheDocument();
+    expect(screen.getByText(/Alex Smith/)).toBeInTheDocument();
+    expect(screen.getByText(/Jamie Lee/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Welcome gifts will be highlighted/, { exact: false })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Taylor Morgan/)).toBeInTheDocument();
+    expect(screen.getByText('Families supported')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'No donation history yet. Trends will appear after donations are recorded.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Comparing Jun 2024 with May 2024')).toBeInTheDocument();
+  });
+
+  it('shows loading skeletons while fetching', () => {
+    mockUseMonetaryDonorInsights.mockReturnValue({
+      insights: undefined,
+      isLoading: true,
+      isRefetching: false,
+      refetch: jest.fn(),
+      error: null,
+    });
+
+    renderDashboard();
+
+    expect(screen.getByTestId('ytd-loading')).toBeInTheDocument();
+    expect(screen.getByTestId('trend-loading')).toBeInTheDocument();
+    expect(screen.getByTestId('top-donors-loading')).toBeInTheDocument();
+  });
+
+  it('renders empty states when datasets are empty', () => {
+    mockUseMonetaryDonorInsights.mockReturnValue({
+      insights: {
+        ...baseInsights,
+        monthly: [],
+        topDonors: [],
+        firstTimeDonors: [],
+        pantryImpact: { families: 0, adults: 0, children: 0, pounds: 0 },
+        givingTiers: {
+          currentMonth: {
+            month: '2024-06',
+            tiers: {
+              '1-100': { donorCount: 0, totalAmount: 0 },
+              '101-500': { donorCount: 0, totalAmount: 0 },
+              '501-1000': { donorCount: 0, totalAmount: 0 },
+              '1001-10000': { donorCount: 0, totalAmount: 0 },
+              '10001-30000': { donorCount: 0, totalAmount: 0 },
+            },
+          },
+          previousMonth: {
+            month: '2024-05',
+            tiers: {
+              '1-100': { donorCount: 0, totalAmount: 0 },
+              '101-500': { donorCount: 0, totalAmount: 0 },
+              '501-1000': { donorCount: 0, totalAmount: 0 },
+              '1001-10000': { donorCount: 0, totalAmount: 0 },
+              '10001-30000': { donorCount: 0, totalAmount: 0 },
+            },
+          },
+        },
+      },
+      isLoading: false,
+      isRefetching: false,
+      refetch: jest.fn(),
+      error: null,
+    });
+
+    renderDashboard();
+
+    expect(
+      screen.getByText('Impact statistics will appear after donations are recorded.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Welcome gifts will be highlighted here once new donors give.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Once donations arrive, top supporters will appear here.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'No donation history yet. Trends will appear after donations are recorded.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Tier comparisons will appear after at least one month of giving data is available.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a permission error message', async () => {
+    const error: Partial<ApiError> = { status: 403, message: 'Forbidden' };
+    mockUseMonetaryDonorInsights.mockReturnValue({
+      insights: undefined,
+      isLoading: false,
+      isRefetching: false,
+      refetch: jest.fn(),
+      error: error as ApiError,
+    });
+
+    renderDashboard();
+
+    expect(
+      await screen.findByText('You do not have permission to view donor insights.'),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- build a monetary donor insights API client and query hook to drive the dashboard
- replace the donor dashboard placeholder with KPI cards, charts, donor lists, pantry impact metrics, and error/empty states
- add a dashboard quick link and update quick link tests alongside new donor dashboard coverage

## Testing
- `npm test -- --runInBand` *(fails: pre-existing RescheduleBooking test cannot locate option in select)*

------
https://chatgpt.com/codex/tasks/task_e_68d03d32de4c832db84ec55e880d6dba