### PR TITLE
Remove client cancellations card from staff dashboard

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/StaffDashboard.test.tsx
@@ -5,7 +5,6 @@ import { getBookings } from '../api/bookings';
 import { getEvents } from '../api/events';
 import { getPantryMonthly } from '../api/pantryAggregations';
 import { getVolunteerBookings, getVolunteerRoles } from '../api/volunteers';
-import { formatReginaDate } from '../utils/time';
 import type { VisitStat } from '../api/clientVisits';
 
 const mockVisitTrendChart = jest.fn();
@@ -148,28 +147,28 @@ describe('StaffDashboard', () => {
     });
   });
 
-  it('shows only today\'s cancellations', async () => {
-    const today = formatReginaDate(new Date());
-    const yesterday = formatReginaDate(
-      new Date(Date.now() - 24 * 60 * 60 * 1000),
-    );
-    (getBookings as jest.Mock).mockResolvedValue([
+  it('shows volunteer shift cancellations', async () => {
+    (getBookings as jest.Mock).mockResolvedValue([]);
+    (getVolunteerBookings as jest.Mock).mockResolvedValue([
       {
         id: 1,
         status: 'cancelled',
-        date: today,
         start_time: '09:00:00',
-        user_name: 'Alice',
+        volunteer_name: 'Alice',
       },
       {
         id: 2,
-        status: 'cancelled',
-        date: yesterday,
+        status: 'approved',
         start_time: '10:00:00',
-        user_name: 'Bob',
+        volunteer_name: 'Bob',
+      },
+      {
+        id: 3,
+        status: 'cancelled',
+        start_time: '11:00:00',
+        volunteer_name: 'Charlie',
       },
     ]);
-    (getVolunteerBookings as jest.Mock).mockResolvedValue([]);
     (getVolunteerRoles as jest.Mock).mockResolvedValue([]);
     (getEvents as jest.Mock).mockResolvedValue({
       today: [],
@@ -186,8 +185,11 @@ describe('StaffDashboard', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Recent Cancellations')).toBeInTheDocument();
+      expect(
+        screen.getByText('Volunteer Shift Changes'),
+      ).toBeInTheDocument();
       expect(screen.getByText(/Alice/)).toBeInTheDocument();
+      expect(screen.getByText(/Charlie/)).toBeInTheDocument();
       expect(screen.queryByText(/Bob/)).toBeNull();
     });
   });

--- a/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/Dashboard.tsx
@@ -12,7 +12,6 @@ import {
 } from '@mui/material';
 import CalendarToday from '@mui/icons-material/CalendarToday';
 import People from '@mui/icons-material/People';
-import CancelIcon from '@mui/icons-material/Cancel';
 import EventAvailable from '@mui/icons-material/EventAvailable';
 import Announcement from '@mui/icons-material/Announcement';
 import { getBookings, getSlotsRange } from '../../api/bookings';
@@ -132,7 +131,6 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
   }, []);
 
   const todayStr = formatReginaDate(new Date());
-  const cancellations = bookings.filter(b => b.status === 'cancelled');
   const volCancellations = volBookings.filter(b => b.status === 'cancelled');
   const stats = {
     appointments: bookings.filter(
@@ -141,13 +139,6 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
         formatReginaDate(toDate(b.date)) === todayStr,
     ).length,
     volunteers: volunteerCount,
-    cancellations:
-      cancellations.filter(
-        b => formatReginaDate(toDate(b.date)) === todayStr,
-      ).length +
-      volCancellations.filter(
-        b => formatReginaDate(toDate(b.date)) === todayStr,
-      ).length,
   };
 
   return (
@@ -180,15 +171,8 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
           <Grid size={{ xs: 12, md: 4 }}>
             <Stat
               icon={<People color="primary" />}
-              label="Volunteers Scheduled"
+              label="Volunteer Shifts Filled"
               value={stats.volunteers}
-            />
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Stat
-              icon={<CancelIcon color="error" />}
-              label="Cancellations"
-              value={stats.cancellations}
             />
           </Grid>
         </Grid>
@@ -247,23 +231,7 @@ function StaffDashboard({ masterRoleFilter }: { masterRoleFilter?: string[] }) {
           </Stack>
         </Stack>
       </SectionCard>
-      <SectionCard title="Recent Cancellations" sx={{ order: 3 }}>
-        <List>
-          {cancellations
-            .filter(c => formatReginaDate(toDate(c.date)) === todayStr)
-            .slice(0, 5)
-            .map(c => (
-              <ListItem key={c.id}>
-                <ListItemText
-                  primary={`${c.user_name || 'Unknown'} - ${formatTime(
-                    c.start_time || '',
-                  )}`}
-                />
-              </ListItem>
-            ))}
-        </List>
-      </SectionCard>
-      <SectionCard title="Volunteer Shift Changes" sx={{ order: 4 }}>
+      <SectionCard title="Volunteer Shift Changes" sx={{ order: 3 }}>
         <List>
           {volCancellations.slice(0, 5).map(c => (
             <ListItem key={c.id}>


### PR DESCRIPTION
## Summary
- remove the staff dashboard "Recent Cancellations" card and related client cancellation calculations
- rename the remaining volunteer stat label to clarify it reflects filled shifts
- update the StaffDashboard test to cover the volunteer shift change list instead of the removed card

## Testing
- npm test -- --runTestsByPath src/__tests__/StaffDashboard.test.tsx
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d064ac36c8832d97b8090d8a203813