### PR TITLE
Filter volunteer cancellations to today

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
@@ -192,6 +192,50 @@ describe('StaffDashboard', () => {
     });
   });
 
+  it("shows only today's volunteer shift changes", async () => {
+    const today = formatReginaDate(new Date());
+    const tomorrow = formatReginaDate(
+      new Date(Date.now() + 24 * 60 * 60 * 1000),
+    );
+    (getBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerBookings as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        status: 'cancelled',
+        date: today,
+        start_time: '09:00:00',
+        volunteer_name: 'Charlie',
+      },
+      {
+        id: 2,
+        status: 'cancelled',
+        date: tomorrow,
+        start_time: '10:00:00',
+        volunteer_name: 'Dana',
+      },
+    ]);
+    (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
+    (getEvents as jest.Mock).mockResolvedValue({
+      today: [],
+      upcoming: [],
+      past: [],
+    });
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <Dashboard role="staff" />
+        </MemoryRouter>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Volunteer Shift Changes')).toBeInTheDocument();
+      expect(screen.getByText(/Charlie/)).toBeInTheDocument();
+      expect(screen.queryByText(/Dana/)).toBeNull();
+    });
+  });
+
   it('omits future months from visit charts', async () => {
     (getBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerBookings as jest.Mock).mockResolvedValue([]);

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -134,6 +134,9 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
   const todayStr = formatReginaDate(new Date());
   const cancellations = bookings.filter(b => b.status === 'cancelled');
   const volCancellations = volBookings.filter(b => b.status === 'cancelled');
+  const todaysVolunteerCancellations = volCancellations.filter(
+    b => formatReginaDate(toDate(b.date)) === todayStr,
+  );
   const stats = {
     appointments: bookings.filter(
       b =>
@@ -145,9 +148,7 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
       cancellations.filter(
         b => formatReginaDate(toDate(b.date)) === todayStr,
       ).length +
-      volCancellations.filter(
-        b => formatReginaDate(toDate(b.date)) === todayStr,
-      ).length,
+      todaysVolunteerCancellations.length,
   };
 
   return (
@@ -265,7 +266,7 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
       </SectionCard>
       <SectionCard title="Volunteer Shift Changes" sx={{ order: 4 }}>
         <List>
-          {volCancellations.slice(0, 5).map(c => (
+          {todaysVolunteerCancellations.slice(0, 5).map(c => (
             <ListItem key={c.id}>
               <ListItemText
                 primary={`${c.volunteer_name || 'Unknown'} - ${formatTime(


### PR DESCRIPTION
## Summary
- filter volunteer cancellation list to only include shifts scheduled for today
- reuse the filtered list when calculating dashboard cancellation totals
- add a unit test ensuring only today's volunteer cancellations render

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d064a5bafc832d803ba013d2667489