### PR TITLE
Use IF NOT EXISTS for donor pet food column migration

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000067_add_pet_food_columns.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000067_add_pet_food_columns.ts
@@ -4,13 +4,9 @@ const DONORS_COLUMN = 'is_pet_food';
 const WAREHOUSE_COLUMN = 'pet_food';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.addColumn('donors', {
-    [DONORS_COLUMN]: {
-      type: 'boolean',
-      notNull: true,
-      default: false,
-    },
-  });
+  pgm.sql(
+    `ALTER TABLE donors ADD COLUMN IF NOT EXISTS ${DONORS_COLUMN} BOOLEAN DEFAULT FALSE NOT NULL;`,
+  );
 
   pgm.addColumn('warehouse_overall', {
     [WAREHOUSE_COLUMN]: {


### PR DESCRIPTION
## Summary
- replace the donor column addColumn helper with raw SQL that uses IF NOT EXISTS so the migration is idempotent when the column already exists

## Testing
- DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/mjfb NODE_PG_MIGRATE_TS_NODE=1 npx node-pg-migrate up 1700000000067_add_pet_food_columns --migrations-dir /tmp/pet_food_migrations --migrations-table pgmigrations_pet_food_test

------
https://chatgpt.com/codex/tasks/task_e_68d08c41acb0832daebf4a8088f6df3b