### PR TITLE
Add donor dashboard layout and tests

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/DonorQuickLinks.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/DonorQuickLinks.test.tsx
@@ -10,6 +10,9 @@ describe('DonorQuickLinks', () => {
       </MemoryRouter>
     );
     expect(
+      screen.getByRole('link', { name: /Dashboard/i })
+    ).toHaveAttribute('href', '/donor-management');
+    expect(
       screen.getByRole('link', { name: /Donors/i })
     ).toHaveAttribute('href', '/donor-management/donors');
     expect(
@@ -21,7 +24,9 @@ describe('DonorQuickLinks', () => {
   });
 
   it.each([
+    ['/donor-management', /Dashboard/i],
     ['/donor-management/donors', /Donors/i],
+    ['/donor-management/donors/123', /Donors/i],
     ['/donor-management/donation-log', /Donor Log/i],
     ['/donor-management/mail-lists', /Mail Lists/i],
   ])('disables current page link %s', (path, label) => {
@@ -34,6 +39,17 @@ describe('DonorQuickLinks', () => {
       'aria-disabled',
       'true'
     );
+  });
+
+  it('keeps other quick links enabled when viewing dashboard', () => {
+    render(
+      <MemoryRouter initialEntries={['/donor-management']}>
+        <DonorQuickLinks />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: /Donors/i })).not.toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('link', { name: /Donor Log/i })).not.toHaveAttribute('aria-disabled', 'true');
   });
 });
 

