### PR TITLE
Add pantry record delivery form

### DIFF
--- a/MJ_FB_Frontend/src/api/deliveryOrders.ts
+++ b/MJ_FB_Frontend/src/api/deliveryOrders.ts
@@ -1,5 +1,31 @@
 import { API_BASE, apiFetch, handleResponse } from './client';
-import type { DeliveryOrder, DeliveryOutstandingOrder } from '../types';
+import type {
+  DeliveryOrder,
+  DeliveryOutstandingOrder,
+  DeliveryOrderStatus,
+} from '../types';
+
+export interface CreateDeliveryOrderPayload {
+  clientId: number;
+  address: string;
+  phone: string;
+  email?: string | null;
+  notes?: string | null;
+  scheduledFor?: string | null;
+  status?: DeliveryOrderStatus;
+  selections?: { itemId: number; quantity: number }[];
+}
+
+export async function createDeliveryOrder(
+  payload: CreateDeliveryOrderPayload,
+): Promise<DeliveryOrder> {
+  const res = await apiFetch(`${API_BASE}/delivery/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<DeliveryOrder>(res);
+}
 
 export async function getOutstandingDeliveryOrders(): Promise<DeliveryOutstandingOrder[]> {
   const res = await apiFetch(`${API_BASE}/delivery/orders/outstanding`);

--- a/MJ_FB_Frontend/src/pages/pantry/RecordDelivery.tsx
+++ b/MJ_FB_Frontend/src/pages/pantry/RecordDelivery.tsx
@@ -14,7 +14,7 @@ import Page from '../../components/Page';
 import PantryQuickLinks from '../../components/PantryQuickLinks';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import { getApiErrorMessage } from '../../api/client';
-import { markDeliveryOrderCompleted } from '../../api/deliveryOrders';
+import { createDeliveryOrder } from '../../api/deliveryOrders';
 
 type SnackbarState = {
   open: boolean;
@@ -22,9 +22,26 @@ type SnackbarState = {
   severity: 'success' | 'error';
 };
 
+type FormErrors = {
+  clientId?: string;
+  address?: string;
+  phone?: string;
+  email?: string;
+  scheduledFor?: string;
+  notes?: string;
+};
+
+const PHONE_REGEX = /^\+?[0-9 ()-]{7,}$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export default function RecordDelivery() {
-  const [orderId, setOrderId] = useState('');
-  const [inputError, setInputError] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [address, setAddress] = useState('');
+  const [phone, setPhone] = useState('');
+  const [email, setEmail] = useState('');
+  const [scheduledFor, setScheduledFor] = useState('');
+  const [notes, setNotes] = useState('');
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
   const [snackbar, setSnackbar] = useState<SnackbarState>({
     open: false,
@@ -38,29 +55,77 @@ export default function RecordDelivery() {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setInputError('');
+    const errors: FormErrors = {};
 
-    const trimmed = orderId.trim();
-    if (!trimmed) {
-      setInputError('Enter the delivery order number.');
+    const trimmedClientId = clientId.trim();
+    const parsedClientId = Number(trimmedClientId);
+    if (!trimmedClientId) {
+      errors.clientId = 'Enter the client ID.';
+    } else if (!Number.isInteger(parsedClientId) || parsedClientId <= 0) {
+      errors.clientId = 'Client IDs must be whole numbers.';
+    }
+
+    const trimmedAddress = address.trim();
+    if (!trimmedAddress) {
+      errors.address = 'Enter the delivery address.';
+    }
+
+    const trimmedPhone = phone.trim();
+    if (!trimmedPhone) {
+      errors.phone = 'Enter the contact phone number.';
+    } else if (!PHONE_REGEX.test(trimmedPhone)) {
+      errors.phone = 'Enter a valid phone number.';
+    }
+
+    const trimmedEmail = email.trim();
+    if (trimmedEmail && !EMAIL_REGEX.test(trimmedEmail)) {
+      errors.email = 'Enter a valid email address.';
+    }
+
+    const trimmedNotes = notes.trim();
+    if (trimmedNotes.length > 1000) {
+      errors.notes = 'Notes must be 1000 characters or less.';
+    }
+
+    let scheduledForIso: string | null = null;
+    if (scheduledFor.trim()) {
+      const parsedDate = new Date(scheduledFor);
+      if (Number.isNaN(parsedDate.getTime())) {
+        errors.scheduledFor = 'Enter a valid delivery date and time.';
+      } else {
+        scheduledForIso = parsedDate.toISOString();
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      setFormErrors(errors);
       return;
     }
 
-    const parsed = Number(trimmed);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      setInputError('Delivery order numbers must be whole numbers.');
-      return;
-    }
-
+    setFormErrors({});
     setSubmitting(true);
     try {
-      await markDeliveryOrderCompleted(parsed);
+      await createDeliveryOrder({
+        clientId: parsedClientId,
+        address: trimmedAddress,
+        phone: trimmedPhone,
+        email: trimmedEmail || null,
+        notes: trimmedNotes || null,
+        scheduledFor: scheduledForIso,
+        status: 'completed',
+        selections: [],
+      });
       setSnackbar({
         open: true,
-        message: `Delivery order #${parsed} recorded as completed.`,
+        message: `Delivery recorded for client ${parsedClientId}.`,
         severity: 'success',
       });
