### PR TITLE
Guard volunteer availability updates during unmount

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerDashboard.tsx
@@ -191,6 +191,8 @@ export default function VolunteerDashboard() {
   }, []);
 
   useEffect(() => {
+    let active = true;
+    let loadingActive = true;
     async function loadAvailability() {
       startLoading();
       try {
@@ -206,6 +208,7 @@ export default function VolunteerDashboard() {
         const requests = days.map(day =>
           getVolunteerRolesForVolunteer(formatRegina(day, 'yyyy-MM-dd')).catch(
             () => {
+              if (!active) return [];
               setSnackbarSeverity('error');
               setMessage('Failed to load availability');
               return [];
@@ -213,12 +216,23 @@ export default function VolunteerDashboard() {
           ),
         );
         const results = await Promise.all(requests);
+        if (!active) return;
         setAvailability(results.flat());
       } finally {
-        stopLoading();
+        if (loadingActive) {
+          stopLoading();
+          loadingActive = false;
+        }
       }
     }
     loadAvailability();
+    return () => {
+      active = false;
+      if (loadingActive) {
+        stopLoading();
+        loadingActive = false;
+      }
+    };
   }, [dateMode]);
 
   const nextShift = useMemo(() => {


### PR DESCRIPTION
## Summary
- prevent the volunteer availability effect from updating state after unmount by tracking an active flag
- ensure the effect's cleanup balances the loading counter when it exits early

## Testing
- npm test -- --watch=false *(fails: existing StaffDashboard.test.tsx transform error)*

------
https://chatgpt.com/codex/tasks/task_e_68d07bf9e120832d8fd717b3a00b13f0