### PR TITLE
Remove agency consent column changes from migration

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000046_add_consent_columns.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000046_add_consent_columns.ts
@@ -4,12 +4,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.addColumn('clients', { consent: { type: 'boolean', notNull: true, default: false } });
   pgm.addColumn('staff', { consent: { type: 'boolean', notNull: true, default: false } });
   pgm.addColumn('volunteers', { consent: { type: 'boolean', notNull: true, default: false } });
-  pgm.addColumn('agencies', { consent: { type: 'boolean', notNull: true, default: false } });
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.dropColumn('clients', 'consent');
   pgm.dropColumn('staff', 'consent');
   pgm.dropColumn('volunteers', 'consent');
-  pgm.dropColumn('agencies', 'consent');
 }


### PR DESCRIPTION
## Summary
- stop adding and dropping consent column on the agencies table in the consent migration so it succeeds when agencies are absent

## Testing
- npm test *(fails: bookingReminderJob.test.ts, expiredTokenCleanupJob.test.ts, passwordTokenCleanupJob.test.ts — cron scheduler mocks not invoked in this environment)*
- PGUSER=postgres PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=mjfb_test JWT_SECRET=devsecret JWT_REFRESH_SECRET=devrefresh FRONTEND_ORIGIN=http://localhost:5173 WEBAUTHN_RP_ID=localhost WEBAUTHN_ORIGIN=http://localhost:5173 npx node-pg-migrate up --file 1700000000046_add_consent_columns -m src/migrations --migrations-table=pgmigrations --database-url postgres://postgres:postgres@127.0.0.1:5432/mjfb_test --tsx


------
https://chatgpt.com/codex/tasks/task_e_68d1de71ff00832d8a326c7e58d23b12