### PR TITLE
Ensure daily job starters run under test

### DIFF
--- a/MJ_FB_Backend/src/utils/bookingReminderJob.ts
+++ b/MJ_FB_Backend/src/utils/bookingReminderJob.ts
@@ -7,12 +7,20 @@ import {
   formatTimeToAmPm,
 } from './dateUtils';
 import logger from './logger';
-import scheduleDailyJob from './scheduleDailyJob';
+import scheduleDailyJob, { createDailyJob as namedCreateDailyJob } from './scheduleDailyJob';
 import { buildCancelRescheduleLinks } from './emailUtils';
 import config from '../config';
 import { alertOps, notifyOps } from './opsAlert';
 
-const createDailyJob = scheduleDailyJob.createDailyJob ?? scheduleDailyJob;
+const createDailyJob =
+  typeof namedCreateDailyJob === 'function'
+    ? namedCreateDailyJob
+    : (
+        callback: () => void | Promise<void>,
+        schedule: string,
+        runOnStart: boolean,
+        skipInTest: boolean,
+      ) => scheduleDailyJob(callback, schedule, runOnStart, skipInTest);
 
 /**
  * Send reminder emails for bookings scheduled for the next day.
@@ -98,6 +106,11 @@ const bookingReminderJob = createDailyJob(
   false,
 );
 
-export const startBookingReminderJob = bookingReminderJob.start;
-export const stopBookingReminderJob = bookingReminderJob.stop;
+export const startBookingReminderJob = (): void => {
+  bookingReminderJob.start();
+};
+
+export const stopBookingReminderJob = (): void => {
+  bookingReminderJob.stop();
+};
 

--- a/MJ_FB_Backend/src/utils/emailQueueCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/emailQueueCleanupJob.ts
@@ -1,10 +1,18 @@
 import pool from '../db';
 import config from '../config';
 import logger from './logger';
-import scheduleDailyJob from './scheduleDailyJob';
+import scheduleDailyJob, { createDailyJob as namedCreateDailyJob } from './scheduleDailyJob';
 import { alertOps, notifyOps } from './opsAlert';
 
-const createDailyJob = scheduleDailyJob.createDailyJob ?? scheduleDailyJob;
+const createDailyJob =
+  typeof namedCreateDailyJob === 'function'
+    ? namedCreateDailyJob
+    : (
+        callback: () => void | Promise<void>,
+        schedule: string,
+        runOnStart: boolean,
+        skipInTest: boolean,
+      ) => scheduleDailyJob(callback, schedule, runOnStart, skipInTest);
 
 export async function cleanupEmailQueue(): Promise<void> {
   try {
@@ -34,6 +42,11 @@ const emailQueueCleanupJob = createDailyJob(
   false,
 );
 
-export const startEmailQueueCleanupJob = emailQueueCleanupJob.start;
-export const stopEmailQueueCleanupJob = emailQueueCleanupJob.stop;
+export const startEmailQueueCleanupJob = (): void => {
+  emailQueueCleanupJob.start();
+};
+
+export const stopEmailQueueCleanupJob = (): void => {
+  emailQueueCleanupJob.stop();
+};
 

--- a/MJ_FB_Backend/src/utils/passwordTokenCleanupJob.ts
+++ b/MJ_FB_Backend/src/utils/passwordTokenCleanupJob.ts
@@ -1,8 +1,16 @@
 import pool from '../db';
 import logger from './logger';
-import scheduleDailyJob from './scheduleDailyJob';
+import scheduleDailyJob, { createDailyJob as namedCreateDailyJob } from './scheduleDailyJob';
 
-const createDailyJob = scheduleDailyJob.createDailyJob ?? scheduleDailyJob;
+const createDailyJob =
+  typeof namedCreateDailyJob === 'function'
+    ? namedCreateDailyJob
+    : (
+        callback: () => void | Promise<void>,
+        schedule: string,
+        runOnStart: boolean,
+        skipInTest: boolean,
+      ) => scheduleDailyJob(callback, schedule, runOnStart, skipInTest);
 
 /**
  * Remove used or expired password setup tokens.
@@ -27,6 +35,11 @@ const passwordTokenCleanupJob = createDailyJob(
   false,
 );
 
-export const startPasswordTokenCleanupJob = passwordTokenCleanupJob.start;
-export const stopPasswordTokenCleanupJob = passwordTokenCleanupJob.stop;
+export const startPasswordTokenCleanupJob = (): void => {
+  passwordTokenCleanupJob.start();
+};
+
+export const stopPasswordTokenCleanupJob = (): void => {
+  passwordTokenCleanupJob.stop();
+};
 

--- a/MJ_FB_Backend/tests/passwordTokenCleanupJob.test.ts
+++ b/MJ_FB_Backend/tests/passwordTokenCleanupJob.test.ts
@@ -10,9 +10,11 @@ jest.mock(
 );
 jest.mock('../src/utils/scheduleDailyJob', () => {
   const actual = jest.requireActual('../src/utils/scheduleDailyJob');
+  const defaultMock = jest.fn((cb: any, schedule: string) => actual.default(cb, schedule));
   return {
     __esModule: true,
-    default: (cb: any, schedule: string) => actual.default(cb, schedule, false, false),
+    default: defaultMock,
+    createDailyJob: actual.createDailyJob,
   };
 });
 const job = require('../src/utils/passwordTokenCleanupJob');


### PR DESCRIPTION
## Summary
- ensure booking reminder, email queue cleanup, and password token cleanup jobs use a helper that forwards runOnStart/skipInTest flags even when scheduleDailyJob is mocked
- wrap exported start/stop helpers to invoke the underlying job methods directly
- update job unit tests to keep node-cron scheduling active in the Jest environment while using mocks that exercise the new helper

## Testing
- npm test -- --runTestsByPath tests/passwordTokenCleanupJob.test.ts
- npm test -- --runTestsByPath tests/emailQueueCleanupJob.test.ts
- npm test -- --runTestsByPath tests/bookingReminderJob.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6e55b8f98832da765e9096e8b238b