### PR TITLE
Fix delivery order user email assignment

### DIFF
--- a/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
+++ b/MJ_FB_Backend/src/controllers/deliveryOrderController.ts
@@ -314,7 +314,7 @@ export const createDeliveryOrder = asyncHandler(async (req: Request, res: Respon
 
     req.user.address = address;
     req.user.phone = phone;
-    req.user.email = email;
+    req.user.email = email ?? undefined;
   }
 
   const requestedStatus = parsed.data.status;


### PR DESCRIPTION
## Summary
- ensure the delivery order controller assigns undefined when no email is provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d091d49bc4832dad73f8e32a996a6e