### PR TITLE
Fix volunteer schedule small screen test

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerSchedule.test.tsx
@@ -265,15 +265,27 @@ describe("VolunteerSchedule", () => {
       },
     ]);
 
+    jest.setSystemTime(new Date("2024-01-29T14:00:00Z"));
     useMediaQueryMock.mockReturnValue(true);
-    renderWithProviders(<VolunteerSchedule />);
 
-    fireEvent.mouseDown(screen.getByLabelText('Department'));
-    fireEvent.click(await screen.findByText('Front'));
+    try {
+      renderWithProviders(<VolunteerSchedule />);
 
-    expect(await screen.findByText(/No bookings\.?/)).toBeInTheDocument();
-    expect(screen.queryByRole("table")).toBeNull();
-    useMediaQueryMock.mockImplementation(actualUseMediaQuery);
+      fireEvent.mouseDown(screen.getByLabelText("Department"));
+      fireEvent.click(await screen.findByText("Front"));
+
+      fireEvent.click(await screen.findByRole("button", { name: "Today" }));
+
+      expect(
+        await screen.findByRole("heading", { name: "Greeter" }),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("9:00 AM - 12:00 PM"),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("table")).toBeNull();
+    } finally {
+      useMediaQueryMock.mockImplementation(actualUseMediaQuery);
+    }
   });
 
   it('books a slot via cell click', async () => {


### PR DESCRIPTION
## Summary
- update the small-screen volunteer schedule test to simulate a time before the shift begins so cards render
- assert the role heading and card times render while the table layout stays hidden
- keep the media query mock scoped to the test and restore the real implementation afterward

## Testing
- npm test -- VolunteerSchedule.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d07cccfa38832db821a53e0b8dd9ca