### PR TITLE
Fix pantry summary regular order count

### DIFF
--- a/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/PantryVisits.tsx
@@ -173,8 +173,8 @@ export default function PantryVisits() {
   }, [form.sunshineBag, form.date]);
 
   const summary = useMemo(() => {
-    const totalOrders = visits.length;
     const anonymous = visits.filter(v => v.anonymous).length;
+    const totalOrders = visits.length - anonymous;
     const totalWeight =
       visits.reduce((sum, v) => sum + v.weightWithoutCart, 0) + sunshineBagWeight;
     const adults = visits.reduce((sum, v) => sum + v.adults, 0);

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/PantryVisits.test.tsx
@@ -264,7 +264,7 @@ describe('PantryVisits', () => {
     const panel = getActivePanel();
     expect(await within(panel).findByText('111')).toBeInTheDocument();
     expect(within(panel).getByText('222 (ANONYMOUS)')).toBeInTheDocument();
-    expect(within(panel).getByText('Orders: 2 (+ 1 anonymous)')).toBeInTheDocument();
+    expect(within(panel).getByText('Orders: 1 (+ 1 anonymous)')).toBeInTheDocument();
     expect(within(panel).getByText('Sunshine Bag Clients: 2')).toBeInTheDocument();
     expect(within(panel).getByText('Total Weight: 32')).toBeInTheDocument();
     expect(within(panel).getByText('Adults: 4')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update the pantry summary so regular orders exclude anonymous visits from the total
- adjust the pantry visits test to match the new summary output

## Testing
- npm test -- --runTestsByPath src/pages/staff/__tests__/PantryVisits.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d5b23599b0832dbc3e1a2cdea92e1b