### PR TITLE
Improve volunteer schedule filter responsiveness

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -802,8 +802,17 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
         </Suspense>
       )}
       {tab === 'schedule' && (
-        <div>
-          <FormControl sx={{ minWidth: 200, mr: 2 }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          sx={{ mb: 2 }}
+        >
+          <FormControl
+            size="medium"
+            fullWidth
+            sx={{ minWidth: { sm: 200 }, flexShrink: { sm: 0 } }}
+          >
             <InputLabel id="schedule-department-label">Department</InputLabel>
             <Select
               labelId="schedule-department-label"
@@ -818,7 +827,11 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
               {departmentItems}
             </Select>
           </FormControl>
-          <FormControl sx={{ minWidth: 200 }}>
+          <FormControl
+            size="medium"
+            fullWidth
+            sx={{ minWidth: { sm: 200 }, flexShrink: { sm: 0 } }}
+          >
             <InputLabel id="schedule-role-label">Role</InputLabel>
             <Select
               labelId="schedule-role-label"
@@ -833,6 +846,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
               {scheduleRoleItems}
             </Select>
           </FormControl>
+        </Stack>
           {selectedRole && roleInfos.length > 0 ? (
             <>
               <Stack


### PR DESCRIPTION
## Summary
- wrap the volunteer schedule department and role filters in a responsive Stack layout
- allow both selects to grow to full width on small screens so the filters are easier to use

## Testing
- npm test -- --runTestsByPath src/__tests__/VolunteerSchedule.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6f9a6619c832db5fa12ff5f105f2a