### PR TITLE
Trim whitespace from login identifier input

### DIFF
--- a/MJ_FB_Frontend/src/pages/auth/Login.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/Login.tsx
@@ -33,19 +33,23 @@ export default function Login({
   const navigate = useNavigate();
   const identifierRef = useRef<HTMLInputElement>(null);
 
-  const identifierError = submitted && identifier === '';
+  const identifierError = submitted && identifier.trim() === '';
   const passwordError = submitted && password === '';
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setSubmitted(true);
-    if (identifier === '' || password === '') {
+    const normalizedIdentifier = identifier.trim();
+    if (identifier !== normalizedIdentifier) {
+      setIdentifier(normalizedIdentifier);
+    }
+    if (normalizedIdentifier === '' || password === '') {
       identifierRef.current?.focus();
       return;
     }
     setLoading(true);
     try {
-      const user = await login(identifier, password);
+      const user = await login(normalizedIdentifier, password);
       const redirect = await onLogin(user);
       navigate(redirect);
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- trim leading and trailing whitespace from the login identifier before validating or submitting
- update the login tests to cover whitespace trimming and ensure the field value is normalized after submit

## Testing
- npm test -- Login.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6c61e5528832d82fbe7a5e1b9f503