### PR TITLE
Use card layout for volunteer schedule on small screens

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/VolunteerScheduleTable.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/VolunteerScheduleTable.test.tsx
@@ -26,4 +26,36 @@ describe('VolunteerScheduleTable', () => {
     const container = screen.getByRole('table').parentElement as HTMLElement;
     expect(container).toHaveStyle('overflow-x: auto');
   });
+  it('renders cards with fallback label on small screens', async () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+    try {
+      const onClick = jest.fn();
+      const { default: VolunteerScheduleTable } = await import('../components/VolunteerScheduleTable');
+      const rows = [
+        {
+          time: '9:00 - 10:00',
+          cells: [
+            { content: undefined, onClick },
+          ],
+        },
+      ];
+      render(<VolunteerScheduleTable maxSlots={2} rows={rows} />);
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+      const signupCell = screen.getByText('Sign up');
+      fireEvent.click(signupCell);
+      expect(onClick).toHaveBeenCalled();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
 });

--- a/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
+++ b/MJ_FB_Frontend/src/components/VolunteerScheduleTable.tsx
@@ -11,6 +11,7 @@ import {
   ButtonBase,
 } from '@mui/material';
 import type { ReactNode } from 'react';
+import ScheduleCards from './ScheduleCards';
 
 interface Cell {
   content: ReactNode;
@@ -33,6 +34,22 @@ export default function VolunteerScheduleTable({ maxSlots, rows }: Props) {
   const safeMaxSlots = Math.max(1, maxSlots);
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'), { noSsr: true });
+  if (isSmall) {
+    const cardRows = rows.map((row) => ({
+      ...row,
+      cells: row.cells.map((cell) => {
+        if (!cell.onClick) {
+          return cell;
+        }
+        const isEmptyContent =
+          cell.content === undefined ||
+          cell.content === null ||
+          (typeof cell.content === 'string' && cell.content.trim().length === 0);
+        return isEmptyContent ? { ...cell, content: 'Sign up' } : cell;
+      }),
+    }));
+    return <ScheduleCards maxSlots={safeMaxSlots} rows={cardRows} />;
+  }
   const cellPadding = isSmall ? 0.5 : 1;
   const fontSize = isSmall ? '0.75rem' : 'inherit';
   const timeColumnWidth = isSmall ? 80 : 160;


### PR DESCRIPTION
## Summary
- render the volunteer schedule as cards on small breakpoints while preserving the sign-up call to action for empty interactive slots
- add a unit test that forces a mobile matchMedia result to verify the card layout and fallback label

## Testing
- npm test -- --runTestsByPath src/__tests__/VolunteerScheduleTable.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7030fdd54832db643d101a52ed126