### PR TITLE
docs: document Lightsail deployment workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 - Telegram alerts are sent when clients or volunteers create, cancel, or reschedule bookings.
 - Stale email queue entries older than `EMAIL_QUEUE_MAX_AGE_DAYS` are purged nightly and the job logs the queue size, warning when it exceeds `EMAIL_QUEUE_WARNING_SIZE`.
 - Maintain database health: set database-level autovacuum thresholds, schedule manual `VACUUM ANALYZE` during low-traffic windows, plan quarterly `REINDEX` or `pg_repack` runs for heavily updated tables, and monitor table bloat metrics. Record these tasks in ops docs.
-- Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to Azure".
+- Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to AWS Lightsail".
 - Always document new environment variables in the repository README and `.env.example` files.
 - Implement all database schema changes via migrations in `MJ_FB_Backend/src/migrations`; do not modify `src/setupDatabase.ts` for schema updates.
 - Volunteers sign in with their email address instead of a username, and volunteer emails must be unique (email remains optional).


### PR DESCRIPTION
## Summary
- replace the README deployment instructions with the Lightsail workflow used in ops runbooks
- include post-deploy verification steps that match the AWS environment
- update the root AGENTS.md guidance to reference the new Lightsail section

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d086778b78832da9a1d1fc88c05f7e