### PR TITLE
Fix password reset dialog validation handling

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/PasswordResetDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/PasswordResetDialog.test.tsx
@@ -13,6 +13,40 @@ describe('PasswordResetDialog', () => {
     jest.resetAllMocks();
   });
 
+  it('disables submit button when identifier is blank', () => {
+    render(<PasswordResetDialog open onClose={() => {}} />);
+    const submitButton = screen.getByRole('button', { name: /submit/i });
+
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/email or client id/i), {
+      target: { value: '   ' },
+    });
+
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/email or client id/i), {
+      target: { value: 'user@example.com' },
+    });
+
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('shows inline error when submitting an empty identifier', async () => {
+    render(<PasswordResetDialog open onClose={() => {}} />);
+
+    const form = screen.getByLabelText(/email or client id/i).closest('form');
+    expect(form).not.toBeNull();
+
+    fireEvent.submit(form!);
+
+    await waitFor(() =>
+      expect(screen.getByText('Enter your email or client ID.')).toBeInTheDocument(),
+    );
+
+    expect(requestPasswordReset).not.toHaveBeenCalled();
+  });
+
   it('submits email identifier', async () => {
     render(<PasswordResetDialog open onClose={() => {}} />);
     fireEvent.change(screen.getByLabelText(/email or client id/i), {
@@ -23,6 +57,27 @@ describe('PasswordResetDialog', () => {
       expect(requestPasswordReset).toHaveBeenCalledWith({
         email: 'user@example.com',
       }),
+    );
+  });
+
+  it('clears inline error when entering a valid identifier after an empty submission', async () => {
+    render(<PasswordResetDialog open onClose={() => {}} />);
+
+    const form = screen.getByLabelText(/email or client id/i).closest('form');
+    expect(form).not.toBeNull();
+
+    fireEvent.submit(form!);
+
+    await waitFor(() =>
+      expect(screen.getByText('Enter your email or client ID.')).toBeInTheDocument(),
+    );
+
+    fireEvent.change(screen.getByLabelText(/email or client id/i), {
+      target: { value: 'user@example.com' },
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText('Enter your email or client ID.')).not.toBeInTheDocument(),
     );
   });
 

--- a/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
+++ b/MJ_FB_Frontend/src/components/PasswordResetDialog.tsx
@@ -16,16 +16,29 @@ export default function PasswordResetDialog({
   onClose: () => void;
 }) {
   const [identifier, setIdentifier] = useState('');
+  const [identifierError, setIdentifierError] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<AlertColor>('success');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const formTitle = 'Reset password';
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    const trimmedIdentifier = identifier.trim();
+
+    if (!trimmedIdentifier) {
+      setIdentifierError('Enter your email or client ID.');
+      return;
+    }
+
+    setIdentifierError('');
+    setError('');
+    setMessage('');
+    setIsSubmitting(true);
+
     try {
-      const trimmedIdentifier = identifier.trim();
       const body: PasswordResetBody =
         trimmedIdentifier.includes('@') || !/^\d+$/.test(trimmedIdentifier)
           ? { email: trimmedIdentifier }
@@ -36,8 +49,12 @@ export default function PasswordResetDialog({
       setIdentifier('');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSubmitting(false);
     }
   }
+
+  const isSubmitDisabled = isSubmitting || identifier.trim().length === 0;
 
   return (
     <>
@@ -51,7 +68,13 @@ export default function PasswordResetDialog({
             title={formTitle}
             onSubmit={handleSubmit}
             actions={
-              <Button type="submit" variant="contained" fullWidth sx={{ minHeight: 48 }}>
+              <Button
+                type="submit"
+                variant="contained"
+                fullWidth
+                sx={{ minHeight: 48 }}
+                disabled={isSubmitDisabled}
+              >
                 Submit
               </Button>
             }
@@ -68,7 +91,15 @@ export default function PasswordResetDialog({
               autoComplete="email"
               fullWidth
               value={identifier}
-              onChange={e => setIdentifier(e.target.value)}
+              onChange={e => {
+                const value = e.target.value;
+                setIdentifier(value);
+                if (identifierError && value.trim().length > 0) {
+                  setIdentifierError('');
+                }
+              }}
+              error={Boolean(identifierError)}
+              helperText={identifierError}
             />
           </FormCard>
         </DialogContent>


### PR DESCRIPTION
## Summary
- add inline validation and submission state handling to the password reset dialog
- keep the snackbar reserved for backend responses while disabling submit until input is valid
- expand password reset dialog tests to cover validation errors and successful submissions

## Testing
- npm test -- PasswordResetDialog

------
https://chatgpt.com/codex/tasks/task_e_68d6cf617550832d8afa81b54a855c68