### PR TITLE
Disable online access toggle for existing accounts

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
@@ -112,7 +112,7 @@ describe('UpdateClientData', () => {
 
     const checkbox = await screen.findByLabelText('Online Access');
     expect(checkbox).toBeChecked();
-    expect(checkbox).not.toBeDisabled();
+    expect(checkbox).toBeDisabled();
     expect(screen.getByTestId('set-password-button')).toBeInTheDocument();
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId('set-password-button'));

--- a/MJ_FB_Frontend/src/components/account/AccountEditForm.tsx
+++ b/MJ_FB_Frontend/src/components/account/AccountEditForm.tsx
@@ -136,6 +136,8 @@ export default function AccountEditForm({
     );
   }
 
+  const disableOnlineAccessToggle = form.hasPassword && form.onlineAccess;
+
   return (
     <>
       <DialogContent>
@@ -151,7 +153,7 @@ export default function AccountEditForm({
             {showOnlineAccessToggle && (
               <Tooltip
                 title={existingPasswordTooltip}
-                disableHoverListener={!form.hasPassword}
+                disableHoverListener={!disableOnlineAccessToggle}
               >
                 <span>
                   <FormControl>
@@ -163,11 +165,17 @@ export default function AccountEditForm({
                             updateForm('onlineAccess', e.target.checked)
                           }
                           data-testid="online-access-toggle"
+                          disabled={disableOnlineAccessToggle}
                         />
                       }
                       label={onlineAccessLabel}
                     />
-                    <FormHelperText>{onlineAccessHelperText}</FormHelperText>
+                    <FormHelperText>
+                      {onlineAccessHelperText}
+                      {disableOnlineAccessToggle
+                        ? ' Users with a password always have online access.'
+                        : ''}
+                    </FormHelperText>
                   </FormControl>
                 </span>
               </Tooltip>

--- a/MJ_FB_Frontend/src/components/account/__tests__/AccountEditForm.test.tsx
+++ b/MJ_FB_Frontend/src/components/account/__tests__/AccountEditForm.test.tsx
@@ -52,8 +52,8 @@ describe('AccountEditForm', () => {
       />,
     );
 
-    const toggle = screen.getByTestId('online-access-toggle');
-    expect(toggle).not.toBeDisabled();
+    const toggle = screen.getByLabelText('Online Access');
+    expect(toggle).toBeDisabled();
 
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
 
@@ -69,7 +69,7 @@ describe('AccountEditForm', () => {
     );
   });
 
-  it('allows toggling online access when the user already has a password', () => {
+  it('keeps online access enabled when the user already has a password', () => {
     const handleSave = jest.fn();
 
     renderWithProviders(
@@ -88,13 +88,13 @@ describe('AccountEditForm', () => {
       />,
     );
 
-    const toggle = screen.getByTestId('online-access-toggle');
-    fireEvent.click(toggle);
+    const toggle = screen.getByLabelText('Online Access');
+    expect(toggle).toBeDisabled();
 
     fireEvent.click(screen.getByTestId('save-button'));
 
     expect(handleSave).toHaveBeenCalledWith(
-      expect.objectContaining({ onlineAccess: false }),
+      expect.objectContaining({ onlineAccess: true }),
     );
   });
 });

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
@@ -47,6 +47,8 @@ describe('EditClientDialog', () => {
 
     expect(await screen.findByText('John Doe')).toBeInTheDocument();
     expect(screen.getByTestId('online-badge')).toBeInTheDocument();
+    const toggle = await screen.findByLabelText(/online access/i);
+    expect(toggle).toBeDisabled();
   });
 
   it('online access switch toggles onlineAccess state', async () => {

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteer.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditVolunteer.test.tsx
@@ -112,6 +112,8 @@ describe('EditVolunteer volunteer info display', () => {
     );
 
     fireEvent.click(await screen.findByRole('button', { name: /edit profile/i }));
+    const toggle = await screen.findByLabelText(/online access/i);
+    expect(toggle).toBeDisabled();
     fireEvent.click(await screen.findByTestId('set-password-button'));
 
     const passwordInput = await screen.findByTestId('volunteer-password-input');
@@ -365,7 +367,7 @@ describe('EditVolunteer profile editing', () => {
     (getVolunteerById as jest.Mock).mockResolvedValue({
       ...mockVolunteer,
       email: 'volunteer@example.com',
-      hasPassword: true,
+      hasPassword: false,
     });
 
     fireEvent.click(
@@ -373,7 +375,8 @@ describe('EditVolunteer profile editing', () => {
     );
     fireEvent.click(await screen.findByRole('button', { name: 'Edit Profile' }));
 
-    const toggle = await screen.findByTestId('online-access-toggle');
+    const toggle = await screen.findByLabelText(/online access/i);
+    expect(toggle).not.toBeDisabled();
     fireEvent.click(toggle);
 
     const passwordInput = await screen.findByLabelText('Password');
@@ -409,7 +412,7 @@ describe('EditVolunteer profile editing', () => {
     );
     fireEvent.click(await screen.findByRole('button', { name: 'Edit Profile' }));
 
-    const toggle = await screen.findByTestId('online-access-toggle');
+    const toggle = await screen.findByLabelText(/online access/i);
     fireEvent.click(toggle);
 
     fireEvent.click(


### PR DESCRIPTION
## Summary
- disable the online access switch when the account already has a password so staff can't toggle it off
- add helper messaging explaining that online access remains enabled for password-protected users
- update client and volunteer account management tests to cover the new disabled state

## Testing
- npm test -- --runTestsByPath src/components/account/__tests__/AccountEditForm.test.tsx src/pages/staff/__tests__/EditClientDialog.test.tsx src/__tests__/UpdateClientData.test.tsx src/pages/staff/__tests__/EditVolunteer.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d55e684d08832d9f876ec5d6b9841e