### PR TITLE
Handle Zeffy payment date header aliases

### DIFF
--- a/MJ_FB_Backend/README.txt
+++ b/MJ_FB_Backend/README.txt
@@ -143,6 +143,22 @@ Response JSON:
 - `firstTimeDonors` – donors whose first recorded gift falls in the most recent month, with donation date and amount.
 - `pantryImpact` – pantry families, adults, children, and pounds served for the selected month.
 
+## Zeffy Donation Import
+
+The Zeffy donation importer accepts spreadsheets exported from Zeffy. Upload files at
+`POST /monetary-donors/import` or through Donor Management → Donors → Import Zeffy Donations.
+Each worksheet must include the following columns:
+
+- `First Name`
+- `Last Name`
+- `Email`
+- `Payment Date` *(or the timezone-specific header `Payment Date (America/Regina)`)*
+- `Payment Status`
+- `Total Amount`
+
+Additional columns are ignored. The importer only records donations whose **Payment Status** is
+`Succeeded` and converts the **Payment Date** to Regina time when timestamps are provided.
+
 ## Warehouse Overall Available Years Endpoint
 
 `GET /warehouse-overall/years`


### PR DESCRIPTION
## Summary
- add a Zeffy header alias map so the importer accepts Payment Date (America/Regina)
- update donor import docs with the accepted columns
- cover the alias header with a new importer test case

## Testing
- npm test tests/monetaryDonors.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6b506bee4832da3aabe60caa06969