### PR TITLE
Add unit tests for normalizeEmail utility

### DIFF
--- a/MJ_FB_Backend/tests/utils/normalizeEmail.test.ts
+++ b/MJ_FB_Backend/tests/utils/normalizeEmail.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+import { normalizeEmail } from '../../src/utils/normalizeEmail';
+
+describe('utils/normalizeEmail', () => {
+  it('trims surrounding whitespace and lowercases email addresses', () => {
+    expect(normalizeEmail('  Foo.Bar@Example.COM  ')).toBe('foo.bar@example.com');
+    expect(normalizeEmail('\nMixEd@Domain.Ca\t')).toBe('mixed@domain.ca');
+  });
+
+  it('returns undefined for empty or whitespace-only strings', () => {
+    expect(normalizeEmail('')).toBeUndefined();
+    expect(normalizeEmail('    ')).toBeUndefined();
+  });
+
+  it('returns undefined for non-string values', () => {
+    expect(normalizeEmail(42)).toBeUndefined();
+    expect(normalizeEmail({ email: 'user@example.com' })).toBeUndefined();
+    expect(normalizeEmail(null)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add focused Jest coverage for normalizeEmail utility covering trimming, casing, and invalid inputs

## Testing
- npm test tests/utils/normalizeEmail.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d07cdd4b1c832d8c8272746696e099