### PR TITLE
Align donation log form date with selected month

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -82,12 +82,17 @@ export default function DonationLog() {
   const [toDelete, setToDelete] = useState<Donation | null>(null);
   const { open, message, showSnackbar, closeSnackbar, severity } = useSnackbar();
 
+  const monthStartDate = useCallback(
+    (value: string) => (value ? `${value}-01` : formatDate()),
+    [],
+  );
+
   const [form, setForm] = useState<{
     date: string;
     donorId: number | null;
     weight: string;
   }>({
-    date: formatDate(),
+    date: monthStartDate(formatMonth()),
     donorId: null,
     weight: '',
   });
@@ -185,7 +190,7 @@ export default function DonationLog() {
       .then(() => {
         setRecordOpen(false);
         setEditing(null);
-        setForm({ date: formatDate(), donorId: null, weight: '' });
+        setForm({ date: monthStartDate(month), donorId: null, weight: '' });
         loadDonations();
         showSnackbar(editing ? 'Donation updated' : 'Donation recorded');
       })
@@ -245,7 +250,7 @@ export default function DonationLog() {
             variant="contained"
             onClick={e => {
               (e.currentTarget as HTMLButtonElement).blur();
-              setForm({ date: formatDate(), donorId: null, weight: '' });
+              setForm({ date: monthStartDate(month), donorId: null, weight: '' });
               setEditing(null);
               setRecordOpen(true);
             }}


### PR DESCRIPTION
## Summary
- default new donation entries to the first day of the selected month
- reset the donation form to the active month after saving

## Testing
- npm test -- WarehouseDonationLog.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6e1f805a4832d8e4314831b438f89