### PR TITLE
Add volunteer detail endpoint and enrich stats

### DIFF
--- a/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
+++ b/MJ_FB_Backend/src/routes/volunteer/volunteers.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import {
+  getVolunteerById,
   updateTrainedArea,
   getVolunteerProfile,
   createVolunteer,
@@ -28,6 +29,13 @@ router.get(
   authMiddleware,
   authorizeRoles('staff'),
   getVolunteerStatsById,
+);
+
+router.get(
+  '/:id',
+  authMiddleware,
+  authorizeRoles('staff'),
+  getVolunteerById,
 );
 
 router.post('/me/badges', authMiddleware, awardVolunteerBadge);

--- a/MJ_FB_Frontend/src/api/volunteers.ts
+++ b/MJ_FB_Frontend/src/api/volunteers.ts
@@ -65,11 +65,27 @@ export async function getVolunteerById(
   return handleResponse(res);
 }
 
+export interface VolunteerMostBookedRole {
+  roleId: number;
+  roleName: string;
+  shifts: number;
+  hours: number;
+}
+
+export interface VolunteerLastCompletedShift {
+  date: string;
+  roleId: number;
+  roleName: string;
+  hours: number;
+}
+
 export interface VolunteerStatsByIdResponse {
   volunteerId: number;
   lifetime: { hours: number; shifts: number };
   yearToDate: { hours: number; shifts: number };
   monthToDate: { hours: number; shifts: number };
+  mostBookedRoles: VolunteerMostBookedRole[];
+  lastCompletedShift: VolunteerLastCompletedShift | null;
 }
 
 export async function getVolunteerStatsById(


### PR DESCRIPTION
## Summary
- add a staff-protected GET /volunteers/:id endpoint that returns volunteer contact, shopper, and trained role details
- extend the volunteer stats query to include top completed roles and the most recent completed shift alongside existing totals
- align frontend API typings and backend tests with the new response shapes

## Testing
- npm test -- tests/volunteers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d70334b0e4832d95c085b046cbff03