### PR TITLE
Add pet food donation tracking to warehouse aggregates

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000067_add_pet_food_columns.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000067_add_pet_food_columns.ts
@@ -1,0 +1,57 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+const DONORS_COLUMN = 'is_pet_food';
+const WAREHOUSE_COLUMN = 'pet_food';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('donors', {
+    [DONORS_COLUMN]: {
+      type: 'boolean',
+      notNull: true,
+      default: false,
+    },
+  });
+
+  pgm.addColumn('warehouse_overall', {
+    [WAREHOUSE_COLUMN]: {
+      type: 'integer',
+      notNull: true,
+      default: 0,
+    },
+  });
+
+  pgm.sql(`
+    WITH monthly_totals AS (
+      SELECT
+        w.year,
+        w.month,
+        COALESCE(SUM(COALESCE(d.weight, 0))::int, 0) AS total_weight,
+        COALESCE(
+          SUM(
+            CASE
+              WHEN COALESCE(o.${DONORS_COLUMN}, FALSE) THEN COALESCE(d.weight, 0)
+              ELSE 0
+            END
+          )::int,
+          0
+        ) AS pet_food_weight
+      FROM warehouse_overall w
+      LEFT JOIN donations d
+        ON EXTRACT(YEAR FROM d.date)::int = w.year
+       AND EXTRACT(MONTH FROM d.date)::int = w.month
+      LEFT JOIN donors o ON d.donor_id = o.id
+      GROUP BY w.year, w.month
+    )
+    UPDATE warehouse_overall w
+       SET donations = COALESCE(mt.total_weight, 0) - COALESCE(mt.pet_food_weight, 0),
+           ${WAREHOUSE_COLUMN} = COALESCE(mt.pet_food_weight, 0)
+      FROM monthly_totals mt
+     WHERE w.year = mt.year
+       AND w.month = mt.month;
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('warehouse_overall', WAREHOUSE_COLUMN, { ifExists: true });
+  pgm.dropColumn('donors', DONORS_COLUMN, { ifExists: true });
+}

--- a/MJ_FB_Backend/tests/controllers/warehouse/warehouseOverallController.test.ts
+++ b/MJ_FB_Backend/tests/controllers/warehouse/warehouseOverallController.test.ts
@@ -15,7 +15,7 @@ describe('warehouseOverallController', () => {
   describe('refreshWarehouseOverall', () => {
     it('aggregates monthly totals and refreshes donor data', async () => {
       (mockDb.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [{ total: 120 }] })
+        .mockResolvedValueOnce({ rows: [{ donations: 100, petFood: 20 }] })
         .mockResolvedValueOnce({ rows: [{ total: 45 }] })
         .mockResolvedValueOnce({ rows: [{ total: 15 }] })
         .mockResolvedValueOnce({ rows: [{ total: 8 }] })
@@ -31,11 +31,7 @@ describe('warehouseOverallController', () => {
       const startDate = new Date(Date.UTC(2024, 4, 1)).toISOString().slice(0, 10);
       const endDate = new Date(Date.UTC(2024, 5, 1)).toISOString().slice(0, 10);
 
-      expect(mockDb.query).toHaveBeenNthCalledWith(
-        1,
-        expect.stringContaining('FROM donations'),
-        [startDate, endDate],
-      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(1, expect.stringContaining('FROM donations d'), [startDate, endDate]);
       expect(mockDb.query).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('FROM surplus_log'),
@@ -59,7 +55,7 @@ describe('warehouseOverallController', () => {
       expect(mockDb.query).toHaveBeenNthCalledWith(
         6,
         expect.stringContaining('INSERT INTO warehouse_overall'),
-        [2024, 5, 120, 45, 15, 8],
+        [2024, 5, 100, 45, 15, 8, 20],
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         7,
@@ -88,7 +84,7 @@ describe('warehouseOverallController', () => {
       expect(mockDb.query).toHaveBeenNthCalledWith(
         6,
         expect.stringContaining('INSERT INTO warehouse_overall'),
-        [2024, 6, 0, 0, 0, 0],
+        [2024, 6, 0, 0, 0, 0, 0],
       );
       expect(mockDb.query).toHaveBeenNthCalledWith(
         7,
@@ -102,7 +98,7 @@ describe('warehouseOverallController', () => {
   describe('listWarehouseOverall', () => {
     it('returns data for the requested year', async () => {
       const rows = [
-        { month: 1, donations: 10, surplus: 2, pigPound: 3, outgoingDonations: 4 },
+        { month: 1, donations: 10, petFood: 1, surplus: 2, pigPound: 3, outgoingDonations: 4 },
       ];
       (mockDb.query as jest.Mock).mockResolvedValueOnce({ rows });
       const req = { query: { year: '2022' } } as any;

--- a/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallExport.test.ts
@@ -36,8 +36,8 @@ describe('GET /warehouse-overall/export', () => {
       })
       .mockResolvedValueOnce({
         rows: [
-          { month: 1, donations: 10, surplus: 2, pigPound: 1, outgoingDonations: 0 },
-          { month: 2, donations: 5, surplus: 3, pigPound: 0, outgoingDonations: 1 },
+          { month: 1, donations: 10, petFood: 2, surplus: 2, pigPound: 1, outgoingDonations: 0 },
+          { month: 2, donations: 5, petFood: 1, surplus: 3, pigPound: 0, outgoingDonations: 1 },
         ],
       });
 
@@ -65,13 +65,14 @@ describe('GET /warehouse-overall/export', () => {
     expect(values[0]).toEqual([
       'Month',
       'Donations',
+      'Pet Food Donations',
       'Surplus',
       'Pig Pound',
       'Outgoing Donations',
     ]);
-    expect(values[1]).toEqual(['January', 10, 2, 1, 0]);
-    expect(values[2]).toEqual(['February', 5, 3, 0, 1]);
-    expect(values[3]).toEqual(['March', 0, 0, 0, 0]);
-    expect(values[13]).toEqual(['Total', 15, 5, 1, 1]);
+    expect(values[1]).toEqual(['January', 10, 2, 2, 1, 0]);
+    expect(values[2]).toEqual(['February', 5, 1, 3, 0, 1]);
+    expect(values[3]).toEqual(['March', 0, 0, 0, 0, 0]);
+    expect(values[13]).toEqual(['Total', 15, 3, 5, 1, 1]);
   });
 });

--- a/MJ_FB_Backend/tests/warehouseOverallManual.test.ts
+++ b/MJ_FB_Backend/tests/warehouseOverallManual.test.ts
@@ -42,6 +42,7 @@ describe('POST /warehouse-overall/manual', () => {
       year,
       month: 5,
       donations: 10,
+      petFood: 4,
       surplus: 2,
       pigPound: 1,
       outgoingDonations: 3,
@@ -53,7 +54,7 @@ describe('POST /warehouse-overall/manual', () => {
     expect(res.body).toEqual({ message: 'Saved' });
     expect(pool.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO warehouse_overall'),
-      [year, 5, 10, 2, 1, 3],
+      [year, 5, 10, 2, 1, 3, 4],
     );
   });
 
@@ -62,16 +63,16 @@ describe('POST /warehouse-overall/manual', () => {
 
     await request(app)
       .post('/warehouse-overall/manual')
-      .send({ year, month: 5, donations: 1, surplus: 2, pigPound: 3, outgoingDonations: 4 });
+      .send({ year, month: 5, donations: 1, petFood: 2, surplus: 2, pigPound: 3, outgoingDonations: 4 });
 
     const res = await request(app)
       .post('/warehouse-overall/manual')
-      .send({ year, month: 5, donations: 5, surplus: 6, pigPound: 7, outgoingDonations: 8 });
+      .send({ year, month: 5, donations: 5, petFood: 6, surplus: 6, pigPound: 7, outgoingDonations: 8 });
 
     expect(res.status).toBe(200);
     expect(pool.query).toHaveBeenLastCalledWith(
       expect.any(String),
-      [year, 5, 5, 6, 7, 8],
+      [year, 5, 5, 6, 7, 8, 6],
     );
   });
 });


### PR DESCRIPTION
## Summary
- add a migration for donors.is_pet_food and warehouse_overall.pet_food columns and backfill existing aggregates
- update monthly warehouse refresh, manual entry, listing, and export logic to separate pet food donations
- adjust warehouse overall tests to cover the new pet food column and spreadsheet output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03d66da24832d850e36b0e282cd74