### PR TITLE
Add bookingsThisMonth to client lookup responses

### DIFF
--- a/MJ_FB_Frontend/src/__tests__/EditClientDialog.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/EditClientDialog.test.tsx
@@ -26,6 +26,7 @@ describe('EditClientDialog', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     render(<EditClientDialog {...props} />);
@@ -42,6 +43,7 @@ describe('EditClientDialog', () => {
       onlineAccess: false,
       hasPassword: false,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     render(<EditClientDialog {...props} />);
@@ -58,6 +60,7 @@ describe('EditClientDialog', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
     (updateUserInfo as jest.Mock).mockResolvedValueOnce(undefined);
 

--- a/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
+++ b/MJ_FB_Frontend/src/__tests__/UpdateClientData.test.tsx
@@ -34,6 +34,7 @@ beforeEach(() => {
     onlineAccess: false,
     hasPassword: false,
     role: 'shopper',
+    bookingsThisMonth: 0,
   });
   (requestPasswordReset as jest.Mock).mockResolvedValue(undefined);
 });
@@ -101,6 +102,7 @@ describe('UpdateClientData', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     render(<UpdateClientData />);
@@ -130,6 +132,7 @@ describe('UpdateClientData', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     render(<UpdateClientData />);

--- a/MJ_FB_Frontend/src/api/users.ts
+++ b/MJ_FB_Frontend/src/api/users.ts
@@ -216,6 +216,7 @@ export interface UserByClientId {
   onlineAccess: boolean;
   hasPassword: boolean;
   role: UserRole;
+  bookingsThisMonth?: number;
 }
 
 export async function getUserByClientId(

--- a/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/__tests__/EditClientDialog.test.tsx
@@ -34,6 +34,7 @@ describe('EditClientDialog', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     renderWithProviders(
@@ -61,6 +62,7 @@ describe('EditClientDialog', () => {
       onlineAccess: false,
       hasPassword: false,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     renderWithProviders(
@@ -88,6 +90,7 @@ describe('EditClientDialog', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
     (updateUserInfo as jest.Mock).mockResolvedValue(undefined);
 
@@ -125,6 +128,7 @@ describe('EditClientDialog', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     const user = userEvent.setup();
@@ -175,6 +179,7 @@ describe('EditClientDialog', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     function Harness() {

--- a/MJ_FB_Frontend/src/pages/staff/client-management/__tests__/UserHistory.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/__tests__/UserHistory.test.tsx
@@ -95,6 +95,7 @@ describe('UserHistory delivery orders', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'shopper',
+      bookingsThisMonth: 0,
     });
 
     renderWithProviders(
@@ -128,6 +129,7 @@ describe('UserHistory delivery orders', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'delivery',
+      bookingsThisMonth: 0,
     });
     mockGetDeliveryOrdersForClient.mockResolvedValueOnce([
       {
@@ -203,6 +205,7 @@ describe('UserHistory delivery orders', () => {
       onlineAccess: true,
       hasPassword: true,
       role: 'delivery',
+      bookingsThisMonth: 0,
     });
     mockGetDeliveryOrdersForClient.mockResolvedValueOnce([
       {

--- a/MJ_FB_Frontend/tests/pages/pantry/RecordDelivery.test.tsx
+++ b/MJ_FB_Frontend/tests/pages/pantry/RecordDelivery.test.tsx
@@ -145,6 +145,7 @@ describe('RecordDelivery page', () => {
     address: '123 Main St',
     phone: searchResult.phone,
     email: searchResult.email,
+    bookingsThisMonth: 0,
   } as const;
 
   const renderPage = () =>

--- a/MJ_FB_Frontend/tests/pages/staff/EditClientDialog.test.tsx
+++ b/MJ_FB_Frontend/tests/pages/staff/EditClientDialog.test.tsx
@@ -26,6 +26,7 @@ describe('EditClientDialog', () => {
       phone: '555-1111',
       onlineAccess: true,
       hasPassword: true,
+      bookingsThisMonth: 0,
     } as any);
   });
 

--- a/MJ_FB_Frontend/tests/pages/staff/PantryVisits.test.tsx
+++ b/MJ_FB_Frontend/tests/pages/staff/PantryVisits.test.tsx
@@ -62,6 +62,7 @@ describe('PantryVisits record dialog', () => {
       onlineAccess: false,
       hasPassword: false,
       role: 'shopper',
+      bookingsThisMonth: 0,
     } as any);
     addUserMock.mockResolvedValue();
   });


### PR DESCRIPTION
## Summary
- refresh the staff client lookup to include the bookings_this_month column, call getClientBookingsThisMonth, and surface the value in the JSON response
- expand backend tests to cover the refreshed value and cached fallback path
- add an optional bookingsThisMonth field to the frontend client lookup type and update related mocks/tests to expect it

## Testing
- npm test -- userController.test.ts
- npm test -- --runTestsByPath src/pages/staff/client-management/__tests__/UserHistory.test.tsx
- npm test -- --runTestsByPath src/__tests__/EditClientDialog.test.tsx
- npm test -- --runTestsByPath src/__tests__/UpdateClientData.test.tsx
- npm test -- --runTestsByPath tests/pages/pantry/RecordDelivery.test.tsx
- npm test -- --runTestsByPath tests/pages/staff/PantryVisits.test.tsx
- npm test -- --runTestsByPath tests/pages/staff/EditClientDialog.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d8104ec050832d92173fd1cd1effd3