### PR TITLE
Improve change password validation

### DIFF
--- a/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/ChangePasswordForm.tsx
@@ -5,21 +5,59 @@ import Page from '../../components/Page';
 import { changePassword } from '../../api/users';
 import FeedbackSnackbar from '../../components/FeedbackSnackbar';
 import FormCard from '../../components/FormCard';
+import PasswordChecklist from '../../components/PasswordChecklist';
+
+function getNewPasswordError(password: string) {
+  if (!password) {
+    return 'Enter a new password.';
+  }
+  if (password.length < 8) {
+    return 'Password must be at least 8 characters long.';
+  }
+  if (!/[A-Z]/.test(password) || !/[a-z]/.test(password)) {
+    return 'Password must include uppercase and lowercase letters.';
+  }
+  if (!/[^A-Za-z0-9]/.test(password)) {
+    return 'Password must include a symbol.';
+  }
+  return '';
+}
 
 export default function ChangePasswordForm() {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [success, setSuccess] = useState('');
   const [error, setError] = useState('');
+  const [currentPasswordTouched, setCurrentPasswordTouched] = useState(false);
+  const [newPasswordTouched, setNewPasswordTouched] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const currentPasswordErrorMessage = currentPasswordTouched && !currentPassword ? 'Enter your current password.' : '';
+  const newPasswordValidationError = getNewPasswordError(newPassword);
+  const shouldShowNewPasswordError = newPasswordTouched && !!newPasswordValidationError;
+  const canSubmit = !!currentPassword && !newPasswordValidationError && !submitting;
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    setCurrentPasswordTouched(true);
+    setNewPasswordTouched(true);
+    setSuccess('');
+    setError('');
+    if (!currentPassword || newPasswordValidationError) {
+      return;
+    }
     try {
+      setSubmitting(true);
       await changePassword(currentPassword, newPassword);
       setSuccess('Password updated');
       setCurrentPassword('');
       setNewPassword('');
+      setCurrentPasswordTouched(false);
+      setNewPasswordTouched(false);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -30,26 +68,63 @@ export default function ChangePasswordForm() {
         title="Change Password"
         centered={false}
         actions={
-          <Button type="submit" variant="contained" color="primary" fullWidth>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={!canSubmit}
+          >
             Reset Password
           </Button>
         }
       >
         <PasswordField
           label="Current Password"
+          name="current-password"
+          autoComplete="current-password"
           value={currentPassword}
-          onChange={e => setCurrentPassword(e.target.value)}
+          onChange={e => {
+            setCurrentPassword(e.target.value);
+          }}
+          onBlur={() => setCurrentPasswordTouched(true)}
+          error={!!currentPasswordErrorMessage}
+          helperText={currentPasswordErrorMessage || undefined}
           fullWidth
+          required
         />
         <PasswordField
           label="New Password"
+          name="new-password"
+          autoComplete="new-password"
           value={newPassword}
-          onChange={e => setNewPassword(e.target.value)}
+          onChange={e => {
+            setNewPassword(e.target.value);
+          }}
+          onBlur={() => setNewPasswordTouched(true)}
+          error={shouldShowNewPasswordError}
+          helperText={
+            shouldShowNewPasswordError
+              ? newPasswordValidationError
+              : 'Must be at least 8 characters and include uppercase, lowercase, and special characters.'
+          }
           fullWidth
+          required
         />
+        <PasswordChecklist password={newPassword} />
       </FormCard>
-      <FeedbackSnackbar open={!!success} onClose={() => setSuccess('')} message={success} severity="success" />
-      <FeedbackSnackbar open={!!error} onClose={() => setError('')} message={error} severity="error" />
+      <FeedbackSnackbar
+        open={!!error}
+        onClose={() => setError('')}
+        message={error}
+        severity="error"
+      />
+      <FeedbackSnackbar
+        open={!!success}
+        onClose={() => setSuccess('')}
+        message={success}
+        severity="success"
+      />
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/auth/__tests__/ChangePasswordForm.test.tsx
+++ b/MJ_FB_Frontend/src/pages/auth/__tests__/ChangePasswordForm.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ChangePasswordForm from '../ChangePasswordForm';
+import { changePassword } from '../../../api/users';
+
+jest.mock('../../../api/users', () => ({
+  ...jest.requireActual('../../../api/users'),
+  changePassword: jest.fn(),
+}));
+
+const mockedChangePassword = changePassword as jest.MockedFunction<typeof changePassword>;
+
+function renderForm() {
+  render(
+    <MemoryRouter>
+      <ChangePasswordForm />
+    </MemoryRouter>,
+  );
+}
+
+describe('ChangePasswordForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedChangePassword.mockResolvedValue(undefined);
+  });
+
+  it('disables submission until the current password and new password are valid', () => {
+    renderForm();
+
+    const submitButton = screen.getByRole('button', { name: /reset password/i });
+    const currentPasswordField = screen.getByLabelText(/current password/i, { selector: 'input' });
+    const newPasswordField = screen.getByLabelText(/new password/i, { selector: 'input' });
+
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(currentPasswordField, { target: { value: 'Current1!' } });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(newPasswordField, { target: { value: 'short' } });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(newPasswordField, { target: { value: 'ValidPass!' } });
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it('shows inline errors when validation fails', () => {
+    renderForm();
+
+    const currentPasswordField = screen.getByLabelText(/current password/i, { selector: 'input' });
+    const newPasswordField = screen.getByLabelText(/new password/i, { selector: 'input' });
+
+    fireEvent.focus(currentPasswordField);
+    fireEvent.blur(currentPasswordField);
+    expect(screen.getByText(/enter your current password/i)).toBeInTheDocument();
+
+    fireEvent.focus(newPasswordField);
+    fireEvent.blur(newPasswordField);
+    expect(screen.getByText(/enter a new password/i)).toBeInTheDocument();
+
+    fireEvent.change(currentPasswordField, { target: { value: 'Current1!' } });
+    fireEvent.change(newPasswordField, { target: { value: 'alllower!' } });
+    fireEvent.blur(newPasswordField);
+
+    expect(screen.getByText(/password must include uppercase and lowercase letters/i)).toBeInTheDocument();
+    expect(mockedChangePassword).not.toHaveBeenCalled();
+  });
+
+  it('submits successfully when all rules are met', async () => {
+    renderForm();
+
+    const currentPasswordField = screen.getByLabelText(/current password/i, { selector: 'input' });
+    const newPasswordField = screen.getByLabelText(/new password/i, { selector: 'input' });
+    const submitButton = screen.getByRole('button', { name: /reset password/i });
+
+    fireEvent.change(currentPasswordField, { target: { value: 'Current1!' } });
+    fireEvent.change(newPasswordField, { target: { value: 'ValidPass!' } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockedChangePassword).toHaveBeenCalledWith('Current1!', 'ValidPass!');
+    });
+
+    expect(await screen.findByText(/password updated/i)).toBeInTheDocument();
+    expect(currentPasswordField).toHaveValue('');
+    expect(newPasswordField).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## Summary
- add inline validation and password checklist feedback to ChangePasswordForm
- prevent submissions until the new password satisfies setup rules and the current password is provided
- cover successful submissions and validation errors with dedicated tests

## Testing
- npm test -- ChangePasswordForm

------
https://chatgpt.com/codex/tasks/task_e_68d6cdf1b2f8832d839f388842f27d56