### PR TITLE
Document donor dashboard insights

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -124,7 +124,24 @@ Returns a list of donors with their total donated weight for each month of the s
 Every donor in the system is included even if they have no donations in that year; months
 without records report `0`.
 
+## Monetary Donor Insights Endpoint
 
+`GET /monetary-donors/insights?months=NUMBER&endMonth=YYYY-MM`
+
+Returns windowed metrics used by the donor dashboard. Authentication requires a staff session with the `donor_management` access flag.
+
+- `months` (optional, default 6) – number of months to include, clamped between 1 and 24.
+- `endMonth` (optional) – ISO year-month for the final month in the window. If omitted, the API uses the previous calendar month.
+
+Response JSON:
+
+- `window` – `{ startMonth, endMonth, months }` reflecting the reporting range.
+- `monthly` – array of `{ month, totalAmount, donationCount, donorCount, averageGift }` summarizing each month in the range.
+- `ytd` – year-to-date totals with `totalAmount`, `donationCount`, `donorCount`, `averageGift`, `averageDonationsPerDonor`, and `lastDonationISO`.
+- `topDonors` – top five donors in the window including `id`, `firstName`, `lastName`, `email`, `windowAmount`, `lifetimeAmount`, and `lastDonationISO`.
+- `givingTiers` – current and previous month tallies for donor tiers (`1-100`, `101-500`, `501-1000`, `1001-10000`, `10001-30000`) with `donorCount` and `totalAmount` per tier.
+- `firstTimeDonors` – donors whose first recorded gift falls in the most recent month, with donation date and amount.
+- `pantryImpact` – pantry families, adults, children, and pounds served for the selected month.
 
 ## Warehouse Overall Available Years Endpoint
 

--- a/MJ_FB_Frontend/README.md
+++ b/MJ_FB_Frontend/README.md
@@ -7,6 +7,10 @@ Volunteers are prompted to install the app on their first visit to volunteer pag
 
 Client bookings include a confirmation step that lists the selected date, time, and current-month visit count on separate lines, with an optional client note field for staff.
 
+## Donor Dashboard
+
+Staff with **donor_management** permission can review donor revenue, retention, and trend visualizations from **Donor Management → Dashboard**. The dashboard reuses the trends chart component introduced for donor insights so future analytics can plug into the same visualization pattern.
+
 ## Node Version
 
 Use **Node.js 22+**. Run `nvm use` to switch to the version pinned in the repository’s `.nvmrc`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,6 +2,7 @@
 
 > Historical note: Items referencing the former partner portal describe previously shipped features. Partner bookings now go through staff assistance.
 
+- feat(donor-dashboard): add revenue metrics cards, donor retention visuals, and reusable trends chart component
 - feat: add maintenance mode notices
 - feat: allow manual warehouse overall aggregates
 - feat: allow manual pantry monthly aggregates

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -2,3 +2,4 @@
 
 Clients can access the dashboard from the navigation menu.
 Admins can manage maintenance windows from **Admin → Maintenance**.
+Staff with donor management access open the donor insights at **Donor Management → Dashboard**.


### PR DESCRIPTION
## Summary
- log the new donor dashboard metrics and reusable trends chart in the feature log and navigation docs
- highlight the donor dashboard access requirements in the frontend README
- document the monetary donor insights API, including query parameters, response fields, and required permissions

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d04244f700832d9691d18d6cd0927f