-      setOrderId('');
+      setClientId('');
+      setAddress('');
+      setPhone('');
+      setEmail('');
+      setScheduledFor('');
+      setNotes('');
     } catch (err) {
       const message = getApiErrorMessage(
         err,
@@ -81,10 +146,11 @@ export default function RecordDelivery() {
         severity={snackbar.severity}
       />
 
-      <Stack spacing={3} sx={{ maxWidth: 560 }}>
+      <Stack spacing={3} sx={{ maxWidth: 720 }}>
         <Typography variant="body1" color="text.secondary">
-          Enter a delivery order number to mark the delivery as completed once the
-          groceries are dropped off.
+          Record deliveries made outside the queue by entering the client and contact
+          information. Deliveries submitted here are stored as completed requests in
+          the client history.
         </Typography>
 
         <Card>
@@ -92,17 +158,98 @@ export default function RecordDelivery() {
             <Box component="form" onSubmit={handleSubmit} noValidate>
               <Stack spacing={2}>
                 <TextField
-                  label="Delivery order #"
-                  value={orderId}
+                  label="Client ID"
+                  value={clientId}
                   onChange={event => {
-                    setOrderId(event.target.value);
-                    if (inputError) setInputError('');
+                    setClientId(event.target.value);
+                    if (formErrors.clientId) {
+                      setFormErrors(prev => ({ ...prev, clientId: undefined }));
+                    }
                   }}
                   inputMode="numeric"
-                  error={!!inputError}
-                  helperText={inputError || 'Order numbers are available on the delivery request.'}
+                  error={!!formErrors.clientId}
+                  helperText={formErrors.clientId || 'Enter the numeric client ID.'}
                   disabled={submitting}
                   autoFocus
+                  required
+                />
+                <TextField
+                  label="Delivery address"
+                  value={address}
+                  onChange={event => {
+                    setAddress(event.target.value);
+                    if (formErrors.address) {
+                      setFormErrors(prev => ({ ...prev, address: undefined }));
+                    }
+                  }}
+                  error={!!formErrors.address}
+                  helperText={formErrors.address || 'Include apartment or buzzer details if needed.'}
+                  disabled={submitting}
+                  required
+                  multiline
+                  minRows={2}
+                />
+                <TextField
+                  label="Phone number"
+                  value={phone}
+                  onChange={event => {
+                    setPhone(event.target.value);
+                    if (formErrors.phone) {
+                      setFormErrors(prev => ({ ...prev, phone: undefined }));
+                    }
+                  }}
+                  error={!!formErrors.phone}
+                  helperText={formErrors.phone || 'Use a number the driver can reach day-of.'}
+                  disabled={submitting}
+                  required
+                />
+                <TextField
+                  label="Email"
+                  value={email}
+                  onChange={event => {
+                    setEmail(event.target.value);
+                    if (formErrors.email) {
+                      setFormErrors(prev => ({ ...prev, email: undefined }));
+                    }
+                  }}
+                  error={!!formErrors.email}
+                  helperText={formErrors.email || 'Optional but helps with confirmations.'}
+                  disabled={submitting}
+                />
+                <TextField
+                  label="Scheduled for"
+                  type="datetime-local"
+                  value={scheduledFor}
+                  onChange={event => {
+                    setScheduledFor(event.target.value);
+                    if (formErrors.scheduledFor) {
+                      setFormErrors(prev => ({ ...prev, scheduledFor: undefined }));
+                    }
+                  }}
+                  error={!!formErrors.scheduledFor}
+                  helperText={
+                    formErrors.scheduledFor ||
+                    'Optional — set when the delivery has a confirmed time.'
+                  }
+                  disabled={submitting}
+                  InputLabelProps={{ shrink: true }}
+                />
+                <TextField
+                  label="Notes"
+                  value={notes}
+                  onChange={event => {
+                    setNotes(event.target.value);
+                    if (formErrors.notes) {
+                      setFormErrors(prev => ({ ...prev, notes: undefined }));
+                    }
+                  }}
+                  error={!!formErrors.notes}
+                  helperText={
+                    formErrors.notes || 'Optional — share quick delivery details for the client.'
+                  }
+                  disabled={submitting}
+                  multiline
+                  minRows={3}
                 />
                 <LoadingButton
                   type="submit"
@@ -110,7 +257,7 @@ export default function RecordDelivery() {
                   loading={submitting}
                   size="medium"
                 >
-                  Mark delivery completed
+                  Record delivery
                 </LoadingButton>
               </Stack>
             </Box>

--- a/MJ_FB_Frontend/tests/PantryRecordDeliveryRoute.test.tsx
+++ b/MJ_FB_Frontend/tests/PantryRecordDeliveryRoute.test.tsx
@@ -66,6 +66,7 @@ describe('Pantry record delivery route', () => {
     expect(
       await screen.findByRole('heading', { name: /record delivery/i }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(/delivery order/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/client id/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/delivery address/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add a delivery order creation helper that posts to the delivery order API
- build a pantry Record Delivery form that captures client details and records completed deliveries
- update the pantry route regression test to assert the new form renders

## Testing
- `npm test` *(fails: StaffDashboard.test.tsx swc parse error; ManageBookingDialog.test.tsx cannot spy on getSlots)*

------
https://chatgpt.com/codex/tasks/task_e_68d082cdfe54832da2d947f86a87688b