### PR TITLE
Remove agency references from user lookup view migration

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000044_add_user_lookup_view.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000044_add_user_lookup_view.ts
@@ -2,21 +2,17 @@ import type { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.sql(`CREATE UNIQUE INDEX IF NOT EXISTS staff_email_lower_idx ON staff (LOWER(email));`);
-  pgm.sql(`CREATE UNIQUE INDEX IF NOT EXISTS agencies_email_lower_idx ON agencies (LOWER(email));`);
   pgm.sql(`
     CREATE VIEW user_lookup AS
     SELECT id, email, 'staff' AS user_type, 1 AS ord FROM staff
     UNION ALL
     SELECT id, email, 'volunteers' AS user_type, 2 AS ord FROM volunteers
     UNION ALL
-    SELECT id, email, 'agencies' AS user_type, 3 AS ord FROM agencies
-    UNION ALL
-    SELECT client_id AS id, email, 'clients' AS user_type, 4 AS ord FROM clients;
+    SELECT client_id AS id, email, 'clients' AS user_type, 3 AS ord FROM clients;
   `);
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.sql('DROP VIEW IF EXISTS user_lookup;');
   pgm.sql('DROP INDEX IF EXISTS staff_email_lower_idx;');
-  pgm.sql('DROP INDEX IF EXISTS agencies_email_lower_idx;');
 }


### PR DESCRIPTION
## Summary
- remove the agencies email index and UNION from the user_lookup view migration
- adjust the client ord value after removing agencies rows

## Testing
- npm run migrate

------
https://chatgpt.com/codex/tasks/task_e_68d1de794d30832d83cb192783c054b1