### PR TITLE
Improve password dialogs tap targets

### DIFF
--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -50,7 +50,11 @@ export default function PasswordResetDialog({
           <FormCard
             title={formTitle}
             onSubmit={handleSubmit}
-            actions={<Button type="submit" variant="contained">Submit</Button>}
+            actions={
+              <Button type="submit" variant="contained" fullWidth sx={{ minHeight: 48 }}>
+                Submit
+              </Button>
+            }
             boxProps={{ minHeight: 'auto', p: 0 }}
           >
             <Typography variant="body2">
@@ -58,7 +62,6 @@ export default function PasswordResetDialog({
             </Typography>
             <TextField
               autoFocus
-              margin="dense"
               label="Email or client ID"
               type="text"
               name="identifier"

--- a/MJ_FB_Frontend/src/components/ResendPasswordSetupDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ResendPasswordSetupDialog.tsx
@@ -43,7 +43,11 @@ export default function ResendPasswordSetupDialog({
           <FormCard
             title="Resend password setup link"
             onSubmit={handleSubmit}
-            actions={<Button type="submit" variant="contained">Submit</Button>}
+            actions={
+              <Button type="submit" variant="contained" fullWidth sx={{ minHeight: 48 }}>
+                Submit
+              </Button>
+            }
             boxProps={{ minHeight: 'auto', p: 0 }}
           >
             <Typography variant="body2">
@@ -51,7 +55,6 @@ export default function ResendPasswordSetupDialog({
             </Typography>
             <TextField
               autoFocus
-              margin="dense"
               label="Email or client ID"
               name="email"
               autoComplete="email"


### PR DESCRIPTION
## Summary
- remove dense margin override from password reset identifier fields so they use the default sizing
- expand the submit buttons in both password reset dialogs to full width with a 48px minimum height for consistent tap targets

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cae782e8832da83925666ff8eedd