### PR TITLE
Validate numeric client IDs for password reset

### DIFF
--- a/MJ_FB_Backend/src/controllers/authController.ts
+++ b/MJ_FB_Backend/src/controllers/authController.ts
@@ -54,9 +54,11 @@ function normalizeIdentifiers({ email, clientId }: IdentifierPayload) {
   if (typeof rawClientId === 'number' && Number.isFinite(rawClientId)) {
     normalizedClientId = rawClientId;
   } else if (typeof rawClientId === 'string' && rawClientId !== '') {
-    const parsed = Number.parseInt(rawClientId, 10);
-    if (!Number.isNaN(parsed)) {
-      normalizedClientId = parsed;
+    if (/^\d+$/.test(rawClientId)) {
+      const parsed = Number.parseInt(rawClientId, 10);
+      if (!Number.isNaN(parsed)) {
+        normalizedClientId = parsed;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure auth controller only normalizes client IDs when the provided value is entirely numeric
- add password reset flow regression coverage asserting alphanumeric client IDs are ignored and reset rate limiting between tests

## Testing
- npm test tests/passwordResetFlow.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d07fd9b340832db5bd2372d5418ec6