### PR TITLE
Align donation log form defaults with selected month

### DIFF
--- a/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
+++ b/MJ_FB_Frontend/src/pages/warehouse-management/DonationLog.tsx
@@ -31,7 +31,7 @@ import {
 import type { Donor } from '../../api/donors';
 import type { Donation } from '../../api/donations';
 import ResponsiveTable, { type Column } from '../../components/ResponsiveTable';
-import { formatLocaleDate, formatDate } from '../../utils/date';
+import { formatLocaleDate } from '../../utils/date';
 
 function formatMonth(date = new Date()) {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
@@ -82,10 +82,10 @@ export default function DonationLog() {
   const [toDelete, setToDelete] = useState<Donation | null>(null);
   const { open, message, showSnackbar, closeSnackbar, severity } = useSnackbar();
 
-  const monthStartDate = useCallback(
-    (value: string) => (value ? `${value}-01` : formatDate()),
-    [],
-  );
+  const monthStartDate = useCallback((value: string) => {
+    const activeMonth = value || formatMonth();
+    return `${activeMonth}-01`;
+  }, []);
 
   const [form, setForm] = useState<{
     date: string;


### PR DESCRIPTION
## Summary
- ensure the donation form defaults to the first day of the selected month when opening or resetting
- remove the unused `formatDate` helper import from the donation log page

## Testing
- npm test -- WarehouseDonationLog

------
https://chatgpt.com/codex/tasks/task_e_68d6e33f2a78832d89377cffe8722b01