### PR TITLE
Move Manage Availability link to staff profile dropdown

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/Navbar.test.tsx
@@ -32,8 +32,9 @@ describe('Navbar component', () => {
           role="staff"
           profileLinks={[
             { label: 'News & Events', to: '/events' },
+            { label: 'Manage Availability', to: '/pantry/manage-availability' },
             { label: 'Timesheets', to: '/timesheet' },
-            { label: 'Leave Management', to: '/leave-requests' },
+            { label: 'Leave Requests', to: '/leave-requests' },
           ]}
         />
       </MemoryRouter>,
@@ -43,7 +44,8 @@ describe('Navbar component', () => {
     fireEvent.click(screen.getByText(/Hello, Tester/i));
     const profileMenu = document.getElementById('profile-menu') as HTMLElement;
     expect(within(profileMenu).getByText(/Timesheets/i)).toBeInTheDocument();
-    expect(within(profileMenu).getByText(/Leave Management/i)).toBeInTheDocument();
+    expect(within(profileMenu).getByText(/Manage Availability/i)).toBeInTheDocument();
+    expect(within(profileMenu).getByText(/Leave Requests/i)).toBeInTheDocument();
   });
 
   it('renders without greeting when name is absent', () => {

--- a/MJ_FB_Frontend/src/utils/navConfig.ts
+++ b/MJ_FB_Frontend/src/utils/navConfig.ts
@@ -15,6 +15,7 @@ interface BuildNavOptions {
 
 const STAFF_PROFILE_LINKS: NavLink[] = [
   { label: 'News & Events', to: '/events' },
+  { label: 'Manage Availability', to: '/pantry/manage-availability' },
   { label: 'Timesheets', to: '/timesheet' },
   { label: 'Leave Requests', to: '/leave-requests' },
 ];
@@ -42,7 +43,6 @@ export function buildNavData({
   if (isStaff) {
     const staffLinks: NavLink[] = [
       { label: 'Dashboard', to: '/pantry' },
-      { label: 'Manage Availability', to: '/pantry/manage-availability' },
       { label: 'Pantry Schedule', to: '/pantry/schedule' },
       { label: 'Pantry Visits', to: '/pantry/visits' },
       { label: 'Client Management', to: '/pantry/client-management' },


### PR DESCRIPTION
## Summary
- add the Manage Availability route to the reusable staff profile links and remove it from the Harvest Pantry navigation group
- update the navbar unit test to expect the Manage Availability and Leave Requests entries in the staff profile dropdown

## Testing
- npm test -- --runTestsByPath src/__tests__/Navbar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6fb38ffd0832da8d6daabc523e81b