### PR TITLE
Add keep booking option to client cancel dialog

### DIFF
--- a/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
+++ b/MJ_FB_Frontend/src/pages/client/ClientDashboard.tsx
@@ -389,6 +389,14 @@ export default function ClientDashboard() {
           <DialogActions>
             <Button
 
+              variant="outlined"
+              sx={{ textTransform: 'none' }}
+              onClick={() => setCancelId(null)}
+            >
+              Keep booking
+            </Button>
+            <Button
+
               color="error"
               variant="contained"
               sx={{ textTransform: 'none' }}


### PR DESCRIPTION
## Summary
- add a Keep booking secondary action to the client cancellation confirmation dialog so the destructive button remains last
- update the ClientDashboard tests to expect the new button and verify it dismisses the dialog without cancelling

## Testing
- npm test -- ClientDashboard

------
https://chatgpt.com/codex/tasks/task_e_68d6ce0d09e8832dad8b768c5450af03