### PR TITLE
Reset scheduleDailyJob mock between tests

### DIFF
--- a/MJ_FB_Backend/tests/bookingRetentionJob.test.ts
+++ b/MJ_FB_Backend/tests/bookingRetentionJob.test.ts
@@ -11,6 +11,10 @@ const scheduleDailyJob = require('../src/utils/scheduleDailyJob').default;
 const job = require('../src/utils/bookingRetentionJob');
 const { cleanupOldRecords } = job;
 
+afterAll(() => {
+  jest.resetModules();
+});
+
 describe('bookingRetentionJob scheduling', () => {
   it('invokes scheduleDailyJob with nightly schedule', () => {
     expect(scheduleDailyJob).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- reset the scheduleDailyJob mock after booking retention job tests to avoid leaking the stub into later suites

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d56022e578832da87922efceef5e46