### PR TITLE
Validate identifier input in resend password dialog

### DIFF
--- a/MJ_FB_Frontend/src/components/ResendPasswordSetupDialog.tsx
+++ b/MJ_FB_Frontend/src/components/ResendPasswordSetupDialog.tsx
@@ -16,17 +16,30 @@ export default function ResendPasswordSetupDialog({
   const [identifier, setIdentifier] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [identifierError, setIdentifierError] = useState('');
+
+  const trimmedIdentifier = identifier.trim();
+  const isSubmitDisabled = trimmedIdentifier.length === 0;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (!trimmedIdentifier) {
+      setIdentifierError('Enter your email or client ID.');
+      return;
+    }
+
+    setIdentifierError('');
+    setMessage('');
+    setError('');
+
     try {
-      const value = identifier.trim();
-      const body = /^\d+$/.test(value)
-        ? { clientId: value }
-        : { email: value };
+      const body = /^\d+$/.test(trimmedIdentifier)
+        ? { clientId: trimmedIdentifier }
+        : { email: trimmedIdentifier };
       await resendPasswordSetup(body);
       setMessage('Password setup link sent');
       setIdentifier('');
+      setIdentifierError('');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     }
@@ -44,7 +57,13 @@ export default function ResendPasswordSetupDialog({
             title="Resend password setup link"
             onSubmit={handleSubmit}
             actions={
-              <Button type="submit" variant="contained" fullWidth sx={{ minHeight: 48 }}>
+              <Button
+                type="submit"
+                variant="contained"
+                fullWidth
+                sx={{ minHeight: 48 }}
+                disabled={isSubmitDisabled}
+              >
                 Submit
               </Button>
             }
@@ -60,7 +79,14 @@ export default function ResendPasswordSetupDialog({
               autoComplete="email"
               fullWidth
               value={identifier}
-              onChange={e => setIdentifier(e.target.value)}
+              onChange={e => {
+                setIdentifier(e.target.value);
+                if (identifierError) {
+                  setIdentifierError('');
+                }
+              }}
+              error={Boolean(identifierError)}
+              helperText={identifierError}
             />
           </FormCard>
         </DialogContent>

--- a/MJ_FB_Frontend/src/components/__tests__/ResendPasswordSetupDialog.test.tsx
+++ b/MJ_FB_Frontend/src/components/__tests__/ResendPasswordSetupDialog.test.tsx
@@ -1,0 +1,74 @@
+import ResendPasswordSetupDialog from '../ResendPasswordSetupDialog';
+import userEvent from '@testing-library/user-event';
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '../../../testUtils/renderWithProviders';
+import * as usersApi from '../../api/users';
+
+jest.mock('../../api/users', () => ({
+  resendPasswordSetup: jest.fn(),
+}));
+
+describe('ResendPasswordSetupDialog', () => {
+  const resendPasswordSetupMock =
+    usersApi.resendPasswordSetup as jest.MockedFunction<
+      typeof usersApi.resendPasswordSetup
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows inline error when submitted with a blank identifier', async () => {
+    renderWithProviders(
+      <ResendPasswordSetupDialog open onClose={() => {}} />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: /submit/i });
+    expect(submitButton).toBeDisabled();
+
+    const form = submitButton.closest('form');
+    expect(form).toBeTruthy();
+
+    fireEvent.submit(form!);
+
+    expect(
+      await screen.findByText('Enter your email or client ID.'),
+    ).toBeInTheDocument();
+    expect(resendPasswordSetupMock).not.toHaveBeenCalled();
+  });
+
+  it('submits successfully and shows a confirmation message', async () => {
+    const user = userEvent.setup();
+    resendPasswordSetupMock.mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <ResendPasswordSetupDialog open onClose={() => {}} />,
+    );
+
+    const identifierField = screen.getByLabelText('Email or client ID');
+
+    await user.type(identifierField, 'client@example.com');
+
+    const submitButton = screen.getByRole('button', { name: /submit/i });
+    expect(submitButton).toBeEnabled();
+
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(resendPasswordSetupMock).toHaveBeenCalledWith({
+        email: 'client@example.com',
+      });
+    });
+
+    expect(
+      await screen.findByText('Password setup link sent'),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(identifierField).toHaveValue('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- prevent submitting the resend password dialog with a blank identifier and surface inline field errors
- disable the submit action until input is provided while keeping snackbar feedback for API responses
- add unit tests covering validation errors and successful resend submissions

## Testing
- npm test -- ResendPasswordSetupDialog

------
https://chatgpt.com/codex/tasks/task_e_68d6cf6f0ca0832dbbc7d9436c993c2b