### PR TITLE
docs: update lightsail deployment workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 - Telegram alerts are sent when clients or volunteers create, cancel, or reschedule bookings.
 - Stale email queue entries older than `EMAIL_QUEUE_MAX_AGE_DAYS` are purged nightly and the job logs the queue size, warning when it exceeds `EMAIL_QUEUE_WARNING_SIZE`.
 - Maintain database health: set database-level autovacuum thresholds, schedule manual `VACUUM ANALYZE` during low-traffic windows, plan quarterly `REINDEX` or `pg_repack` runs for heavily updated tables, and monitor table bloat metrics. Record these tasks in ops docs.
-- Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to AWS Lightsail".
+- Deployments are performed manually; follow the steps in the repository `README.md` under "Deploying to AWS Lightsail" and complete the post-deploy verification checklist in that section.
 - Always document new environment variables in the repository README and `.env.example` files.
 - Implement all database schema changes via migrations in `MJ_FB_Backend/src/migrations`; do not modify `src/setupDatabase.ts` for schema updates.
 - Volunteers sign in with their email address instead of a username, and volunteer emails must be unique (email remains optional).

--- a/README.md
+++ b/README.md
@@ -495,6 +495,8 @@ Production runs on an AWS Lightsail instance with the repository checked out at 
 process is named `mjfb-api` and the built frontend is served by Nginx from `/var/www/mjfb-frontend` at
 [`https://app.mjfoodbank.org`](https://app.mjfoodbank.org).
 
+Follow these manual steps for every deployment.
+
 ### 1. Push local changes
 
 ```bash
@@ -504,7 +506,7 @@ git commit -m "frontend: <change>; backend: <change>"
 git push origin main
 ```
 
-### 2. Update the server (SSH into Lightsail)
+### 2. Server Pull & Build (SSH into Lightsail instance)
 
 ```bash
 ssh ubuntu@<lightsail-host>
@@ -512,17 +514,17 @@ cd ~/apps/MJ_FoodBank_Booking
 git pull origin master
 ```
 
-#### Backend (API)
+#### 2A) Backend (API)
 
 ```bash
 cd MJ_FB_Backend
 npm install
-NODE_OPTIONS=--max-old-space-size=4096 npm run build
+NODE_OPTIONS=--max-old-space-size=4096 npm run build   # if TS → dist
 pm2 restart mjfb-api --update-env
 pm2 logs mjfb-api --lines 80
 ```
 
-#### Frontend (React/Vite)
+#### 2B) Frontend (React/Vite)
 
 ```bash
 cd ../MJ_FB_Frontend


### PR DESCRIPTION
## Summary
- replace the README deployment section with the AWS Lightsail workflow used in production and reuse the server pull/build commands from the ops cheatsheet
- clarify the root AGENTS instructions so deployers follow the Lightsail steps and complete the post-deploy checks

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d08b603a94832d80b6672d9aef012f