### PR TITLE
Update delivery selection copy to match limit behavior

### DIFF
--- a/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/delivery/BookDelivery.tsx
@@ -401,7 +401,7 @@ export default function BookDelivery() {
               const remaining = remainingSelections(category);
               const selectedId = category.items.find(item => selectedItems[item.id])?.id;
               const title = Number.isFinite(limit)
-                ? `${category.name} (Select ${limit})`
+                ? `${category.name} (Select up to ${limit})`
                 : category.name;
               return (
                 <Card key={category.id}>
@@ -414,7 +414,7 @@ export default function BookDelivery() {
                     )}
                     {Number.isFinite(limit) && (
                       <Typography color="error" sx={{ mb: 2 }}>
-                        {`Select exactly ${limit} ${limit === 1 ? 'choice' : 'choices'}.`}
+                        {`Select up to ${limit} ${limit === 1 ? 'choice' : 'choices'}.`}
                       </Typography>
                     )}
                     {limit === 1 ? (

--- a/MJ_FB_Frontend/tests/BookDeliveryPage.test.tsx
+++ b/MJ_FB_Frontend/tests/BookDeliveryPage.test.tsx
@@ -86,9 +86,13 @@ describe('BookDelivery page', () => {
       </MemoryRouter>,
     );
 
-    const categoryTitle = await screen.findByText('Fresh $tart (Select 2)');
+    const categoryTitle = await screen.findByText('Fresh $tart (Select up to 2)');
     expect(categoryTitle).toBeInTheDocument();
     const dollarMatches = categoryTitle.textContent?.match(/\$/g) ?? [];
     expect(dollarMatches).toHaveLength(1);
+
+    expect(
+      screen.getByText('Select up to 2 choices.'),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- update delivery category card headers and helper copy to explain customers can select up to the configured limit
- adjust BookDelivery page test to cover new wording while retaining dollar sign check

## Testing
- npm test -- --runTestsByPath tests/BookDeliveryPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d081282bec832d8504f355cf5b27fe