### PR TITLE
Add error handling coverage to deliveries page tests

### DIFF
--- a/MJ_FB_Frontend/tests/DeliveriesPage.test.tsx
+++ b/MJ_FB_Frontend/tests/DeliveriesPage.test.tsx
@@ -57,6 +57,32 @@ describe('Pantry Deliveries page', () => {
     mockedGetOutstanding.mockResolvedValue(mockOrders);
   });
 
+  it('shows an error state when outstanding delivery orders fail to load', async () => {
+    const errorMessage = 'We could not load outstanding delivery orders. Please try again.';
+    mockedGetOutstanding.mockRejectedValueOnce({});
+
+    render(
+      <MemoryRouter>
+        <Deliveries />
+      </MemoryRouter>,
+    );
+
+    expect(mockedGetOutstanding).toHaveBeenCalled();
+
+    expect(await screen.findByText('No deliveries to display')).toBeInTheDocument();
+    expect(
+      screen.getByText('Resolve the issue above and refresh to try again.'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts).toHaveLength(2);
+      alerts.forEach(alert => {
+        expect(alert).toHaveTextContent(errorMessage);
+      });
+    });
+  });
+
   it('renders outstanding delivery orders with contact details and items', async () => {
     render(
       <MemoryRouter>


### PR DESCRIPTION
## Summary
- add a test that covers the outstanding delivery orders fetch error path
- assert the error snackbar, alert message, and empty state copy when the fetch fails

## Testing
- npm test -- --runTestsByPath tests/DeliveriesPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d082bf01d4832dac050dd933b7c66c