### PR TITLE
Adjust pantry schedule day navigation spacing

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantrySchedule.tsx
@@ -408,8 +408,11 @@ export default function PantrySchedule({
               variant="outlined"
               color="primary"
               size="large"
-              fullWidth
-              sx={{ flexBasis: { xs: "100%", md: "25%" }, flexGrow: 1 }}
+              sx={{
+                width: { xs: "100%", md: "auto" },
+                minWidth: { md: 120 },
+                flexGrow: { md: 0 },
+              }}
             >
               Previous
             </Button>
@@ -422,16 +425,19 @@ export default function PantrySchedule({
               variant="outlined"
               color="primary"
               size="large"
-              fullWidth
-              sx={{ flexBasis: { xs: "100%", md: "25%" }, flexGrow: 1 }}
+              sx={{
+                width: { xs: "100%", md: "auto" },
+                minWidth: { md: 120 },
+                flexGrow: { md: 0 },
+              }}
             >
               Today
             </Button>
             <Box
               sx={{
-                flexBasis: { xs: "100%", md: "25%" },
-                flexGrow: 1,
-                minWidth: { md: 220 },
+                width: { xs: "100%", md: "auto" },
+                flexGrow: { md: 1 },
+                minWidth: { md: 200 },
               }}
             >
               <LocalizationProvider
@@ -465,8 +471,11 @@ export default function PantrySchedule({
               variant="outlined"
               color="primary"
               size="large"
-              fullWidth
-              sx={{ flexBasis: { xs: "100%", md: "25%" }, flexGrow: 1 }}
+              sx={{
+                width: { xs: "100%", md: "auto" },
+                minWidth: { md: 120 },
+                flexGrow: { md: 0 },
+              }}
             >
               Next
             </Button>


### PR DESCRIPTION
## Summary
- reduce the pantry schedule day navigation button widths on larger breakpoints so the controls remain on one line
- allow the date picker to flex into the remaining space while keeping all controls full width on small screens

## Testing
- npm test -- --passWithNoTests --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d574484bf4832d8e6886c9333580bc