--- a/MJ_FB_Frontend/src/components/DonorQuickLinks.tsx
+++ b/MJ_FB_Frontend/src/components/DonorQuickLinks.tsx
@@ -3,11 +3,13 @@ import { Link as RouterLink, useLocation } from 'react-router-dom';
 
 export default function DonorQuickLinks() {
   const { pathname } = useLocation();
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/';
   const buttonSx = {
     textTransform: 'none',
     '&:hover': { color: 'primary.main' },
   } as const;
   const links = [
+    { to: '/donor-management', label: 'Dashboard', match: (path: string) => path === '/donor-management' },
     { to: '/donor-management/donors', label: 'Donors' },
     { to: '/donor-management/donation-log', label: 'Donor Log' },
     { to: '/donor-management/mail-lists', label: 'Mail Lists' },
@@ -19,18 +21,23 @@ export default function DonorQuickLinks() {
       spacing={{ xs: 1, sm: 2 }}
       sx={{ width: '100%', mb: 2 }}
     >
-      {links.map(link => (
+      {links.map(link => {
+        const isActive = link.match
+          ? link.match(normalizedPath)
+          : normalizedPath === link.to || normalizedPath.startsWith(`${link.to}/`);
+        return (
         <Button
           key={link.to}
           variant="outlined"
           sx={{ ...buttonSx, flex: 1 }}
           component={RouterLink}
           to={link.to}
-          disabled={pathname === link.to}
+          disabled={isActive}
         >
           {link.label}
         </Button>
-      ))}
+        );
+      })}
     </Stack>
   );
 }

--- a/MJ_FB_Frontend/src/pages/donor-management/DonorDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/DonorDashboard.tsx
@@ -1,11 +1,392 @@
+import { Fragment, useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import Grid from '@mui/material/Grid';
+import Savings from '@mui/icons-material/Savings';
+import ShowChart from '@mui/icons-material/ShowChart';
+import Leaderboard from '@mui/icons-material/Leaderboard';
+import EmojiEvents from '@mui/icons-material/EmojiEvents';
+import AutoAwesome from '@mui/icons-material/AutoAwesome';
+import VolunteerActivism from '@mui/icons-material/VolunteerActivism';
+import { format, parse } from 'date-fns';
 import Page from '../../components/Page';
 import DonorQuickLinks from '../../components/DonorQuickLinks';
+import SectionCard from '../../components/dashboard/SectionCard';
+import MonetaryDonationTrendChart from '../../components/dashboard/MonetaryDonationTrendChart';
+import MonetaryGivingTierChart, {
+  type MonetaryGivingTierDatum,
+} from '../../components/dashboard/MonetaryGivingTierChart';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import useMonetaryDonorInsights from '../../hooks/useMonetaryDonorInsights';
+import type { ApiError } from '../../api/client';
+import type { MonetaryDonorMonthBucket } from '../../api/monetaryDonors';
+import getApiErrorMessage from '../../utils/getApiErrorMessage';
+import { formatLocaleDate } from '../../utils/date';
+
+const tierLabels: Record<MonetaryDonorMonthBucket, string> = {
+  '1-100': '$1–$100',
+  '101-500': '$101–$500',
+  '501-1000': '$501–$1,000',
+  '1001-10000': '$1,001–$10,000',
+  '10001-30000': '$10,001–$30,000',
+};
+
+function formatMonthLabel(month: string) {
+  const parsed = parse(month, 'yyyy-MM', new Date());
+  if (Number.isNaN(parsed.getTime())) {
+    return month;
+  }
+  return format(parsed, 'MMM yyyy');
+}
+
+function buildTierData(
+  current: Record<MonetaryDonorMonthBucket, { donorCount: number; totalAmount: number }>,
+  previous?: Record<MonetaryDonorMonthBucket, { donorCount: number; totalAmount: number }>,
+): MonetaryGivingTierDatum[] {
+  return (Object.keys(current) as MonetaryDonorMonthBucket[]).map(tier => {
+    const currentTier = current[tier];
+    const previousCount = previous?.[tier]?.donorCount ?? 0;
+    return {
+      tierLabel: tierLabels[tier],
+      donorCount: currentTier.donorCount,
+      amount: currentTier.totalAmount,
+      deltaFromPreviousMonth: currentTier.donorCount - previousCount,
+    };
+  });
+}
+
+function renderStat({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <Stack direction="row" spacing={1.5} alignItems="center" key={label}>
+      {icon}
+      <Stack spacing={0.25}>
+        <Typography variant="body2" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="h6">{value}</Typography>
+      </Stack>
+    </Stack>
+  );
+}
 
 export default function DonorDashboard() {
+  const { data, isLoading, isFetching, isError, error } = useMonetaryDonorInsights();
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+
+  useEffect(() => {
+    if (!isError) return;
+    const apiError = error as ApiError | undefined;
+    const message =
+      apiError?.status === 403
+        ? 'You do not have access to donor insights. Ask an administrator to grant donor management access.'
+        : getApiErrorMessage(apiError, 'Failed to load donor insights.');
+    setSnackbarMessage(message);
+    setSnackbarOpen(true);
+  }, [error, isError]);
+
+  const currency = useMemo(
+    () => new Intl.NumberFormat('en-CA', { style: 'currency', currency: 'CAD' }),
+    [],
+  );
+
+  const trendData = useMemo(
+    () =>
+      (data?.monthly ?? []).map(summary => ({
+        month: summary.month,
+        amount: summary.totalAmount,
+        donationCount: summary.donationCount,
+        donorCount: summary.donorCount,
+        averageGift: summary.averageGift,
+      })),
+    [data?.monthly],
+  );
+
+  const tierData = useMemo(() => {
+    if (!data?.givingTiers) return [] as MonetaryGivingTierDatum[];
+    return buildTierData(data.givingTiers.currentMonth.tiers, data.givingTiers.previousMonth?.tiers);
+  }, [data?.givingTiers]);
+
+  const hasTierData = tierData.some(item => item.donorCount > 0 || item.amount > 0);
+  const topDonors = data?.topDonors ?? [];
+  const firstTimeDonors = data?.firstTimeDonors ?? [];
+  const pantryImpact = data?.pantryImpact;
+  const hasPantryImpact =
+    !!pantryImpact &&
+    [pantryImpact.families, pantryImpact.adults, pantryImpact.children, pantryImpact.pounds].some(value => value > 0);
+
+  const windowLabel = data?.window
+    ? `${formatMonthLabel(data.window.startMonth)} – ${formatMonthLabel(data.window.endMonth)} (${data.window.months} month${
+        data.window.months === 1 ? '' : 's'
+      })`
+    : '';
+
+  const ytdStats = data
+    ? [
+        {
+          label: 'Total received',
+          value: currency.format(data.ytd.totalAmount),
+          icon: <Savings color="primary" />,
+        },
+        {
+          label: 'Donations recorded',
+          value: data.ytd.donationCount.toLocaleString('en-CA'),
+          icon: <EmojiEvents color="primary" />,
+        },
+        {
+          label: 'Donors engaged',
+          value: data.ytd.donorCount.toLocaleString('en-CA'),
+          icon: <Leaderboard color="primary" />,
+        },
+        {
+          label: 'Average gift',
+          value: currency.format(data.ytd.averageGift),
+          icon: <ShowChart color="primary" />,
+        },
+        {
+          label: 'Gifts per donor',
+          value: data.ytd.averageDonationsPerDonor.toFixed(1),
+          icon: <AutoAwesome color="primary" />,
+        },
+        {
+          label: 'Last gift received',
+          value: data.ytd.lastDonationISO
+            ? formatLocaleDate(data.ytd.lastDonationISO, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })
+            : 'No gifts recorded yet',
+          icon: <VolunteerActivism color="primary" />,
+        },
+      ]
+    : [];
+
   return (
     <>
       <DonorQuickLinks />
-      <Page title="Donor Dashboard">{null}</Page>
+      <Page title="Donor Dashboard">
+        <FeedbackSnackbar
+          open={snackbarOpen}
+          onClose={() => setSnackbarOpen(false)}
+          message={snackbarMessage}
+          severity="error"
+        />
+        {isFetching && !isLoading && data ? (
+          <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-end" sx={{ mb: 2 }}>
+            <CircularProgress size={16} />
+            <Typography variant="caption" color="text.secondary">
+              Updating donor insights…
+            </Typography>
+          </Stack>
+        ) : null}
+
+        {isLoading ? (
+          <Grid container spacing={2} data-testid="donor-dashboard-loading">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <Grid
+                key={index}
+                size={{ xs: 12, md: index === 0 ? 12 : 6 }}
+              >
+                <SectionCard title={<Skeleton variant="text" width={180} />}>
+                  <Stack spacing={2}>
+                    <Skeleton variant="rectangular" height={120} />
+                    <Skeleton variant="text" width="60%" />
+                    <Skeleton variant="text" width="40%" />
+                  </Stack>
+                </SectionCard>
+              </Grid>
+            ))}
+          </Grid>
+        ) : isError && !data ? (
+          <Stack spacing={1.5} data-testid="donor-dashboard-error">
+            <Typography variant="body1">{snackbarMessage}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Try refreshing the page or come back later.
+            </Typography>
+          </Stack>
+        ) : data ? (
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12 }}>
+              <SectionCard
+                title={
+                  <Stack
+                    direction={{ xs: 'column', sm: 'row' }}
+                    spacing={0.5}
+                    sx={{ alignItems: { xs: 'flex-start', sm: 'center' } }}
+                  >
+                    <Typography variant="subtitle1" component="span" sx={{ fontWeight: 600 }}>
+                      Year-to-date overview
+                    </Typography>
+                    {windowLabel ? (
+                      <Typography variant="body2" color="text.secondary">
+                        {windowLabel}
+                      </Typography>
+                    ) : null}
+                  </Stack>
+                }
+                icon={<Savings color="primary" />}
+              >
+                <Grid container spacing={2}>
+                  {ytdStats.map(stat => (
+                    <Grid key={stat.label} size={{ xs: 12, md: 4 }}>
+                      {renderStat(stat)}
+                    </Grid>
+                  ))}
+                </Grid>
+              </SectionCard>
+            </Grid>
+
+            <Grid size={{ xs: 12, lg: 8 }}>
+              <SectionCard title="Giving trends" icon={<ShowChart color="primary" />}>
+                {trendData.length ? (
+                  <Box sx={{ height: 320 }}>
+                    <MonetaryDonationTrendChart data={trendData} />
+                  </Box>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    No giving trends to display yet. Record donations to see momentum over time.
+                  </Typography>
+                )}
+              </SectionCard>
+            </Grid>
+
+            <Grid size={{ xs: 12, lg: 4 }}>
+              <SectionCard title="Giving tiers" icon={<Leaderboard color="primary" />}>
+                {hasTierData ? (
+                  <Box sx={{ height: 320 }}>
+                    <MonetaryGivingTierChart data={tierData} />
+                  </Box>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    Tier data will appear once donors start giving this month.
+                  </Typography>
+                )}
+              </SectionCard>
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <SectionCard title="Top donors" icon={<EmojiEvents color="primary" />}>
+                {topDonors.length ? (
+                  <List disablePadding>
+                    {topDonors.map((donor, index) => (
+                      <Fragment key={donor.id}>
+                        <ListItem alignItems="flex-start" sx={{ py: 1.25 }}>
+                          <ListItemText
+                            primary={`${donor.firstName} ${donor.lastName}`.trim() || 'Unnamed donor'}
+                            secondary={
+                              donor.lastDonationISO
+                                ? `Last gift ${formatLocaleDate(donor.lastDonationISO, {
+                                    year: 'numeric',
+                                    month: 'short',
+                                    day: 'numeric',
+                                  })}`
+                                : 'No recent gift on file'
+                            }
+                          />
+                          <Typography variant="subtitle1" component="div">
+                            {currency.format(donor.windowAmount)}
+                          </Typography>
+                        </ListItem>
+                        {index < topDonors.length - 1 ? <Divider component="li" /> : null}
+                      </Fragment>
+                    ))}
+                  </List>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    No top donors for this period yet. Donations will appear here as they come in.
+                  </Typography>
+                )}
+              </SectionCard>
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <SectionCard title="First-time donor highlights" icon={<AutoAwesome color="primary" />}>
+                {firstTimeDonors.length ? (
+                  <List disablePadding>
+                    {firstTimeDonors.map((donor, index) => (
+                      <Fragment key={donor.id}>
+                        <ListItem alignItems="flex-start" sx={{ py: 1.25 }}>
+                          <ListItemText
+                            primary={`${donor.firstName} ${donor.lastName}`.trim() || 'Unnamed donor'}
+                            secondary={`First gift on ${formatLocaleDate(donor.firstDonationISO, {
+                              year: 'numeric',
+                              month: 'short',
+                              day: 'numeric',
+                            })}`}
+                          />
+                          <Typography variant="subtitle1" component="div">
+                            {currency.format(donor.amount)}
+                          </Typography>
+                        </ListItem>
+                        {index < firstTimeDonors.length - 1 ? <Divider component="li" /> : null}
+                      </Fragment>
+                    ))}
+                  </List>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    We’ll highlight first-time donors once new supporters give during this window.
+                  </Typography>
+                )}
+              </SectionCard>
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6, lg: 4 }}>
+              <SectionCard title="Pantry impact" icon={<VolunteerActivism color="primary" />}>
+                {hasPantryImpact ? (
+                  <Stack spacing={2}>
+                    <Stack direction="row" spacing={2} flexWrap="wrap">
+                      <Stack spacing={0.25}>
+                        <Typography variant="body2" color="text.secondary">
+                          Families supported
+                        </Typography>
+                        <Typography variant="h6">{pantryImpact.families.toLocaleString('en-CA')}</Typography>
+                      </Stack>
+                      <Stack spacing={0.25}>
+                        <Typography variant="body2" color="text.secondary">
+                          Adults reached
+                        </Typography>
+                        <Typography variant="h6">{pantryImpact.adults.toLocaleString('en-CA')}</Typography>
+                      </Stack>
+                    </Stack>
+                    <Stack direction="row" spacing={2} flexWrap="wrap">
+                      <Stack spacing={0.25}>
+                        <Typography variant="body2" color="text.secondary">
+                          Children supported
+                        </Typography>
+                        <Typography variant="h6">{pantryImpact.children.toLocaleString('en-CA')}</Typography>
+                      </Stack>
+                      <Stack spacing={0.25}>
+                        <Typography variant="body2" color="text.secondary">
+                          Pounds of food
+                        </Typography>
+                        <Typography variant="h6">{pantryImpact.pounds.toLocaleString('en-CA')} lbs</Typography>
+                      </Stack>
+                    </Stack>
+                  </Stack>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    Pantry impact metrics will populate once donations fund pantry programs.
+                  </Typography>
+                )}
+              </SectionCard>
+            </Grid>
+          </Grid>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            Donor insights are not available yet. Check back after donations are recorded.
+          </Typography>
+        )}
+      </Page>
     </>
   );
 }

