### PR TITLE
Add record delivery route for pantry staff

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -133,6 +133,9 @@ const DeliveryDashboard = React.lazy(
 const PantryDeliveries = React.lazy(
   () => import('./pages/pantry/Deliveries')
 );
+const RecordDelivery = React.lazy(
+  () => import('./pages/pantry/RecordDelivery')
+);
 
 const Spinner = () => <CircularProgress />;
 
@@ -247,6 +250,9 @@ export default function App() {
                   )}
                   {showStaff && (
                     <Route path="/pantry/deliveries" element={<PantryDeliveries />} />
+                  )}
+                  {showStaff && (
+                    <Route path="/pantry/deliveries/record" element={<RecordDelivery />} />
                   )}
                   {showStaff && (
                     <Route path="/pantry/visits" element={<PantryVisits />} />

--- a/MJ_FB_Frontend/src/pages/pantry/RecordDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/pantry/RecordDelivery.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Stack,
+  TextField,
+  Typography,
+  Button,
+} from '@mui/material';
+import { LoadingButton } from '@mui/lab';
+import { Link as RouterLink } from 'react-router-dom';
+import Page from '../../components/Page';
+import PantryQuickLinks from '../../components/PantryQuickLinks';
+import FeedbackSnackbar from '../../components/FeedbackSnackbar';
+import { getApiErrorMessage } from '../../api/client';
+import { markDeliveryOrderCompleted } from '../../api/deliveryOrders';
+
+type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+};
+
+export default function RecordDelivery() {
+  const [orderId, setOrderId] = useState('');
+  const [inputError, setInputError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  const handleSnackbarClose = () => {
+    setSnackbar(prev => ({ ...prev, open: false }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setInputError('');
+
+    const trimmed = orderId.trim();
+    if (!trimmed) {
+      setInputError('Enter the delivery order number.');
+      return;
+    }
+
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      setInputError('Delivery order numbers must be whole numbers.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await markDeliveryOrderCompleted(parsed);
+      setSnackbar({
+        open: true,
+        message: `Delivery order #${parsed} recorded as completed.`,
+        severity: 'success',
+      });
+      setOrderId('');
+    } catch (err) {
+      const message = getApiErrorMessage(
+        err,
+        'We could not record this delivery. Please try again.',
+      );
+      setSnackbar({ open: true, message, severity: 'error' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Page title="Record Delivery" header={<PantryQuickLinks />}>
+      <FeedbackSnackbar
+        open={snackbar.open}
+        onClose={handleSnackbarClose}
+        message={snackbar.message}
+        severity={snackbar.severity}
+      />
+
+      <Stack spacing={3} sx={{ maxWidth: 560 }}>
+        <Typography variant="body1" color="text.secondary">
+          Enter a delivery order number to mark the delivery as completed once the
+          groceries are dropped off.
+        </Typography>
+
+        <Card>
+          <CardContent>
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <Stack spacing={2}>
+                <TextField
+                  label="Delivery order #"
+                  value={orderId}
+                  onChange={event => {
+                    setOrderId(event.target.value);
+                    if (inputError) setInputError('');
+                  }}
+                  inputMode="numeric"
+                  error={!!inputError}
+                  helperText={inputError || 'Order numbers are available on the delivery request.'}
+                  disabled={submitting}
+                  autoFocus
+                />
+                <LoadingButton
+                  type="submit"
+                  variant="contained"
+                  loading={submitting}
+                  size="medium"
+                >
+                  Mark delivery completed
+                </LoadingButton>
+              </Stack>
+            </Box>
+          </CardContent>
+        </Card>
+
+        <Button
+          component={RouterLink}
+          to="/pantry/deliveries"
+          variant="text"
+          size="medium"
+          sx={{ alignSelf: 'flex-start' }}
+        >
+          Back to outstanding deliveries
+        </Button>
+      </Stack>
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/tests/PantryRecordDeliveryRoute.test.tsx
+++ b/MJ_FB_Frontend/tests/PantryRecordDeliveryRoute.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import App from '../src/App';
+import { useAuth } from '../src/hooks/useAuth';
+import useMaintenance from '../src/hooks/useMaintenance';
+
+jest.mock('../src/hooks/useAuth', () => ({
+  useAuth: jest.fn(),
+  DonorManagementGuard: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('../src/hooks/useMaintenance', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../src/components/InstallAppButton', () => () => null);
+jest.mock('../src/components/Navbar', () => () => <div />);
+jest.mock('../src/components/layout/MainLayout', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    usePageTitle: jest.fn(),
+    useBreadcrumbActions: jest.fn(),
+  };
+});
+jest.mock('../src/components/MaintenanceBanner', () => ({ children }: { children: React.ReactNode }) => <>{children}</>);
+jest.mock('../src/components/MaintenanceOverlay', () => () => null);
+jest.mock('../src/components/FeedbackSnackbar', () => () => null);
+
+describe('Pantry record delivery route', () => {
+  const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+  const mockedUseMaintenance = useMaintenance as jest.MockedFunction<typeof useMaintenance>;
+
+  beforeEach(() => {
+    mockedUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      role: 'staff',
+      name: 'Pantry Staff',
+      userRole: '',
+      access: ['pantry'],
+      id: 1,
+      login: jest.fn(),
+      logout: jest.fn(),
+      cardUrl: '',
+      ready: true,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    mockedUseMaintenance.mockReturnValue({
+      maintenanceMode: false,
+      notice: undefined,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the record delivery page for pantry staff', async () => {
+    window.history.pushState({}, '', '/pantry/deliveries/record');
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole('heading', { name: /record delivery/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/delivery order/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a pantry Record Delivery page with a completion form that calls the delivery order API
- register the record-delivery route alongside the other pantry routes in the app router
- add a regression test to ensure the new pantry delivery route renders for staff users

## Testing
- npm test -- --runTestsByPath tests/DeliveriesPage.test.tsx tests/PantryRecordDeliveryRoute.test.tsx
- npm test *(fails: existing StaffDashboard.test.tsx parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68d0810d6750832dbff90dd705116e7b