### PR TITLE
Fix edit account dialogs losing focus when typing

### DIFF
--- a/MJ_FB_Frontend/src/components/account/AccountEditForm.tsx
+++ b/MJ_FB_Frontend/src/components/account/AccountEditForm.tsx
@@ -25,6 +25,20 @@ export interface AccountEditFormData {
   hasPassword: boolean;
 }
 
+interface FormSectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+function FormSection({ title, children }: FormSectionProps) {
+  return (
+    <Stack spacing={2} component="section">
+      <Typography variant="subtitle1">{title}</Typography>
+      {children}
+    </Stack>
+  );
+}
+
 interface AccountEditFormProps {
   open: boolean;
   initialData: AccountEditFormData;
@@ -125,15 +139,6 @@ export default function AccountEditForm({
       updateForm('password', '');
     }
     setShowPasswordOverride(prev => !prev);
-  }
-
-  function FormSection({ title, children }: { title: string; children: ReactNode }) {
-    return (
-      <Stack spacing={2} component="section">
-        <Typography variant="subtitle1">{title}</Typography>
-        {children}
-      </Stack>
-    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- hoist the FormSection component out of AccountEditForm to keep stable component identity
- prevent Material UI text fields in edit dialogs from being recreated on every keystroke so focus is preserved

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d55c3a98c0832da7cd5335f1cc86ce