### PR TITLE
Limit volunteer role menus to viewport

### DIFF
--- a/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/VolunteerManagement.tsx
@@ -156,6 +156,19 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
     no_show: 'rgb(255, 200, 200)',
     completed: 'rgb(111,146,113)',
   };
+  const roleMenuProps = useMemo(
+    () => ({
+      slotProps: {
+        paper: {
+          sx: {
+            maxHeight: 'min(360px, calc(100vh - 96px))',
+            overflowY: 'auto',
+          },
+        },
+      },
+    }),
+    []
+  );
 
   useEffect(() => {
     if (tab !== 'search') {
@@ -1141,6 +1154,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                           toggleTrained(val, true);
                           setNewTrainedRole('');
                         }}
+                        MenuProps={roleMenuProps}
                       >
                         {groupedRoles.flatMap(g => [
                           <ListSubheader key={`${g.category}-header`}>
@@ -1256,6 +1270,7 @@ export default function VolunteerManagement({ initialTab }: VolunteerManagementP
                   const names = selected as string[];
                   return names.length ? names.join(', ') : 'Select roles';
                 }}
+                MenuProps={roleMenuProps}
               >
                 {groupedRoles.flatMap(g => [
                   <ListSubheader key={`${g.category}-header`}>{g.category}</ListSubheader>,


### PR DESCRIPTION
## Summary
- add shared MenuProps for volunteer role selects to cap menu height and enable scrolling
- apply the constrained menu styling to both the edit dialog and create volunteer form role pickers

## Testing
- npm test -- --watch=false *(fails: existing tests expect privacy notice modal to stay dismissed and cannot find links when it appears)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f83ffffc832d979e58a7c27f5f5c