### PR TITLE
Add critical backend test script

### DIFF
--- a/MJ_FB_Backend/package.json
+++ b/MJ_FB_Backend/package.json
@@ -61,6 +61,7 @@
     "start": "node dist/server.js",
     "pretest": "node -e \"if (!process.version.startsWith('v22')) { console.error('Node v22 is required'); process.exit(1); }\"",
     "test": "jest",
+    "test:critical": "jest tests/bookingController.test.ts tests/bookingCancelByToken.test.ts tests/bookingRescheduleEmail.test.ts tests/volunteerBooking.test.ts tests/volunteerReschedule.test.ts tests/bookingHistoryVisits.test.ts tests/slots.test.ts tests/clientVisitController.test.ts tests/outgoingDonationController.test.ts",
     "migrate": "tsx src/runMigrations.ts",
     "migration:create": "node-pg-migrate create -m src/migrations -j ts",
     "seed:delivery": "tsx --env-file=.env src/utils/deliverySeeder.ts",

--- a/README.md
+++ b/README.md
@@ -185,7 +185,11 @@ All schema changes must be implemented via migrations in `MJ_FB_Backend/src/migr
 ```bash
 npm run test:backend   # backend tests
 npm run test:frontend  # frontend tests
+npm run test:critical  # priority backend booking and volunteer flow tests
 ```
+
+- Use `npm run test:critical` to run the focused backend suite covering booking creation, cancellations, rescheduling, history,
+  slot availability, volunteer scheduling, and outgoing donation flows.
 
 - Update `AGENTS.md` with new repository instructions.
 - Reflect user-facing or setup changes in this `README.md`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "test:backend": "npm --prefix MJ_FB_Backend test",
     "test:frontend": "npm --prefix MJ_FB_Frontend test",
+    "test:critical": "npm --prefix MJ_FB_Backend run test:critical",
     "build": "npm --prefix MJ_FB_Backend run build && npm --prefix MJ_FB_Frontend run build"
   }
 }


### PR DESCRIPTION
## Summary
- add a root npm script to launch the backend critical test suite
- define a backend `test:critical` script to execute the priority Jest specs
- document how to run the focused test suite in the contribution guidelines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d083af7e3c832d8a1043edaec439c3