### PR TITLE
Require client lookup success before saving pantry visit

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -621,7 +621,7 @@ export default function PantryVisits() {
                     }
                     sx={{ alignItems: 'center' }}
                   >
-                    Client not present in database
+                    Client not present in database. Create the client before saving this visit.
                   </Alert>
                 )}
                 <TextField
@@ -678,7 +678,11 @@ export default function PantryVisits() {
               saving ||
               (form.sunshineBag
                 ? !form.sunshineWeight || !form.sunshineClients
-                : !form.weightWithCart || !form.weightWithoutCart || !form.clientId)
+                :
+                  !form.weightWithCart ||
+                  !form.weightWithoutCart ||
+                  !form.clientId ||
+                  (!form.anonymous && clientFound !== true))
             }
           >
             Save

--- a/MJ_FB_Frontend/tests/pages/staff/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/tests/pages/staff/PantryVisits.test.tsx
@@ -1,0 +1,111 @@
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import PantryVisits from '../../../src/pages/staff/PantryVisits';
+import { renderWithProviders, screen, waitFor, within } from '../../../testUtils/renderWithProviders';
+import { getClientVisits } from '../../../src/api/clientVisits';
+import { getSunshineBag } from '../../../src/api/sunshineBags';
+import { addUser, getUserByClientId } from '../../../src/api/users';
+
+jest.mock('../../../src/api/clientVisits', () => ({
+  getClientVisits: jest.fn(),
+  createClientVisit: jest.fn(),
+  updateClientVisit: jest.fn(),
+  deleteClientVisit: jest.fn(),
+  toggleClientVisitVerification: jest.fn(),
+}));
+
+jest.mock('../../../src/api/sunshineBags', () => ({
+  getSunshineBag: jest.fn(),
+  saveSunshineBag: jest.fn(),
+}));
+
+jest.mock('../../../src/api/users', () => ({
+  addUser: jest.fn(),
+  getUserByClientId: jest.fn(),
+}));
+
+jest.mock('../../../src/hooks/useAppConfig', () => ({
+  __esModule: true,
+  default: () => ({
+    appConfig: { cartTare: 0 },
+    isLoading: false,
+    refetch: jest.fn(),
+    error: null,
+  }),
+}));
+
+jest.mock('../../../src/components/PantryQuickLinks', () => () => (
+  <div data-testid="pantry-quick-links" />
+));
+
+jest.mock('../../../src/components/ResponsiveTable', () => ({
+  __esModule: true,
+  default: () => <div data-testid="responsive-table" />,
+}));
+
+describe('PantryVisits record dialog', () => {
+  const getClientVisitsMock = getClientVisits as jest.MockedFunction<typeof getClientVisits>;
+  const getSunshineBagMock = getSunshineBag as jest.MockedFunction<typeof getSunshineBag>;
+  const getUserByClientIdMock = getUserByClientId as jest.MockedFunction<typeof getUserByClientId>;
+  const addUserMock = addUser as jest.MockedFunction<typeof addUser>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getClientVisitsMock.mockResolvedValue([]);
+    getSunshineBagMock.mockResolvedValue({ weight: 0, clientCount: 0 });
+    getUserByClientIdMock.mockResolvedValue({
+      clientId: 1234,
+      firstName: 'Test',
+      lastName: 'User',
+      email: null,
+      phone: null,
+      onlineAccess: false,
+      hasPassword: false,
+      role: 'shopper',
+    } as any);
+    addUserMock.mockResolvedValue();
+  });
+
+  it('keeps Save disabled after a failed lookup until the client is created', async () => {
+    getUserByClientIdMock.mockRejectedValueOnce(new Error('not found'));
+
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/pantry/visits']}>
+        <PantryVisits />
+      </MemoryRouter>,
+    );
+
+    const recordButton = await screen.findByRole('button', { name: /record visit/i });
+    await user.click(recordButton);
+
+    const dialog = await screen.findByRole('dialog', { name: /record visit/i });
+
+    const clientIdField = within(dialog).getByLabelText(/client id/i);
+    await user.type(clientIdField, '1234');
+
+    const weightWithCartField = within(dialog).getByLabelText(/weight with cart/i);
+    const weightWithoutCartField = within(dialog).getByLabelText(/weight without cart/i);
+    await user.type(weightWithCartField, '50');
+    await user.type(weightWithoutCartField, '45');
+
+    const saveButton = within(dialog).getByRole('button', { name: /save/i });
+
+    expect(
+      await within(dialog).findByText(/client not present in database/i),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(saveButton).toBeDisabled();
+    });
+
+    const createButton = within(dialog).getByRole('button', { name: /create/i });
+    await user.click(createButton);
+
+    await waitFor(() => {
+      expect(saveButton).toBeEnabled();
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- disable the Record Visit Save button until a non-anonymous client lookup succeeds
- clarify the missing-client alert so staff know to create the client before saving
- add a regression test covering Save button enablement around failed lookups and client creation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d91339e8832da23cf4dba8392980