### PR TITLE
Unify password setup redirect

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PasswordSetup.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PasswordSetup.test.tsx
@@ -146,7 +146,7 @@ describe('PasswordSetup', () => {
     expect(await screen.findByText(/staff@example.com/)).toBeInTheDocument();
   });
 
-  it('shows role-specific login button', async () => {
+  it('shows login button', async () => {
     (getPasswordSetupInfo as jest.Mock).mockResolvedValue({ userType: 'volunteer' });
     render(
       <MemoryRouter initialEntries={["/set-password?token=tok"]}>
@@ -159,7 +159,7 @@ describe('PasswordSetup', () => {
     await waitFor(() =>
       expect(
         screen.getByRole('link', { name: /back to login/i }),
-      ).toHaveAttribute('href', '/login/volunteer'),
+      ).toHaveAttribute('href', '/login'),
     );
   });
 });

--- a/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/PasswordSetup.tsx
@@ -23,12 +23,6 @@ export default function PasswordSetup() {
   const [tokenInvalid, setTokenInvalid] = useState(false);
   const navigate = useNavigate();
 
-  const loginPathMap: Record<PasswordSetupInfo['userType'], string> = {
-    client: '/login',
-    volunteer: '/login/volunteer',
-    staff: '/login/staff',
-  };
-
   useEffect(() => {
     if (!token) {
       setError('Invalid or expired token.');
@@ -63,8 +57,8 @@ export default function PasswordSetup() {
       return;
     }
     try {
-      const loginPath = await setPasswordApi(token, password);
-      navigate(loginPath);
+      await setPasswordApi(token, password);
+      navigate('/login');
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       setError(msg);
@@ -121,11 +115,7 @@ export default function PasswordSetup() {
               helperText="Must be at least 8 characters and include uppercase, lowercase, and special characters."
             />
             <PasswordChecklist password={password} />
-            <Button
-              component={RouterLink}
-              to={info ? loginPathMap[info.userType] : '/login'}
-              variant="outlined"
-            >
+            <Button component={RouterLink} to="/login" variant="outlined">
               Back to login
             </Button>
           </>


### PR DESCRIPTION
## Summary
- remove role-based login mapping from the password setup page and always route to /login after success
- update the password setup back-to-login button and related test expectation to the unified login path

## Testing
- npm test -- --runTestsByPath src/__tests__/PasswordSetup.test.tsx src/pages/auth/__tests__/PasswordSetup.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d0811c57b8832d961ce5c674dae1d8