### PR TITLE
Validate timesheet query params

### DIFF
--- a/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
+++ b/MJ_FB_Backend/tests/timesheets/timesheetController.test.ts
@@ -45,6 +45,21 @@ describe('timesheet controller', () => {
     expect(res.json).toHaveBeenCalledWith([{ id: 3 }]);
   });
 
+  it('responds with 400 for invalid query parameters', async () => {
+    (mockPool.query as jest.Mock).mockClear();
+    const req: any = {
+      user: { id: '99', role: 'admin', type: 'staff' },
+      query: { staffId: 'abc' },
+    };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await listTimesheets(req, res, () => {});
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid query parameters' });
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
   it('filters timesheets by overlapping month', async () => {
     (mockPool.query as jest.Mock).mockClear();
     (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ id: 4 }], rowCount: 1 });


### PR DESCRIPTION
## Summary
- ensure timesheet list endpoint rejects non-integer staffId, year, and month query values
- cover the invalid query scenario with a controller test that expects a 400 response

## Testing
- npm test tests/timesheets/timesheetController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d07fe66cf4832da2a9c50366cd70f3