### PR TITLE
Persist Edit Client dialog drafts between reopenings

### DIFF
--- a/MJ_FB_Frontend/src/components/account/AccountEditForm.tsx
+++ b/MJ_FB_Frontend/src/components/account/AccountEditForm.tsx
@@ -42,6 +42,7 @@ interface AccountEditFormProps {
   secondaryActionTestId?: string;
   passwordFieldTestId?: string;
   secondaryActionVariant?: ButtonProps['variant'];
+  draftKey?: string;
 }
 
 export default function AccountEditForm({
@@ -61,6 +62,7 @@ export default function AccountEditForm({
   secondaryActionTestId = 'secondary-action-button',
   passwordFieldTestId = 'password-input',
   secondaryActionVariant = 'outlined',
+  draftKey,
 }: AccountEditFormProps) {
   const [form, setForm] = useState<AccountEditFormData>(initialData);
   const [showPasswordOverride, setShowPasswordOverride] = useState(
@@ -68,13 +70,111 @@ export default function AccountEditForm({
   );
   const firstNameInputRef = useRef<HTMLInputElement | null>(null);
   const previousOpenRef = useRef(false);
+  const isDirtyRef = useRef(false);
+  const dirtyFieldsRef = useRef(new Set<keyof AccountEditFormData>());
+  const formRef = useRef(form);
+
+  type DraftPayload = {
+    data: AccountEditFormData;
+    dirtyKeys: Array<keyof AccountEditFormData>;
+  };
+
+  useEffect(() => {
+    formRef.current = form;
+  }, [form]);
+
+  const loadDraft = (): DraftPayload | null => {
+    if (!draftKey || typeof window === 'undefined') return null;
+    try {
+      const raw = window.sessionStorage.getItem(draftKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as Partial<DraftPayload> | AccountEditFormData;
+      if (parsed && typeof parsed === 'object' && 'data' in parsed) {
+        const payload = parsed as Partial<DraftPayload>;
+        if (payload.data) {
+          return {
+            data: payload.data,
+            dirtyKeys: payload.dirtyKeys ?? [],
+          };
+        }
+      }
+      return {
+        data: parsed as AccountEditFormData,
+        dirtyKeys: [],
+      };
+    } catch (err) {
+      console.warn('Failed to read account edit draft', err);
+      return null;
+    }
+  };
+
+  const saveDraft = (data: AccountEditFormData) => {
+    if (!draftKey || typeof window === 'undefined') return;
+    try {
+      const payload: DraftPayload = {
+        data,
+        dirtyKeys: Array.from(dirtyFieldsRef.current),
+      };
+      window.sessionStorage.setItem(draftKey, JSON.stringify(payload));
+    } catch (err) {
+      console.warn('Failed to store account edit draft', err);
+    }
+  };
 
   useEffect(() => {
     if (open) {
-      setForm(initialData);
-      setShowPasswordOverride(initialData.onlineAccess && !initialData.hasPassword);
+      const draft = loadDraft();
+      if (draft) {
+        const base: AccountEditFormData = {
+          ...initialData,
+          hasPassword: initialData.hasPassword,
+        };
+
+        const dirtyKeys = draft.dirtyKeys.length
+          ? draft.dirtyKeys
+          : (Object.keys(draft.data) as Array<keyof AccountEditFormData>).filter(
+              key => draft.data[key] !== base[key],
+            );
+
+        const merged: AccountEditFormData = { ...base };
+        dirtyKeys.forEach(key => {
+          merged[key] = draft.data[key];
+        });
+
+        dirtyFieldsRef.current = new Set(dirtyKeys);
+        isDirtyRef.current = dirtyFieldsRef.current.size > 0;
+        setForm(merged);
+        setShowPasswordOverride(
+          merged.onlineAccess && (!merged.hasPassword || Boolean(merged.password)),
+        );
+        if (isDirtyRef.current && dirtyFieldsRef.current.size > 0) {
+          saveDraft(merged);
+        }
+        return;
+      }
+
+      if (!isDirtyRef.current) {
+        dirtyFieldsRef.current.clear();
+        setForm(initialData);
+        setShowPasswordOverride(initialData.onlineAccess && !initialData.hasPassword);
+        return;
+      }
+
+      const merged: AccountEditFormData = {
+        ...initialData,
+        hasPassword: initialData.hasPassword,
+      };
+
+      dirtyFieldsRef.current.forEach(key => {
+        merged[key] = formRef.current[key];
+      });
+
+      setForm(merged);
+      setShowPasswordOverride(
+        merged.onlineAccess && (!merged.hasPassword || Boolean(merged.password)),
+      );
     }
-  }, [open, initialData]);
+  }, [open, initialData, draftKey]);
 
   useEffect(() => {
     let timeout: number | undefined;
@@ -98,6 +198,8 @@ export default function AccountEditForm({
     key: K,
     value: AccountEditFormData[K],
   ) {
+    isDirtyRef.current = true;
+    dirtyFieldsRef.current.add(key);
     setForm(prev => ({ ...prev, [key]: value }));
   }
 
@@ -113,9 +215,16 @@ export default function AccountEditForm({
 
   useEffect(() => {
     if (!form.onlineAccess && form.password) {
+      dirtyFieldsRef.current.delete('password');
       setForm(prev => ({ ...prev, password: '' }));
     }
   }, [form.onlineAccess, form.password]);
+
+  useEffect(() => {
+    if (!open || !draftKey) return;
+    if (!isDirtyRef.current || dirtyFieldsRef.current.size === 0) return;
+    saveDraft(formRef.current);
+  }, [form, open, draftKey]);
 
   function togglePasswordField() {
     if (!showPasswordOverride && !form.onlineAccess) {

--- a/MJ_FB_Frontend/src/components/account/__tests__/AccountEditForm.test.tsx
+++ b/MJ_FB_Frontend/src/components/account/__tests__/AccountEditForm.test.tsx
@@ -1,8 +1,12 @@
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProviders, screen } from '../../../../testUtils/renderWithProviders';
 import AccountEditForm from '../AccountEditForm';
 
 describe('AccountEditForm', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('shows account and contact fields without expanding any sections', () => {
     const handleSave = jest.fn();
 
@@ -96,5 +100,61 @@ describe('AccountEditForm', () => {
     expect(handleSave).toHaveBeenCalledWith(
       expect.objectContaining({ onlineAccess: false }),
     );
+  });
+
+  it('restores drafts when reopened with the same key', async () => {
+    const handleSave = jest.fn();
+
+    const initialData = {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      phone: '555-1234',
+      onlineAccess: true,
+      password: '',
+      hasPassword: true,
+    };
+
+    const { unmount } = renderWithProviders(
+      <AccountEditForm
+        open
+        initialData={initialData}
+        onSave={handleSave}
+        draftKey="client-1"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('First Name'), {
+      target: { value: 'Grace' },
+    });
+    fireEvent.change(screen.getByLabelText('Email (optional)'), {
+      target: { value: 'grace@example.com' },
+    });
+
+    await waitFor(() =>
+      expect(window.sessionStorage.getItem('client-1')).toContain('Grace'),
+    );
+
+    unmount();
+
+    renderWithProviders(
+      <AccountEditForm
+        open
+        initialData={{
+          firstName: 'New',
+          lastName: 'Name',
+          email: 'new@example.com',
+          phone: '',
+          onlineAccess: false,
+          password: '',
+          hasPassword: false,
+        }}
+        onSave={handleSave}
+        draftKey="client-1"
+      />,
+    );
+
+    expect(screen.getByLabelText('First Name')).toHaveValue('Grace');
+    expect(screen.getByLabelText('Email (optional)')).toHaveValue('grace@example.com');
   });
 });

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
@@ -22,6 +22,7 @@ jest.mock('../../../api/users', () => ({
 describe('EditClientDialog', () => {
   beforeEach(() => {
     (getUserByClientId as jest.Mock).mockReset();
+    window.sessionStorage.clear();
   });
 
   it('renders name and online badge when hasPassword is true', async () => {
@@ -161,6 +162,54 @@ describe('EditClientDialog', () => {
 
     await waitFor(() => expect(getUserByClientId).toHaveBeenCalledTimes(1));
     expect(getUserByClientId).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores unsaved edits after closing and reopening', async () => {
+    (getUserByClientId as jest.Mock).mockResolvedValue({
+      firstName: 'Riley',
+      lastName: 'Johnson',
+      email: 'riley@example.com',
+      phone: '3065551000',
+      onlineAccess: true,
+      hasPassword: true,
+      role: 'shopper',
+    });
+
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <EditClientDialog
+            open={open}
+            clientId={8}
+            onClose={() => setOpen(false)}
+            onUpdated={jest.fn()}
+            onClientUpdated={jest.fn()}
+          />
+          <button type="button" data-testid="reopen" onClick={() => setOpen(true)}>
+            Reopen
+          </button>
+        </>
+      );
+    }
+
+    renderWithProviders(<Harness />);
+
+    fireEvent.change(screen.getByTestId('phone-input'), {
+      target: { value: '3065552020' },
+    });
+
+    await waitFor(() =>
+      expect(window.sessionStorage.getItem('edit-client-8')).toContain('3065552020'),
+    );
+
+    fireEvent.click(screen.getByLabelText('close'));
+
+    fireEvent.click(screen.getByTestId('reopen'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('phone-input')).toHaveValue('3065552020'),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add optional draftKey handling to AccountEditForm with dirty-field tracking and sessionStorage persistence
- teach EditClientDialog to use per-client draft keys, clear stored drafts after save/reset, and guard handleSendReset return values
- extend component and dialog tests to reset sessionStorage and verify draft restoration across reopen cycles

## Testing
- npm test -- --runTestsByPath src/pages/staff/__tests__/EditClientDialog.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d55c9e8748832d9995d9d59479a5a1