### PR TITLE
Allow staff manage availability route for non-pantry access

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -242,7 +242,7 @@ export default function App() {
                       }
                     />
                   )}
-                  {showStaff && (
+                  {isStaff && (
                     <Route path="/pantry/manage-availability" element={<ManageAvailability />} />
                   )}
                   {showStaff && (

--- a/MJ_FB_Frontend/src/__tests__/AppManageAvailabilityRoute.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/AppManageAvailabilityRoute.test.tsx
@@ -1,0 +1,119 @@
+import { act, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import App from '../App';
+import { mockFetch, restoreFetch } from '../../testUtils/mockFetch';
+import useMaintenance from '../hooks/useMaintenance';
+import { useAuth } from '../hooks/useAuth';
+
+type RecordedRoute = { path?: string };
+const recordedRoutes: RecordedRoute[] = [];
+let mockPathname = '/';
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  BrowserRouter: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Routes: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Route: ({ path, element }: { path?: string; element?: ReactNode }) => {
+    recordedRoutes.push({ path, element });
+    return null;
+  },
+  Navigate: () => null,
+  useLocation: () => ({ pathname: mockPathname }),
+  Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+  NavLink: ({ children }: { children: ReactNode }) => <>{children}</>,
+  __setMockPath: (path: string) => {
+    mockPathname = path;
+  },
+  __getRecordedRoutes: () => recordedRoutes,
+}));
+
+jest.mock('../hooks/useAuth', () => ({
+  __esModule: true,
+  useAuth: jest.fn(),
+  AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DonorManagementGuard: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('../components/FeedbackSnackbar', () => () => null);
+
+jest.mock('../hooks/useMaintenance', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../pages/staff/ManageAvailability', () => {
+  const mod = {
+    __esModule: true,
+    default: () => <div>ManageAvailabilityPage</div>,
+  };
+  (mod as any).then = (res: any) => Promise.resolve(res ? res(mod) : mod);
+  return mod;
+});
+
+const { __setMockPath, __getRecordedRoutes } = jest.requireMock('react-router-dom') as {
+  __setMockPath: (path: string) => void;
+  __getRecordedRoutes: () => RecordedRoute[];
+};
+
+const useAuthMock = useAuth as jest.MockedFunction<typeof useAuth>;
+const useMaintenanceMock = useMaintenance as jest.MockedFunction<typeof useMaintenance>;
+
+async function renderAppAt(path: string) {
+  window.history.pushState({}, '', path);
+  await act(async () => {
+    render(<App />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('Manage availability route access', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = mockFetch();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+
+    const routes = __getRecordedRoutes();
+    routes.length = 0;
+    __setMockPath('/');
+
+    useAuthMock.mockReturnValue({
+      isAuthenticated: true,
+      ready: true,
+      role: 'staff',
+      name: 'Test Staff',
+      userRole: '',
+      access: [],
+      id: null,
+      login: jest.fn(),
+      logout: jest.fn(),
+      cardUrl: '',
+    });
+
+    useMaintenanceMock.mockReturnValue({
+      maintenanceMode: false,
+      notice: undefined,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    jest.clearAllMocks();
+  });
+
+  it('renders manage availability for staff without pantry access', async () => {
+    __setMockPath('/pantry/manage-availability');
+    await renderAppAt('/pantry/manage-availability');
+
+    const routes = __getRecordedRoutes();
+    expect(routes.some(route => route.path === '/pantry/manage-availability')).toBe(true);
+  });
+});

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailabilityBreadcrumbs.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/ManageAvailabilityBreadcrumbs.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import ManageAvailability from '../ManageAvailability';
+import { useAuth } from '../../../hooks/useAuth';
+import { getAllSlots } from '../../../api/slots';
+import { getBreaks, getRecurringBlockedSlots, getBlockedSlots } from '../../../api/bookings';
+
+jest.mock('../../../hooks/useAuth', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('../../../api/bookings', () => ({
+  getHolidays: jest.fn().mockResolvedValue([]),
+  addHoliday: jest.fn(),
+  removeHoliday: jest.fn(),
+  addBlockedSlot: jest.fn(),
+  addRecurringBlockedSlot: jest.fn(),
+  removeBlockedSlot: jest.fn(),
+  removeRecurringBlockedSlot: jest.fn(),
+  getBlockedSlots: jest.fn().mockResolvedValue([]),
+  addBreak: jest.fn(),
+  removeBreak: jest.fn(),
+  getBreaks: jest.fn().mockResolvedValue([]),
+  getRecurringBlockedSlots: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../../api/slots', () => ({
+  getAllSlots: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../../components/FeedbackSnackbar', () => () => null);
+
+jest.mock('../../../components/ConfirmDialog', () => () => null);
+
+type MockTab = { label: string; content: ReactNode };
+
+jest.mock('../../../components/StyledTabs', () => ({
+  __esModule: true,
+  default: ({ tabs }: { tabs: MockTab[] }) => (
+    <div data-testid="styled-tabs">
+      {tabs.map((tab, index) => (
+        <div key={index} data-testid={`tab-${index}`}>
+          {tab.content}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('../../../components/Page', () => ({
+  __esModule: true,
+  default: ({
+    title,
+    header,
+    children,
+  }: {
+    title: string;
+    header?: ReactNode;
+    children: ReactNode;
+  }) => (
+    <div data-testid="page-wrapper">
+      <div data-testid="page-title">{title}</div>
+      {header ? <div data-testid="page-header">{header}</div> : null}
+      <div data-testid="page-content">{children}</div>
+    </div>
+  ),
+}));
+
+const useAuthMock = useAuth as jest.MockedFunction<typeof useAuth>;
+const getAllSlotsMock = getAllSlots as jest.MockedFunction<typeof getAllSlots>;
+const getBreaksMock = getBreaks as jest.MockedFunction<typeof getBreaks>;
+const getRecurringBlockedSlotsMock = getRecurringBlockedSlots as jest.MockedFunction<
+  typeof getRecurringBlockedSlots
+>;
+const getBlockedSlotsMock = getBlockedSlots as jest.MockedFunction<typeof getBlockedSlots>;
+
+describe('ManageAvailability breadcrumbs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthMock.mockReturnValue({ access: [] } as any);
+  });
+
+  it('shows pantry quick links for staff with pantry access', async () => {
+    useAuthMock.mockReturnValue({ access: ['pantry'] } as any);
+
+    render(
+      <MemoryRouter>
+        <ManageAvailability />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(getAllSlotsMock).toHaveBeenCalled();
+      expect(getBreaksMock).toHaveBeenCalled();
+      expect(getRecurringBlockedSlotsMock).toHaveBeenCalled();
+      expect(getBlockedSlotsMock).toHaveBeenCalled();
+    });
+
+    expect(screen.getByRole('link', { name: /pantry schedule/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /record a visit/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /search client/i })).toBeInTheDocument();
+  });
+
+  it('hides pantry quick links when staff lacks pantry access', async () => {
+    useAuthMock.mockReturnValue({ access: ['warehouse'] } as any);
+
+    render(
+      <MemoryRouter>
+        <ManageAvailability />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(getAllSlotsMock).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole('link', { name: /pantry schedule/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /record a visit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /search client/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- update the pantry manage-availability route guard to allow any staff member to reach it
- add a focused app-level test that verifies the manage-availability route is present for staff users without pantry access
- add manage-availability breadcrumbs tests to ensure pantry quick links appear only for staff with pantry access

## Testing
- CI=true npx jest --runInBand --watch=false --forceExit src/__tests__/AppManageAvailabilityRoute.test.tsx
- CI=true npx jest --runInBand --watch=false src/pages/staff/__tests__/ManageAvailabilityBreadcrumbs.test.tsx
- CI=true npx jest --runInBand --watch=false src/pages/staff/__tests__/ManageAvailability.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d6fb429934832d8c785a5db58fd34e