### PR TITLE
Add staff client profile page

### DIFF
--- a/MJ_FB_Frontend/src/App.tsx
+++ b/MJ_FB_Frontend/src/App.tsx
@@ -26,6 +26,9 @@ const UserHistory = React.lazy(() =>
 const ClientManagement = React.lazy(() =>
   import('./pages/staff/ClientManagement')
 );
+const ClientProfile = React.lazy(() =>
+  import('./pages/staff/client-management/ClientProfile')
+);
 const BookingUI = React.lazy(() => import('./pages/BookingUI'));
 const PantrySchedule = React.lazy(() =>
   import('./pages/staff/PantrySchedule')
@@ -357,6 +360,12 @@ export default function App() {
                     <Route
                       path="/pantry/client-management"
                       element={<ClientManagement />}
+                    />
+                  )}
+                  {showStaff && (
+                    <Route
+                      path="/pantry/client-management/clients/:clientId"
+                      element={<ClientProfile />}
                     />
                   )}
                   {isStaff && <Route path="/events" element={<Events />} />}

--- a/MJ_FB_Frontend/src/components/dashboard/UpcomingHolidaysCard.tsx
+++ b/MJ_FB_Frontend/src/components/dashboard/UpcomingHolidaysCard.tsx
@@ -23,14 +23,18 @@ export function useUpcomingHolidays(limit?: number): UpcomingHolidayItem[] {
     const end = reginaStartOfDay().add(30, 'day').endOf('day');
 
     const filtered = holidays
-      .map(holiday => ({ ...holiday, date: toDayjs(holiday.date) }))
+      .map(holiday => ({
+        ...holiday,
+        date: toDayjs(holiday.date),
+        originalDate: holiday.date,
+      }))
       .filter(({ date }) => date.isValid() && !date.isBefore(start) && !date.isAfter(end))
       .sort((a, b) => a.date.valueOf() - b.date.valueOf());
 
     const limited = typeof limit === 'number' ? filtered.slice(0, limit) : filtered;
 
-    return limited.map(({ date, reason, ...holiday }, index) => ({
-      key: `${holiday.date}-${index}`,
+    return limited.map(({ date, reason, originalDate }, index) => ({
+      key: `${originalDate ?? date.format('YYYY-MM-DD')}-${index}`,
       label: `${date.format('MMM D (ddd)')} – ${reason?.trim() || 'Holiday'}`,
     }));
   }, [holidays, limit]);

--- a/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/ClientManagement.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useMemo } from 'react';
+import { Box, Typography } from '@mui/material';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import StyledTabs from '../../components/StyledTabs';
 import Page from '../../components/Page';
 import PantryQuickLinks from '../../components/PantryQuickLinks';
-import { useSearchParams } from 'react-router-dom';
+import EntitySearch from '../../components/EntitySearch';
+import ConfirmDialog from '../../components/ConfirmDialog';
 import AddClient from './client-management/AddClient';
 import UpdateClientData from './client-management/UpdateClientData';
-import UserHistory from './client-management/UserHistory';
 import NewClients from './client-management/NewClients';
 import NoShowWeek from './client-management/NoShowWeek';
 import DeleteClient from './client-management/DeleteClient';
@@ -13,28 +15,61 @@ import DeleteClient from './client-management/DeleteClient';
 const tabNames = ['history', 'add', 'update', 'new', 'noshow', 'delete'] as const;
 
 export default function ClientManagement() {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [tab, setTab] = useState(() => {
     const initial = (searchParams.get('tab') ?? tabNames[0]) as (typeof tabNames)[number];
     const idx = tabNames.indexOf(initial);
     return idx === -1 ? 0 : idx;
   });
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const selectedClientId = searchParams.get('clientId');
 
   useEffect(() => {
     const t = (searchParams.get('tab') ?? tabNames[0]) as (typeof tabNames)[number];
     const idx = tabNames.indexOf(t);
     setTab(idx === -1 ? 0 : idx);
   }, [searchParams]);
+
+  useEffect(() => {
+    if (selectedClientId) {
+      navigate(`/pantry/client-management/clients/${selectedClientId}`);
+    }
+  }, [navigate, selectedClientId]);
+
   const tabs = useMemo(
     () => [
-      { label: 'Search Client', content: <UserHistory /> },
+      {
+        label: 'Search Client',
+        content: (
+          <Box sx={{ maxWidth: 600, mx: 'auto', width: '100%', mt: 2 }}>
+            <Typography variant="h5" gutterBottom>
+              Search for a client
+            </Typography>
+            <EntitySearch
+              type="user"
+              placeholder="Search by name or client ID"
+              onSelect={value => {
+                const user = value as { client_id?: number };
+                if (user?.client_id) {
+                  navigate(`/pantry/client-management/clients/${user.client_id}`);
+                }
+              }}
+              onNotFound={id => {
+                (document.activeElement as HTMLElement | null)?.blur();
+                setPendingId(id);
+              }}
+            />
+          </Box>
+        ),
+      },
       { label: 'Add', content: <AddClient /> },
       { label: 'Update', content: <UpdateClientData /> },
       { label: 'New Clients', content: <NewClients /> },
       { label: 'No Shows', content: <NoShowWeek /> },
       { label: 'Delete', content: <DeleteClient /> },
     ],
-    [],
+    [navigate],
   );
 
   return (
@@ -47,6 +82,16 @@ export default function ClientManagement() {
           setSearchParams({ tab: tabNames[v] });
         }}
       />
+      {pendingId && (
+        <ConfirmDialog
+          message={`Add client ${pendingId}?`}
+          onConfirm={() => {
+            navigate(`/pantry/client-management?tab=add&clientId=${pendingId}`);
+            setPendingId(null);
+          }}
+          onCancel={() => setPendingId(null)}
+        />
+      )}
     </Page>
   );
 }

--- a/MJ_FB_Frontend/src/pages/staff/client-management/ClientProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/ClientProfile.tsx
@@ -1,0 +1,534 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+  type AlertColor,
+} from '@mui/material';
+import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Page from '../../../components/Page';
+import PantryQuickLinks from '../../../components/PantryQuickLinks';
+import PageCard from '../../../components/layout/PageCard';
+import FeedbackSnackbar from '../../../components/FeedbackSnackbar';
+import BookingManagementBase from '../../../components/BookingManagementBase';
+import AccountEditForm, {
+  type AccountEditFormData,
+} from '../../../components/account/AccountEditForm';
+import FormDialog from '../../../components/FormDialog';
+import DialogCloseButton from '../../../components/DialogCloseButton';
+import {
+  cancelBooking,
+  getBookingHistory,
+  getSlots,
+  rescheduleBookingByToken,
+} from '../../../api/bookings';
+import { deleteClientVisit } from '../../../api/clientVisits';
+import { getUserByClientId, type UserByClientId } from '../../../api/users';
+import { handleSave, handleSendReset } from './EditClientDialog';
+import getApiErrorMessage from '../../../utils/getApiErrorMessage';
+import { getDeliveryOrdersForClient } from '../../../api/deliveryOrders';
+import type { DeliveryOrder, DeliveryOrderStatus } from '../../../types';
+import { formatLocaleDate } from '../../../utils/date';
+
+type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: AlertColor;
+};
+
+function getStatusColor(
+  status?: DeliveryOrderStatus | null,
+): 'default' | 'info' | 'success' | 'warning' | 'error' {
+  switch (status) {
+    case 'approved':
+      return 'info';
+    case 'scheduled':
+      return 'warning';
+    case 'completed':
+      return 'success';
+    case 'cancelled':
+      return 'error';
+    default:
+      return 'default';
+  }
+}
+
+function formatStatusLabel(status?: DeliveryOrderStatus | null) {
+  if (!status) return 'Pending';
+  return `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
+}
+
+function DeliveryOrderSummary({ order }: { order: DeliveryOrder }) {
+  const scheduledLabel = order.scheduledFor
+    ? formatLocaleDate(order.scheduledFor, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : 'Not scheduled';
+
+  return (
+    <Box>
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Typography variant="subtitle1">{`Order #${order.id}`}</Typography>
+        <Chip
+          size="small"
+          label={formatStatusLabel(order.status)}
+          color={getStatusColor(order.status)}
+        />
+      </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        {`Scheduled: ${scheduledLabel}`}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        {`Address: ${order.address}`}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        {`Phone: ${order.phone}`}
+      </Typography>
+      {order.email && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {`Email: ${order.email}`}
+        </Typography>
+      )}
+      {order.notes && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {`Notes: ${order.notes}`}
+        </Typography>
+      )}
+      <Typography variant="subtitle2" sx={{ mt: 1 }}>
+        Items
+      </Typography>
+      {order.items.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No items recorded
+        </Typography>
+      ) : (
+        <List dense disablePadding>
+          {order.items.map((item, index) => (
+            <ListItem key={`${order.id}-${item.itemId ?? index}`} disableGutters sx={{ py: 0 }}>
+              <ListItemText
+                primary={`${item.itemName || item.name || 'Item'} × ${item.quantity}`}
+                secondary={item.categoryName ?? undefined}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+}
+
+interface ProfileDetailProps {
+  label: string;
+  value: string;
+  testId?: string;
+}
+
+function ProfileDetail({ label, value, testId }: ProfileDetailProps) {
+  return (
+    <Stack spacing={0.5}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body1" data-testid={testId}>
+        {value}
+      </Typography>
+    </Stack>
+  );
+}
+
+function formatRole(role: UserByClientId['role']) {
+  switch (role) {
+    case 'shopper':
+      return 'Pantry shopper';
+    case 'delivery':
+      return 'Delivery client';
+    default:
+      return 'Client';
+  }
+}
+
+export default function ClientProfile() {
+  const { clientId } = useParams<{ clientId: string }>();
+  const [client, setClient] = useState<UserByClientId | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [snackbar, setSnackbar] = useState<SnackbarState | null>(null);
+  const [activeDeliveryOrders, setActiveDeliveryOrders] = useState<DeliveryOrder[]>([]);
+  const [completedDeliveryOrders, setCompletedDeliveryOrders] = useState<DeliveryOrder[]>([]);
+  const [deliveryLoading, setDeliveryLoading] = useState(false);
+  const [deliveryError, setDeliveryError] = useState<string | null>(null);
+  const [completedExpanded, setCompletedExpanded] = useState(false);
+
+  const parsedId = clientId ? Number(clientId) : NaN;
+  const validId = Number.isInteger(parsedId) ? String(parsedId) : null;
+
+  const handleSnackbar = useCallback((message: string, severity: AlertColor) => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
+
+  const closeSnackbar = useCallback(() => {
+    setSnackbar(prev => (prev ? { ...prev, open: false } : prev));
+  }, []);
+
+  const loadClient = useCallback(async () => {
+    if (!validId) {
+      setClient(null);
+      setLoadError('Client not found');
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setLoadError('');
+    try {
+      const data = await getUserByClientId(validId);
+      setClient(data);
+    } catch (err) {
+      setClient(null);
+      setLoadError('Unable to load client');
+      handleSnackbar(getApiErrorMessage(err, 'Unable to load client'), 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [validId, handleSnackbar]);
+
+  const refreshClient = useCallback(async () => {
+    if (!validId) return;
+    try {
+      const data = await getUserByClientId(validId);
+      setClient(data);
+    } catch (err) {
+      handleSnackbar(getApiErrorMessage(err, 'Failed to refresh client'), 'error');
+    }
+  }, [validId, handleSnackbar]);
+
+  useEffect(() => {
+    loadClient();
+  }, [loadClient]);
+
+  useEffect(() => {
+    if (!client || client.role !== 'delivery') {
+      setActiveDeliveryOrders([]);
+      setCompletedDeliveryOrders([]);
+      setDeliveryError(null);
+      setDeliveryLoading(false);
+      setCompletedExpanded(false);
+      return;
+    }
+
+    let active = true;
+    setDeliveryLoading(true);
+    setDeliveryError(null);
+
+    getDeliveryOrdersForClient(client.clientId)
+      .then(orders => {
+        if (!active) return;
+        const activeStatuses: DeliveryOrderStatus[] = ['pending', 'approved', 'scheduled'];
+        const activeOrders: DeliveryOrder[] = [];
+        const completedOrders: DeliveryOrder[] = [];
+        orders.forEach(order => {
+          if (!order.status || activeStatuses.includes(order.status)) {
+            activeOrders.push(order);
+          } else {
+            completedOrders.push(order);
+          }
+        });
+        setActiveDeliveryOrders(activeOrders);
+        setCompletedDeliveryOrders(completedOrders);
+        setCompletedExpanded(false);
+      })
+      .catch(err => {
+        if (!active) return;
+        setActiveDeliveryOrders([]);
+        setCompletedDeliveryOrders([]);
+        setDeliveryError(getApiErrorMessage(err, 'Unable to load delivery orders'));
+      })
+      .finally(() => {
+        if (active) setDeliveryLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [client]);
+
+  const displayName = useMemo(() => {
+    if (!client) return '';
+    const name = `${client.firstName ?? ''} ${client.lastName ?? ''}`.trim();
+    if (name) return name;
+    return `Client #${client.clientId}`;
+  }, [client]);
+
+  const accountInitialData = useMemo<AccountEditFormData>(() => ({
+    firstName: client?.firstName || '',
+    lastName: client?.lastName || '',
+    email: client?.email || '',
+    phone: client?.phone || '',
+    onlineAccess: Boolean(client?.onlineAccess),
+    password: '',
+    hasPassword: Boolean(client?.hasPassword),
+  }), [
+    client?.firstName,
+    client?.lastName,
+    client?.email,
+    client?.phone,
+    client?.onlineAccess,
+    client?.hasPassword,
+  ]);
+
+  const retentionNotice = (
+    'Bookings, cancellations, and visits older than one year are removed from history.'
+  );
+
+  const draftKey = client ? `client-profile-${client.clientId}` : undefined;
+
+  const title = client ? `${displayName} · Client Profile` : 'Client Profile';
+
+  return (
+    <Page title={title} header={<PantryQuickLinks />}> 
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress aria-label="Loading client" />
+        </Box>
+      ) : loadError ? (
+        <Typography color="error" variant="body1">
+          {loadError}
+        </Typography>
+      ) : !client ? (
+        <Typography variant="body1">Client not found.</Typography>
+      ) : (
+        <Stack spacing={2}>
+          <PageCard>
+            <Stack spacing={3}>
+              <Stack spacing={1}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Typography variant="h5" data-testid="client-name">
+                    {displayName}
+                  </Typography>
+                  {client.hasPassword && (
+                    <Chip
+                      icon={<CheckCircleOutline fontSize="small" />}
+                      label="Online account"
+                      color="success"
+                      size="small"
+                      variant="outlined"
+                      data-testid="online-account-chip"
+                    />
+                  )}
+                  <Chip
+                    label={`${client.bookingsThisMonth ?? 0} uses this month`}
+                    color="info"
+                    size="small"
+                    variant="outlined"
+                    data-testid="monthly-usage-chip"
+                  />
+                </Stack>
+                <Typography variant="body2" color="text.secondary">
+                  Client ID #{client.clientId}
+                </Typography>
+                <Typography variant="body1" color="text.secondary">
+                  {formatRole(client.role)}
+                </Typography>
+              </Stack>
+              <Box
+                sx={{
+                  display: 'grid',
+                  gap: 2,
+                  gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+                }}
+              >
+                <ProfileDetail
+                  label="Email"
+                  value={client.email || 'Not provided'}
+                  testId="client-email"
+                />
+                <ProfileDetail
+                  label="Phone"
+                  value={client.phone || 'Not provided'}
+                  testId="client-phone"
+                />
+                <ProfileDetail
+                  label="Address"
+                  value={client.address || 'Not provided'}
+                />
+              </Box>
+            </Stack>
+          </PageCard>
+
+          <PageCard>
+            <BookingManagementBase
+              user={{ name: displayName, client_id: client.clientId }}
+              getBookingHistory={getBookingHistory}
+              cancelBooking={cancelBooking}
+              rescheduleBookingByToken={rescheduleBookingByToken}
+              getSlots={getSlots}
+              onDeleteVisit={deleteClientVisit}
+              showNotes
+              showUserHeading={false}
+              retentionNotice={retentionNotice}
+              renderEditDialog={({ open, onClose, onUpdated }) => (
+                <FormDialog open={open} onClose={onClose}>
+                  <DialogCloseButton onClose={onClose} />
+                  <Typography component="h2" variant="h6" sx={{ px: 3, pt: 3 }}>
+                    Edit Client
+                  </Typography>
+                  <AccountEditForm
+                    open={open}
+                    initialData={accountInitialData}
+                    onSave={async data => {
+                      if (!client) return false;
+                      const showFeedback = (message: string, severity: AlertColor) => {
+                        onUpdated(message, severity);
+                        handleSnackbar(message, severity);
+                      };
+                      const saved = await handleSave(
+                        client.clientId,
+                        data,
+                        () => undefined,
+                        showFeedback,
+                        onClose,
+                      );
+                      if (saved) {
+                        await refreshClient();
+                      }
+                      return saved;
+                    }}
+                    onSecondaryAction={async data => {
+                      if (!client) return;
+                      const showFeedback = (message: string, severity: AlertColor) => {
+                        onUpdated(message, severity);
+                        handleSnackbar(message, severity);
+                      };
+                      const saved = await handleSendReset(
+                        client.clientId,
+                        data,
+                        () => undefined,
+                        showFeedback,
+                        onClose,
+                      );
+                      if (saved) {
+                        await refreshClient();
+                      }
+                    }}
+                    secondaryActionLabel="Send password reset link"
+                    onlineAccessHelperText="Allow the client to sign in online."
+                    existingPasswordTooltip="Client already has a password"
+                    secondaryActionTestId="send-reset-button"
+                    titleAdornment={data =>
+                      data.hasPassword ? (
+                        <Chip
+                          color="success"
+                          icon={<CheckCircleOutline />}
+                          label="Online account"
+                          data-testid="dialog-online-badge"
+                        />
+                      ) : null
+                    }
+                    draftKey={draftKey}
+                  />
+                </FormDialog>
+              )}
+              renderDeleteVisitButton={(booking, isSmall, openDelete) =>
+                booking.status === 'visited' && !booking.slot_id ? (
+                  <Button
+                    key="deleteVisit"
+                    onClick={openDelete}
+                    variant="outlined"
+                    color="error"
+                    fullWidth={isSmall}
+                  >
+                    Delete visit
+                  </Button>
+                ) : null
+              }
+            />
+          </PageCard>
+          {client.role === 'delivery' && (
+            <PageCard>
+              <Stack spacing={3}>
+                <Typography variant="h6">Delivery history</Typography>
+                {deliveryLoading ? (
+                  <Box display="flex" justifyContent="center" py={2}>
+                    <CircularProgress size={24} aria-label="Loading delivery history" />
+                  </Box>
+                ) : deliveryError ? (
+                  <Typography color="error">{deliveryError}</Typography>
+                ) : (
+                  <Stack spacing={3}>
+                    <Box>
+                      <Typography variant="subtitle1" gutterBottom>
+                        Active deliveries
+                      </Typography>
+                      {activeDeliveryOrders.length === 0 ? (
+                        <Typography color="text.secondary">
+                          No active delivery requests right now.
+                        </Typography>
+                      ) : (
+                        <Stack spacing={2} divider={<Divider flexItem />}>
+                          {activeDeliveryOrders.map(order => (
+                            <DeliveryOrderSummary key={order.id} order={order} />
+                          ))}
+                        </Stack>
+                      )}
+                    </Box>
+                    <Accordion
+                      expanded={completedExpanded}
+                      onChange={(_, expanded) => setCompletedExpanded(expanded)}
+                    >
+                      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                        <Typography variant="subtitle1">
+                          {completedExpanded
+                            ? 'Hide completed deliveries'
+                            : 'Show completed deliveries'}
+                        </Typography>
+                      </AccordionSummary>
+                      <AccordionDetails>
+                        {completedDeliveryOrders.length === 0 ? (
+                          <Typography color="text.secondary">
+                            No completed deliveries yet.
+                          </Typography>
+                        ) : (
+                          <Stack spacing={2} divider={<Divider flexItem />}>
+                            {completedDeliveryOrders.map(order => (
+                              <DeliveryOrderSummary key={order.id} order={order} />
+                            ))}
+                          </Stack>
+                        )}
+                      </AccordionDetails>
+                    </Accordion>
+                  </Stack>
+                )}
+              </Stack>
+            </PageCard>
+          )}
+        </Stack>
+      )}
+      <FeedbackSnackbar
+        open={Boolean(snackbar?.open)}
+        message={snackbar?.message ?? ''}
+        severity={snackbar?.severity}
+        onClose={closeSnackbar}
+      />
+    </Page>
+  );
+}

--- a/MJ_FB_Frontend/src/pages/staff/client-management/__tests__/ClientProfile.test.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/client-management/__tests__/ClientProfile.test.tsx
@@ -1,0 +1,225 @@
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from '../../../../../testUtils/renderWithProviders';
+import * as Router from 'react-router-dom';
+import ClientProfile from '../ClientProfile';
+import { getUserByClientId } from '../../../../api/users';
+import {
+  getBookingHistory,
+  getSlots,
+  cancelBooking,
+  rescheduleBookingByToken,
+} from '../../../../api/bookings';
+import { deleteClientVisit } from '../../../../api/clientVisits';
+import { getDeliveryOrdersForClient } from '../../../../api/deliveryOrders';
+import { handleSave, handleSendReset } from '../EditClientDialog';
+
+jest.mock('../../../../components/PantryQuickLinks', () => ({
+  __esModule: true,
+  default: () => <div data-testid="pantry-quick-links" />,
+}));
+
+jest.mock('../../../../components/account/AccountEditForm', () => ({
+  __esModule: true,
+  default: ({
+    onSave,
+    onSecondaryAction,
+    initialData,
+  }: {
+    onSave: (data: any) => Promise<boolean> | boolean;
+    onSecondaryAction?: (data: any) => void;
+    initialData: any;
+  }) => (
+    <div data-testid="account-edit-form">
+      <button onClick={() => onSave(initialData)}>Save changes</button>
+      {onSecondaryAction && (
+        <button onClick={() => onSecondaryAction(initialData)}>Send reset</button>
+      )}
+    </div>
+  ),
+}));
+
+jest.mock('../../../../api/users', () => ({
+  __esModule: true,
+  getUserByClientId: jest.fn(),
+}));
+
+jest.mock('../../../../api/bookings', () => ({
+  __esModule: true,
+  getBookingHistory: jest.fn(),
+  getSlots: jest.fn(),
+  cancelBooking: jest.fn(),
+  rescheduleBookingByToken: jest.fn(),
+}));
+
+jest.mock('../../../../api/clientVisits', () => ({
+  __esModule: true,
+  deleteClientVisit: jest.fn(),
+}));
+
+jest.mock('../../../../api/deliveryOrders', () => ({
+  __esModule: true,
+  getDeliveryOrdersForClient: jest.fn(),
+}));
+
+jest.mock('../EditClientDialog', () => ({
+  handleSave: jest.fn(),
+  handleSendReset: jest.fn(),
+}));
+
+const mockGetUserByClientId = getUserByClientId as jest.MockedFunction<
+  typeof getUserByClientId
+>;
+const mockGetBookingHistory = getBookingHistory as jest.MockedFunction<
+  typeof getBookingHistory
+>;
+const mockGetSlots = getSlots as jest.MockedFunction<typeof getSlots>;
+const mockCancelBooking = cancelBooking as jest.MockedFunction<typeof cancelBooking>;
+const mockReschedule = rescheduleBookingByToken as jest.MockedFunction<
+  typeof rescheduleBookingByToken
+>;
+const mockDeleteVisit = deleteClientVisit as jest.MockedFunction<typeof deleteClientVisit>;
+const mockGetDeliveryOrdersForClient = getDeliveryOrdersForClient as jest.MockedFunction<
+  typeof getDeliveryOrdersForClient
+>;
+const mockHandleSave = handleSave as jest.MockedFunction<typeof handleSave>;
+const mockHandleSendReset = handleSendReset as jest.MockedFunction<typeof handleSendReset>;
+
+const originalFetch = globalThis.fetch;
+
+beforeAll(() => {
+  (globalThis as any).fetch = jest.fn(async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+    if (url.includes('/auth/csrf-token')) {
+      return new Response(JSON.stringify({ csrfToken: 'test-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/auth/refresh')) {
+      return new Response(null, { status: 200 });
+    }
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem('role', 'staff');
+  localStorage.setItem('name', 'Staff Member');
+  localStorage.setItem('access', '[]');
+});
+
+const renderProfile = () => {
+  return renderWithProviders(
+    <Router.MemoryRouter initialEntries={['/pantry/client-management/clients/456']}>
+      <Router.Routes>
+        <Router.Route
+          path="/pantry/client-management/clients/:clientId"
+          element={<ClientProfile />}
+        />
+      </Router.Routes>
+    </Router.MemoryRouter>,
+  );
+};
+
+describe('ClientProfile', () => {
+  it('renders client details, booking history, edit dialog, and delivery history', async () => {
+    mockGetUserByClientId.mockResolvedValue({
+      clientId: 456,
+      firstName: 'Search',
+      lastName: 'Result',
+      email: 'client@example.com',
+      phone: '306-555-1234',
+      address: '123 Main St',
+      onlineAccess: true,
+      hasPassword: true,
+      role: 'delivery',
+      bookingsThisMonth: 2,
+    } as any);
+    mockGetBookingHistory.mockResolvedValue([
+      {
+        id: 1,
+        status: 'visited',
+        date: '2024-05-01',
+        slot_id: null,
+        client_id: 456,
+        reschedule_token: 'token',
+        rescheduleToken: 'token',
+        newClientId: null,
+        start_time: '09:00',
+        end_time: '09:15',
+        startTime: '09:00',
+        endTime: '09:15',
+      },
+    ] as any);
+    mockGetSlots.mockResolvedValue([]);
+    mockCancelBooking.mockResolvedValue(undefined);
+    mockReschedule.mockResolvedValue(undefined);
+    mockDeleteVisit.mockResolvedValue(undefined);
+    mockGetDeliveryOrdersForClient.mockResolvedValue([
+      {
+        id: 10,
+        clientId: 456,
+        status: 'scheduled',
+        createdAt: '2024-05-01T17:00:00.000Z',
+        scheduledFor: '2024-05-14T15:30:00.000Z',
+        address: '123 Main St',
+        phone: '306-555-1234',
+        email: 'client@example.com',
+        notes: 'Leave at the back door',
+        items: [
+          { itemId: 1, quantity: 2, categoryId: 7, itemName: 'Milk', categoryName: 'Dairy' },
+        ],
+      },
+    ] as any);
+    mockHandleSave.mockImplementation(async (_id, _data, _onClientUpdated, onUpdated, onClose) => {
+      onUpdated('Client updated', 'success');
+      onClose();
+      return true;
+    });
+    mockHandleSendReset.mockImplementation(async (_id, _data, _onClientUpdated, onUpdated, onClose) => {
+      onUpdated('Password reset link sent', 'success');
+      onClose();
+      return true;
+    });
+
+    renderProfile();
+
+    expect(screen.getByLabelText('Loading client')).toBeInTheDocument();
+
+    await waitFor(() => expect(mockGetUserByClientId).toHaveBeenCalledWith('456'));
+
+    expect(screen.getByTestId('client-name')).toHaveTextContent('Search Result');
+    expect(screen.getByTestId('monthly-usage-chip')).toHaveTextContent('2 uses this month');
+    expect(screen.getByText('client@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Edit Client/i })).toBeInTheDocument();
+    await screen.findByText('Order #10');
+    await screen.findByText('Delete visit');
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit Client/i }));
+    const form = await screen.findByTestId('account-edit-form');
+    expect(form).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
+
+    const messages = await screen.findAllByText('Client updated');
+    expect(messages.length).toBeGreaterThan(0);
+  });
+});

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/EditVolunteer.tsx
@@ -7,10 +7,6 @@ import type { VolunteerSearchResult } from '../../../api/volunteers';
 export default function EditVolunteer() {
   const navigate = useNavigate();
 
-  function handleSelect(result: VolunteerSearchResult) {
-    navigate(`/volunteer-management/volunteers/${result.id}`);
-  }
-
   return (
     <PageCard>
       <Stack spacing={2}>
@@ -18,10 +14,13 @@ export default function EditVolunteer() {
         <Typography variant="body2" color="text.secondary">
           Find a volunteer to open their profile, manage roles, and review stats.
         </Typography>
-        <EntitySearch<VolunteerSearchResult>
+        <EntitySearch
           type="volunteer"
           placeholder="Search volunteer"
-          onSelect={handleSelect}
+          onSelect={result => {
+            const volunteer = result as VolunteerSearchResult;
+            navigate(`/volunteer-management/volunteers/${volunteer.id}`);
+          }}
           clearOnSelect
         />
       </Stack>

--- a/MJ_FB_Frontend/src/pages/staff/volunteer-management/VolunteerProfile.tsx
+++ b/MJ_FB_Frontend/src/pages/staff/volunteer-management/VolunteerProfile.tsx
@@ -598,11 +598,12 @@ export default function VolunteerProfile() {
                       onChange={handleRoleChange}
                       label="Roles"
                       data-testid="roles-select"
-                      renderValue={selectedValue => {
-                        const values =
-                          typeof selectedValue === 'string'
-                            ? selectedValue.split(',')
-                            : selectedValue;
+                      renderValue={(selectedValue: string | string[]) => {
+                        const values = Array.isArray(selectedValue)
+                          ? selectedValue
+                          : typeof selectedValue === 'string'
+                          ? selectedValue.split(',')
+                          : [];
                         return values.length ? `${values.length} selected` : 'Select roles';
                       }}
                     >

--- a/MJ_FB_Frontend/src/pages/volunteer-management/RoleSelectionDialog.tsx
+++ b/MJ_FB_Frontend/src/pages/volunteer-management/RoleSelectionDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Button,
   Checkbox,


### PR DESCRIPTION
## Summary
- add a dedicated ClientProfile page with inline account editing, booking history, and delivery order sections for staff
- redirect staff searches and history views to the profile route while keeping existing behaviour for non-staff contexts
- update supporting components and test coverage for the new workflow and TypeScript checks

## Testing
- npm test -- --runTestsByPath src/pages/staff/client-management/__tests__/UserHistory.test.tsx src/pages/staff/client-management/__tests__/ClientProfile.test.tsx src/__tests__/ClientBookingHistory.test.tsx
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8156a8b4c832dbb30e2b022c1ca8a