### PR TITLE
Add failure scenario test for delivery completion

### DIFF
--- a/MJ_FB_Frontend/tests/DeliveriesPage.test.tsx
+++ b/MJ_FB_Frontend/tests/DeliveriesPage.test.tsx
@@ -97,4 +97,36 @@ describe('Pantry Deliveries page', () => {
     expect(await screen.findByText('Delivery marked completed.')).toBeInTheDocument();
     expect(screen.getByText(/Client 5678/)).toBeInTheDocument();
   });
+
+  it('shows an error and keeps the order when marking completion fails', async () => {
+    mockedMarkCompleted.mockRejectedValue({});
+    const user = userEvent.setup();
+
+    try {
+      render(
+        <MemoryRouter>
+          <Deliveries />
+        </MemoryRouter>,
+      );
+
+      const buttons = await screen.findAllByRole('button', { name: /mark completed/i });
+      await user.click(buttons[0]);
+
+      expect(mockedMarkCompleted).toHaveBeenCalledWith(101);
+
+      expect(screen.getByText(/Client 1234 · Jane Doe/)).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(buttons[0]).toBeEnabled();
+      });
+
+      expect(
+        await screen.findByText(
+          'We could not mark this delivery as completed. Please try again.',
+        ),
+      ).toBeInTheDocument();
+    } finally {
+      mockedMarkCompleted.mockReset();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add a regression test for marking delivery orders completed when the API rejects
- ensure the error case keeps the order visible, clears the loading state, and shows the fallback snackbar message

## Testing
- npm test -- DeliveriesPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d080c4ca28832d9ab90f67e9b5852f