### PR TITLE
Ensure anonymous pantry visits roll into totals

### DIFF
--- a/MJ_FB_Backend/src/migrations/1700000000071_remove_anonymous_columns_from_pantry_overall.ts
+++ b/MJ_FB_Backend/src/migrations/1700000000071_remove_anonymous_columns_from_pantry_overall.ts
@@ -1,0 +1,47 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('pantry_weekly_overall', 'anonymous_orders', { ifExists: true });
+  pgm.dropColumn('pantry_weekly_overall', 'anonymous_adults', { ifExists: true });
+  pgm.dropColumn('pantry_weekly_overall', 'anonymous_children', { ifExists: true });
+  pgm.dropColumn('pantry_weekly_overall', 'anonymous_people', { ifExists: true });
+  pgm.dropColumn('pantry_weekly_overall', 'anonymous_weight', { ifExists: true });
+
+  pgm.dropColumn('pantry_monthly_overall', 'anonymous_orders', { ifExists: true });
+  pgm.dropColumn('pantry_monthly_overall', 'anonymous_adults', { ifExists: true });
+  pgm.dropColumn('pantry_monthly_overall', 'anonymous_children', { ifExists: true });
+  pgm.dropColumn('pantry_monthly_overall', 'anonymous_people', { ifExists: true });
+  pgm.dropColumn('pantry_monthly_overall', 'anonymous_weight', { ifExists: true });
+
+  pgm.dropColumn('pantry_yearly_overall', 'anonymous_orders', { ifExists: true });
+  pgm.dropColumn('pantry_yearly_overall', 'anonymous_adults', { ifExists: true });
+  pgm.dropColumn('pantry_yearly_overall', 'anonymous_children', { ifExists: true });
+  pgm.dropColumn('pantry_yearly_overall', 'anonymous_people', { ifExists: true });
+  pgm.dropColumn('pantry_yearly_overall', 'anonymous_weight', { ifExists: true });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('pantry_weekly_overall', {
+    anonymous_orders: { type: 'integer', notNull: true, default: 0 },
+    anonymous_adults: { type: 'integer', notNull: true, default: 0 },
+    anonymous_children: { type: 'integer', notNull: true, default: 0 },
+    anonymous_people: { type: 'integer', notNull: true, default: 0 },
+    anonymous_weight: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.addColumn('pantry_monthly_overall', {
+    anonymous_orders: { type: 'integer', notNull: true, default: 0 },
+    anonymous_adults: { type: 'integer', notNull: true, default: 0 },
+    anonymous_children: { type: 'integer', notNull: true, default: 0 },
+    anonymous_people: { type: 'integer', notNull: true, default: 0 },
+    anonymous_weight: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.addColumn('pantry_yearly_overall', {
+    anonymous_orders: { type: 'integer', notNull: true, default: 0 },
+    anonymous_adults: { type: 'integer', notNull: true, default: 0 },
+    anonymous_children: { type: 'integer', notNull: true, default: 0 },
+    anonymous_people: { type: 'integer', notNull: true, default: 0 },
+    anonymous_weight: { type: 'integer', notNull: true, default: 0 },
+  });
+}

--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -173,13 +173,13 @@ export default function PantryVisits() {
   }, [form.sunshineBag, form.date]);
 
   const summary = useMemo(() => {
-    const orders = visits.filter(v => !v.anonymous).length;
-    const anonymous = visits.length - orders;
+    const totalOrders = visits.length;
+    const anonymous = visits.filter(v => v.anonymous).length;
     const totalWeight =
       visits.reduce((sum, v) => sum + v.weightWithoutCart, 0) + sunshineBagWeight;
     const adults = visits.reduce((sum, v) => sum + v.adults, 0);
     const children = visits.reduce((sum, v) => sum + v.children, 0);
-    return { orders, anonymous, totalWeight, adults, children };
+    return { orders: totalOrders, anonymous, totalWeight, adults, children };
   }, [visits, sunshineBagWeight]);
 
   function handleSaveVisit() {

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -264,7 +264,7 @@ describe('PantryVisits', () => {
     const panel = getActivePanel();
     expect(await within(panel).findByText('111')).toBeInTheDocument();
     expect(within(panel).getByText('222 (ANONYMOUS)')).toBeInTheDocument();
-    expect(within(panel).getByText('Orders: 1 (+ 1 anonymous)')).toBeInTheDocument();
+    expect(within(panel).getByText('Orders: 2 (+ 1 anonymous)')).toBeInTheDocument();
     expect(within(panel).getByText('Sunshine Bag Clients: 2')).toBeInTheDocument();
     expect(within(panel).getByText('Total Weight: 32')).toBeInTheDocument();
     expect(within(panel).getByText('Adults: 4')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- remove the anonymous-specific pantry aggregation columns and treat anonymous visits as part of the standard rollups again
- drop the unused anonymous columns via a new migration and restore the API/test surface to the original shape
- update the pantry visits summary UI so totals include anonymous visits while still indicating how many were anonymous

## Testing
- npm test (MJ_FB_Backend) *(fails: cron job scheduling specs expect mocked node-cron.schedule calls)*
- npm test tests/bookingReminderJob.test.ts
- npm test tests/emailQueueCleanupJob.test.ts
- npm test src/pages/staff/__tests__/PantryVisits.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d4516ab1f4832d80c5a4e3bdd9b801