--- a/MJ_FB_Frontend/src/pages/donor-management/__tests__/DonorDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/pages/donor-management/__tests__/DonorDashboard.test.tsx
@@ -1,0 +1,225 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DonorDashboard from '../DonorDashboard';
+import useMonetaryDonorInsights from '../../../hooks/useMonetaryDonorInsights';
+
+jest.mock('../../../hooks/useMonetaryDonorInsights');
+
+jest.mock('../../../components/dashboard/MonetaryDonationTrendChart', () => ({
+  __esModule: true,
+  default: ({ data }: { data: unknown }) => (
+    <div data-testid="mock-donation-trend">{JSON.stringify(data)}</div>
+  ),
+}));
+
+jest.mock('../../../components/dashboard/MonetaryGivingTierChart', () => ({
+  __esModule: true,
+  default: ({ data }: { data: unknown }) => (
+    <div data-testid="mock-giving-tier">{JSON.stringify(data)}</div>
+  ),
+}));
+
+const mockUseMonetaryDonorInsights = useMonetaryDonorInsights as jest.MockedFunction<
+  typeof useMonetaryDonorInsights
+>;
+
+describe('DonorDashboard', () => {
+  const fullData = {
+    window: { startMonth: '2024-01', endMonth: '2024-03', months: 3 },
+    monthly: [
+      { month: '2024-01', totalAmount: 1200, donationCount: 6, donorCount: 4, averageGift: 200 },
+      { month: '2024-02', totalAmount: 1500, donationCount: 8, donorCount: 5, averageGift: 187.5 },
+    ],
+    ytd: {
+      totalAmount: 4200,
+      donationCount: 20,
+      donorCount: 12,
+      averageGift: 210,
+      averageDonationsPerDonor: 1.7,
+      lastDonationISO: '2024-03-18T00:00:00Z',
+    },
+    topDonors: [
+      {
+        id: 1,
+        firstName: 'Alex',
+        lastName: 'Morgan',
+        email: 'alex@example.com',
+        windowAmount: 2500,
+        lifetimeAmount: 7200,
+        lastDonationISO: '2024-03-10T00:00:00Z',
+      },
+    ],
+    givingTiers: {
+      currentMonth: {
+        month: '2024-03',
+        tiers: {
+          '1-100': { donorCount: 4, totalAmount: 250 },
+          '101-500': { donorCount: 3, totalAmount: 900 },
+          '501-1000': { donorCount: 1, totalAmount: 650 },
+          '1001-10000': { donorCount: 0, totalAmount: 0 },
+          '10001-30000': { donorCount: 0, totalAmount: 0 },
+        },
+      },
+      previousMonth: {
+        month: '2024-02',
+        tiers: {
+          '1-100': { donorCount: 2, totalAmount: 150 },
+          '101-500': { donorCount: 2, totalAmount: 600 },
+          '501-1000': { donorCount: 1, totalAmount: 700 },
+          '1001-10000': { donorCount: 0, totalAmount: 0 },
+          '10001-30000': { donorCount: 0, totalAmount: 0 },
+        },
+      },
+    },
+    firstTimeDonors: [
+      {
+        id: 2,
+        firstName: 'Jamie',
+        lastName: 'Lee',
+        email: null,
+        firstDonationISO: '2024-03-05T00:00:00Z',
+        amount: 300,
+      },
+    ],
+    pantryImpact: {
+      families: 85,
+      adults: 210,
+      children: 140,
+      pounds: 3250,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders donor insights when data loads', () => {
+    mockUseMonetaryDonorInsights.mockReturnValue({
+      data: fullData,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/donor-management']}>
+        <DonorDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Year-to-date overview')).toBeInTheDocument();
+    expect(screen.getByText('$4,200.00')).toBeInTheDocument();
+    expect(screen.getByText('Donations recorded')).toBeInTheDocument();
+    expect(screen.getByText('Alex Morgan')).toBeInTheDocument();
+    expect(screen.getByText('$2,500.00')).toBeInTheDocument();
+    expect(screen.getByText(/First gift on/)).toHaveTextContent('Mar');
+    expect(screen.getByText('Families supported')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-donation-trend')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-giving-tier')).toBeInTheDocument();
+  });
+
+  it('shows loading skeletons while insights load', () => {
+    mockUseMonetaryDonorInsights.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/donor-management']}>
+        <DonorDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('donor-dashboard-loading')).toBeInTheDocument();
+  });
+
+  it('shows empty states when datasets are empty', () => {
+    mockUseMonetaryDonorInsights.mockReturnValue({
+      data: {
+        ...fullData,
+        monthly: [],
+        topDonors: [],
+        firstTimeDonors: [],
+        givingTiers: {
+          currentMonth: {
+            month: '2024-03',
+            tiers: {
+              '1-100': { donorCount: 0, totalAmount: 0 },
+              '101-500': { donorCount: 0, totalAmount: 0 },
+              '501-1000': { donorCount: 0, totalAmount: 0 },
+              '1001-10000': { donorCount: 0, totalAmount: 0 },
+              '10001-30000': { donorCount: 0, totalAmount: 0 },
+            },
+          },
+          previousMonth: {
+            month: '2024-02',
+            tiers: {
+              '1-100': { donorCount: 0, totalAmount: 0 },
+              '101-500': { donorCount: 0, totalAmount: 0 },
+              '501-1000': { donorCount: 0, totalAmount: 0 },
+              '1001-10000': { donorCount: 0, totalAmount: 0 },
+              '10001-30000': { donorCount: 0, totalAmount: 0 },
+            },
+          },
+        },
+        pantryImpact: { families: 0, adults: 0, children: 0, pounds: 0 },
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/donor-management']}>
+        <DonorDashboard />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText('No giving trends to display yet. Record donations to see momentum over time.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Tier data will appear once donors start giving this month.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('No top donors for this period yet. Donations will appear here as they come in.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('We’ll highlight first-time donors once new supporters give during this window.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Pantry impact metrics will populate once donations fund pantry programs.'),
+    ).toBeInTheDocument();
+  });
+
+  it('displays access error messaging for forbidden responses', async () => {
+    mockUseMonetaryDonorInsights.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: Object.assign(new Error('Forbidden'), { status: 403 }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/donor-management']}>
+        <DonorDashboard />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          'You do not have access to donor insights. Ask an administrator to grant donor management access.',
+        ),
+      ).not.toHaveLength(0);
+    });
+    expect(screen.getByTestId('donor-dashboard-error')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement the donor dashboard layout with insight cards, charts, loading states, and error handling
- update donor quick links with a dashboard entry and improved active-state detection
- add Jest coverage for the donor dashboard view and quick links behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d04207f674832d9bef354f2e4dfbf6